### PR TITLE
fix issue #271 config ConnectTimeout and ReadTimeout separately

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -22,9 +22,6 @@ public class DeviceMethod
 {
     private IotHubConnectionString iotHubConnectionString = null;
     private Integer requestId = 0;
-    private static final int DEFAULT_RESPONSE_TIMEOUT = 30; // default response timeout is 30 seconds
-    private static final int DEFAULT_CONNECT_TIMEOUT = 0;
-    private static final int THOUSAND_MS = 1000;
     /**
      * Create a DeviceMethod instance from the information in the connection string.
      *
@@ -147,32 +144,31 @@ public class DeviceMethod
             throw new IllegalArgumentException("MethodParser return null Json");
         }
 
-        long  responseTimeout, connectTimeout;
+        long responseTimeoutInMs;
+        long connectTimeoutInMs;
         
         if (responseTimeoutInSeconds == null)
         {
-            responseTimeout  = DEFAULT_RESPONSE_TIMEOUT; // If timeout is not set, it defaults to 30 seconds
+            responseTimeoutInMs  = DeviceOperations.DEFAULT_RESPONSE_TIMEOUT_MS; // If timeout is not set, it defaults to 24 seconds
         }
         else
         {
-            responseTimeout  = responseTimeoutInSeconds;
+            responseTimeoutInMs  = responseTimeoutInSeconds * 1000;
         }
         
         if (connectTimeoutInSeconds == null)
         {
-            connectTimeout  = DEFAULT_CONNECT_TIMEOUT;
+            connectTimeoutInMs  = DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS;  // default is 6 seconds
         }
         else
         {
-            connectTimeout  = connectTimeoutInSeconds;
+            connectTimeoutInMs  = connectTimeoutInSeconds * 1000;
         }
-        
-        // Calculate total timeout in milliseconds
-        long timeoutInMs = (responseTimeout + connectTimeout) * THOUSAND_MS; 
-               
+
         /* Codes_SRS_DEVICEMETHOD_21_009: [The invoke shall send the created request and get the response using the HttpRequester.] */
         /* Codes_SRS_DEVICEMETHOD_21_010: [The invoke shall create a new HttpRequest with http method as `POST`.] */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.POST, json.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++), timeoutInMs);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.POST, json.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++),
+                connectTimeoutInMs, responseTimeoutInMs);
 
         /* Codes_SRS_DEVICEMETHOD_21_013: [The invoke shall deserialize the payload using the `serializer.MethodParser`.] */
         MethodParser methodParserResponse = new MethodParser();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -22,7 +22,6 @@ public class DeviceTwin
 {
     private IotHubConnectionString iotHubConnectionString = null;
     private Integer requestId = 0;
-    private final long USE_DEFAULT_TIMEOUT = 0;
     private final int DEFAULT_PAGE_SIZE = 100;
 
     /**
@@ -104,7 +103,7 @@ public class DeviceTwin
          **Codes_SRS_DEVICETWIN_25_009: [** The function shall send the created request and get the response **]**
          **Codes_SRS_DEVICETWIN_25_010: [** The function shall verify the response status and throw proper Exception **]**
          */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[0], String.valueOf(requestId++), USE_DEFAULT_TIMEOUT);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[0], String.valueOf(requestId++));
         String twin = new String(response.getBody(), StandardCharsets.UTF_8);
 
         /*
@@ -189,7 +188,7 @@ public class DeviceTwin
 
         **Codes_SRS_DEVICETWIN_25_020: [** The function shall verify the response status and throw proper Exception **]**
          */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PATCH, twinJson.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++),0);
+        DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PATCH, twinJson.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++));
     }
 
     /**
@@ -259,7 +258,7 @@ public class DeviceTwin
 
         //Codes_SRS_DEVICETWIN_25_049: [ The method shall build the URL for this operation by calling getUrlTwinQuery ]
         //Codes_SRS_DEVICETWIN_25_051: [ The method shall send a Query Request to IotHub as HTTP Method Post on the query Object by calling sendQueryRequest.]
-        deviceTwinQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+        deviceTwinQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS, DeviceOperations.DEFAULT_RESPONSE_TIMEOUT_MS);
         return deviceTwinQuery;
     }
 
@@ -302,7 +301,7 @@ public class DeviceTwin
     public synchronized QueryCollection queryTwinCollection(String sqlQuery, Integer pageSize) throws MalformedURLException
     {
         //Codes_SRS_DEVICETWIN_34_070: [This function shall return a new QueryCollection object of type TWIN with the provided sql query and page size.]
-        return new QueryCollection(sqlQuery, pageSize, QueryType.TWIN, this.iotHubConnectionString, this.iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+        return new QueryCollection(sqlQuery, pageSize, QueryType.TWIN, this.iotHubConnectionString, this.iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS, DeviceOperations.DEFAULT_RESPONSE_TIMEOUT_MS);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
@@ -35,7 +35,9 @@ public class QueryCollection
     private IotHubConnectionString iotHubConnectionString;
     private URL url;
     private HttpMethod httpMethod;
-    private long timeout;
+    //private long timeout;
+    private long connectTimeoutInMs;
+    private long responseTimeoutInMs;
 
     private boolean isInitialQuery;
 
@@ -48,11 +50,12 @@ public class QueryCollection
      * @param iotHubConnectionString the connection string to connect with to query against
      * @param url the url to query against
      * @param httpMethod the http method to call with the query
-     * @param timeout timeout until the request expires
+     * @param connectTimeoutInMs  connect timeout in milliseconds
+     * @param responseTimeoutInMs  response timeout in milliseconds
      * @throws IllegalArgumentException if page size is 0 or negative, or if the query type is null or unknown, of if the query string is null or empty,
      *  or if the provided connection string is null, or if the provided url is null, or if the provided http method is null
      */
