### PR TITLE
Removing incorrectly-added import statement

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/iothubservices/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/iothubservices/SendMessagesCommon.java
@@ -9,7 +9,6 @@ import com.microsoft.azure.sdk.iot.common.*;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
-import com.sun.org.apache.bcel.internal.generic.RET;
 import org.junit.Assert;
 
 import java.io.IOException;


### PR DESCRIPTION
`import com.sun.org.apache.bcel.internal.generic.RET;` was added to `SendMessagesCommon`, breaking the build when run under JDK 9, as the `RET` class is not exposed as public API in the module. It also turns out that this class is not used in `SendMessagesCommon`, so removing the import does not appear to result in any issue. 