### PR TITLE
Minor changes to enable compilation under JDK 9. Mainly bringing the …

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadNotificationParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadNotificationParser.java
@@ -7,7 +7,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 
 import java.util.Date;
 
@@ -44,7 +43,7 @@ public class FileUploadNotificationParser
     @Expose(serialize = true, deserialize = true)
     @SerializedName(LAST_UPDATED_TIME_TAG)
     private String lastUpdatedTime = null;
-    @Ignore
+
     private Date lastUpdatedTimeDate;
 
     private static final String BLOB_SIZE_IN_BYTES_TAG = "blobSizeInBytes";
@@ -56,7 +55,7 @@ public class FileUploadNotificationParser
     @Expose(serialize = true, deserialize = true)
     @SerializedName(ENQUEUED_TIME_UTC_TAG)
     private String enqueuedTimeUtc = null;
-    @Ignore
+
     private Date enqueuedTimeUtcDate;
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -11,7 +11,6 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -209,7 +208,7 @@ public class DeviceTwin
         }
 
         // Currently this is not supported by service - Please use Update twin to update desired properties
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
         /*
         **Codes_SRS_DEVICETWIN_25_024: [** The function shall create a new SAS token **]**
 
@@ -275,7 +274,7 @@ public class DeviceTwin
 
         }
 
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
 
         /*
         **Codes_SRS_DEVICETWIN_25_032: [** The function shall create a new SAS token **]**
@@ -358,7 +357,7 @@ public class DeviceTwin
         **Codes_SRS_DEVICETWIN_25_044: [** The function shall verify the response status and throw proper Exception **]**
 
          */
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
         // Currently not implemented on service
         // HttpResponse response = this.processHttpTwinRequest(url, HttpMethod.PUT, tags.getBytes(), String.valueOf(requestId++));
     }

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Minor changes to enable compilation under JDK 9. Mainly bringing the source / target of a few poms up from Java 5 to Java 6 (the minimum version under JDK 9), and removing some references to unavailable classes.