### PR TITLE
RegistryManager.removeDevice: Contents of If-Match header in http request must be double quoted

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/DeviceParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/DeviceParser.java
@@ -282,7 +282,7 @@ public class DeviceParser
     public String geteTag()
     {
         //Codes_SRS_DEVICE_PARSER_34_014: [This method shall return the value of this object's ETag.]
-        return eTag;
+    	return "\"" + eTag + "\"";
     }
 
     /**

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/DeviceParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/DeviceParserTest.java
@@ -176,7 +176,7 @@ public class DeviceParserTest
         assertEquals(AuthenticationTypeParser.CERTIFICATE_AUTHORITY, parser.getAuthenticationParser().getType());
         assertEquals(deviceId, parser.getDeviceId());
         assertEquals(generationId, parser.getGenerationId());
-        assertEquals(ETag, parser.geteTag());
+        assertEquals("\"" + ETag + "\"", parser.geteTag());
         assertEquals(status, parser.getStatus());
         assertEquals(statusReason, parser.getStatusReason());
         assertEquals(connectionState, parser.getConnectionState());
@@ -311,7 +311,7 @@ public class DeviceParserTest
         assertEquals(connectionState, parser.getConnectionState());
         assertEquals(connectionStateUpdatedTime, parser.getConnectionStateUpdatedTime());
         assertEquals(deviceId, parser.getDeviceId());
-        assertEquals(eTag, parser.geteTag());
+        assertEquals("\"" + eTag + "\"", parser.geteTag());
         assertEquals(generationId, parser.getGenerationId());
         assertEquals(lastActivityTime, parser.getLastActivityTime());
         assertEquals(status, parser.getStatus());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -513,7 +513,7 @@ public class RegistryManager
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_084: [The function shall call provide device object's etag as with etag of device to be removed]
-        removeDeviceOperation(device.getDeviceId(), "\"" + device.geteTag() + "\"");
+        removeDeviceOperation(device.getDeviceId(), device.geteTag());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -513,7 +513,7 @@ public class RegistryManager
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_084: [The function shall call provide device object's etag as with etag of device to be removed]
-        removeDeviceOperation(device.getDeviceId(), device.geteTag());
+        removeDeviceOperation(device.getDeviceId(), "\"" + device.geteTag() + "\"");
     }
 
     /**


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Solves #292 

# Description of the problem
Constantly fails with IotHubPreconditionFailedException 

# Description of the solution
The contents of the If-Match http request header, that contains the etag of the device, gets surrounded with double quotes 