### PR TITLE
In Mqtt publish method, while waiting for number of pending tokens to…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -291,6 +291,14 @@ abstract public class Mqtt implements MqttCallback
                     * And if there are pending tokens publish shall sleep until the number of pending tokens are less than 10 as per paho limitations**]**
                     */
                     Thread.sleep(10);
+
+                    if (!Mqtt.info.mqttAsyncClient.isConnected())
+                    {
+                    /*
+                    ** Codes_SRS_Mqtt_25_012: [**If the MQTT connection is closed, the function shall throw an IOException.**]**
+                     */
+                        throw new IOException("Cannot publish when mqtt client is disconnected");
+                    }
                 }
 
                 MqttMessage mqttMessage = (payload.length == 0) ? new MqttMessage() : new MqttMessage(payload);


### PR DESCRIPTION
… reduce, check if the client has disconnected in every loop to avoid deadlock

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Apparent deadlock in the Mqtt publishing when connection is lost to the broker and there are many messages in-flight. 

In the Mqtt.java publish method, there is a loop that waits for the number of in-flight messages to go below a certain limit before publishing a message. In that loop, the function has previously grabbed a lock.

If the connection to the broker is lost, the connectionLost method is waiting to grab that lock which is grabbed by the thread in the publish method. The latter will never exit the loop since the connection has been lost to the broker but the number of in-flight messages does not go down.

Here is a portion of a stack trace for those 2 threads. The version of the SDK used is iot-device-client-1.2.27


```
   java.lang.Thread.State: BLOCKED (on object monitor)
        at com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt.connectionLost(Mqtt.java:484)
        - waiting to lock <0x00000000df53d650> (a java.lang.Object)
        at org.eclipse.paho.client.mqttv3.internal.CommsCallback.connectionLost(CommsCallback.java:269)
        at org.eclipse.paho.client.mqttv3.internal.ClientComms.shutdownConnection(ClientComms.java:385)
        at org.eclipse.paho.client.mqttv3.internal.CommsReceiver.run(CommsReceiver.java:146)
        at java.lang.Thread.run(Thread.java:745)
```




```
   java.lang.Thread.State: TIMED_WAITING (sleeping)
        at java.lang.Thread.sleep(Native Method)
        at com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt.publish(Mqtt.java:301)
        - locked <0x00000000df53d650> (a java.lang.Object)
        at com.microsoft.azure.sdk.iot.device.transport.mqtt.MqttMessaging.send(MqttMessaging.java:242)
        at com.microsoft.azure.sdk.iot.device.transport.mqtt.MqttIotHubConnection.sendEvent(MqttIotHubConnection.java:210)
        - locked <0x00000000df5e3008> (a java.lang.Object)
        at com.microsoft.azure.sdk.iot.device.transport.mqtt.MqttTransport.sendMessages(MqttTransport.java:174)
        - locked <0x00000000df5b5988> (a java.lang.Object)
        at com.microsoft.azure.sdk.iot.device.transport.IotHubSendTask.run(IotHubSendTask.java:25)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->

One possible solution to the problem would be to check if the connection to the broker has been lost in the loop waiting for the number of in-flight messages to decrease. If that is the case, the thread should exit the loop. Following the documentation and the other check of connectionLost in the same function, if this case is detected and I/O Exception is thrown.

[](https://github.com/Azure/azure-iot-sdk-java/blob/master/device/iot-device-client/devdoc/requirement_docs/com/microsoft/azure/iothub/transport/mqtt/mqtt_requirements.md)

SRS_Mqtt_25_012: [If the MQTT connection is closed, the function shall throw an IOException.]