### PR TITLE
Fix logic error in logging that logs errors in normal cases

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -20,7 +20,8 @@ public final class IotHubReceiveTask implements Runnable
     public IotHubReceiveTask(IotHubTransport transport)
     {
 
-        if (transport == null) {
+        if (transport == null)
+        {
 
             logger.LogError("IotHubReceiveTask constructor called with null value for parameter transport");
             throw new IllegalArgumentException("Parameter 'transport' must not be null");

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -20,14 +20,15 @@ public final class IotHubReceiveTask implements Runnable
     public IotHubReceiveTask(IotHubTransport transport)
     {
 
+        if (transport == null) {
 
-        if (transport == null)
+            logger.LogError("IotHubReceiveTask constructor called with null value for parameter transport");
             throw new IllegalArgumentException("Parameter 'transport' must not be null");
+        }
 
         // Codes_SRS_IOTHUBRECEIVETASK_11_001: [The constructor shall save the transport.]
         this.transport = transport;
 
-        logger.LogError("IotHubReceiveTask constructor called with null value for parameter transport");
     }
 
     public void run()

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -20,13 +20,14 @@ public final class IotHubSendTask implements Runnable
 
     public IotHubSendTask(IotHubTransport transport)
     {
-        if (transport == null)
+        if (transport == null) {
+
+            logger.LogError("IotHubSendTask constructor called with null value for parameter transport");
             throw new IllegalArgumentException("Parameter 'transport' must not be null");
+        }
 
         // Codes_SRS_IOTHUBSENDTASK_11_001: [The constructor shall save the transport.]
         this.transport = transport;
-
-        logger.LogError("IotHubSendTask constructor called with null value for parameter transport");
     }
 
     public void run()

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -20,7 +20,8 @@ public final class IotHubSendTask implements Runnable
 
     public IotHubSendTask(IotHubTransport transport)
     {
-        if (transport == null) {
+        if (transport == null)
+        {
 
             logger.LogError("IotHubSendTask constructor called with null value for parameter transport");
             throw new IllegalArgumentException("Parameter 'transport' must not be null");


### PR DESCRIPTION
There are coding mistakes in the constructers of both IotHubSendTask and IotHubReceiveTask that log errors under all normal conditions

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down). Should not need more coverage if tests already cover the null/not null cases.
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements. No API changes.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Description of the problem
Please correctly use braces

# Description of the solution
```
 public IotHubReceiveTask(IotHubTransport transport)
    {
        if (transport == null)
            throw new IllegalArgumentException("Parameter 'transport' must not be null");

        // Codes_SRS_IOTHUBRECEIVETASK_11_001: [The constructor shall save the transport.]
        this.transport = transport;

        logger.LogError("IotHubReceiveTask constructor called with null value for parameter transport");
    }
```
should become 
```
 public IotHubReceiveTask(IotHubTransport transport)
    {
        if (transport == null) {

             logger.LogError("IotHubReceiveTask constructor called with null value for parameter transport");
            throw new IllegalArgumentException("Parameter 'transport' must not be null");
       }
        
        // Codes_SRS_IOTHUBRECEIVETASK_11_001: [The constructor shall save the transport.]
        this.transport = transport;
    }
```