### PR TITLE
log level passed to debug in AmqpsTransport.handleMessage()

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTransport.java
@@ -399,7 +399,7 @@ public final class AmqpsTransport implements IotHubTransport, ServerListener
             throw new IllegalStateException("Cannot handle messages when AMQPS transport is closed.");
         }
         
-        logger.LogInfo("Get the callback function for the received message, method name is %s ", logger.getMethodName());
+        logger.LogDebug("Get the callback function for the received message, method name is %s ", logger.getMethodName());
 
         // Codes_SRS_AMQPSTRANSPORT_15_023: [The function shall attempt to consume a message from the IoT Hub.]
         // Codes_SRS_AMQPSTRANSPORT_15_024: [If no message was received from IotHub, the function shall return.]


### PR DESCRIPTION
Log level passed to debug because the method is called dozens times per second even if there's no message. Other useful logs are unreadable because of the amount of lines.
