### PR TITLE
Set Java version from 1.6 to 1.8 to make device-manager-sample compilable again

### DIFF
--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Fix  for #299 

# Description of the problem
device-manager-sample project uses classes from java.time package that are only available since Java 1.8. But project is set up to compile with Java 1.6

# Description of the solution
Changed compiler settings of project device-manager-sample to 1.8
 