-    protected QueryCollection(String query, int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long timeout)
+    protected QueryCollection(String query, int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long connectTimeoutInMs, long  responseTimeoutInMs)
     {
         //Codes_SRS_QUERYCOLLECTION_34_037: [If the provided connection string, url, or http method is null, this function shall throw an IllegalArgumentException.]
         //Codes_SRS_QUERYCOLLECTION_34_004: [If the provided QueryType is null or UNKNOWN, an IllegalArgumentException shall be thrown.]
@@ -69,7 +72,8 @@ public class QueryCollection
         this.iotHubConnectionString = iotHubConnectionString;
         this.responseContinuationToken = null;
         this.httpMethod = httpMethod;
-        this.timeout = timeout;
+        this.connectTimeoutInMs = connectTimeoutInMs;
+        this.responseTimeoutInMs = responseTimeoutInMs;
         this.url = url;
         this.responseQueryType = QueryType.UNKNOWN;
 
@@ -87,11 +91,12 @@ public class QueryCollection
      * @param iotHubConnectionString the connection string to connect with to query against
      * @param url the url to query against
      * @param httpMethod the http method to call with the query
-     * @param timeout timeout until the request expires
+     * @param connectTimeoutInMs  connect timeout in milliseconds
+     * @param responseTimeoutInMs  response timeout in milliseconds
      * @throws IllegalArgumentException if page size is 0 or negative, or if the query type is null or unknown,
      *  or if the provided connection string is null, or if the provided url is null, or if the provided http method is null
      */
-    protected QueryCollection(int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long timeout)
+    protected QueryCollection(int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long connectTimeoutInMs, long responseTimeoutInMs)
     {
         //Codes_SRS_QUERYCOLLECTION_34_038: [If the provided connection string, url, or http method is null, this function shall throw an IllegalArgumentException.]
         //Codes_SRS_QUERYCOLLECTION_34_003: [If the provided page size is not a positive integer, an IllegalArgumentException shall be thrown.]
@@ -107,7 +112,8 @@ public class QueryCollection
         this.responseContinuationToken = null;
         this.iotHubConnectionString = iotHubConnectionString;
         this.httpMethod = httpMethod;
-        this.timeout = timeout;
+        this.connectTimeoutInMs = connectTimeoutInMs;
+        this.responseTimeoutInMs = responseTimeoutInMs;
         this.url = url;
 
         //Codes_SRS_QUERYCOLLECTION_34_009: [The constructed QueryCollection shall not be a sql query type.]
@@ -147,7 +153,7 @@ public class QueryCollection
         }
 
         //Codes_SRS_QUERYCOLLECTION_34_017: [This function shall send an HTTPS request using DeviceOperations.]
-        HttpResponse httpResponse = DeviceOperations.request(this.iotHubConnectionString, this.url, this.httpMethod, payload, null, this.timeout);
+        HttpResponse httpResponse = DeviceOperations.request(this.iotHubConnectionString, this.url, this.httpMethod, payload, null, this.connectTimeoutInMs, this.responseTimeoutInMs);
 
         //Codes_SRS_QUERYCOLLECTION_34_018: [The method shall read the continuation token (x-ms-continuation) and response type (x-ms-item-type) from the HTTP Headers and save it.]
         handleQueryResponse(httpResponse);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -16,7 +16,6 @@ import java.util.NoSuchElementException;
 public class RawTwinQuery
 {
     private IotHubConnectionString iotHubConnectionString = null;
-    private final long USE_DEFAULT_TIMEOUT = 0;
     private final int DEFAULT_PAGE_SIZE = 100;
 
     private RawTwinQuery()
@@ -74,7 +73,7 @@ public class RawTwinQuery
         Query rawQuery = new Query(sqlQuery, pageSize, QueryType.RAW);
         //Codes_SRS_RAW_QUERY_25_006: [ The method shall build the URL for this operation by calling getUrlTwinQuery ]
         //Codes_SRS_RAW_QUERY_25_008: [ The method shall send a Query Request to IotHub as HTTP Method Post on the query Object by calling sendQueryRequest.]
-        rawQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+        rawQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS, DeviceOperations.DEFAULT_RESPONSE_TIMEOUT_MS);
         return rawQuery;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -25,7 +25,6 @@ import java.util.*;
  */
 public class JobClient
 {
-    private final static long USE_DEFAULT_TIMEOUT = 0L;
     private final static long MAX_TIMEOUT = Integer.MAX_VALUE - 24000;
     private final static Integer DEFAULT_PAGE_SIZE = 100;
 
@@ -122,7 +121,7 @@ public class JobClient
         /* Codes_SRS_JOBCLIENT_21_010: [The scheduleUpdateTwin shall send a PUT request to the iothub using the created uri and json.] */
         /* Codes_SRS_JOBCLIENT_21_011: [If the scheduleUpdateTwin failed to send a PUT request, it shall throw IOException.] */
         /* Codes_SRS_JOBCLIENT_21_012: [If the scheduleUpdateTwin failed to verify the iothub response, it shall throw IotHubException.] */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), null, USE_DEFAULT_TIMEOUT);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), null);
 
         /* Codes_SRS_JOBCLIENT_21_013: [The scheduleUpdateTwin shall parse the iothub response and return it as JobResult.] */
         return new JobResult(response.getBody());
