### PR TITLE
feat(iot-dev): Enable fileupload with SelfSigned device client

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -393,6 +393,9 @@ public final class DeviceClient extends InternalClient implements Closeable
     /**
      * Asynchronously upload a stream to the IoT Hub.
      *
+     * NOTE: IotHub does not currently support CA signed devices using file upload. Please use SAS based authentication or
+     * self signed certificates.
+     *
      * @param destinationBlobName is a string with the name of the file in the storage.
      * @param inputStream is a InputStream with the stream to upload in the blob.
      * @param streamLength is a long with the number of bytes in the stream to upload.
@@ -402,10 +405,9 @@ public final class DeviceClient extends InternalClient implements Closeable
      * @throws IllegalArgumentException if the provided blob name, or the file path is {@code null},
      *          empty or not valid, or if the callback is {@code null}.
      * @throws IOException if the client cannot create a instance of the FileUpload or the transport.
-     * @throws UnsupportedOperationException if this method is called when using x509 authentication
      */
     public void uploadToBlobAsync(String destinationBlobName, InputStream inputStream, long streamLength,
-                                  IotHubEventCallback callback, Object callbackContext) throws IllegalArgumentException, IOException, UnsupportedOperationException
+                                  IotHubEventCallback callback, Object callbackContext) throws IllegalArgumentException, IOException
     {
         if (callback == null)
         {
@@ -423,11 +425,6 @@ public final class DeviceClient extends InternalClient implements Closeable
         }
 
         ParserUtility.validateBlobName(destinationBlobName);
-
-        if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.X509_CERTIFICATE)
-        {
-            throw new UnsupportedOperationException("File Upload does not support x509 authentication");
-        }
 
         if (this.fileUpload == null)
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -1854,32 +1854,6 @@ public class DeviceClientTest
         Deencapsulation.invoke(client, "uploadToBlobAsync", destinationBlobName, mockInputStream, streamLength, mockedStatusCB, mockedPropertyCB);
     }
 
-    // Tests_SRS_INTERNALCLIENT_34_066: [If this function is called when the device client is using x509 authentication, an UnsupportedOperationException shall be thrown.]
-    @Test (expected = UnsupportedOperationException.class)
-    public void startFileUploadUploadToBlobAsyncAuthTypeThrows(@Mocked final FileUpload mockedFileUpload,
-                                                               @Mocked final InputStream mockInputStream,
-                                                               @Mocked final IotHubEventCallback mockedStatusCB,
-                                                               @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException, TransportException
-    {
-        //arrange
-        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-        final String destinationBlobName = "valid/blob/name.txt";
-        final long streamLength = 100;
-
-        new NonStrictExpectations()
-        {
-            {
-                mockConfig.getAuthenticationType();
-                result = DeviceClientConfig.AuthType.X509_CERTIFICATE;
-            }
-        };
-        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class, new Class[] {String.class, IotHubClientProtocol.class}, "some conn string", protocol);
-        Deencapsulation.setField(client, "config", mockConfig);
-
-        // act
-        Deencapsulation.invoke(client, "uploadToBlobAsync", destinationBlobName, mockInputStream, streamLength, mockedStatusCB, mockedPropertyCB);
-    }
-
     /* Tests_SRS_INTERNALCLIENT_21_051: [If uploadToBlobAsync failed to start the upload using the FileUpload, it shall bypass the exception.] */
     @Test (expected = IllegalArgumentException.class)
     public void startFileUploadUploadToBlobAsyncThrows(@Mocked final FileUpload mockedFileUpload,

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -10,6 +10,8 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
+import com.microsoft.azure.sdk.iot.deps.util.Base64;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -28,8 +30,13 @@ public class FileUploadAndroidRunner extends FileUploadTests
     @BeforeClass
     public static void setup() throws IOException
     {
+        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
+        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        FileUploadTests.setUp();
+        String x509Thumbprint = BuildConfig.IotHubThumbprint;
+        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
+        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
+        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
     }
 
     @Ignore

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
@@ -7,17 +7,25 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices;
 
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
+import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 
 public class FileUploadJVMRunner extends FileUploadTests
 {
     @BeforeClass
-    public static void setup() throws IOException
+    public static void setup() throws IOException, GeneralSecurityException
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        FileUploadTests.setUp();
+        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
+        String publicKeyCert = cert.getPublicCertLeafPem();
+        String privateKey =  cert.getPrivateKeyLeafPem();
+        String x509Thumbprint = cert.getThumbPrintLeaf();
+        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
     }
 }


### PR DESCRIPTION
Adding e2e test, too

# Reference/Link to the issue solved with this PR (if any)
fixes #371 

# Description of the problem
Currently, file upload code path throws unsupported operation exception when using self signed or ca signed certs as the authentication mechanism of your device client. While the service does not allow CA signed certs for file upload, it does allow self signed certs.

# Description of the solution
Removed the unsupported operation exception, and added a note about the gap with CA signed certs. Also added end to end tests to cover this scenario