### PR TITLE
Remove unused (and unavailable) InactiveGroupException import statement that breaks the build.

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
@@ -8,7 +8,6 @@ import com.microsoft.azure.sdk.iot.deps.twin.TwinMetadata;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
-import sun.rmi.server.InactiveGroupException;
 
 import java.io.IOException;
 import java.util.Date;


### PR DESCRIPTION
A `import sun.rmi.server.InactiveGroupException` statement is added to DeviceTwin but the class is not used. This is fortunate as under JDK 9 this fails to compile. This PR removes this import and restores the ability to build this project under JDK 9. 