### PR TITLE
fix(iot-device): Fix issue where amqp cbs auth did not proactively re…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -393,6 +393,9 @@ public final class DeviceClient extends InternalClient implements Closeable
     /**
      * Asynchronously upload a stream to the IoT Hub.
      *
+     * NOTE: IotHub does not currently support CA signed devices using file upload. Please use SAS based authentication or
+     * self signed certificates.
+     *
      * @param destinationBlobName is a string with the name of the file in the storage.
      * @param inputStream is a InputStream with the stream to upload in the blob.
      * @param streamLength is a long with the number of bytes in the stream to upload.
@@ -402,10 +405,9 @@ public final class DeviceClient extends InternalClient implements Closeable
      * @throws IllegalArgumentException if the provided blob name, or the file path is {@code null},
      *          empty or not valid, or if the callback is {@code null}.
      * @throws IOException if the client cannot create a instance of the FileUpload or the transport.
-     * @throws UnsupportedOperationException if this method is called when using x509 authentication
      */
     public void uploadToBlobAsync(String destinationBlobName, InputStream inputStream, long streamLength,
-                                  IotHubEventCallback callback, Object callbackContext) throws IllegalArgumentException, IOException, UnsupportedOperationException
+                                  IotHubEventCallback callback, Object callbackContext) throws IllegalArgumentException, IOException
     {
         if (callback == null)
         {
@@ -423,11 +425,6 @@ public final class DeviceClient extends InternalClient implements Closeable
         }
 
         ParserUtility.validateBlobName(destinationBlobName);
-
-        if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.X509_CERTIFICATE)
-        {
-            throw new UnsupportedOperationException("File Upload does not support x509 authentication");
-        }
 
         if (this.fileUpload == null)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -97,16 +97,21 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
     /**
      * Getter for SasToken. If the saved token has expired, this method shall renew it if possible
      *
+     * @param proactivelyRenew if true, this method will generate a fresh sas token even if the previously saved token
+     *                                 has not expired yet as long as the current token has lived beyond its buffer.
+     *                                 Use this for pre-emptively renewing sas tokens.
+     *
      * @return The value of SasToken
      */
     @Override
-    public String getRenewedSasToken() throws IOException, TransportException
+    public String getRenewedSasToken(boolean proactivelyRenew) throws IOException, TransportException
     {
-        if (this.sasToken.isExpired())
+        if (this.shouldRefreshToken(proactivelyRenew))
         {
             if (this.deviceKey != null)
             {
                 //Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_004: [If the saved sas token has expired and there is a device key present, the saved sas token shall be renewed.]
+                //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_006: [If the saved sas token has not expired and there is a device key present, but this method is called to proactively renew and the token should renew, the saved sas token shall be renewed.]
                 this.sasToken = new IotHubSasToken(this.hostname, this.deviceId, this.deviceKey, null, this.moduleId, getExpiryTimeInSeconds());
             }
         }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
@@ -79,9 +79,9 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * @throws TransportException If a TransportException is encountered while refreshing the sas token
      */
     @Override
-    public String getRenewedSasToken() throws IOException, TransportException
+    public String getRenewedSasToken(boolean proactivelyRenew) throws IOException, TransportException
     {
-        if (this.shouldRefreshToken())
+        if (this.shouldRefreshToken(proactivelyRenew))
         {
             // Codes_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_004: [This function shall invoke shouldRefreshSasToken, and if it should refresh, this function shall refresh the sas token.]
             this.refreshSasToken();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
@@ -302,7 +302,7 @@ public final class AmqpsDeviceAuthenticationCBS extends AmqpsDeviceAuthenticatio
         Section section = null;
         try
         {
-            section = new AmqpValue(deviceClientConfig.getSasTokenAuthentication().getRenewedSasToken());
+            section = new AmqpValue(deviceClientConfig.getSasTokenAuthentication().getRenewedSasToken(true));
             outgoingMessage.setBody(section);
         }
         catch (IOException e)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -445,7 +445,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
     {
         try
         {
-            return this.config.getSasTokenAuthentication().getRenewedSasToken();
+            return this.config.getSasTokenAuthentication().getRenewedSasToken(false);
         }
         catch (IOException e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -123,7 +123,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
                 SSLContext sslContext = this.config.getAuthenticationProvider().getSSLContext();
                 if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN)
                 {
-                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getRenewedSasToken();
+                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getRenewedSasToken(false);
                 }
                 else if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.X509_CERTIFICATE)
                 {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -1854,32 +1854,6 @@ public class DeviceClientTest
         Deencapsulation.invoke(client, "uploadToBlobAsync", destinationBlobName, mockInputStream, streamLength, mockedStatusCB, mockedPropertyCB);
     }
 
-    // Tests_SRS_INTERNALCLIENT_34_066: [If this function is called when the device client is using x509 authentication, an UnsupportedOperationException shall be thrown.]
-    @Test (expected = UnsupportedOperationException.class)
-    public void startFileUploadUploadToBlobAsyncAuthTypeThrows(@Mocked final FileUpload mockedFileUpload,
-                                                               @Mocked final InputStream mockInputStream,
-                                                               @Mocked final IotHubEventCallback mockedStatusCB,
-                                                               @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException, TransportException
-    {
-        //arrange
-        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-        final String destinationBlobName = "valid/blob/name.txt";
-        final long streamLength = 100;
-
-        new NonStrictExpectations()
-        {
-            {
-                mockConfig.getAuthenticationType();
-                result = DeviceClientConfig.AuthType.X509_CERTIFICATE;
-            }
-        };
-        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class, new Class[] {String.class, IotHubClientProtocol.class}, "some conn string", protocol);
-        Deencapsulation.setField(client, "config", mockConfig);
-
-        // act
-        Deencapsulation.invoke(client, "uploadToBlobAsync", destinationBlobName, mockInputStream, streamLength, mockedStatusCB, mockedPropertyCB);
-    }
-
     /* Tests_SRS_INTERNALCLIENT_21_051: [If uploadToBlobAsync failed to start the upload using the FileUpload, it shall bypass the exception.] */
     @Test (expected = IllegalArgumentException.class)
     public void startFileUploadUploadToBlobAsyncThrows(@Mocked final FileUpload mockedFileUpload,

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
@@ -78,7 +78,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         }
 
         @Override
-        public String getRenewedSasToken() throws IOException
+        public String getRenewedSasToken(boolean proactivelyRenew) throws IOException
         {
             return null;
         }
@@ -247,7 +247,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider authenticationProvider = new mockIotHubSasTokenAuthenticationImplementation(10, 1);
 
         //act
-        boolean result = authenticationProvider.shouldRefreshToken();
+        boolean result = authenticationProvider.shouldRefreshToken(true);
 
         //assert
         assertTrue(result);
@@ -262,7 +262,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider authenticationProvider = new mockIotHubSasTokenAuthenticationImplementation(100000, 100);
 
         //act
-        boolean result = authenticationProvider.shouldRefreshToken();
+        boolean result = authenticationProvider.shouldRefreshToken(true);
 
         //assert
         assertFalse(result);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -38,7 +38,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         }
 
         @Override
-        public boolean shouldRefreshToken()
+        public boolean shouldRefreshToken(boolean proactivelyRenew)
         {
             return this.shouldRefresh;
         }
@@ -126,7 +126,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken();
+        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true);
 
         //assert
         assertEquals(newSasToken.toString(), actual);
@@ -146,10 +146,9 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken();
+        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(false);
 
         //assert
         assertEquals(oldSasToken.toString(), actual);
     }
