### PR TITLE
Fixed extra level for module twins

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.6.2-SNAPSHOT</version>
+    <version>0.6.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
@@ -96,7 +96,7 @@ import java.util.Map;
 public class TwinCollection extends HashMap<String, Object>
 {
     // By definition, Twin maps cannot contain more than 5 levels.
-    private static final int MAX_TWIN_LEVEL = 5;
+    private static final int MAX_TWIN_LEVEL = 6;
 
     // the Twin collection version
     private static final String VERSION_TAG = "$version";
@@ -152,7 +152,7 @@ public class TwinCollection extends HashMap<String, Object>
             /* SRS_TWIN_COLLECTION_21_027: [The constructor shall copy the version and metadata from the provided TwinCollection.] */
             this.version = collection.getVersion();
             this.twinMetadata = collection.getTwinMetadata();
-            for (TwinCollection.Entry entry: collection.entrySet())
+            for (Map.Entry<String, Object> entry: collection.entrySet())
             {
                 if(entry.getValue() instanceof TwinCollection)
                 {
@@ -191,7 +191,7 @@ public class TwinCollection extends HashMap<String, Object>
         }
 
         /* SRS_TWIN_COLLECTION_21_005: [The putAll shall copy all entries in the provided Map to the TwinCollection.] */
-        for(Entry<? extends String, ?> entry: map.entrySet())
+        for(Map.Entry<? extends String, ?> entry: map.entrySet())
         {
             this.put(entry.getKey(), entry.getValue());
         }
@@ -288,7 +288,7 @@ public class TwinCollection extends HashMap<String, Object>
         Map<? extends String, Object> metadata = null;
 
         /* SRS_TWIN_COLLECTION_21_011: [The constructor shall convert the provided rawCollection in a valid TwinCollection.] */
-        for (Entry<? extends String, Object> entry: rawCollection.entrySet())
+        for (Map.Entry<? extends String, Object> entry: rawCollection.entrySet())
         {
             /* SRS_TWIN_COLLECTION_21_012: [If the entity contain the key `$version`, the constructor shall set the version with the value of this entity.] */
             if(entry.getKey().equals(VERSION_TAG))
@@ -325,7 +325,7 @@ public class TwinCollection extends HashMap<String, Object>
     {
         String lastUpdated = null;
         Integer lastUpdatedVersion = null;
-        for(Entry<? extends String, Object> entry: metadata.entrySet())
+        for(Map.Entry<? extends String, Object> entry: metadata.entrySet())
         {
             String key = entry.getKey();
             if(key.equals(TwinMetadata.LAST_UPDATE_TAG))
@@ -417,7 +417,7 @@ public class TwinCollection extends HashMap<String, Object>
             jsonMetadata.addProperty(TwinMetadata.LAST_UPDATE_VERSION_TAG, this.twinMetadata.getLastUpdatedVersion());
         }
 
-        for(Entry<String, TwinMetadata> entry: this.metadataMap.entrySet())
+        for(Map.Entry<String, TwinMetadata> entry: this.metadataMap.entrySet())
         {
             if(entry.getValue() != null)
             {

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/Helpers.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/Helpers.java
@@ -198,7 +198,7 @@ public class Helpers
                 }
             }
 
-            for (TwinCollection.Entry entry : expected.entrySet())
+            for (Map.Entry entry : expected.entrySet())
             {
                 String key = (String)entry.getKey();
                 Object actualValue = actual.get(key);

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
@@ -328,7 +328,12 @@ public class TwinCollectionTest
                                                 put("Inner4", new TwinCollection()
                                                 {
                                                     {
-                                                        put("Inner5", "FinalInnerValue");
+                                                    	put("Inner5", new TwinCollection()
+                                                        {
+                                                    		{
+                                                    			put("Inner6", "FinalInnerValue");
+                                                    		}
+                                                        });
                                                     }
                                                 });
                                             }
@@ -827,7 +832,12 @@ public class TwinCollectionTest
                                                 put("Inner4", new TwinCollection()
                                                 {
                                                     {
-                                                        put("Inner5", "FinalInnerValue");
+                                                    	put("Inner5", new TwinCollection() 
+                                                    	{
+                                                    		{
+                                                    			put("Inner6", "FinalInnerValue");
+                                                    		}
+                                                    	});
                                                     }
                                                 });
                                             }


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
#290 DeviceTwin.getTwin for module twin with IllegalArgumentException

# Description of the problem
Module twin introduced extra level in json format. Before it was just 5, now 6 are used

# Description of the solution
Check for maximum levels in json format increased from 5 to 6. Additionally wrong usage of TwinCollection.Entry was changed to Map.Entry<String, Object> so that it can be compiled with stricter rules like Eclipse is using (didn't compile with Eclipse so far). Version of iot-deps was increased from 0.6.1 to 0.6.2-SNAPSHOT for testing purpose (please adapt accordingly).