### PR TITLE
refactor(iot-service): Removing additional implied exception details to http exceptions

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadFormatException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadFormatException.java
@@ -16,6 +16,6 @@ public class IotHubBadFormatException extends IotHubException
     }
     public IotHubBadFormatException(String message)
     {
-        super("Bad message format!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadGatewayException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadGatewayException.java
@@ -16,6 +16,6 @@ public class IotHubBadGatewayException extends IotHubException
     }
     public IotHubBadGatewayException(String message)
     {
-        super("Bad gateway!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceMaximumQueueDepthExceededException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceMaximumQueueDepthExceededException.java
@@ -17,6 +17,6 @@ public class IotHubDeviceMaximumQueueDepthExceededException extends IotHubExcept
 
     public IotHubDeviceMaximumQueueDepthExceededException(String message)
     {
-        super("Maximum queue depth exceeded!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceNotFoundException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceNotFoundException.java
@@ -17,6 +17,6 @@ public class IotHubDeviceNotFoundException extends IotHubException
 
     public IotHubDeviceNotFoundException(String message)
     {
-        super("Device not found!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubException.java
@@ -11,5 +11,8 @@ package com.microsoft.azure.sdk.iot.service.exceptions;
 public class IotHubException extends Exception
 {
     public IotHubException() { super(); }
-    public IotHubException(String message) { super(message); }
+    public IotHubException(String message)
+    {
+        super(((message == null) || message.isEmpty()) ? "" : message);
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubGatewayTimeoutException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubGatewayTimeoutException.java
@@ -16,6 +16,6 @@ public class IotHubGatewayTimeoutException extends IotHubException
     }
     public IotHubGatewayTimeoutException(String message)
     {
-        super("Gateway timeout!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInternalServerErrorException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInternalServerErrorException.java
@@ -16,6 +16,6 @@ public class IotHubInternalServerErrorException extends IotHubException
     }
     public IotHubInternalServerErrorException(String message)
     {
-        super("Internal server error!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInvalidOperationException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInvalidOperationException.java
@@ -17,6 +17,6 @@ public class IotHubInvalidOperationException extends IotHubException
 
     public IotHubInvalidOperationException(String message)
     {
-        super("Invalid operation!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubMessageTooLargeException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubMessageTooLargeException.java
@@ -17,6 +17,6 @@ public class IotHubMessageTooLargeException extends IotHubException
 
     public IotHubMessageTooLargeException(String message)
     {
-        super("Message too large!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotFoundException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotFoundException.java
@@ -17,6 +17,6 @@ public class IotHubNotFoundException extends IotHubException
 
     public IotHubNotFoundException(String message)
     {
-        super("IoT Hub not found!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotSupportedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotSupportedException.java
@@ -17,6 +17,6 @@ public class IotHubNotSupportedException extends IotHubException
 
     public IotHubNotSupportedException(String message)
     {
-        super("Not supported!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubPreconditionFailedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubPreconditionFailedException.java
@@ -16,6 +16,6 @@ public class IotHubPreconditionFailedException extends IotHubException
     }
     public IotHubPreconditionFailedException(String message)
     {
-        super("Precondition failed!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubServerBusyException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubServerBusyException.java
@@ -16,6 +16,6 @@ public class IotHubServerBusyException extends IotHubException
     }
     public IotHubServerBusyException(String message)
     {
-        super("Server busy!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyDevicesException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyDevicesException.java
@@ -16,6 +16,6 @@ public class IotHubTooManyDevicesException extends IotHubException
     }
     public IotHubTooManyDevicesException(String message)
     {
-        super("Too many devices!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyRequestsException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyRequestsException.java
@@ -16,6 +16,6 @@ public class IotHubTooManyRequestsException extends IotHubException
     }
     public IotHubTooManyRequestsException(String message)
     {
-        super("Too many requests (throttled)!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubUnathorizedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubUnathorizedException.java
@@ -17,6 +17,6 @@ public class IotHubUnathorizedException extends IotHubException
 
     public IotHubUnathorizedException(String message)
     {
-        super("Unauthorized!" + (((message == null) || message.isEmpty()) ? "" : " " + message));
+        super(message);
     }
 }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
@@ -289,7 +289,7 @@ public class IotHubExceptionManagerTest
         catch (IotHubBadFormatException expected)
         {
             // Expected throw.
-            assertThat(expected.getMessage(), is("Bad message format! {\"ExceptionMessage\":\"This is the error message\"}"));
+            assertThat(expected.getMessage(), is("{\"ExceptionMessage\":\"This is the error message\"}"));
         }
     }
 
@@ -313,7 +313,7 @@ public class IotHubExceptionManagerTest
         catch (IotHubBadFormatException expected)
         {
             // Expected throw.
-            assertThat(expected.getMessage(), is("Bad message format! {\"ExceptionMessage\":null}"));
+            assertThat(expected.getMessage(), is("{\"ExceptionMessage\":null}"));
         }
     }
 
@@ -337,7 +337,7 @@ public class IotHubExceptionManagerTest
         catch (IotHubBadFormatException expected)
         {
             // Expected throw.
-            assertThat(expected.getMessage(), is("Bad message format! {\"ExceptionMessage\":}"));
+            assertThat(expected.getMessage(), is("{\"ExceptionMessage\":}"));
         }
     }
 
@@ -361,7 +361,7 @@ public class IotHubExceptionManagerTest
         catch (IotHubBadFormatException expected)
         {
             // Expected throw.
-            assertThat(expected.getMessage(), is("Bad message format! ErrorCode:IotHubUnauthorizedAccess;Unauthorized Tracking ID:(tracking id)-TimeStamp:12/14/2016 03:15:17"));
+            assertThat(expected.getMessage(), is("ErrorCode:IotHubUnauthorizedAccess;Unauthorized Tracking ID:(tracking id)-TimeStamp:12/14/2016 03:15:17"));
         }
     }
 
@@ -385,7 +385,7 @@ public class IotHubExceptionManagerTest
         catch (IotHubBadFormatException expected)
         {
             // Expected throw.
-            assertThat(expected.getMessage(), is("Bad message format! ErrorCode:ArgumentInvalid;Missing or invalid etag for job type ScheduleUpdateTwin. ScheduleUpdateTwin job type is a force update, which only accepts '*' as the Etag. Tracking ID:1234-TimeStamp:06/26/2017 20:56:33"));
+            assertThat(expected.getMessage(), is("ErrorCode:ArgumentInvalid;Missing or invalid etag for job type ScheduleUpdateTwin. ScheduleUpdateTwin job type is a force update, which only accepts '*' as the Etag. Tracking ID:1234-TimeStamp:06/26/2017 20:56:33"));
         }
     }
 }


### PR DESCRIPTION


Additional exception context beyond what the service provided was more confusing than helpful in certain circumstances

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Reference/Link to the issue solved with this PR (if any)
fixes #329

# Description of the problem
The additional exception descriptions that the Java SDK added beyond what the service gave us caused some confusion. Customers preferred just knowing what the service returned.

# Description of the solution
For service side http exceptions, now they will only contain the details given by the service, rather than adding on some extra assumed context that may be wrong.