### PR TITLE
Allow configurations that don't specify a schemaVersion

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParser.java
@@ -116,12 +116,6 @@ public class ConfigurationParser
             throw new IllegalArgumentException("The provided json must contain the field for configurationId and its value may not be empty");
         }
 
-        //Codes_SRS_CONFIGURATION_PARSER_28_004: [If the provided json is missing the schemaVersion field or its value is empty, an IllegalArgumentException shall be thrown.]
-        if (configurationParser.schemaVersion == null || configurationParser.schemaVersion.isEmpty())
-        {
-            throw new IllegalArgumentException("The provided json must contain the field for schemaVersion and its value may not be empty");
-        }
-
         this.id = configurationParser.id;
         this.schemaVersion = configurationParser.schemaVersion;
         this.labels = configurationParser.labels;
@@ -221,16 +215,9 @@ public class ConfigurationParser
      * Setter for schemaVersion
      *
      * @param schemaVersion the value to set schemaVersion to
-     * @throws IllegalArgumentException if schemaVersion is null
      */
-    public void setSchemaVersion(String schemaVersion) throws IllegalArgumentException
+    public void setSchemaVersion(String schemaVersion)
     {
-        //Codes_SRS_CONFIGURATION_PARSER_28_011: [If the provided schemaVersion value is null, an IllegalArgumentException shall be thrown.]
-        if (schemaVersion == null || schemaVersion.isEmpty())
-        {
-            throw new IllegalArgumentException("SchemaVersion cannot not be null");
-        }
-
         //Codes_SRS_CONFIGURATION_PARSER_28_012: [This method shall set the value of schemaVersion to the provided value.]
         this.schemaVersion = schemaVersion;
     }

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParserTest.java
@@ -48,6 +48,34 @@ public class ConfigurationParserTest
         assertNotNull(parser.getMetrics());
     }
 
+    //Codes_SRS_CONFIGURATION_PARSER_28_003: [This constructor shall take the provided json and convert it into
+    // a new ConfigurationParser and return it even when a schemaVersion is not provided.]
+    @Test
+    public void constructorSucceedsWithoutSchemaVersion()
+    {
+        //arrange
+        String json = "{\"id\":\"someconfig\",\"etag\":\"MQ==\",\"" +
+                "labels\":{\"App\":\"label2\"},\"content\":{\"modulesContent\":{}, \"deviceContent\":{\"properties.desired.settings1\": {\"c\":3,\"d\":4}}}," +
+                "\"targetCondition\":\"*\", \"createdTimeUtc\":\"0001-01-01T00:00:00\", \"lastUpdatedTimeUtc\":\"0001-01-01T00:00:00\"," +
+                "\"priority\":10, \"systemMetrics\":{\"results\":{\"targetedCount\":3, \"appliedCount\":3}, " +
+                "\"queries\":{}}, \"metrics\":{\"results\":{\"customMetric\":3}," +
+                "\"queries\":{}}}";
+
+        //act
+        ConfigurationParser parser = new ConfigurationParser(json);
+
+        //assert
+        assertNotNull(parser);
+        assertEquals("someconfig", parser.getId());
+        assertEquals("1.0", parser.getSchemaVersion());
+        assertEquals("MQ==", parser.getETag());
+        assertEquals(ParserUtility.getDateTimeUtc("0001-01-01T00:00:00"), parser.getCreatedTimeUtc());
+        assertEquals(ParserUtility.getDateTimeUtc("0001-01-01T00:00:00"), parser.getLastUpdatedTimeUtc());
+        assertNotNull(parser.getContent());
+        assertNotNull(parser.getSystemMetrics());
+        assertNotNull(parser.getMetrics());
+    }
+
     //Tests_SRS_CONFIGURATION_PARSER_28_005: [If the provided json cannot be parsed into a ConfigurationParser object, an IllegalArgumentException shall be thrown.]
     @Test (expected = IllegalArgumentException.class)
     public void constructorThrowsForInvalidJson()
@@ -97,22 +125,6 @@ public class ConfigurationParserTest
     {
         //arrange
         String json = "{\"id\":\"\",\"schemaVersion\":\"\",\"etag\":\"MQ==\",\"" +
-                "labels\":{\"App\":\"label2\"},\"content\":{\"modulesContent\":{}, \"deviceContent\":{\"properties.desired.settings1\": {\"c\":3,\"d\":4}}}," +
-                "\"targetCondition\":\"*\", \"createdTimeUtc\":\"0001-01-01T00:00:00\", \"lastUpdatedTimeUtc\":\"0001-01-01T00:00:00\"," +
-                "\"priority\":10, \"systemMetrics\":{\"results\":{\"targetedCount\":3, \"appliedCount\":3}, " +
-                "\"queries\":{}}, \"metrics\":{\"results\":{\"customMetric\":3}," +
-                "\"queries\":{}}}";
-
-        //act
-        new ConfigurationParser(json);
-    }
-
-    //Codes_SRS_CONFIGURATION_PARSER_28_003: [If the provided json is missing the schemaVersion or its value is empty, an IllegalArgumentException shall be thrown.]
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorFromJsonNullSchemaVersion()
-    {
-        //arrange
-        String json = "{\"id\":\"someid\",\"etag\":\"MQ==\",\"" +
                 "labels\":{\"App\":\"label2\"},\"content\":{\"modulesContent\":{}, \"deviceContent\":{\"properties.desired.settings1\": {\"c\":3,\"d\":4}}}," +
                 "\"targetCondition\":\"*\", \"createdTimeUtc\":\"0001-01-01T00:00:00\", \"lastUpdatedTimeUtc\":\"0001-01-01T00:00:00\"," +
                 "\"priority\":10, \"systemMetrics\":{\"results\":{\"targetedCount\":3, \"appliedCount\":3}, " +
@@ -186,13 +198,5 @@ public class ConfigurationParserTest
     {
         //act
         new ConfigurationParser().setId(null);
-    }
-
-    //Tests_SRS_CONFIGURATION_PARSER_28_011: [If the provided schemaVersion value is null, an IllegalArgumentException shall be thrown.]
-    @Test (expected = IllegalArgumentException.class)
-    public void cantSetSchemaVersionNull()
-    {
-        //act
-        new ConfigurationParser().setSchemaVersion(null);
     }
 }

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ConfigurationParserTest.java
@@ -67,7 +67,6 @@ public class ConfigurationParserTest
         //assert
         assertNotNull(parser);
         assertEquals("someconfig", parser.getId());
-        assertEquals("1.0", parser.getSchemaVersion());
         assertEquals("MQ==", parser.getETag());
         assertEquals(ParserUtility.getDateTimeUtc("0001-01-01T00:00:00"), parser.getCreatedTimeUtc());
         assertEquals(ParserUtility.getDateTimeUtc("0001-01-01T00:00:00"), parser.getLastUpdatedTimeUtc());


### PR DESCRIPTION
SchemaVersion is not a required property in configuration and deployments created by Azure don't specify them by default. Therefore it should not be a required property. This PR removes those checks.

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
* Create a configuration in azure portal.
** Note that the json manifest shows no schemaVersion at the top level.
* Calling RegistryManager.getConfigurations and it fails to retrieve the deployment due to the schemaVersion check in ConfigurationParser.

# Description of the solution
Removal of the schemaVersion check to allow it to be missing and adding accompanying unit tests.