### PR TITLE
Fix issue #159 [Use non-parameter constructor of DeviceTwinDevice if device id is null]

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobResult.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobResult.java
@@ -155,7 +155,8 @@ public class JobResult
         TwinParser twinParser = jobsResponseParser.getUpdateTwin();
         if(twinParser != null)
         {
-            this.updateTwin = new DeviceTwinDevice(twinParser.getDeviceId());
+            this.updateTwin = twinParser.getDeviceId() == null || twinParser.getDeviceId().isEmpty() ?
+                new DeviceTwinDevice() : new DeviceTwinDevice(twinParser.getDeviceId());
             this.updateTwin.setETag(twinParser.getETag());
             try
             {

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
@@ -99,7 +99,55 @@ public class JobResultTest
             }
         };
     }
-    
+
+    private void jobsResponseParserWithNullDeviceIdExpectations(String json, TwinParser twinParser, MethodParser methodParser, Date date, MethodParser methodParserResponse, String jobTypeStr)
+    {
+        new NonStrictExpectations()
+        {
+            {
+                JobsResponseParser.createFromJson(json);
+                result = mockedJobsResponseParser;
+
+                mockedJobsResponseParser.getJobId();
+                result = JOB_ID;
+                mockedJobsResponseParser.getQueryCondition();
+                result = QUERY_CONDITION;
+                mockedJobsResponseParser.getCreatedTime();
+                result = date;
+                mockedJobsResponseParser.getStartTime();
+                result = date;
+                mockedJobsResponseParser.getLastUpdatedTimeDate();
+                result = date;
+                mockedJobsResponseParser.getEndTime();
+                result = date;
+                mockedJobsResponseParser.getMaxExecutionTimeInSeconds();
+                result = MAX_EXECUTION_TIME_IN_SECONDS;
+                mockedJobsResponseParser.getType();
+                result = jobTypeStr;
+                mockedJobsResponseParser.getJobsStatus();
+                result = "enqueued";
+                mockedJobsResponseParser.getCloudToDeviceMethod();
+                result = methodParser;
+                mockedJobsResponseParser.getOutcome();
+                result = methodParserResponse;
+                mockedJobsResponseParser.getUpdateTwin();
+                result = twinParser;
+                mockedJobsResponseParser.getFailureReason();
+                result = FAILURE_REASON;
+                mockedJobsResponseParser.getStatusMessage();
+                result = STATUS_MESSAGE;
+                mockedJobsResponseParser.getJobStatistics();
+                result = mockedJobsStatisticsParser;
+                mockedJobsResponseParser.getDeviceId();
+                result = null;
+                mockedJobsResponseParser.getParentJobId();
+                result = PARENT_JOB_ID;
+
+                Deencapsulation.newInstance(JobStatistics.class, mockedJobsStatisticsParser);
+                result = mockedJobStatistics;
+            }
+        };
+    }
     /* Tests_SRS_JOBRESULT_21_001: [The constructor shall throw IllegalArgumentException if the input body is null.] */
     @Test (expected = IllegalArgumentException.class)
     public void constructorThrowsOnNullJson()
@@ -276,6 +324,46 @@ public class JobResultTest
         assertEquals(STATUS_MESSAGE, jobResult.getStatusMessage());
         assertNotNull(jobResult.getJobStatistics());
         assertEquals(DEVICE_ID, jobResult.getDeviceId());
+        assertEquals(PARENT_JOB_ID, jobResult.getParentJobId());
+    }
+
+    /* Tests_SRS_JOBRESULT_21_021: [The getUpdateTwin shall return the nullable deviceId.] */
+    @Test
+    public void gettersTwinContentWithNullDeviceId() throws IOException
+    {
+        //arrange
+        final String json = "validJson";
+        final Date now = new Date();
+
+        Map<String, Object> tags = new HashMap<>();
+        tags.put("tag1", "val1");
+
+        TwinParser twinParser = new TwinParser();
+        twinParser.enableTags();
+        twinParser.setETag(ETAG);
+        twinParser.resetTags(tags);
+
+        jobsResponseParserWithNullDeviceIdExpectations(json, twinParser, null, now, null, "scheduleUpdateTwin");
+
+        //act
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+
+        //assert
+        assertEquals(JOB_ID, jobResult.getJobId());
+        assertEquals(QUERY_CONDITION, jobResult.getQueryCondition());
+        assertEquals(now, jobResult.getCreatedTime());
+        assertEquals(now, jobResult.getStartTime());
+        assertEquals(now, jobResult.getEndTime());
+        assertEquals(MAX_EXECUTION_TIME_IN_SECONDS, (long)jobResult.getMaxExecutionTimeInSeconds());
+        assertEquals(JobType.scheduleUpdateTwin, jobResult.getJobType());
+        assertEquals(JobStatus.enqueued, jobResult.getJobStatus());
+        assertNull(jobResult.getCloudToDeviceMethod());
+        assertNotNull(jobResult.getUpdateTwin());
+        assertEquals(FAILURE_REASON, jobResult.getFailureReason());
+        assertEquals(STATUS_MESSAGE, jobResult.getStatusMessage());
+        assertNotNull(jobResult.getJobStatistics());
+        assertNull(jobResult.getDeviceId());
+        assertNull(jobResult.getUpdateTwin().getDeviceId());
         assertEquals(PARENT_JOB_ID, jobResult.getParentJobId());
     }
 


### PR DESCRIPTION
When scheduling a twin job, the job result contains empty device id which
will fail the constructor of DeviceTwinDevice(String deviceId). The
non-parameter constructor should be used in this case.

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/159

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
When scheduling a twin job, the job result contains null or empty device id which
will fail the constructor of DeviceTwinDevice(String deviceId). The
non-parameter constructor should be used in this case.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 