@@ -196,7 +195,7 @@ public class JobClient
         /* Codes_SRS_JOBCLIENT_21_020: [The scheduleDeviceMethod shall send a PUT request to the iothub using the created url and json.] */
         /* Codes_SRS_JOBCLIENT_21_021: [If the scheduleDeviceMethod failed to send a PUT request, it shall throw IOException.] */
         /* Codes_SRS_JOBCLIENT_21_022: [If the scheduleDeviceMethod failed to verify the iothub response, it shall throw IotHubException.] */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), null, USE_DEFAULT_TIMEOUT);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), null);
 
         /* Codes_SRS_JOBCLIENT_21_023: [The scheduleDeviceMethod shall parse the iothub response and return it as JobResult.] */
         return new JobResult(response.getBody());
@@ -235,7 +234,7 @@ public class JobClient
         /* Codes_SRS_JOBCLIENT_21_026: [The getJob shall send a GET request to the iothub using the created url.] */
         /* Codes_SRS_JOBCLIENT_21_027: [If the getJob failed to send a GET request, it shall throw IOException.] */
         /* Codes_SRS_JOBCLIENT_21_028: [If the getJob failed to verify the iothub response, it shall throw IotHubException.] */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[]{}, null, USE_DEFAULT_TIMEOUT);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[]{}, null);
 
         /* Codes_SRS_JOBCLIENT_21_029: [The getJob shall parse the iothub response and return it as JobResult.] */
         return new JobResult(response.getBody());
@@ -273,7 +272,7 @@ public class JobClient
         /* Codes_SRS_JOBCLIENT_21_032: [The cancelJob shall send a POST request to the iothub using the created url.] */
         /* Codes_SRS_JOBCLIENT_21_033: [If the cancelJob failed to send a POST request, it shall throw IOException.] */
         /* Codes_SRS_JOBCLIENT_21_034: [If the cancelJob failed to verify the iothub response, it shall throw IotHubException.] */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.POST, EMPTY_JSON, null, USE_DEFAULT_TIMEOUT);
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.POST, EMPTY_JSON, null);
 
         /* Codes_SRS_JOBCLIENT_21_035: [The cancelJob shall parse the iothub response and return it as JobResult.] */
         return new JobResult(response.getBody());
@@ -359,7 +358,7 @@ public class JobClient
         Query deviceJobQuery = new Query(sqlQuery, pageSize, QueryType.DEVICE_JOB);
 
         //Codes_SRS_JOBCLIENT_25_040: [The queryDeviceJob shall send a query request on the query object using Query URL, HTTP POST method and wait for the response by calling sendQueryRequest.]
-        deviceJobQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, MAX_TIMEOUT);
+        deviceJobQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS, MAX_TIMEOUT);
         return deviceJobQuery;
     }
 
@@ -448,7 +447,7 @@ public class JobClient
         //Codes_SRS_JOBCLIENT_25_045: [The queryDeviceJob shall send a query request on the query object using Query URL, HTTP GET method and wait for the response by calling sendQueryRequest.]
         String jobTypeString = (jobType == null) ? null : jobType.toString();
         String jobStatusString = (jobStatus == null) ? null : jobStatus.toString();
