### PR TITLE
Device twins can now contain double byte UTF-8 characters - fix for bug#296

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/QueryResponseParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/QueryResponseParser.java
@@ -31,7 +31,10 @@ public class QueryResponseParser
         gson = new GsonBuilder().disableHtmlEscaping().create();
 
         //Codes_SRS_QUERY_RESPONSE_PARSER_25_003: [If the provided json is null, empty, or not valid, the constructor shall throws IllegalArgumentException.]
-        ParserUtility.validateStringUTF8(json);
+        if((json == null) || json.isEmpty())
+        {
+            throw new IllegalArgumentException("parameter is null or empty");
+        }
 
         try
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
@@ -154,7 +154,8 @@ public class QueryCollection
 
         //Codes_SRS_QUERYCOLLECTION_34_021: [The method shall create a QueryResponse object with the contents from the response body and its continuation token and return it.]
         this.isInitialQuery = false;
-        return new QueryCollectionResponse(new String(httpResponse.getBody()), this.responseContinuationToken);
+        return new QueryCollectionResponse<String>(
+        		new String(httpResponse.getBody(), "UTF-8"), this.responseContinuationToken);
     }
 
     /**


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Fix for issue #296 

# Description of the problem
Device twins with valid UTF-8 characters, that used more than 1 byte like '§', caused an IllegalArgumentException, since the check in ParserUtility was wrong

# Description of the solution
Removed the call to the wrong validation in ParserUtilitiy and added check against empty string. Only problem left is that property and tag keys could now contain invalid characters. But this should not never happen, since this is already checked by the IoT Hub service. 