### PR TITLE
fix(iot-dev): increase time limit for waiting for SUBACK when subscri…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -6,7 +6,6 @@ package com.microsoft.azure.sdk.iot.device.transport.mqtt;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.MessageType;
-import com.microsoft.azure.sdk.iot.device.exceptions.ProtocolException;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubListener;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
@@ -17,7 +16,6 @@ import org.eclipse.paho.client.mqttv3.*;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -277,7 +275,7 @@ abstract public class Mqtt implements MqttCallback
                 //Codes_SRS_Mqtt_25_017: [The function shall subscribe to subscribeTopic specified to the IoT Hub given in the configuration.]
                 IMqttToken subToken = this.mqttConnection.getMqttAsyncClient().subscribe(topic, MqttConnection.QOS);
 
-                subToken.waitForCompletion(MqttConnection.MAX_WAIT_TIME);
+                subToken.waitForCompletion(MqttConnection.MAX_SUBSCRIBE_ACK_WAIT_TIME);
             }
             catch (MqttException e)
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnection.java
@@ -28,7 +28,7 @@ public class MqttConnection
     private static final int MQTT_VERSION = 4;
     private static final boolean SET_CLEAN_SESSION = false;
     static final int QOS = 1;
-    static final int MAX_WAIT_TIME = 1000;
+    static final int MAX_SUBSCRIBE_ACK_WAIT_TIME = 15 * 1000;
 
     // paho mqtt only supports 10 messages in flight at the same time
     static final int MAX_IN_FLIGHT_COUNT = 10;


### PR DESCRIPTION
…bing to an MQTT topic

# Description of the problem
Service folks recommend a timespan of 5-15 seconds should be allowed for a SUBACK to be received when subscribing to any topic.

# Description of the solution
Increasing the SUBACK timeout