### PR TITLE
Fix issue #253

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/X509Thumbprint.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/X509Thumbprint.java
@@ -12,7 +12,7 @@ public class X509Thumbprint
     private String primaryThumbprint;
     private String secondaryThumbprint;
 
-    private static final String THUMBPRINT_REGEX = "^([A-Fa-f0-9]{2}){20}$";
+    private static final String THUMBPRINT_REGEX = "^([A-Fa-f0-9]{2}){20}$|^([A-Fa-f0-9]{2}){32}$";
 
     //Thumbprints are made up of 40 hex characters
     private static final int THUMBPRINT_DIGIT_MAX = 16;


### PR DESCRIPTION
Add support for X.509 certificate thumbprints with 64 character length. THUMBPRINT_REGEX changed to support both.

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/253

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 