### PR TITLE
fix(iot-dev): Use CustomLogger in MQTT

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.sdk.iot.device.transport.mqtt;
 
+import com.microsoft.azure.sdk.iot.device.CustomLogger;
 import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubSasToken;
@@ -22,6 +23,7 @@ abstract public class Mqtt implements MqttCallback
 {
     private MqttConnection mqttConnection;
     private DeviceClientConfig deviceClientConfig = null;
+    private CustomLogger logger = null;
     ConcurrentLinkedQueue<Pair<String, byte[]>> allReceivedMessages;
     Object mqttLock = null;
 
@@ -65,6 +67,7 @@ abstract public class Mqtt implements MqttCallback
         this.mqttLock = mqttConnection.getMqttLock();
         this.userSpecifiedSASTokenExpiredOnRetry = false;
         this.listener = listener;
+        this.logger = new CustomLogger(Mqtt.class);
     }
 
     /**
@@ -366,7 +369,7 @@ abstract public class Mqtt implements MqttCallback
                 int currentReconnectionAttempt = 0;
                 while (!this.mqttConnection.getMqttAsyncClient().isConnected())
                 {
-                    System.out.println("Lost connection to the server. Reconnecting " + currentReconnectionAttempt + " time.");
+                    logger.LogInfo("Lost connection to the server. Reconnecting " + currentReconnectionAttempt + " time.");
                     try
                     {
                         currentReconnectionAttempt++;
@@ -430,7 +433,7 @@ abstract public class Mqtt implements MqttCallback
             }
             else
             {
-                System.out.println("Initialise before using this..");
+                logger.LogWarn("Initialise before using this..");
             }
         }
     }


### PR DESCRIPTION
Create and initialize CustomLogger instance to replace System.out calls.
Github issue (fix#210)

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Issue #210 

# Description of the problem
Log messages were using System.out.
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
Introduce, initialize and use CustomLogger instead. No tests should be impacted.
<!-- How you solved the issue and the other things you considered and maybe rejected --> 