### PR TITLE
Fix the class name of a sample

### DIFF
--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -27,7 +27,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>samples.com.microsoft.azure.sdk.iot.MultiplexingSample</mainClass>
+                            <mainClass>samples.com.microsoft.azure.sdk.iot.TransportClientSample</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Without the fix, running this sample would fail to an error like:
`Could not find or load main class`

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

To reproduce without the fix:

```
cd azure-iot-sdk-java/device/iot-device-samples/transportclient-sample
mvn install -DskipTests
java -jar ~/.m2/repository/com/microsoft/azure/sdk/iot/samples/device/transportclient-sample/1.9.0/transportclient-sample-1.9.0-with-deps.jar
Error: Could not find or load main class samples.com.microsoft.azure.sdk.iot.MultiplexingSample
```

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 

The solution is to fix the class name to match what is defined in the source file.