### PR TITLE
feat(iot-service): Add reporting of capabilities in DeviceTwin based …

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -493,6 +493,7 @@ public class DeviceTwin
         deviceTwinDevice.setTags(twinState.getTags());
         deviceTwinDevice.setDesiredProperties(twinState.getDesiredProperty());
         deviceTwinDevice.setReportedProperties(twinState.getReportedProperty());
+        deviceTwinDevice.setCapabilities(twinState.getCapabilities());
 
         if (twinState.getModuleId() != null && !twinState.getModuleId().isEmpty())
         {

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -5,12 +5,10 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
-import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.twin.ConfigurationInfo;
 import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
-import com.microsoft.azure.sdk.iot.service.Configuration;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
@@ -976,6 +974,8 @@ public class DeviceTwinTest
                 result = dp;
                 mockedTwinState.getReportedProperty();
                 result = rp;
+                mockCapabilities.isIotEdge();
+                result = Boolean.TRUE;
             }
         };
 
@@ -1002,6 +1002,7 @@ public class DeviceTwinTest
         assetEqualSetAndMap(result.getTags(), (Map)tags);
         assetEqualSetAndMap(result.getDesiredProperties(), (Map)dp);
         assetEqualSetAndMap(result.getReportedProperties(), (Map)rp);
+        assertTrue(result.getCapabilities().isIotEdge());
         assertNull(result.getModuleId());
     }
 


### PR DESCRIPTION
…on TwinState

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Querying for devices does not properly show the device capabilities to reflect whether or not the device is an IoT Edge device.

# Description of the solution
The set of capabilities is already passed down through the twin state. It just needs to be set on the DeviceTwinDevice.

(rebased version of [pr 351](https://github.com/Azure/azure-iot-sdk-java/pull/351))