-        jobResponseQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlQuery(jobTypeString, jobStatusString), HttpMethod.GET, MAX_TIMEOUT);
+        jobResponseQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlQuery(jobTypeString, jobStatusString), HttpMethod.GET, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS ,MAX_TIMEOUT);
         return jobResponseQuery;
     }
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnection.java
@@ -160,6 +160,15 @@ public class HttpConnection
     }
 
     /**
+     * Sets the connect timeout in milliseconds.
+     *
+     * @param timeout The connect timeout.
+     */
+    public void setConnectTimeoutMillis(int timeout)
+    {
+        this.connection.setConnectTimeout(timeout);
+    }
+    /**
      * Saves the body to be sent with the request.
      *
      * @param body The request body.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpRequest.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpRequest.java
@@ -118,6 +118,21 @@ public class HttpRequest
         return this;
     }
 
+    /**
+     * Sets the connect timeout, in milliseconds, for the request. The connect
+     * timeout is the number of milliseconds the client will wait for the
+     * connection established.
+     *
+     * @param timeout The connect timeout.
+     *
+     * @return  The object itself, for fluent setting.
+     */
+    public HttpRequest setConnectTimeoutMillis(int timeout)
+    {
+        this.connection.setConnectTimeoutMillis(timeout);
+        return this;
+    }
+
     protected HttpRequest()
     {
         this.connection = null;

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
@@ -427,7 +427,8 @@ public class DeviceMethodTest
                     HttpMethod method,
                     byte[] payload,
                     String requestId,
-                    long timeoutInMs)
+                    long connectTimeoutInMs,
+                    long responseTimeoutInMs)
                     throws IOException, IotHubException, IllegalArgumentException
             {
                 throw new IotHubException();

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
@@ -53,7 +53,7 @@ public class DeviceOperationsTest
     private static final String ACCEPT_VALUE = "application/json";
     private static final String ACCEPT_CHARSET = "charset=utf-8";
     private static final String CONTENT_TYPE = "Content-Type";
-    private static final Integer DEFAULT_HTTP_TIMEOUT_MS = 24000;
+    private static final Integer DEFAULT_HTTP_TIMEOUT_MS = 24000;  //default read time out
     
     private IotHubConnectionString IOT_HUB_CONNECTION_STRING;
     private String STANDARD_SASTOKEN_STRING;
@@ -77,8 +77,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         //assert
     }
@@ -96,8 +95,7 @@ public class DeviceOperationsTest
                 null,
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         //assert
     }
@@ -114,8 +112,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 null,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         //assert
     }
@@ -132,8 +129,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 null,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         //assert
     }
@@ -151,8 +147,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                null,
-                0);
+                null);
 
         //assert
         new Verifications()
@@ -164,7 +159,7 @@ public class DeviceOperationsTest
         };
     }
     
-    /* Tests_SRS_DEVICE_OPERATIONS_99_018: [The request shall throw IllegalArgumentException if the provided `timeoutInMs` plus DEFAULT_HTTP_TIMEOUT_MS exceed Integer.MAX_VALUE.] */
+    /* Tests_SRS_DEVICE_OPERATIONS_99_018: [The request shall throw IllegalArgumentException if the provided responseTimeInMs exceed Integer.MAX_VALUE.] */
     @Test (expected = IllegalArgumentException.class)
     public void requestTimeoutExceedsFailed() throws Exception
     {
@@ -177,7 +172,8 @@ public class DeviceOperationsTest
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
                 STANDARD_REQUEST_ID,
-                Integer.MAX_VALUE);
+                DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS,
+                Integer.MAX_VALUE + 100L);
 
         //assert
     }
@@ -195,8 +191,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                "",
-                0);
+                "");
 
         //assert
         new Verifications()
@@ -228,8 +223,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_007: [If the SASToken is null or empty, the request shall throw IOException.] */
@@ -251,8 +245,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_007: [If the SASToken is null or empty, the request shall throw IOException.] */
@@ -274,8 +267,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_008: [The request shall create a new HttpRequest with the provided `url`, http `method`, and `payload`.] */
@@ -304,8 +296,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                DEFAULT_HTTP_TIMEOUT_MS);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_009: [The request shall add to the HTTP header the sum of timeout and default timeout in milliseconds.] */
@@ -332,8 +323,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_010: [The request shall add to the HTTP header an `authorization` key with the SASToken.] */
@@ -362,8 +352,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_011: [The request shall add to the HTTP header a `Request-Id` key with a new unique string value for every request.] */
@@ -394,8 +383,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_012: [The request shall add to the HTTP header a `User-Agent` key with the client Id and service version.] */
@@ -428,8 +416,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_013: [The request shall add to the HTTP header a `Accept` key with `application/json`.] */
@@ -464,8 +451,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_014: [The request shall add to the HTTP header a `Content-Type` key with `application/json; charset=utf-8`.] */
@@ -502,8 +488,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_015: [The request shall send the created request and get the response.] */
@@ -542,8 +527,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_016: [If the resulted HttpResponseStatus represents fail, the request shall throw proper Exception by calling httpResponseVerification.] */
@@ -590,8 +574,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
     }
 
     /* Tests_SRS_DEVICE_OPERATIONS_21_017: [If the resulted status represents success, the request shall return the http response.] */
