### PR TITLE
Changed from direct usage of log4j to logging facacde from slf4j

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -91,18 +91,18 @@
             <artifactId>commons-codec</artifactId>
             <version>1.10</version>
         </dependency>
-        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.11.0</version>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.11.1</version>
+			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.11.0</version>
-		</dependency>	
-		
     </dependencies>
     <build>
         <plugins>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/CustomLogger.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/CustomLogger.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.azure.sdk.iot.device;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CustomLogger {
 
@@ -13,7 +13,7 @@ public class CustomLogger {
 
     public CustomLogger(Class<?> clazz)
     {
-        logger = LogManager.getLogger(clazz);
+        logger = LoggerFactory.getLogger(clazz);
     }
 
     public void LogInfo(String message, Object...params)
@@ -56,11 +56,16 @@ public class CustomLogger {
         }
     }
 
+    /**
+     * @param message
+     * @param params
+     * @deprecated Since the switch from Log4j to slf4j there is no fatal log level anymore. Mapped to error level
+     */
     public void LogFatal(String message, Object...params)
     {
-        if(logger.isFatalEnabled())
+        if(logger.isErrorEnabled())
         {
-            logger.fatal(String.format(message, params));
+            logger.error(String.format(message, params));
         }
     }
 
@@ -76,7 +81,7 @@ public class CustomLogger {
     {
         if(logger.isErrorEnabled())
         {
-            logger.error(exception);
+            logger.error(exception.toString());
         }
     }
 


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Solved #310 and older closed one as well

# Description of the problem
Device client SDK used log4j directly, forcing users to use this kind of logging implementation. Therefore usage of other logging implementations like logback were not possible

# Description of the solution
CustomLogger class of Device client SDK uses logging facade slf4j now 