### PR TITLE
Fix issue 257: remove unnecessary logging in IotHubTransport

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -163,8 +163,8 @@ public class IotHubTransport implements IotHubListener
         {
             //Codes_SRS_IOTHUBTRANSPORT_34_009: [If this function is called with a non-null message and a null
             // exception, this function shall add that message to the receivedMessagesQueue.]
-            logger.LogInfo("Message with hashcode %s is received from IotHub on %s, method name is %s ",
-                    message.hashCode(), new Date(), logger.getMethodName());
+            logger.LogInfo("Message with hashcode %s is received from IotHub on %s, method name is onMessageReceived",
+                    message.hashCode(), new Date());
             this.receivedMessagesQueue.add(message);
         }
         else if (e != null)
@@ -415,9 +415,6 @@ public class IotHubTransport implements IotHubListener
         //Codes_SRS_IOTHUBTRANSPORT_34_046: [If this object's connection status is not CONNECTED, this function shall do nothing.]
         if (this.connectionStatus == IotHubConnectionStatus.CONNECTED)
         {
-            logger.LogDebug("Get the callback function for the received message, method name is %s ",
-                    logger.getMethodName());
-
             if (this.iotHubTransportConnection instanceof HttpsIotHubConnection)
             {
                 //Codes_SRS_IOTHUBTRANSPORT_34_047: [If this object's connection status is CONNECTED and is using HTTPS,
@@ -568,6 +565,8 @@ public class IotHubTransport implements IotHubListener
         if (transportMessage != null)
         {
             //Codes_SRS_IOTHUBTRANSPORT_34_056: [If the saved http transport connection can receive a message, add it to receivedMessagesQueue.]
+            logger.LogInfo("Message with hashcode %s is received from IotHub on %s, method name is addReceivedMessagesOverHttpToReceivedQueue",
+                    transportMessage.hashCode(), new Date());
             this.receivedMessagesQueue.add(transportMessage);
         }
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -1271,6 +1271,14 @@ public class IotHubTransportTest
 
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
 
+        new Expectations(transport)
+        {
+            {
+                Deencapsulation.invoke(transport, "addReceivedMessagesOverHttpToReceivedQueue");
+                times = 0;
+            }
+        };
+
         //act
         transport.handleMessage();
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/257

# Description of the problem
The useless log is printed every 10ms as long as loglevel is set to DEBUG.

# Description of the solution
Since the received message has already been logged in onMessageReceived, the log in handleMessage is redundant and can be removed.
Another INFO log is added into addReceivedMessagesOverHttpToReceivedQueue
so all received messages are equally logged in transport level.

Note, the change in IotHubTransportTest.java is not for covering added code. But if without this change, the added logging in addReceivedMessagesOverHttpToReceivedQueue() will result in jmockit to complain missing invocation of HttpsIotHubConnection.receiveMessage(). Not sure why, but since the case is only to ensure addReceivedMessagesOverHttpToReceivedQueue() is not called, the added expectation is for mocking that method only.