@@ -637,8 +620,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         //assert
         assertEquals(response, sendResponse);
@@ -667,12 +649,9 @@ public class DeviceOperationsTest
             throws Exception
     {
         //arrange
-        final long responseTimeout = 30000; // 30 seconds
+        final long responseTimeout = 30000  + DEFAULT_HTTP_TIMEOUT_MS; // 30 seconds
         final long connectTimeout = 5000;   // 5 seconds
         
-        // Calculate total timeout in milliseconds
-        int timeoutInMs = (int)(responseTimeout + connectTimeout);
-
         final int status = 200;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
@@ -684,7 +663,7 @@ public class DeviceOperationsTest
             {
                 iotHubServiceSasToken.toString();
                 result = STANDARD_SASTOKEN_STRING;
-                httpRequest.setReadTimeoutMillis(timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS);
+                httpRequest.setReadTimeoutMillis((int)responseTimeout);
                 result = httpRequest;
                 httpRequest.setHeaderField(AUTHORIZATION, STANDARD_SASTOKEN_STRING);
                 result = httpRequest;
@@ -709,7 +688,8 @@ public class DeviceOperationsTest
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
                 STANDARD_REQUEST_ID,
-                timeoutInMs);
+                connectTimeout,
+                responseTimeout);
 
         //assert
         assertEquals(response, sendResponse);
@@ -718,7 +698,7 @@ public class DeviceOperationsTest
             {
                 iotHubServiceSasToken.toString();
                 times = 1;
-                httpRequest.setReadTimeoutMillis(timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS);
+                httpRequest.setReadTimeoutMillis((int)responseTimeout);
                 times = 1;
                 httpRequest.setHeaderField(anyString, anyString);
                 times = 5;
@@ -746,8 +726,7 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         assertNull(Deencapsulation.getField(DeviceOperations.class, "headers"));
 
@@ -776,16 +755,14 @@ public class DeviceOperationsTest
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
 
         DeviceOperations.request(
                 IOT_HUB_CONNECTION_STRING,
                 new URL(STANDARD_URL),
                 HttpMethod.POST,
                 STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
+                STANDARD_REQUEST_ID);
         //assert
         new Verifications()
         {

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -793,7 +793,7 @@ public class DeviceTwinTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.TWIN);
                 times = 1;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -857,7 +857,7 @@ public class DeviceTwinTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.TWIN);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 result = new IotHubException();
             }
         };
@@ -894,7 +894,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -999,7 +999,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -1069,7 +1069,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -1387,7 +1387,7 @@ public class DeviceTwinTest
                 //returning mock URL seems to break this test for some reason
                 mockedConnectionString.getUrlTwinQuery();
                 result = null;
-                Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedSqlQuery, expectedPageSize, QueryType.TWIN, mockedConnectionString, null, HttpMethod.POST, 0);
+                Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedSqlQuery, expectedPageSize, QueryType.TWIN, mockedConnectionString, null, HttpMethod.POST, DeviceOperations.DEFAULT_CONNECT_TIMEOUT_MS, DeviceOperations.DEFAULT_RESPONSE_TIMEOUT_MS);
                 result = mockQueryCollection;
             }
         };

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
@@ -66,6 +66,7 @@ public class QueryCollectionTest
     private static final String expectedRequestContinuationToken = "someContinuationToken";
     private static final String expectedResponseContinuationToken = "someNewContinuationToken";
 
+    private static final long connectTimeout = 60000;
     private static final long expectedTimeout = 10000;
     private static HashMap<String, String> expectedValidRequestHeaders;
     private static HashMap<String, String> expectedValidResponseHeaders;
@@ -203,7 +204,7 @@ public class QueryCollectionTest
         QueryType expectedQueryType = QueryType.JOB_RESPONSE;
 
         //act
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedQuery, expectedPageSize, expectedQueryType, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedQuery, expectedPageSize, expectedQueryType, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //assert
         String actualQuery = Deencapsulation.getField(queryCollection, "query");
@@ -213,7 +214,8 @@ public class QueryCollectionTest
         IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
-        long actualTimeout = Deencapsulation.getField(queryCollection, "timeout");
+        long connectTimeoutInMs = Deencapsulation.getField(queryCollection, "connectTimeoutInMs");
+        long responseTimeoutInMs = Deencapsulation.getField(queryCollection, "responseTimeoutInMs");
 
         assertEquals(expectedQuery, actualQuery);
         assertEquals(expectedPageSize, actualPageSize);
@@ -221,7 +223,8 @@ public class QueryCollectionTest
         assertTrue(actualIsSqlQuery);
         assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
-        assertEquals(actualTimeout, expectedTimeout);
+        assertEquals(connectTimeoutInMs, connectTimeout);
+        assertEquals(responseTimeoutInMs, expectedTimeout);
         assertEquals(actualUrl, mockUrl);
     }
 