-
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -66,7 +66,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result=testSasToken;
             }
         };
@@ -262,7 +262,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = tokenStr;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
@@ -627,7 +627,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = tokenStr;
             }
         };
@@ -876,7 +876,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = tokenStr;
             }
         };
@@ -1517,7 +1517,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = tokenStr;
             }
         };
@@ -1706,7 +1706,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 times = 1;
             }
         };
@@ -1733,7 +1733,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 times = 1;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
@@ -270,7 +270,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -320,7 +320,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = true;
@@ -365,7 +365,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -433,7 +433,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean);
                 result = mockDeviceMessaging;
@@ -489,7 +489,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean);
                 result = mockDeviceMessaging;
@@ -1070,7 +1070,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1107,7 +1107,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1155,7 +1155,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken();
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -10,6 +10,8 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
+import com.microsoft.azure.sdk.iot.deps.util.Base64;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -28,8 +30,13 @@ public class FileUploadAndroidRunner extends FileUploadTests
     @BeforeClass
     public static void setup() throws IOException
     {
+        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
+        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        FileUploadTests.setUp();
+        String x509Thumbprint = BuildConfig.IotHubThumbprint;
+        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
+        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
+        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
     }
 
     @Ignore

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
@@ -7,17 +7,25 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices;
 
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
+import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 
 public class FileUploadJVMRunner extends FileUploadTests
 {
     @BeforeClass
-    public static void setup() throws IOException
+    public static void setup() throws IOException, GeneralSecurityException
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        FileUploadTests.setUp();
+        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
+        String publicKeyCert = cert.getPublicCertLeafPem();
+        String privateKey =  cert.getPrivateKeyLeafPem();
+        String x509Thumbprint = cert.getThumbPrintLeaf();
+        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
     }
 }


### PR DESCRIPTION
…new sas token

# Reference/Link to the issue solved with this PR (if any)
fixes #365 

# Description of the problem
cbs task does not send a proactively refreshed sas token, so amqp connection is being lost frequently even though the SDK can renew the connection ahead of time.

# Description of the solution
added to the sas-based auth providers the ability to get a renewed sas token even when the current token has not expired yet.