### PR TITLE
Upgrade Maven pom dependencies to support JDK 11

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.version}</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.version}</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/device/iot-device-samples/device-method-sample/pom.xml
+++ b/device/iot-device-samples/device-method-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/device-twin-sample/pom.xml
+++ b/device/iot-device-samples/device-twin-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/file-upload-sample/pom.xml
+++ b/device/iot-device-samples/file-upload-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/handle-messages/pom.xml
+++ b/device/iot-device-samples/handle-messages/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/module-invoke-method-sample/pom.xml
+++ b/device/iot-device-samples/module-invoke-method-sample/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/module-method-sample/pom.xml
+++ b/device/iot-device-samples/module-method-sample/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/module-twin-sample/pom.xml
+++ b/device/iot-device-samples/module-twin-sample/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-event-x509/pom.xml
+++ b/device/iot-device-samples/send-event-x509/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-event/pom.xml
+++ b/device/iot-device-samples/send-event/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-receive-module-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-module-sample/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-receive-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-sample/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-receive-x509-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-x509-sample/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/send-serialized-event/pom.xml
+++ b/device/iot-device-samples/send-serialized-event/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>iot-e2e-common</artifactId>
             <version>0.19.3</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
             <name>Microsoft</name>
         </developer>
     </developers>
+    <properties>
+        <maven.javadoc.version>3.0.1</maven.javadoc.version>
+    </properties>
     <modules>
         <module>device</module>
         <module>service</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <properties>
-        <maven.javadoc.version>3.0.1</maven.javadoc.version>
-    </properties>
     <modules>
         <module>device</module>
         <module>service</module>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.version}</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.version}</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -62,6 +62,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -62,6 +62,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.version}</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>${maven.javadoc.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
Building the SDK under JDK 11 fails due to the outdated versions of plugins specified in the Maven pom file. This helps get this repo closer to supporting JDK 11.