@@ -240,7 +243,7 @@ public class QueryCollectionTest
         QueryType expectedQueryType = QueryType.JOB_RESPONSE;
 
         //act
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedPageSize, expectedQueryType, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedPageSize, expectedQueryType, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //assert
         int actualPageSize = Deencapsulation.getField(queryCollection, "pageSize");
@@ -249,14 +252,16 @@ public class QueryCollectionTest
         IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
-        long actualTimeout = Deencapsulation.getField(queryCollection, "timeout");
+        long connectTimeoutInMs = Deencapsulation.getField(queryCollection, "connectTimeoutInMs");
+        long responseTimeoutInMs = Deencapsulation.getField(queryCollection, "responseTimeoutInMs");
 
         assertEquals(expectedPageSize, actualPageSize);
         assertEquals(expectedQueryType, actualQueryType);
         assertFalse(actualIsSqlQuery);
         assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
-        assertEquals(actualTimeout, expectedTimeout);
+        assertEquals(connectTimeoutInMs, connectTimeout);
+        assertEquals(responseTimeoutInMs, expectedTimeout);
         assertEquals(actualUrl, mockUrl);
     }
 
@@ -301,7 +306,7 @@ public class QueryCollectionTest
     public void sendQueryRequestPrioritizesOptionsContinuationToken() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "isSqlQuery", false);
 
         new NonStrictExpectations()
@@ -313,7 +318,7 @@ public class QueryCollectionTest
                 mockQueryOptions.getPageSize();
                 result = expectedPageSize;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, connectTimeout ,expectedTimeout);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -331,7 +336,7 @@ public class QueryCollectionTest
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, connectTimeout,expectedTimeout);
                 times = 1;
             }
         };
@@ -343,7 +348,7 @@ public class QueryCollectionTest
     public void sendQueryRequestThrowsForUnknownResponseQueryType() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         new NonStrictExpectations()
         {
@@ -354,7 +359,7 @@ public class QueryCollectionTest
                 mockQueryOptions.getPageSize();
                 result = expectedPageSize;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, connectTimeout, expectedTimeout);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -372,14 +377,14 @@ public class QueryCollectionTest
     public void sendQueryRequestGetsContinuationTokenFromCurrentIfOptionsHasNone() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "isSqlQuery", false);
         Deencapsulation.setField(queryCollection, "responseContinuationToken", expectedRequestContinuationToken);
 
         new NonStrictExpectations()
         {
             {
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, connectTimeout, expectedTimeout);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -399,7 +404,7 @@ public class QueryCollectionTest
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, connectTimeout, expectedTimeout);
                 times = 1;
             }
         };
@@ -413,7 +418,7 @@ public class QueryCollectionTest
         String expectedQueryString = "some query";
         String expectedQueryStringJson = "some query json";
         byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes();
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         new NonStrictExpectations()
         {
@@ -430,7 +435,7 @@ public class QueryCollectionTest
                 expectedQueryStringJson.getBytes();
                 result = expectedQueryStringBytes;
 
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);
+                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, connectTimeout, expectedTimeout);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -445,7 +450,7 @@ public class QueryCollectionTest
         new Verifications()
         {
             {
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);
+                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, connectTimeout, expectedTimeout);
                 times = 1;
             }
         };
@@ -460,7 +465,7 @@ public class QueryCollectionTest
         String expectedQueryString = "some query";
         String expectedQueryStringJson = "some query json";
         byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes();
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         new NonStrictExpectations()
         {
@@ -477,7 +482,7 @@ public class QueryCollectionTest
                 expectedQueryStringJson.getBytes();
                 result = expectedQueryStringBytes;
 
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);
+                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -506,7 +511,7 @@ public class QueryCollectionTest
     public void sendQueryRequestThrowsForMismatchedResponseQueryType() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         new NonStrictExpectations()
         {
@@ -517,7 +522,7 @@ public class QueryCollectionTest
                 mockQueryOptions.getPageSize();
                 result = expectedPageSize;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, connectTimeout, expectedTimeout);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -534,7 +539,7 @@ public class QueryCollectionTest
     public void hasNextReturnsTrueIfItIsTheInitialQuery()
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "isInitialQuery", true);
 
         //act
@@ -549,7 +554,7 @@ public class QueryCollectionTest
     public void hasNextReturnsFalseIfNoContinuationToken() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "responseContinuationToken", null);
         Deencapsulation.setField(queryCollection, "isInitialQuery", false);
 
@@ -565,7 +570,7 @@ public class QueryCollectionTest
     public void hasNextReturnsTrueIfContinuationTokenSaved() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class}, "some query", expectedPageSize, QueryType.DEVICE_JOB, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "responseContinuationToken", "any continuation token");
         Deencapsulation.setField(queryCollection, "isInitialQuery", false);
 
