### PR TITLE
fix nesting depth bug

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
@@ -95,8 +95,9 @@ import java.util.Map;
  */
 public class TwinCollection extends HashMap<String, Object>
 {
-    // By definition, Twin maps cannot contain more than 5 levels.
-    private static final int MAX_TWIN_LEVEL = 6;
+    // By definition, Twin maps cannot contain more than 5 levels,
+    // discounting top-level -> "reported", and allowing for a flat inner level
+    private static final int MAX_TWIN_LEVEL = 8;
 
     // the Twin collection version
     private static final String VERSION_TAG = "$version";

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
@@ -311,28 +311,32 @@ public class TwinCollectionTest
         {
             {
                 put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
+                //added the properties -> reported levels that were missing
+                put("properties", new TwinCollection() {
                     {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
+                        put("reported", new TwinCollection(){
                             {
-                                put("Inner2", new TwinCollection()
-                                {
+                                put("MaxSpeed", new TwinCollection() {
                                     {
-                                        put("Inner3", new TwinCollection()
-                                        {
+                                        put("Value", 500.0);
+                                        put("NewValue", 300.0);
+                                        put("Inner1", new TwinCollection() {
                                             {
-                                                put("Inner4", new TwinCollection()
-                                                {
+                                                put("Inner2", new TwinCollection() {
                                                     {
-                                                    	put("Inner5", new TwinCollection()
-                                                        {
-                                                    		{
-                                                    			put("Inner6", "FinalInnerValue");
-                                                    		}
+                                                        put("Inner3", new TwinCollection() {
+                                                            {
+                                                                put("Inner4", new TwinCollection() {
+                                                                    {
+                                                                        put("Inner5", new TwinCollection()
+                                                                        {
+                                                                            {
+                                                                                put("Inner6", "FinalInnerValue");
+                                                                            }
+                                                                        });
+                                                                    }
+                                                                });
+                                                            }
                                                         });
                                                     }
                                                 });
@@ -492,24 +496,28 @@ public class TwinCollectionTest
         {
             {
                 put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
+                //added the properties -> reported levels that were missing
+                put("properties", new TwinCollection() {
                     {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
+                        put("reported", new TwinCollection(){
                             {
-                                put("Inner2", new TwinCollection()
-                                {
+                                put("MaxSpeed", new TwinCollection() {
                                     {
-                                        put("Inner3", new TwinCollection()
-                                        {
+                                        put("Value", 500.0);
+                                        put("NewValue", 300.0);
+                                        put("Inner1", new TwinCollection() {
                                             {
-                                                put("Inner4", new TwinCollection()
-                                                {
+                                                put("Inner2", new TwinCollection() {
                                                     {
-                                                        put("Inner5", "FinalInnerValue");
+                                                        put("Inner3", new TwinCollection() {
+                                                            {
+                                                                put("Inner4", new TwinCollection() {
+                                                                    {
+                                                                        put("Inner5", "FinalInnerValue");
+                                                                    }
+                                                                });
+                                                            }
+                                                        });
                                                     }
                                                 });
                                             }
@@ -815,29 +823,33 @@ public class TwinCollectionTest
         {
             {
                 put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
+                //added the properties -> reported levels that were missing
+                put("properties", new TwinCollection() {
                     {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
+                        put("reported", new TwinCollection(){
                             {
-                                put("Inner2", new TwinCollection()
-                                {
+                                put("MaxSpeed", new TwinCollection() {
                                     {
-                                        put("Inner3", new TwinCollection()
-                                        {
+                                        put("Value", 500.0);
+                                        put("NewValue", 300.0);
+                                        put("Inner1", new TwinCollection() {
                                             {
-                                                put("Inner4", new TwinCollection()
-                                                {
+                                                put("Inner2", new TwinCollection() {
                                                     {
-                                                    	put("Inner5", new TwinCollection() 
-                                                    	{
-                                                    		{
-                                                    			put("Inner6", "FinalInnerValue");
-                                                    		}
-                                                    	});
+                                                        put("Inner3", new TwinCollection() {
+                                                            {
+                                                                put("Inner4", new TwinCollection() {
+                                                                    {
+                                                                        put("Inner5", new TwinCollection()
+                                                                        {
+                                                                            {
+                                                                                put("Inner6", "FinalInnerValue");
+                                                                            }
+                                                                        });
+                                                                    }
+                                                                });
+                                                            }
+                                                        });
                                                     }
                                                 });
                                             }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [NA] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/338

# Description of the problem
The nesting depth in TwinCollection.java didn't account for the full structure of a device/module twin, specifically, it didn't account for the following structure existing outside of the properties sent by a device:
```
{
    "properties":
        {
            "reported": { ... },
            "desired":{...},
            ...
        }
}
```

# Description of the solution
Increased the constant specifying nesting depth to 8 from 6 to account for the two layers that weren't considered.