### PR TITLE
fix(iot-device): Removing duplicated escaping in DeviceMethod class

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethod.java
@@ -4,8 +4,19 @@
 package com.microsoft.azure.sdk.iot.device.DeviceTwin;
 
 import com.microsoft.azure.sdk.iot.deps.serializer.MethodParser;
-import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.CustomLogger;
+import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
+import com.microsoft.azure.sdk.iot.device.DeviceIO;
+import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
+import com.microsoft.azure.sdk.iot.device.IotHubMessageResult;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageCallback;
+import com.microsoft.azure.sdk.iot.device.MessageType;
+import com.microsoft.azure.sdk.iot.device.ObjectLock;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
+
+import java.nio.charset.StandardCharsets;
 
 public final class DeviceMethod
 {
@@ -74,8 +85,16 @@ public final class DeviceMethod
                                     **Codes_SRS_DEVICEMETHOD_25_011: [**If the user callback is successful and user has successfully provided the response message and status, then this method shall build a device method message of type DEVICE_OPERATION_METHOD_SEND_RESPONSE, serilize the user data by invoking MethodParser from serializer and save the user data as payload in the message before sending it to IotHub via sendeventAsync before marking the result as complete**]**
                                     **Codes_SRS_DEVICEMETHOD_25_015: [**User can provide null response message upon invoking the device method callback which will be serialized as is, before sending it to IotHub.**]**
                                      */
-                                    MethodParser methodParserObject = new MethodParser(responseData.getResponseMessage());
-                                    IotHubTransportMessage responseMessage = new IotHubTransportMessage(methodParserObject.toJson().getBytes(), MessageType.DEVICE_METHODS);
+                                    String payload;
+                                    if (responseData.getJsonResponseMessage() == null)
+                                    {
+                                        payload = new MethodParser(responseData.getResponseMessage()).toJson();
+                                    }
+                                    else
+                                    {
+                                        payload = responseData.getJsonResponseMessage().toString();
+                                    }
+                                    IotHubTransportMessage responseMessage = new IotHubTransportMessage(payload.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_METHODS);
                                     /*
                                     **Codes_SRS_DEVICEMETHOD_25_012: [**The device method message sent to IotHub shall have same the request id as the invoking message.**]**
                                      */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodData.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodData.java
@@ -3,10 +3,13 @@
 
 package com.microsoft.azure.sdk.iot.device.DeviceTwin;
 
+import com.google.gson.JsonElement;
+
 public class DeviceMethodData
 {
     private int status;
     private String responseMessage;
+    private JsonElement jsonResponseMessage;
 
     public DeviceMethodData(int status, String responseMessage)
     {
@@ -15,6 +18,15 @@ public class DeviceMethodData
          */
         this.status = status;
         this.responseMessage = responseMessage;
+    }
+
+    public DeviceMethodData(int status, JsonElement jsonResponseMessage)
+    {
+        /*
+        **Codes_SRS_DEVICEMETHODDATA_25_001: [**The constructor shall save the status and response message provided by user.**]**
+         */
+        this.status = status;
+        this.jsonResponseMessage = jsonResponseMessage;
     }
 
     public int getStatus()
@@ -47,5 +59,10 @@ public class DeviceMethodData
         **Codes_SRS_DEVICEMETHODDATA_25_007: [**The method shall set the status.**]**
          */
         this.status = status;
+    }
+
+    public JsonElement getJsonResponseMessage()
+    {
+        return jsonResponseMessage;
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodDataTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodDataTest.java
@@ -3,6 +3,8 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.device.DeviceTwin;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
 import org.junit.Test;
 
@@ -94,6 +96,21 @@ public class DeviceMethodDataTest
         //assert
         String testResponse = testData.getResponseMessage();
         assertEquals(testResponse, "testMessage");
+
+    }
+
+    @Test
+    public void getJsonResponseMessageTest()
+    {
+        //arrange
+        JsonPrimitive primitiveValue = new JsonPrimitive("testMessage");
+        DeviceMethodData testData = new DeviceMethodData(0, primitiveValue);
+
+        //act
+        JsonElement testJsonResponseMessage = testData.getJsonResponseMessage();
+
+        //assert
+        assertEquals(testJsonResponseMessage, primitiveValue);
 
     }
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
@@ -3,9 +3,17 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.device.DeviceTwin;
 
-import com.microsoft.azure.sdk.iot.device.*;
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
-import com.microsoft.azure.sdk.iot.device.transport.IotHubTransport;
+import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
+import com.microsoft.azure.sdk.iot.device.DeviceIO;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethod;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
+import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
+import com.microsoft.azure.sdk.iot.device.IotHubMessageResult;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageCallback;
+import com.microsoft.azure.sdk.iot.device.MessageType;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import mockit.Deencapsulation;
 import mockit.Mocked;
@@ -16,7 +24,10 @@ import org.junit.Test;
 import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST;
 import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /* Unit tests for DeviceMethod
 * 100% methods covered
@@ -24,6 +35,8 @@ import static org.junit.Assert.*;
 */
 public class DeviceMethodTest
 {
+    public final static String NULL_STRING = null;
+
     @Mocked
     DeviceIO mockedDeviceIO;
 
@@ -333,7 +346,7 @@ public class DeviceMethodTest
         IotHubTransportMessage testMessage = new IotHubTransportMessage(testPayload, DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
 
-        final DeviceMethodData testUserData = new DeviceMethodData(100, null);
+        final DeviceMethodData testUserData = new DeviceMethodData(100, NULL_STRING);
 
         MessageCallback testDeviceMethodResponseMessageCallback = Deencapsulation.newInnerInstance("deviceMethodResponseCallback", testMethod);
         new NonStrictExpectations()

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.common.setup;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -53,6 +55,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
     protected static final Long RESPONSE_TIMEOUT = TimeUnit.SECONDS.toSeconds(200);
     protected static final Long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toSeconds(5);
     protected static final String PAYLOAD_STRING = "This is a valid payload";
+    protected static final JsonElement PAYLOAD_JSON = new JsonPrimitive(PAYLOAD_STRING);
 
     protected static final int NUMBER_INVOKES_PARALLEL = 10;
     protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
@@ -389,6 +392,31 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         else
         {
             result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+        }
+
+        deviceTestManger.waitIotHub(1, 10);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
+        Assert.assertEquals(0, deviceTestManger.getStatusError());
+    }
+
+    protected void invokeMethodJsonSucceed() throws Exception
+    {
+        // Arrange
+        DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
+
+        // Act
+        MethodResult result;
+        if (testInstance.identity instanceof Module)
+        {
+            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module)testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_JSON);
+        }
+        else
+        {
+            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_JSON);
         }
 
         deviceTestManger.waitIotHub(1, 10);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -44,6 +44,12 @@ public class DeviceMethodTests extends DeviceMethodCommon
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    public void invokeMethodJsonSucceed() throws Exception
+    {
+        super.invokeMethodJsonSucceed();
+    }
+
+    @Test(timeout=DEFAULT_TEST_TIMEOUT)
     public void invokeMethodInvokeParallelSucceed() throws Exception
     {
         // Arrange


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/378
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
[Device Client] DeviceMethodCallback message contains backslashes
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Fixed the issue by removing duplicated escaping in DeviceMethod class