@@ -581,7 +586,7 @@ public class QueryCollectionTest
     public void nextReturnsNextSetIfItHasOne() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //only mocking one method for QueryCollection, not the whole class
         new NonStrictExpectations(queryCollection)
@@ -610,7 +615,7 @@ public class QueryCollectionTest
     public void nextReturnsNullIfItDoesNotHaveNext() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //only mocking one method for QueryCollection, not the whole class
         new NonStrictExpectations(queryCollection)
@@ -633,7 +638,7 @@ public class QueryCollectionTest
     public void nextWithOptionsReturnsNextSetIfItHasOne() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //only mocking one method for QueryCollection, not the whole class
         new NonStrictExpectations(queryCollection)
@@ -659,7 +664,7 @@ public class QueryCollectionTest
     public void nextWithOptionsReturnsNullIfItDoesNotHaveNext() throws IOException, IotHubException
     {
         //arrange
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
 
         //only mocking one method for QueryCollection, not the whole class
         new NonStrictExpectations(queryCollection)
@@ -683,7 +688,7 @@ public class QueryCollectionTest
     {
         //arrange
         Integer expectedPageSize = 290;
-        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
+        QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class, long.class},"anyString", expectedPageSize, QueryType.JOB_RESPONSE, mockConnectionString, mockUrl, mockHttpMethod, connectTimeout, expectedTimeout);
         Deencapsulation.setField(queryCollection, "pageSize", expectedPageSize);
 
         //act
@@ -701,7 +706,7 @@ public class QueryCollectionTest
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, null, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, null, connectTimeout, expectedTimeout);
                 times = 1;
             }
         };

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryTest.java
@@ -34,7 +34,6 @@ public class QueryTest
 {
     private static final QueryType DEFAULT_QUERY_TYPE = QueryType.TWIN;
     private static final int DEFAULT_PAGE_SIZE = 100;
-    private static final long DEFAULT_TIMEOUT = 100;
     private static final String DEFAULT_QUERY = "select * from devices";
 
     @Mocked
@@ -240,7 +239,7 @@ public class QueryTest
         final String testToken = UUID.randomUUID().toString();
         Query testQuery = Deencapsulation.newInstance(Query.class, DEFAULT_QUERY, DEFAULT_PAGE_SIZE, DEFAULT_QUERY_TYPE);
         setupSendQuery(testQuery, testToken);
-        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod, DEFAULT_TIMEOUT);
+        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         Deencapsulation.invoke(testQuery, "continueQuery", testToken);
@@ -273,7 +272,7 @@ public class QueryTest
         Query testQuery = Deencapsulation.newInstance(Query.class, DEFAULT_QUERY, DEFAULT_PAGE_SIZE, DEFAULT_QUERY_TYPE);
 
         setupSendQuery(testQuery, testToken);
-        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod, DEFAULT_TIMEOUT);
+        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         Deencapsulation.invoke(testQuery, "continueQuery", testToken, testPageSize);
@@ -294,7 +293,7 @@ public class QueryTest
         Query testQuery = Deencapsulation.newInstance(Query.class, DEFAULT_QUERY, DEFAULT_PAGE_SIZE, DEFAULT_QUERY_TYPE);
 
         setupSendQuery(testQuery, testToken);
-        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod, DEFAULT_TIMEOUT);
+        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         Deencapsulation.invoke(testQuery, "continueQuery", testToken, testPageSize);
@@ -337,7 +336,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod, (long)0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         new Verifications()
@@ -378,7 +377,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod, (long)0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         new Verifications()
@@ -421,7 +420,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod, (long)0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod);
         Deencapsulation.invoke(testQuery, "continueQuery", testToken, newPageSize);
 
         //assert
@@ -463,7 +462,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod, (long)0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest",  mockIotHubConnectionString, mockUrl, mockHttpMethod);
         Deencapsulation.invoke(testQuery, "continueQuery", String.class);
 
         //assert
@@ -508,7 +507,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         assertEquals(testResponseToken, Deencapsulation.getField(testQuery, "responseContinuationToken"));
@@ -536,7 +535,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         assertEquals(testResponseToken, Deencapsulation.getField(testQuery, "responseContinuationToken"));
@@ -561,7 +560,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         assertNull(Deencapsulation.getField(testQuery, "responseContinuationToken"));
@@ -585,7 +584,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //assert
         assertNull(Deencapsulation.getField(testQuery, "responseContinuationToken"));
@@ -610,7 +609,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
     }
 
     //Tests_SRS_QUERY_25_012: [If the response type is Unknown or not found then this method shall throw IOException.]
@@ -632,7 +631,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
     }
 
     //Tests_SRS_QUERY_25_011: [If the request type and response does not match then the method shall throw IOException.]
@@ -654,7 +653,7 @@ public class QueryTest
         };
 
         //act
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
     }
 
     //Tests_SRS_QUERY_25_019: [This method shall throw IllegalArgumentException if any of the parameters are null or empty.]
@@ -678,7 +677,7 @@ public class QueryTest
         };
 
         //act
