### PR TITLE
Fix build failures under JDK 9

### DIFF
--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/ReceiveMessagesIT.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/ReceiveMessagesIT.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.*;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.*;

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/serviceclient/RegistryManagerIT.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/serviceclient/RegistryManagerIT.java
@@ -6,6 +6,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.serviceclient;
 
 import com.microsoft.azure.sdk.iot.service.*;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.auth.SymmetricKey;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubBadFormatException;

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.ConfigurationContentParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.ConfigurationParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.DeviceParser;
 import com.microsoft.azure.sdk.iot.service.*;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubExceptionManager;


### PR DESCRIPTION
A few test classes reference a Module class, but this results in compilation issues under JDK 9+, because java.lang.Module is implicitly imported, but in the test classes I fix in this PR, the Module class that is intended to be used is another, IoT-specific class.