-        testQuery.sendQueryRequest(null, mockUrl, mockHttpMethod, (long) 0);
+        testQuery.sendQueryRequest(null, mockUrl, mockHttpMethod);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -701,7 +700,7 @@ public class QueryTest
         };
 
         //act
-        testQuery.sendQueryRequest(mockIotHubConnectionString, null, mockHttpMethod, (long) 0);
+        testQuery.sendQueryRequest(mockIotHubConnectionString, null, mockHttpMethod);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -724,7 +723,7 @@ public class QueryTest
         };
 
         //act
-        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, null, (long) 0);
+        testQuery.sendQueryRequest(mockIotHubConnectionString, mockUrl, null);
     }
 
     //Tests_SRS_QUERY_25_014: [The method shall return the continuation token found in response to a query (which can be null).]
@@ -747,7 +746,7 @@ public class QueryTest
             }
         };
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         String actualContinuationToken = Deencapsulation.invoke(testQuery, "getContinuationToken");
@@ -777,7 +776,7 @@ public class QueryTest
             }
         };
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         boolean hasNext = Deencapsulation.invoke(testQuery, "hasNext");
@@ -807,7 +806,7 @@ public class QueryTest
             }
         };
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         boolean hasNext = Deencapsulation.invoke(testQuery, "hasNext");
@@ -841,7 +840,7 @@ public class QueryTest
         // continue query setup
         setupSendQuery(testQuery, testResponseToken);
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         boolean hasNext = Deencapsulation.invoke(testQuery, "hasNext");
@@ -888,7 +887,7 @@ public class QueryTest
             }
         };
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         Object next = Deencapsulation.invoke(testQuery, "next");
@@ -919,7 +918,7 @@ public class QueryTest
             }
         };
 
-        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod, (long) 0);
+        Deencapsulation.invoke(testQuery, "sendQueryRequest", mockIotHubConnectionString, mockUrl, mockHttpMethod);
 
         //act
         Object next = Deencapsulation.invoke(testQuery, "next");

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQueryTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQueryTest.java
@@ -100,7 +100,7 @@ public class RawTwinQueryTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.RAW);
                 times = 1;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -159,7 +159,7 @@ public class RawTwinQueryTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.RAW);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 result = new IotHubException();
             }
         };
@@ -195,7 +195,7 @@ public class RawTwinQueryTest
         new Verifications()
         {
             {
-                 Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                 Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -275,7 +275,7 @@ public class RawTwinQueryTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
@@ -192,7 +192,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -267,7 +267,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -346,7 +346,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -610,7 +610,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -683,7 +683,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -700,7 +700,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 times = 1;
             }
         };
@@ -757,7 +757,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = new IOException();
             }
         };
@@ -818,7 +818,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1113,7 +1113,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1172,7 +1172,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1227,7 +1227,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1244,7 +1244,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 times = 1;
             }
         };
@@ -1283,7 +1283,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = new IOException();
             }
         };
@@ -1326,7 +1326,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1441,7 +1441,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1487,7 +1487,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1510,7 +1510,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any);
                 times = 1;
             }
         };
@@ -1534,7 +1534,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any);
                 result = new IOException();
             }
         };
@@ -1568,7 +1568,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobs(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1688,7 +1688,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobsCancel(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1734,7 +1734,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobsCancel(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1757,7 +1757,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any);
                 times = 1;
             }
         };
@@ -1781,7 +1781,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobsCancel(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any);
                 result = new IOException();
             }
         };
@@ -1815,7 +1815,7 @@ public class JobClientTest
                 mockedIotHubConnectionString.getUrlJobsCancel(jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1871,7 +1871,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.DEVICE_JOB);
                 times = 1;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -1935,7 +1935,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.DEVICE_JOB);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 result = new IotHubException();
             }
         };
@@ -1972,7 +1972,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {Integer.class, QueryType.class}, anyInt, QueryType.JOB_RESPONSE);
                 times = 1;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.GET, any, any);
                 times = 1;
             }
         };
@@ -2002,7 +2002,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {Integer.class, QueryType.class}, anyInt, QueryType.JOB_RESPONSE);
                 times = 1;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.GET, any, any);
                 times = 1;
             }
         };
@@ -2043,7 +2043,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {Integer.class, QueryType.class}, anyInt, QueryType.JOB_RESPONSE);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.GET, any, any);
                 result = new IotHubException();
             }
         };
@@ -2079,7 +2079,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
             }
         };
@@ -2166,7 +2166,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class, Long.class}, any, any, HttpMethod.POST, any, any);
                 times = 1;
                 Deencapsulation.newInstance(JobResult.class, new Class [] {byte[].class}, expectedString.getBytes());
                 times = 1;


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/271

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-java/issues/271

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
add setConnectTimeoutMillis(int timeout) to com.microsoft.azure.sdk.iot.service.transport.http.HttpRequest