### PR TITLE
refactor(e2e): Adding correlation logging details to e2e test failures

### DIFF
--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,6 +32,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
+@Ignore
 @RunWith(Parameterized.class)
 public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -44,7 +44,7 @@ public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErr
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,6 +31,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupB
 @RunWith(Parameterized.class)
 public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -44,7 +44,7 @@ public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErr
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,6 +31,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupA
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -44,7 +44,7 @@ public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,6 +31,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupB
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -44,7 +44,7 @@ public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
@@ -46,7 +46,7 @@ public class DeviceMethodErrInjDeviceAndroidRunner extends DeviceMethodErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodErrInjDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,6 +32,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@Ignore
 @TestGroupA
 @RunWith(Parameterized.class)
 public class DeviceMethodErrInjDeviceAndroidRunner extends DeviceMethodErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
@@ -46,7 +46,7 @@ public class DeviceMethodErrInjModuleAndroidRunner extends DeviceMethodErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodErrInjModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,6 +32,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@Ignore
 @TestGroupB
 @RunWith(Parameterized.class)
 public class DeviceMethodErrInjModuleAndroidRunner extends DeviceMethodErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupC
 @RunWith(Parameterized.class)
 public class DesiredPropertiesErrInjDeviceAndroidRunner extends DesiredPropertiesErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
@@ -40,7 +40,7 @@ public class DesiredPropertiesErrInjDeviceAndroidRunner extends DesiredPropertie
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @RunWith(Parameterized.class)
 public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertiesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -38,7 +38,7 @@ public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertie
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupC
 @RunWith(Parameterized.class)
 public class GetTwinErrInjDeviceAndroidRunner extends GetTwinErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
@@ -40,7 +40,7 @@ public class GetTwinErrInjDeviceAndroidRunner extends GetTwinErrInjTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
@@ -38,7 +38,7 @@ public class GetTwinErrInjModuleAndroidRunner extends GetTwinErrInjTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @RunWith(Parameterized.class)
 public class GetTwinErrInjModuleAndroidRunner extends GetTwinErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @TestGroupC
 @RunWith(Parameterized.class)
 public class ReportedPropertiesErrInjDeviceAndroidRunner extends ReportedPropertiesErrInjTests

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
@@ -40,7 +40,7 @@ public class ReportedPropertiesErrInjDeviceAndroidRunner extends ReportedPropert
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
+@Ignore
 @RunWith(Parameterized.class)
 public class ReportedPropertiesErrInjModuleAndroidRunner extends ReportedPropertiesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
@@ -38,7 +38,7 @@ public class ReportedPropertiesErrInjModuleAndroidRunner extends ReportedPropert
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -41,7 +41,7 @@ public class ReceiveMessagesDeviceAndroidRunner extends ReceiveMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -43,7 +43,7 @@ public class ReceiveMessagesModuleAndroidRunner extends ReceiveMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -41,7 +41,7 @@ public class SendMessagesDeviceAndroidRunner extends SendMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
@@ -42,7 +42,7 @@ public class SendMessagesModuleAndroidRunner extends SendMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -43,7 +43,7 @@ public class DeviceMethodDeviceAndroidRunner extends DeviceMethodTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
@@ -44,7 +44,7 @@ public class DeviceMethodModuleAndroidRunner extends DeviceMethodTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class DesiredPropertiesDeviceAndroidRunner extends DesiredPropertiesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class DesiredPropertiesModuleAndroidRunner extends DesiredPropertiesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class GetTwinDeviceAndroidRunner extends GetTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class GetTwinModuleAndroidRunner extends GetTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class QueryTwinDeviceAndroidRunner extends QueryTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public QueryTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class QueryTwinModuleAndroidRunner extends QueryTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public QueryTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class ReportedPropertiesDeviceAndroidRunner extends ReportedPropertiesTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class ReportedPropertiesModuleAndroidRunner extends ReportedPropertiesTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class TwinTagsDeviceAndroidRunner extends TwinTagsTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public TwinTagsDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class TwinTagsModuleAndroidRunner extends TwinTagsTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public TwinTagsModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/CorrelationDetailsLoggingAssert.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/CorrelationDetailsLoggingAssert.java
@@ -1,0 +1,260 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.common.helpers;
+
+import com.microsoft.azure.sdk.iot.device.InternalClient;
+import org.junit.ComparisonFailure;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+
+public class CorrelationDetailsLoggingAssert
+{
+    String hostname;
+    Collection<String> deviceIds;
+    String protocol;
+    Collection<String> moduleIds;
+
+    public CorrelationDetailsLoggingAssert(String hostname, String deviceId, String protocol, String moduleId)
+    {
+        this.hostname = hostname;
+        this.deviceIds = new ArrayList<>();
+        this.deviceIds.add(deviceId);
+        this.protocol = protocol;
+
+        if (moduleId != null && !moduleId.isEmpty())
+        {
+            this.moduleIds = new ArrayList<>();
+            this.moduleIds.add(moduleId);
+        }
+    }
+
+    public CorrelationDetailsLoggingAssert(String hostname, Collection<String> deviceIds, String protocol, Collection<String> moduleIds)
+    {
+        this.hostname = hostname;
+        this.deviceIds = deviceIds;
+        this.protocol = protocol;
+        this.moduleIds = moduleIds;
+    }
+
+    public CorrelationDetailsLoggingAssert(InternalClient internalClient)
+    {
+        this(internalClient.getConfig().getIotHubHostname(),
+                internalClient.getConfig().getDeviceId(),
+                internalClient.getConfig().getProtocol().toString(),
+                internalClient.getConfig().getModuleId());
+    }
+
+    public static String buildExceptionMessage(String baseMessage, Collection<String> deviceIds, String protocol, String hostname, Collection<String> moduleIds)
+    {
+        String timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss").format(new Date());
+        String correlationString = "Hostname:" + hostname;
+        if (deviceIds.size() > 0)
+        {
+            correlationString += " Device id: ";
+            boolean isFirstDevice = true;
+            for (String deviceId : deviceIds)
+            {
+                if (isFirstDevice)
+                {
+                    correlationString += deviceId;
+                }
+                else
+                {
+                    correlationString += ", " + deviceId;
+                }
+
+                isFirstDevice = false;
+            }
+        }
+
+        if (moduleIds.size() > 0)
+        {
+            correlationString += " Module id: ";
+            boolean isFirstModule = true;
+            for (String moduleId : moduleIds)
+            {
+                if (isFirstModule)
+                {
+                    correlationString += moduleId;
+                }
+                else
+                {
+                    correlationString += ", " + moduleId;
+                }
+
+                isFirstModule = false;
+            }
+        }
+
+        correlationString = correlationString + " Protocol: " + protocol + " Timestamp: " + timeStamp;
+
+        return baseMessage + "\n(Correlation details: <" + correlationString + ">)";
+    }
+
+    public static String buildExceptionMessage(String baseMessage, String deviceId, String protocol, String hostname, String moduleId)
+    {
+        Collection<String> deviceIds = new ArrayList<>();
+        deviceIds.add(deviceId);
+
+        Collection<String> moduleIds = new ArrayList<>();
+        if (moduleId != null && !moduleId.isEmpty())
+        {
+            moduleIds.add(moduleId);
+        }
+
+        return buildExceptionMessage(baseMessage, deviceIds, protocol, hostname, moduleIds);
+    }
+
+    public static String buildExceptionMessage(String baseMessage, InternalClient client)
+    {
+        if (client == null || client.getConfig() == null)
+        {
+            throw new IllegalArgumentException("client and config must not be null");
+        }
+
+        return buildExceptionMessage(
+                baseMessage,
+                client.getConfig().getDeviceId(),
+                client.getConfig().getProtocol().toString(),
+                client.getConfig().getIotHubHostname(),
+                client.getConfig().getModuleId());
+    }
+
+    public static String buildExceptionMessage(String baseMessage, Collection<InternalClient> clients)
+    {
+        String hostname = "";
+        String protocol = "";
+        Collection<String> deviceIds = new ArrayList<>();
+        Collection<String> moduleIds = new ArrayList<>();
+
+        for (InternalClient client : clients)
+        {
+            hostname = client.getConfig().getIotHubHostname();
+            protocol = client.getConfig().getProtocol().toString();
+            deviceIds.add(client.getConfig().getDeviceId());
+
+            if (client.getConfig().getModuleId() != null && !client.getConfig().getModuleId().isEmpty())
+            {
+                moduleIds.add(client.getConfig().getModuleId());
+            }
+        }
+
+        return buildExceptionMessage(
+                baseMessage,
+                deviceIds,
+                protocol,
+                hostname,
+                moduleIds);
+    }
+
+    public void assertTrue(String message, boolean condition)
+    {
+        if (!condition)
+        {
+            fail(message);
+        }
+    }
+
+    public void assertTrue(boolean condition)
+    {
+        assertTrue(null, condition);
+    }
+
+    public void assertFalse(String message, boolean condition)
+    {
+        assertTrue(message, !condition);
+    }
+
+    public void assertFalse(boolean condition)
+    {
+        assertFalse(null, condition);
+    }
+
+    public void fail(String message)
+    {
+        if (message == null)
+        {
+            throw new AssertionError(buildExceptionMessage("", this.deviceIds, this.protocol, this.hostname, this.moduleIds));
+        }
+
+        throw new AssertionError(buildExceptionMessage(message, this.deviceIds, this.protocol, this.hostname, this.moduleIds));
+    }
+
+    public void fail()
+    {
+        fail(null);
+    }
+
+    public void assertEquals(String message, Object expected, Object actual)
+    {
+        if (equalsRegardingNull(expected, actual))
+        {
+            return;
+        }
+        else if (expected instanceof String && actual instanceof String)
+        {
+            String cleanMessage = message == null ? "" : message;
+            throw new ComparisonFailure(cleanMessage, (String) expected, (String) actual);
+        }
+        else
+        {
+            failNotEquals(message, expected, actual);
+        }
+    }
+
+    public void assertEquals(Object expected, Object actual)
+    {
+        assertEquals(null, expected, actual);
+    }
+
+    private boolean equalsRegardingNull(Object expected, Object actual)
+    {
+        if (expected == null)
+        {
+            return actual == null;
+        }
+
+        return isEquals(expected, actual);
+    }
+
+    private void failNotEquals(String message, Object expected, Object actual)
+    {
+        fail(format(message, expected, actual));
+    }
+
+    String format(String message, Object expected, Object actual)
+    {
+        String formatted = "";
+        if (message != null && !message.equals(""))
+        {
+            formatted = message + " ";
+        }
+        String expectedString = String.valueOf(expected);
+        String actualString = String.valueOf(actual);
+        if (expectedString.equals(actualString))
+        {
+            return formatted + "expected: " + formatClassAndValue(expected, expectedString) + " but was: " + formatClassAndValue(actual, actualString);
+        }
+        else
+        {
+            return formatted + "expected:<" + expectedString + "> but was:<" + actualString + ">";
+        }
+    }
+
+    private String formatClassAndValue(Object value, String valueString)
+    {
+        String className = value == null ? "null" : value.getClass().getName();
+        return className + "<" + valueString + ">";
+    }
+
+    private boolean isEquals(Object expected, Object actual)
+    {
+        return expected.equals(actual);
+    }
+}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
@@ -12,10 +12,10 @@ import org.junit.Assert;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 
 /*
  * This class contains common code for Junit and Android test cases
@@ -43,7 +43,7 @@ public class IotHubServicesCommon
             openClientWithRetry(client);
             if (statusUpdates != null)
             {
-                confirmOpenStabilized(statusUpdates, 120000);
+                confirmOpenStabilized(statusUpdates, 120000, client);
             }
 
             for (int i = 0; i < messagesToSend.size(); ++i)
@@ -68,7 +68,7 @@ public class IotHubServicesCommon
 
                         if (System.currentTimeMillis() - startTime > ERROR_INJECTION_MESSAGE_EFFECT_TIMEOUT)
                         {
-                            fail("Sending message over " + protocol + " protocol failed: Error injection message never caused connection to be lost");
+                            Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: Error injection message never caused connection to be lost", client));
                         }
                     }
                 }
@@ -97,14 +97,15 @@ public class IotHubServicesCommon
         client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeCallback()
         {
             @Override
-            public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext) {
+            public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
+            {
                 actualStatusUpdates.add(status);
             }
         }, new Object());
 
         sendMessages(client, protocol, messagesToSend, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, interMessageDelay, actualStatusUpdates);
 
-        assertTrue(protocol + ", " + authType + ": Expected connection status update to occur: " + expectedStatus, actualStatusUpdates.contains(expectedStatus));
+        Assert.assertTrue(buildExceptionMessage(protocol + ", " + authType + ": Expected connection status update to occur: " + expectedStatus, client), actualStatusUpdates.contains(expectedStatus));
     }
 
     /**
@@ -140,20 +141,20 @@ public class IotHubServicesCommon
                     Thread.sleep(retryMilliseconds);
                     if (System.currentTimeMillis() - startTime > timeoutMilliseconds)
                     {
-                        fail(protocol + ", " + authType + ": Sending message over " + protocol + " protocol failed: " +
+                        Assert.fail(buildExceptionMessage(protocol + ", " + authType + ": Sending message over " + protocol + " protocol failed: " +
                                 "never received connection status update for SAS_TOKEN_EXPIRED " +
-                                "or never received UNAUTHORIZED message callback");
+                                "or never received UNAUTHORIZED message callback", client));
                     }
                 }
 
                 if (messageSent.getCallbackStatusCode() != IotHubStatusCode.UNAUTHORIZED)
                 {
-                    fail(protocol + ", " + authType + ": Send messages expecting sas token expiration failed: expected UNAUTHORIZED message callback, but got " + messageSent.getCallbackStatusCode());
+                    Assert.fail(buildExceptionMessage(protocol + ", " + authType + ": Send messages expecting sas token expiration failed: expected UNAUTHORIZED message callback, but got " + messageSent.getCallbackStatusCode(), client));
                 }
             }
             catch (Exception e)
             {
-                Assert.fail(protocol + ", " + authType + ": Sending message over " + protocol + " protocol failed");
+                Assert.fail(buildExceptionMessage(protocol + ", " + authType + ": Sending message over " + protocol + " protocol failed", client));
             }
         }
     }
@@ -161,7 +162,7 @@ public class IotHubServicesCommon
     /*
      * method to send message over given DeviceClient
      */
-    public static void sendMessagesMultiplex(DeviceClient client,
+    public static void sendMessagesMultiplex(InternalClient client,
                                              IotHubClientProtocol protocol,
                                              final int NUM_MESSAGES_PER_CONNECTION,
                                              final long RETRY_MILLISECONDS,
@@ -184,18 +185,18 @@ public class IotHubServicesCommon
                     Thread.sleep(RETRY_MILLISECONDS);
                     if (System.currentTimeMillis() - startTime > SEND_TIMEOUT_MILLISECONDS)
                     {
-                        fail("Timed out waiting for message callback");
+                        Assert.fail(buildExceptionMessage("Timed out waiting for message callback", client));
                     }
                 }
 
                 if (messageSent.getCallbackStatusCode() != IotHubStatusCode.OK_EMPTY)
                 {
-                    Assert.fail("Sending message over " + protocol + " protocol failed: expected status code OK_EMPTY but received: " + messageSent.getCallbackStatusCode());
+                    Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: expected status code OK_EMPTY but received: " + messageSent.getCallbackStatusCode(), client));
                 }
             }
             catch (Exception e)
             {
-                Assert.fail("Sending message over " + protocol + " protocol failed: Exception encountered while sending messages: " + e.getMessage());
+                Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: Exception encountered while sending messages: " + e.getMessage(), client));
             }
         }
     }
@@ -221,7 +222,7 @@ public class IotHubServicesCommon
                 Thread.sleep(RETRY_MILLISECONDS);
                 if (System.currentTimeMillis() - startTime > SEND_TIMEOUT_MILLISECONDS)
                 {
-                    fail(protocol + ", " + authType + ": Timed out waiting for a message callback");
+                    Assert.fail(buildExceptionMessage(protocol + ", " + authType + ": Timed out waiting for a message callback", client));
                 }
             }
 
@@ -229,13 +230,13 @@ public class IotHubServicesCommon
 
             if (messageSentExpiredCallback.getCallbackStatusCode() != IotHubStatusCode.MESSAGE_EXPIRED)
             {
-                Assert.fail("Sending message over " + protocol + " protocol failed: expected status code MESSAGE_EXPIRED but received: " + messageSentExpiredCallback.getCallbackStatusCode());
+                Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: expected status code MESSAGE_EXPIRED but received: " + messageSentExpiredCallback.getCallbackStatusCode(), client));
             }
         }
         catch (Exception e)
         {
             client.closeNow();
-            Assert.fail("Sending expired message over " + protocol + " protocol failed: Exception encountered while sending message and waiting for MESSAGE_EXPIRED callback: " + e.getMessage());
+            Assert.fail(buildExceptionMessage("Sending expired message over " + protocol + " protocol failed: Exception encountered while sending message and waiting for MESSAGE_EXPIRED callback: " + e.getMessage(), client));
         }
     }
 
@@ -268,8 +269,8 @@ public class IotHubServicesCommon
             }
         }
 
-        assertTrue(protocol + ", " + authType + ": Expected notification about disconnected but retrying.", statusUpdates.contains(IotHubConnectionStatus.DISCONNECTED_RETRYING));
-        assertTrue(protocol + ", " + authType + ": Expected notification about disconnected.", statusUpdates.contains(IotHubConnectionStatus.DISCONNECTED));
+        Assert.assertTrue(buildExceptionMessage(protocol + ", " + authType + ": Expected notification about disconnected but retrying.", client), statusUpdates.contains(IotHubConnectionStatus.DISCONNECTED_RETRYING));
+        Assert.assertTrue(buildExceptionMessage(protocol + ", " + authType + ": Expected notification about disconnected.", client), statusUpdates.contains(IotHubConnectionStatus.DISCONNECTED));
 
         client.closeNow();
     }
@@ -288,19 +289,19 @@ public class IotHubServicesCommon
                 Thread.sleep(RETRY_MILLISECONDS);
                 if (System.currentTimeMillis() - startTime > SEND_TIMEOUT_MILLISECONDS)
                 {
-                    fail("Timed out waiting for a message callback");
+                    Assert.fail(buildExceptionMessage("Timed out waiting for a message callback", client));
                     break;
                 }
             }
 
             if (messageAndResult.statusCode != null && messageSent.getCallbackStatusCode() != messageAndResult.statusCode)
             {
-                Assert.fail("Sending message over " + protocol + " protocol failed: expected " + messageAndResult.statusCode + " but received " + messageSent.getCallbackStatusCode());
+                Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: expected " + messageAndResult.statusCode + " but received " + messageSent.getCallbackStatusCode(), client));
             }
         }
         catch (Exception e)
         {
-            Assert.fail("Sending message over " + protocol + " protocol failed: Exception encountered while sending and waiting on a message: " + e.getMessage());
+            Assert.fail(buildExceptionMessage("Sending message over " + protocol + " protocol failed: Exception encountered while sending and waiting on a message: " + e.getMessage(), client));
         }
     }
 
@@ -320,7 +321,6 @@ public class IotHubServicesCommon
 
     public static void openClientWithRetry(InternalClient client) throws InterruptedException
     {
-
         //Check again
         int count =0;
         boolean clientOpenSucceeded = false;
@@ -329,7 +329,7 @@ public class IotHubServicesCommon
         {
             if (System.currentTimeMillis() - startTime > OPEN_RETRY_TIMEOUT)
             {
-                Assert.fail("Timed out trying to open the client " + count);
+                Assert.fail(buildExceptionMessage("Timed out trying to open the client " + count, client));
             }
 
             try
@@ -350,7 +350,7 @@ public class IotHubServicesCommon
         System.out.println("Successfully opened connection!");
     }
 
-    public static void openTransportClientWithRetry(TransportClient client) throws InterruptedException
+    public static void openTransportClientWithRetry(TransportClient client, Collection<InternalClient> clients) throws InterruptedException
     {
         boolean clientOpenSucceeded = false;
         long startTime = System.currentTimeMillis();
@@ -358,7 +358,7 @@ public class IotHubServicesCommon
         {
             if (System.currentTimeMillis() - startTime > OPEN_RETRY_TIMEOUT)
             {
-                Assert.fail("Timed out trying to open the transport client");
+                Assert.fail(CorrelationDetailsLoggingAssert.buildExceptionMessage("Timed out trying to open the transport client", clients));
             }
 
             try
@@ -388,7 +388,7 @@ public class IotHubServicesCommon
         System.out.println("Successfully opened connection!");
     }
 
-    public static void waitForStabilizedConnection(List actualStatusUpdates, long timeout) throws InterruptedException
+    public static void waitForStabilizedConnection(List actualStatusUpdates, long timeout, InternalClient client) throws InterruptedException
     {
         System.out.println("Waiting for stabilized connection...");
 
@@ -404,7 +404,7 @@ public class IotHubServicesCommon
             // 2 minutes timeout waiting for error injection to occur
             if (timeElapsed > timeout)
             {
-                fail("Timed out waiting for error injection message to take effect");
+                Assert.fail(buildExceptionMessage("Timed out waiting for error injection message to take effect", client));
             }
         }
 
@@ -418,7 +418,7 @@ public class IotHubServicesCommon
             // 2 minutes timeout waiting for first connection to occur
             if (timeElapsed > 20000)
             {
-                fail("Timed out waiting for a first connection success");
+                Assert.fail(buildExceptionMessage("Timed out waiting for a first connection success", client));
             }
         }
 
@@ -432,7 +432,7 @@ public class IotHubServicesCommon
             // 2 minutes timeout waiting for connection to stabilized
             if (timeElapsed > timeout)
             {
-                fail("Timed out waiting for a stable connection after error injection");
+                Assert.fail(buildExceptionMessage("Timed out waiting for a stable connection after error injection", client));
             }
         }
 
@@ -442,7 +442,7 @@ public class IotHubServicesCommon
         }
     }
 
-    public static void confirmOpenStabilized(List actualStatusUpdates, long timeout) throws InterruptedException
+    public static void confirmOpenStabilized(List actualStatusUpdates, long timeout, InternalClient client) throws InterruptedException
     {
         long startTime = System.currentTimeMillis();
         long timeElapsed;
@@ -458,7 +458,7 @@ public class IotHubServicesCommon
 
                 if (timeElapsed > timeout)
                 {
-                    fail("Timed out waiting for a stable connection on first open");
+                    Assert.fail(buildExceptionMessage("Timed out waiting for a stable connection on first open", client));
                 }
             }
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Rerun.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Rerun.java
@@ -37,7 +37,7 @@ public class Rerun implements TestRule
                         return;
                     } catch (Throwable t) {
                         lastThrowable = t;
-                        System.err.println(description.getDisplayName() + ": Failed run " + (i+1));
+                        System.err.println(description.getDisplayName() + ": Failed run " + (i+1) + " with throwable " + Tools.getStackTraceFromThrowable(t));
                     }
                 }
                 System.err.println(description.getDisplayName() + ": Test failed after " + count + " failures");

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -40,7 +41,6 @@ public class Tools
     {
         return possibleExceptionCause.isInstance(exceptionToSearch) || (exceptionToSearch != null && isCause(possibleExceptionCause, exceptionToSearch.getCause()));
     }
-
 
     /**
      * Uses the provided registry manager to delete all the devices and modules specified in the arguments
@@ -77,5 +77,10 @@ public class Tools
                 e.printStackTrace();
             }
         }
+    }
+
+    public static String getStackTraceFromThrowable(Throwable throwable)
+    {
+        return ExceptionUtils.getStackTrace(throwable);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -142,7 +142,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                     else if (clientType == ClientType.MODULE_CLIENT)
                     {
                         //x509 module client
-                        ModuleClient moduleClientX509 = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), protocol, publicKeyCert, false, privateKey, false);
+                        ModuleClient moduleClientX509 = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager moduleClientX509TestManager = new DeviceTestManager(moduleClientX509);
                         deviceTestManagers.add(moduleClientX509TestManager);
                         inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, ClientType.MODULE_CLIENT, moduleX509, publicKeyCert, privateKey, x509Thumbprint));

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -123,7 +123,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                 else if (clientType == ClientType.MODULE_CLIENT)
                 {
                     //sas module client
-                    ModuleClient moduleClient = new ModuleClient(registryManager.getDeviceConnectionString(device) + ";ModuleId=" + module.getId(), protocol);
+                    ModuleClient moduleClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), protocol);
                     DeviceTestManager moduleClientSasTestManager = new DeviceTestManager(moduleClient);
                     deviceTestManagers.add(moduleClientSasTestManager);
                     inputs.add(makeSubArray(moduleClientSasTestManager, protocol, SAS, ClientType.MODULE_CLIENT, module, publicKeyCert, privateKey, x509Thumbprint));
@@ -142,7 +142,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                     else if (clientType == ClientType.MODULE_CLIENT)
                     {
                         //x509 module client
-                        ModuleClient moduleClientX509 = new ModuleClient(registryManager.getDeviceConnectionString(deviceX509) + ";ModuleId=" + moduleX509.getId(), protocol, publicKeyCert, false, privateKey, false);
+                        ModuleClient moduleClientX509 = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager moduleClientX509TestManager = new DeviceTestManager(moduleClientX509);
                         deviceTestManagers.add(moduleClientX509TestManager);
                         inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, ClientType.MODULE_CLIENT, moduleX509, publicKeyCert, privateKey, x509Thumbprint));
@@ -405,6 +405,6 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
 
     protected String getModuleConnectionString(Module module) throws IotHubException, IOException
     {
-        return registryManager.getDeviceConnectionString(registryManager.getDevice(module.getDeviceId())) + ";ModuleId=" + module.getId();
+        return DeviceConnectionString.get(iotHubConnectionString, registryManager.getDevice(module.getDeviceId()), module);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.common.setup;
 
 import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -63,7 +64,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
     //How many milliseconds between retry
     protected static final Integer RETRY_MILLISECONDS = 100;
 
-    private List<IotHubConnectionStatus> actualStatusUpdates;
+    private List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates;
 
     protected DeviceMethodTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT = 1 * 60 * 1000; // 1 minute
@@ -228,7 +229,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
     @Before
     public void cleanToStart()
     {
-        actualStatusUpdates = new ArrayList<>();
+        actualStatusUpdates = new ArrayList<Pair<IotHubConnectionStatus, Throwable>>();
         setConnectionStatusCallBack(actualStatusUpdates);
 
         try
@@ -362,14 +363,15 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         registryManager.close();
     }
 
-    protected void setConnectionStatusCallBack(final List actualStatusUpdates)
+    protected void setConnectionStatusCallBack(final List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
     {
 
         IotHubConnectionStatusChangeCallback connectionStatusUpdateCallback = new IotHubConnectionStatusChangeCallback()
         {
             @Override
-            public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext) {
-                actualStatusUpdates.add(status);
+            public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
+            {
+                actualStatusUpdates.add(new Pair<>(status, throwable));
             }
         };
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -118,7 +118,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                     DeviceClient deviceClient = new DeviceClient(registryManager.getDeviceConnectionString(device), protocol);
                     DeviceTestManager deviceClientSasTestManager = new DeviceTestManager(deviceClient);
                     deviceTestManagers.add(deviceClientSasTestManager);
-                    inputs.add(makeSubArray(deviceClientSasTestManager, protocol, SAS, "DeviceClient", device, publicKeyCert, privateKey, x509Thumbprint));
+                    inputs.add(makeSubArray(deviceClientSasTestManager, protocol, SAS, ClientType.DEVICE_CLIENT, device, publicKeyCert, privateKey, x509Thumbprint));
                 }
                 else if (clientType == ClientType.MODULE_CLIENT)
                 {
@@ -126,7 +126,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                     ModuleClient moduleClient = new ModuleClient(registryManager.getDeviceConnectionString(device) + ";ModuleId=" + module.getId(), protocol);
                     DeviceTestManager moduleClientSasTestManager = new DeviceTestManager(moduleClient);
                     deviceTestManagers.add(moduleClientSasTestManager);
-                    inputs.add(makeSubArray(moduleClientSasTestManager, protocol, SAS, "ModuleClient", module, publicKeyCert, privateKey, x509Thumbprint));
+                    inputs.add(makeSubArray(moduleClientSasTestManager, protocol, SAS, ClientType.MODULE_CLIENT, module, publicKeyCert, privateKey, x509Thumbprint));
                 }
 
                 if (protocol != MQTT_WS && protocol != AMQPS_WS)
@@ -137,7 +137,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                         DeviceClient deviceClientX509 = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager deviceClientX509TestManager = new DeviceTestManager(deviceClientX509);
                         deviceTestManagers.add(deviceClientX509TestManager);
-                        inputs.add(makeSubArray(deviceClientX509TestManager, protocol, SELF_SIGNED, "DeviceClient", deviceX509, publicKeyCert, privateKey, x509Thumbprint));
+                        inputs.add(makeSubArray(deviceClientX509TestManager, protocol, SELF_SIGNED, ClientType.DEVICE_CLIENT, deviceX509, publicKeyCert, privateKey, x509Thumbprint));
                     }
                     else if (clientType == ClientType.MODULE_CLIENT)
                     {
@@ -145,7 +145,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
                         ModuleClient moduleClientX509 = new ModuleClient(registryManager.getDeviceConnectionString(deviceX509) + ";ModuleId=" + moduleX509.getId(), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager moduleClientX509TestManager = new DeviceTestManager(moduleClientX509);
                         deviceTestManagers.add(moduleClientX509TestManager);
-                        inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, "ModuleClient", moduleX509, publicKeyCert, privateKey, x509Thumbprint));
+                        inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, ClientType.MODULE_CLIENT, moduleX509, publicKeyCert, privateKey, x509Thumbprint));
                     }
                 }
             }
@@ -154,7 +154,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         return inputs;
     }
 
-    private static Object[] makeSubArray(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    private static Object[] makeSubArray(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         Object[] inputSubArray = new Object[8];
         inputSubArray[0] = deviceTestManager;
@@ -168,7 +168,7 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         return inputSubArray;
     }
 
-    protected DeviceMethodCommon(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    protected DeviceMethodCommon(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new DeviceMethodTestInstance(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -178,13 +178,13 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         public DeviceTestManager deviceTestManager;
         public IotHubClientProtocol protocol;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public BaseDevice identity;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
 
-        protected DeviceMethodTestInstance(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+        protected DeviceMethodTestInstance(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.deviceTestManager = deviceTestManager;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
@@ -248,12 +249,12 @@ public class DeviceMethodCommon extends MethodNameLoggingIntegrationTest
         try
         {
             this.testInstance.deviceTestManager.start();
-            IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000);
+            IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
         }
         catch (IOException | InterruptedException e)
         {
             e.printStackTrace();
-            fail(e.getMessage());
+            fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + e.getMessage(), this.testInstance.deviceTestManager.client));
         }
         catch (UnsupportedOperationException e)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -29,6 +29,7 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
@@ -78,12 +79,12 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
 
     // States of SDK
     protected static RegistryManager registryManager;
-    protected static InternalClient internalClient;
+    protected InternalClient internalClient;
     protected static RawTwinQuery scRawTwinQueryClient;
     protected static DeviceTwin sCDeviceTwin;
-    protected static DeviceState deviceUnderTest = null;
+    protected DeviceState deviceUnderTest = null;
 
-    protected static DeviceState[] devicesUnderTest;
+    protected DeviceState[] devicesUnderTest;
 
     protected DeviceTwinTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT = 1 * 60 * 1000; // 1 minute
@@ -299,7 +300,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         }
     }
 
-    protected static void tearDownTwin(DeviceState deviceState) throws IOException
+    protected void tearDownTwin(DeviceState deviceState) throws IOException
     {
         // tear down twin on device client
         if (deviceState.sCDeviceForTwin != null)
@@ -457,7 +458,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         catch (InterruptedException e)
         {
             e.printStackTrace();
-            fail("Unexpected exception encountered");
+            fail(buildExceptionMessage("Unexpected exception encountered", internalClient));
         }
     }
 
@@ -477,7 +478,6 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
 
         registryManager = null;
         sCDeviceTwin = null;
-        internalClient = null;
     }
 
     protected void readReportedPropertiesAndVerify(DeviceState deviceState, String startsWithKey, String startsWithValue, int expectedReportedPropCount) throws IOException, IotHubException, InterruptedException
@@ -509,7 +509,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 }
             }
         }
-        assertEquals(expectedReportedPropCount, actualCount);
+        assertEquals(buildExceptionMessage("Expected " + expectedReportedPropCount + " but had " + actualCount, internalClient), expectedReportedPropCount, actualCount);
     }
 
     protected void waitAndVerifyTwinStatusBecomesSuccess() throws InterruptedException
@@ -526,7 +526,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 break;
             }
         }
-        assertEquals(STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but was " + deviceUnderTest.deviceTwinStatus, internalClient), STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
     }
 
     protected void sendReportedPropertiesAndVerify(int numOfProp) throws IOException, IotHubException, InterruptedException
@@ -559,11 +559,11 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                     break;
                 }
             }
-            assertTrue("Callback was not triggered for one or more properties", propertyState.callBackTriggered);
-            assertTrue(((String) propertyState.propertyNewValue).startsWith(propPrefix));
+            assertTrue(buildExceptionMessage("Callback was not triggered for one or more properties", internalClient), propertyState.callBackTriggered);
+            assertTrue(buildExceptionMessage("Missing the expected prefix, was " + propertyState.propertyNewValue, internalClient), ((String) propertyState.propertyNewValue).startsWith(propPrefix));
             if (withVersion)
             {
-                assertNotEquals("Version was not set in the callback", (int) propertyState.propertyNewVersion, -1);
+                assertNotEquals(buildExceptionMessage("Version was not set in the callback", internalClient), (int) propertyState.propertyNewVersion, -1);
             }
         }
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -583,6 +583,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
     protected void subscribeToDesiredPropertiesAndVerify(int numOfProp) throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.sCDeviceForTwin.clearDesiredProperties();
         deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < numOfProp; i++)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -345,14 +345,14 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token, device client
-                                    {deviceIdAmqps, null, AMQPS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, null, MQTT, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqps, null, AMQPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqtt, null, MQTT, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509, device client
-                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
                             }
             );
         }
@@ -362,10 +362,10 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token, module client
-                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -247,7 +247,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 }
                 else
                 {
-                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId + this.testInstance.uuid,
+                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager, deviceState.sCModuleForRegistryManager),
                             this.testInstance.protocol);
                 }
             }
@@ -264,7 +264,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 }
                 else
                 {
-                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId,
+                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager, deviceState.sCModuleForRegistryManager),
                             this.testInstance.protocol,
                             testInstance.publicKeyCert,
                             false,

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -597,14 +597,14 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    protected void setConnectionStatusCallBack(final List actualStatusUpdates)
+    protected void setConnectionStatusCallBack(final List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
     {
         IotHubConnectionStatusChangeCallback connectionStatusUpdateCallback = new IotHubConnectionStatusChangeCallback()
         {
             @Override
             public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
             {
-                actualStatusUpdates.add(status);
+                actualStatusUpdates.add(new com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<>(status, throwable));
             }
         };
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -373,7 +373,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         return inputs;
     }
 
-    public DeviceTwinCommon(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceTwinCommon(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new DeviceTwinTestInstance(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -389,7 +389,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         public String x509Thumbprint;
         public String uuid;
 
-        public DeviceTwinTestInstance(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public DeviceTwinTestInstance(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.deviceId = deviceId;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -155,7 +155,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
 
     public class DeviceExtension extends Device
     {
-        public List<PropertyState> propertyStateList = new LinkedList<>();
+        public PropertyState[] propertyStateList = new PropertyState[MAX_PROPERTIES_TO_TEST];
 
         @Override
         public void PropertyCall(String propertyKey, Object propertyValue, Object context)
@@ -311,6 +311,11 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         if (deviceState.dCDeviceForTwin != null)
         {
             deviceState.dCDeviceForTwin.clean();
+
+            if (deviceState.dCDeviceForTwin.getDesiredProp() != null)
+            {
+                deviceState.dCDeviceForTwin.getDesiredProp().clear();
+            }
         }
         if (internalClient != null)
         {
@@ -583,7 +588,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
             PropertyState propertyState = new PropertyState();
             propertyState.callBackTriggered = false;
             propertyState.property = new Property(PROPERTY_KEY + i, PROPERTY_VALUE);
-            deviceUnderTest.dCDeviceForTwin.propertyStateList.add(propertyState);
+            deviceUnderTest.dCDeviceForTwin.propertyStateList[i] = propertyState;
             deviceUnderTest.dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, deviceUnderTest.dCDeviceForTwin, propertyState);
         }
 
@@ -626,7 +631,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         {
             PropertyState propertyState = new PropertyState();
             propertyState.property = new Property(PROPERTY_KEY + i, PROPERTY_VALUE);
-            deviceUnderTest.dCDeviceForTwin.propertyStateList.add(propertyState);
+            deviceUnderTest.dCDeviceForTwin.propertyStateList[i] = propertyState;
             desiredPropertiesCB.put(propertyState.property, new com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<TwinPropertyCallBack, Object>(deviceUnderTest.dCOnProperty, propertyState));
         }
         internalClient.subscribeToTwinDesiredProperties(desiredPropertiesCB);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -583,6 +583,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
     protected void subscribeToDesiredPropertiesAndVerify(int numOfProp) throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < numOfProp; i++)
         {
             PropertyState propertyState = new PropertyState();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -20,6 +20,7 @@ import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.devicetwin.RawTwinQuery;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.exceptions.IotHubNotFoundException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -246,7 +247,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 }
                 else
                 {
-                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId,
+                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId + this.testInstance.uuid,
                             this.testInstance.protocol);
                 }
             }
@@ -324,18 +325,18 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         scRawTwinQueryClient = RawTwinQuery.createFromConnectionString(iotHubConnectionString);
 
-        String uuid = UUID.randomUUID().toString();
-        String deviceIdAmqps = "java-device-client-e2e-test-amqps".concat("-" + uuid);
-        String deviceIdAmqpsWs = "java-device-client-e2e-test-amqpsws".concat("-" + uuid);
-        String deviceIdMqtt = "java-device-client-e2e-test-mqtt".concat("-" + uuid);
-        String deviceIdMqttWs = "java-device-client-e2e-test-mqttws".concat("-" + uuid);
-        String deviceIdMqttX509 = "java-device-client-e2e-test-mqtt-X509".concat("-" + uuid);
-        String deviceIdAmqpsX509 = "java-device-client-e2e-test-amqps-X509".concat("-" + uuid);
+        //base names for devices and modules. Each test creates a device/module with this as the prefix, and a unique uuid as the suffix
+        String deviceIdAmqps = "java-device-client-e2e-test-amqps-";
+        String deviceIdAmqpsWs = "java-device-client-e2e-test-amqpsws-";
+        String deviceIdMqtt = "java-device-client-e2e-test-mqtt-";
+        String deviceIdMqttWs = "java-device-client-e2e-test-mqttws-";
+        String deviceIdMqttX509 = "java-device-client-e2e-test-mqtt-X509-";
+        String deviceIdAmqpsX509 = "java-device-client-e2e-test-amqps-X509-";
 
-        String moduleIdAmqps = "java-device-client-e2e-test-amqps-module".concat("-" + uuid);
-        String moduleIdAmqpsWs = "java-device-client-e2e-test-amqpsws-module".concat("-" + uuid);
-        String moduleIdMqtt = "java-device-client-e2e-test-mqtt-module".concat("-" + uuid);
-        String moduleIdMqttWs = "java-device-client-e2e-test-mqttws-module".concat("-" + uuid);
+        String moduleIdAmqps = "java-device-client-e2e-test-amqps-module-";
+        String moduleIdAmqpsWs = "java-device-client-e2e-test-amqpsws-module-";
+        String moduleIdMqtt = "java-device-client-e2e-test-mqtt-module-";
+        String moduleIdMqttWs = "java-device-client-e2e-test-mqttws-module-";
 
         List inputs;
         if (clientType == ClientType.DEVICE_CLIENT)
@@ -386,6 +387,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
+        public String uuid;
 
         public DeviceTwinTestInstance(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
@@ -419,27 +421,32 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
     public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
     {
         deviceUnderTest = new DeviceState();
+        this.testInstance.uuid = UUID.randomUUID().toString();
+
         if (this.testInstance.authenticationType == SAS)
         {
-            deviceUnderTest.sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(this.testInstance.deviceId, null, null);
+            deviceUnderTest.sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(this.testInstance.deviceId + this.testInstance.uuid, null, null);
 
             if (this.testInstance.moduleId != null)
             {
-                deviceUnderTest.sCModuleForRegistryManager = com.microsoft.azure.sdk.iot.service.Module.createFromId(this.testInstance.deviceId, this.testInstance.moduleId, null);
+                deviceUnderTest.sCModuleForRegistryManager = com.microsoft.azure.sdk.iot.service.Module.createFromId(this.testInstance.deviceId + this.testInstance.uuid, this.testInstance.moduleId + this.testInstance.uuid, null);
             }
         }
         else if (this.testInstance.authenticationType == SELF_SIGNED)
         {
-            deviceUnderTest.sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createDevice(this.testInstance.deviceId, SELF_SIGNED);
+            deviceUnderTest.sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createDevice(this.testInstance.deviceId + this.testInstance.uuid, SELF_SIGNED);
             deviceUnderTest.sCDeviceForRegistryManager.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
         }
+
+
         deviceUnderTest.sCDeviceForRegistryManager = registryManager.addDevice(deviceUnderTest.sCDeviceForRegistryManager);
-        Thread.sleep(2000);
 
         if (deviceUnderTest.sCModuleForRegistryManager != null)
         {
             registryManager.addModule(deviceUnderTest.sCModuleForRegistryManager);
         }
+
+        Thread.sleep(2000);
 
         setUpTwin(deviceUnderTest);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -560,9 +560,10 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         long startTime = System.currentTimeMillis();
         long timeElapsed = 0;
 
-        for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
+        for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
-            while (!propertyState.callBackTriggered || !((String) propertyState.propertyNewValue).startsWith(propPrefix))
+            PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];
+            while (!propertyState.callBackTriggered || propertyState.propertyNewValue == null || !((String) propertyState.propertyNewValue).startsWith(propPrefix))
             {
                 Thread.sleep(PERIODIC_WAIT_TIME_FOR_VERIFICATION);
                 timeElapsed = System.currentTimeMillis() - startTime;
@@ -585,6 +586,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         // arrange
         deviceUnderTest.sCDeviceForTwin.clearDesiredProperties();
         deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
+        deviceUnderTest.dCDeviceForTwin.propertyStateList = new PropertyState[numOfProp];
         for (int i = 0; i < numOfProp; i++)
         {
             PropertyState propertyState = new PropertyState();
@@ -648,8 +650,9 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
         Thread.sleep(DELAY_BETWEEN_OPERATIONS);
 
-        for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
+        for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
+            PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];
             propertyState.callBackTriggered = false;
             propertyState.propertyNewVersion = -1;
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -68,7 +68,7 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
 
     public ReceiveMessagesTestInstance testInstance;
 
-    public ReceiveMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new ReceiveMessagesTestInstance(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -154,16 +154,16 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }
@@ -173,14 +173,14 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}                           }
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}                           }
             );
         }
 
@@ -193,12 +193,12 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
         public IotHubClientProtocol protocol;
         public BaseDevice identity;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
 
-        public ReceiveMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public ReceiveMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.client = client;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
@@ -342,18 +343,18 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
 
                 if (System.currentTimeMillis() - startTime > RECEIVE_TIMEOUT)
                 {
-                    fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Timed out waiting to receive message");
+                    Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Timed out waiting to receive message", testInstance.client));
                 }
             }
 
             if (!messageReceived.getResult())
             {
-                Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Received message was missing expected properties");
+                Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Received message was missing expected properties", testInstance.client));
             }
         }
         catch (InterruptedException e)
         {
-            Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Unexpected interrupted exception occurred");
+            Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Unexpected interrupted exception occurred", testInstance.client));
         }
     }
 
@@ -372,13 +373,13 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
 
                 if (System.currentTimeMillis() - startTime > RECEIVE_TIMEOUT)
                 {
-                    Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving messages timed out.");
+                    Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving messages timed out.", testInstance.client));
                 }
             }
         }
         catch (InterruptedException e)
         {
-            Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message failed. Unexpected interrupted exception occurred.");
+            Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message failed. Unexpected interrupted exception occurred.", testInstance.client));
         }
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -369,8 +369,6 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
             {
                 Thread.sleep(100);
 
-                System.out.println(messageIdListStoredOnReceive.size());
-
                 if (System.currentTimeMillis() - startTime > RECEIVE_TIMEOUT)
                 {
                     Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving messages timed out.", testInstance.client));

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -87,7 +87,7 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
 
     protected static RegistryManager registryManager;
 
-    public SendMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new SendMessagesTestInstance(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -144,16 +144,16 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }
@@ -163,14 +163,14 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                     }
             );
         }
@@ -186,13 +186,13 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
         public IotHubClientProtocol protocol;
         public BaseDevice identity;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
         public CorrelationDetailsLoggingAssert correlationDetailsLoggingAssert;
 
-        public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.client = client;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -51,6 +51,7 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
     protected static final Integer RETRY_MILLISECONDS = 100;
 
     protected static final long DEFAULT_TEST_TIMEOUT = 1 * 60 * 1000;
+    protected static final long ERROR_INJECTION_EXECUTION_TIMEOUT = 2 * 60 * 1000; // 2 minutes
     protected static String iotHubConnectionString = "";
     protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -189,6 +189,7 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
+        public CorrelationDetailsLoggingAssert correlationDetailsLoggingAssert;
 
         public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
@@ -200,6 +201,20 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
             this.publicKeyCert = publicKeyCert;
             this.privateKey = privateKey;
             this.x509Thumbprint = x509Thumbprint;
+
+            String deviceId = "";
+            String moduleId = "";
+            if (identity instanceof Module)
+            {
+                deviceId = identity.getDeviceId();
+                moduleId = ((Module) identity).getId();
+            }
+            else if (identity instanceof Device)
+            {
+                deviceId = identity.getDeviceId();
+            }
+
+            this.correlationDetailsLoggingAssert = new CorrelationDetailsLoggingAssert(this.client.getConfig().getIotHubHostname(), deviceId, protocol.toString(), moduleId);
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.*;
 public class FileUploadTests extends MethodNameLoggingIntegrationTest
 {
     // Max time to wait to see it on Hub
-    private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 10000; // 10 sec
+    private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 20000; // 20 sec
 
     //Max time to wait before timing out test
     private static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB + 50000; // 50 secs

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests.STATUS.FAILURE;
 import static com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests.STATUS.SUCCESS;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
@@ -204,7 +205,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
     public static void tearDown() throws IotHubException, IOException, InterruptedException
     {
         // flush all the notifications caused by this test suite to avoid failures running on different test suite attempt
-        assertNotNull(fileUploadNotificationReceiver);
+        assertNotNull("file upload notification receiver was not null", fileUploadNotificationReceiver);
         fileUploadNotificationReceiver.open();
         fileUploadNotificationReceiver.receive(MAX_MILLISECS_TIMEOUT_FLUSH_NOTIFICATION);
         fileUploadNotificationReceiver.close();
@@ -239,7 +240,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
     private void verifyNotification(FileUploadNotification fileUploadNotification, FileUploadState fileUploadState) throws IOException
     {
-        assertTrue("File upload notification blob size not equal to expected file length", fileUploadNotification.getBlobSizeInBytes() == fileUploadState.fileLength);
+        assertTrue(buildExceptionMessage("File upload notification blob size not equal to expected file length", deviceClient), fileUploadNotification.getBlobSizeInBytes() == fileUploadState.fileLength);
 
         URL u = new URL(fileUploadNotification.getBlobUri());
         try (InputStream inputStream = u.openStream())
@@ -249,11 +250,11 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
             byte[] actualBuf = new byte[(int)fileUploadState.fileLength];
             fileUploadState.fileInputStream.reset();
             int actualLen = (fileUploadState.fileLength == 0) ? (int) fileUploadState.fileLength : fileUploadState.fileInputStream.read(actualBuf, 0, (int) fileUploadState.fileLength);
-            assertEquals(testLen, actualLen);
-            assertTrue(Arrays.equals(testBuf, actualBuf));
+            assertEquals(buildExceptionMessage("Expected length " + testLen + " but was " + actualLen, deviceClient), testLen, actualLen);
+            assertTrue(buildExceptionMessage("testBuf was different from actualBuf", deviceClient), Arrays.equals(testBuf, actualBuf));
         }
 
-        assertTrue(fileUploadNotification.getBlobName().contains(fileUploadState.blobName));
+        assertTrue(buildExceptionMessage("File upload notification did not contain the expected blob name", deviceClient), fileUploadNotification.getBlobName().contains(fileUploadState.blobName));
         fileUploadState.fileUploadNotificationReceived = SUCCESS;
     }
 
@@ -270,8 +271,8 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         // assert
         verifyNotification(fileUploadNotification, fileUploadState[0]);
-        assertTrue(fileUploadState[0].isCallBackTriggered);
-        assertEquals(fileUploadState[0].fileUploadStatus, SUCCESS);
+        assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[0].isCallBackTriggered);
+        assertEquals(buildExceptionMessage("File upload status expected SUCCESS but was " + fileUploadState[0].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[0].fileUploadStatus);
         tearDownDeviceClient();
     }
 
@@ -286,10 +287,10 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
         FileUploadNotification fileUploadNotification = getFileUploadNotificationForThisDevice(scDevice);
 
         // assert
-        assertNotNull(fileUploadNotification);
+        assertNotNull(buildExceptionMessage("file upload notification was null", deviceClient), fileUploadNotification);
         verifyNotification(fileUploadNotification, fileUploadState[MAX_FILES_TO_UPLOAD - 1]);
-        assertTrue(fileUploadState[MAX_FILES_TO_UPLOAD - 1].isCallBackTriggered);
-        assertEquals(fileUploadState[MAX_FILES_TO_UPLOAD - 1].fileUploadStatus, SUCCESS);
+        assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[MAX_FILES_TO_UPLOAD - 1].isCallBackTriggered);
+        assertEquals(buildExceptionMessage("File upload status should be SUCCESS but was " + fileUploadState[MAX_FILES_TO_UPLOAD - 1].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[MAX_FILES_TO_UPLOAD - 1].fileUploadStatus);
 
         tearDownDeviceClient();
     }
@@ -308,13 +309,14 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -342,7 +344,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -351,8 +353,8 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -363,7 +365,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -391,7 +393,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -410,9 +412,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
 
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -423,7 +425,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -451,7 +453,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -470,9 +472,10 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
 
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -483,7 +486,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -511,7 +514,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -529,9 +532,10 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -542,7 +546,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -570,7 +574,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -588,9 +592,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -601,7 +605,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -629,7 +633,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -647,9 +651,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -660,7 +664,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -688,7 +692,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -706,9 +710,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -719,7 +723,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -747,7 +751,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -766,9 +770,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
 
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -779,7 +783,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -807,7 +811,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("IOException occurred during upload: " + e.getMessage(), deviceClient));
                     }
                 }
             });
@@ -825,9 +829,9 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
             // assert
             verifyNotification(fileUploadNotification, fileUploadState[i]);
-            assertTrue(fileUploadState[i].isCallBackTriggered);
-            assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-            assertEquals(messageStates[i].messageStatus, SUCCESS);
+            assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), fileUploadState[i].isCallBackTriggered);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but file upload status " + i + " was " + fileUploadState[i].fileUploadStatus, deviceClient), SUCCESS, fileUploadState[i].fileUploadStatus);            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but message status " + i + " was " + messageStates[i].messageStatus, deviceClient), SUCCESS, messageStates[i].messageStatus);
         }
 
         executor.shutdown();
@@ -838,7 +842,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            assertEquals(buildExceptionMessage("File" + i + " has no notification", deviceClient), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         tearDownDeviceClient();
@@ -850,7 +854,7 @@ public class FileUploadTests extends MethodNameLoggingIntegrationTest
         do
         {
             fileUploadNotification = fileUploadNotificationReceiver.receive(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
-            assertNotNull(fileUploadNotification);
+            assertNotNull(buildExceptionMessage("file upload notification was null", deviceClient), fileUploadNotification);
 
             //ignore any file upload notifications received that are not about this device
         } while (!fileUploadNotification.getDeviceId().equals(device.getDeviceId()));

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -89,7 +89,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
     private static final Integer MAX_FILES_TO_UPLOAD = 1;
 
-    private static ArrayList<String> clientConnectionStringArrayList = new ArrayList<>();
+    private static String[] clientConnectionStringArrayList = new String[MAX_DEVICE_MULTIPLEX];
 
     private static DeviceMethod methodServiceClient;
 
@@ -98,7 +98,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     private static final String METHOD_NAME = "methodName";
     private static final String METHOD_PAYLOAD = "This is a good payload";
 
-    private static ArrayList<DeviceState> devicesUnderTest = new ArrayList<>();
+    private static DeviceState[] devicesUnderTest = new DeviceState[MAX_DEVICE_MULTIPLEX];
     private static DeviceTwin sCDeviceTwin;
 
     private static final String PROPERTY_KEY = "Key";
@@ -120,7 +120,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
             deviceListAmqps[i] = Device.createFromId(deviceId, null, null);
             registryManager.addDevice(deviceListAmqps[i]);
-            clientConnectionStringArrayList.add(registryManager.getDeviceConnectionString(deviceListAmqps[i]));
+            clientConnectionStringArrayList[i] = registryManager.getDeviceConnectionString(deviceListAmqps[i]);
         }
 
         Thread.sleep(MAX_DEVICE_MULTIPLEX * REGISTRY_MANAGER_DEVICE_CREATION_DELAY_MILLISECONDS);
@@ -163,16 +163,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             registryManager.close();
 
             registryManager = null;
-
-            clientConnectionStringArrayList.clear();
         }
 
         if (serviceClient != null)
         {
             serviceClient.close();
         }
-
-        clientConnectionStringArrayList.clear();
     }
 
     @After
@@ -197,7 +193,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         openTransportClientWithRetry(transportClient, clientArrayList);
@@ -218,7 +214,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         openTransportClientWithRetry(transportClient, clientArrayList);
@@ -239,7 +235,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -267,7 +263,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -295,7 +291,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
 
@@ -326,7 +322,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
@@ -360,7 +356,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -434,7 +430,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -507,7 +503,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -538,7 +534,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -579,7 +575,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -610,7 +606,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -658,12 +654,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                 PropertyState propertyState = new PropertyState();
                 propertyState.callBackTriggered = false;
                 propertyState.property = new Property(PROPERTY_KEY + j, PROPERTY_VALUE);
-                devicesUnderTest.get(i).dCDeviceForTwin.propertyStateList.add(propertyState);
-                devicesUnderTest.get(i).dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, devicesUnderTest.get(i).dCDeviceForTwin, propertyState);
+                devicesUnderTest[i].dCDeviceForTwin.propertyStateList.add(propertyState);
+                devicesUnderTest[i].dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, devicesUnderTest[i].dCDeviceForTwin, propertyState);
             }
 
             // act
-            devicesUnderTest.get(i).deviceClient.subscribeToDesiredProperties(devicesUnderTest.get(i).dCDeviceForTwin.getDesiredProp());
+            devicesUnderTest[i].deviceClient.subscribeToDesiredProperties(devicesUnderTest[i].dCDeviceForTwin.getDesiredProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             Set<Pair> desiredProperties = new HashSet<>();
@@ -671,17 +667,17 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             {
                 desiredProperties.add(new Pair(PROPERTY_KEY + j, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
             }
-            devicesUnderTest.get(i).sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(devicesUnderTest.get(i).sCDeviceForTwin);
+            devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
+            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            Assert.assertEquals(buildExceptionMessage("Device twin status expected to be SUCCESS, but was: " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
-            for (PropertyState propertyState : devicesUnderTest.get(i).dCDeviceForTwin.propertyStateList)
+            Assert.assertEquals(buildExceptionMessage("Device twin status expected to be SUCCESS, but was: " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
+            for (PropertyState propertyState : devicesUnderTest[i].dCDeviceForTwin.propertyStateList)
             {
-                Assert.assertTrue(buildExceptionMessage("One or more property callbacks were not triggered", devicesUnderTest.get(i).deviceClient), propertyState.callBackTriggered);
-                Assert.assertTrue(buildExceptionMessage("Property new value did not start with " + PROPERTY_VALUE_UPDATE, devicesUnderTest.get(i).deviceClient), ((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
-                Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but device twin status was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+                Assert.assertTrue(buildExceptionMessage("One or more property callbacks were not triggered", devicesUnderTest[i].deviceClient), propertyState.callBackTriggered);
+                Assert.assertTrue(buildExceptionMessage("Property new value did not start with " + PROPERTY_VALUE_UPDATE, devicesUnderTest[i].deviceClient), ((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
+                Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but device twin status was " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
             }
         }
 
@@ -690,23 +686,23 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         {
             // act
             // send max_prop RP all at once
-            devicesUnderTest.get(i).dCDeviceForTwin.createNewReportedProperties(MAX_PROPERTIES_TO_TEST);
-            devicesUnderTest.get(i).deviceClient.sendReportedProperties(devicesUnderTest.get(i).dCDeviceForTwin.getReportedProp());
+            devicesUnderTest[i].dCDeviceForTwin.createNewReportedProperties(MAX_PROPERTIES_TO_TEST);
+            devicesUnderTest[i].deviceClient.sendReportedProperties(devicesUnderTest[i].dCDeviceForTwin.getReportedProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // act
             // Update RP
-            devicesUnderTest.get(i).dCDeviceForTwin.updateAllExistingReportedProperties();
-            devicesUnderTest.get(i).deviceClient.sendReportedProperties(devicesUnderTest.get(i).dCDeviceForTwin.getReportedProp());
+            devicesUnderTest[i].dCDeviceForTwin.updateAllExistingReportedProperties();
+            devicesUnderTest[i].deviceClient.sendReportedProperties(devicesUnderTest[i].dCDeviceForTwin.getReportedProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            Assert.assertEquals(buildExceptionMessage("Expected status SUCCESS but was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+            Assert.assertEquals(buildExceptionMessage("Expected status SUCCESS but was " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
 
             // verify if they are received by SC
             Thread.sleep(MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS);
-            int actualReportedPropFound = readReportedProperties(devicesUnderTest.get(i), PROPERTY_KEY, PROPERTY_VALUE_UPDATE);
-            Assert.assertEquals(buildExceptionMessage("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX,devicesUnderTest.get(i).deviceClient), MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
+            int actualReportedPropFound = readReportedProperties(devicesUnderTest[i], PROPERTY_KEY, PROPERTY_VALUE_UPDATE);
+            Assert.assertEquals(buildExceptionMessage("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX,devicesUnderTest[i].deviceClient), MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
         }
 
         // send max_prop RP one at a time in parallel
@@ -722,26 +718,26 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     // testSendReportedPropertiesMultiThreaded
                     try
                     {
-                        devicesUnderTest.get(finalI).dCDeviceForTwin.createNewReportedProperties(1);
-                        devicesUnderTest.get(finalI).deviceClient.sendReportedProperties(devicesUnderTest.get(finalI).dCDeviceForTwin.getReportedProp());
+                        devicesUnderTest[finalI].dCDeviceForTwin.createNewReportedProperties(1);
+                        devicesUnderTest[finalI].deviceClient.sendReportedProperties(devicesUnderTest[finalI].dCDeviceForTwin.getReportedProp());
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest[finalI].deviceClient));
                     }
-                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest[finalI].deviceTwinStatus, devicesUnderTest[finalI].deviceClient), SUCCESS, devicesUnderTest[finalI].deviceTwinStatus);
 
                     // testUpdateReportedPropertiesMultiThreaded
                     try
                     {
-                        devicesUnderTest.get(finalI).dCDeviceForTwin.updateExistingReportedProperty(finalI);
-                        devicesUnderTest.get(finalI).deviceClient.sendReportedProperties(devicesUnderTest.get(finalI).dCDeviceForTwin.getReportedProp());
+                        devicesUnderTest[finalI].dCDeviceForTwin.updateExistingReportedProperty(finalI);
+                        devicesUnderTest[finalI].deviceClient.sendReportedProperties(devicesUnderTest[finalI].dCDeviceForTwin.getReportedProp());
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest[finalI].deviceClient));
                     }
-                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest[finalI].deviceTwinStatus, devicesUnderTest[finalI].deviceClient), SUCCESS, devicesUnderTest[finalI].deviceTwinStatus);
                 }
             });
         }
@@ -1158,7 +1154,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             DeviceState deviceState = new DeviceState();
             deviceState.sCDeviceForRegistryManager = deviceListAmqps[i];
             deviceState.connectionString = registryManager.getDeviceConnectionString(deviceState.sCDeviceForRegistryManager);
-            devicesUnderTest.add(deviceState);
+            devicesUnderTest[i] = deviceState;
 
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
         }
@@ -1168,9 +1164,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         ArrayList<InternalClient> clientArrayList = new ArrayList<>();
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            DeviceState deviceState = devicesUnderTest.get(i);
+            DeviceState deviceState = devicesUnderTest[i];
             deviceState.deviceClient = new DeviceClient(deviceState.connectionString, transportClient);
-            devicesUnderTest.get(i).dCDeviceForTwin = new DeviceExtension();
+            devicesUnderTest[i].dCDeviceForTwin = new DeviceExtension();
             clientArrayList.add(deviceState.deviceClient);
         }
 
@@ -1178,10 +1174,10 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            devicesUnderTest.get(i).deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), devicesUnderTest.get(i), devicesUnderTest.get(i).dCDeviceForTwin, devicesUnderTest.get(i));
-            devicesUnderTest.get(i).deviceTwinStatus = SUCCESS;
-            devicesUnderTest.get(i).sCDeviceForTwin = new DeviceTwinDevice(devicesUnderTest.get(i).sCDeviceForRegistryManager.getDeviceId());
-            sCDeviceTwin.getTwin(devicesUnderTest.get(i).sCDeviceForTwin);
+            devicesUnderTest[i].deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), devicesUnderTest[i], devicesUnderTest[i].dCDeviceForTwin, devicesUnderTest[i]);
+            devicesUnderTest[i].deviceTwinStatus = SUCCESS;
+            devicesUnderTest[i].sCDeviceForTwin = new DeviceTwinDevice(devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
+            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
         }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -408,7 +408,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }
@@ -483,7 +483,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }
@@ -754,7 +754,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -114,6 +114,8 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         String uuid = UUID.randomUUID().toString();
 
+        System.out.print("TransportClientTests UUID: " + uuid);
+
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             String deviceId = "java-device-client-e2e-test-multiplexing".concat(i + "-" + uuid);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -655,6 +655,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         //Testing subscribing to desired properties.
         for (int i = 0; i < MAX_DEVICES; i++)
         {
+            devicesUnderTest[i].dCDeviceForTwin.getDesiredProp().clear();
             for (int j = 0; j < MAX_PROPERTIES_TO_TEST; j++)
             {
                 PropertyState propertyState = new PropertyState();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -644,7 +644,16 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
     public void testTwin() throws IOException, InterruptedException, IotHubException, URISyntaxException
     {
-        TransportClient transportClient = setUpTwin();
+        TransportClient transportClient = null;
+        try
+        {
+            transportClient = setUpTwin();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            fail("Encountered exception during setUpTwin: " + e.getMessage());
+        }
 
         ExecutorService executor = Executors.newFixedThreadPool(MAX_PROPERTIES_TO_TEST);
 
@@ -751,7 +760,15 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
 
         System.out.println("Tearing down twin status...");
-        tearDownTwin(transportClient);
+        try
+        {
+            tearDownTwin(transportClient);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            fail("Encountered exception during tearDownTwin: " + e.getMessage());
+        }
     }
     
     private void verifyNotification(FileUploadNotification fileUploadNotification, FileUploadState fileUploadState, InternalClient client) throws IOException

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -187,7 +187,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void sendMessagesOverAmqps() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -208,7 +208,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void sendMessagesOverAmqpsWs() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -229,7 +229,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void receiveMessagesOverAmqpsIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -257,7 +257,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void receiveMessagesOverAmqpWSIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -348,7 +348,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void uploadToBlobAsyncSingleFileAndTelemetryOnAMQP() throws Exception
     {
         // arrange
@@ -422,7 +422,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         tearDownFileUploadState();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void uploadToBlobAsyncSingleFileAndTelemetryOnAMQPWS() throws Exception
     {
         // arrange
@@ -497,7 +497,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         tearDownFileUploadState();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -528,7 +528,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -569,7 +569,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSWSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -600,7 +600,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSWSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -641,7 +641,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testTwin() throws IOException, InterruptedException, IotHubException, URISyntaxException
     {
         TransportClient transportClient = null;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -38,7 +38,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionSubscribeToDesiredPropertiesFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -46,7 +46,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -59,7 +59,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -72,7 +72,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsCBSReqLinkrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -91,7 +91,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -110,7 +110,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsD2CDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -123,7 +123,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromC2DDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -143,7 +143,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -163,7 +163,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -183,7 +183,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -203,7 +203,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -34,6 +34,8 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
@@ -238,9 +239,9 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
         deviceUnderTest.dCDeviceForTwin.propertyStateList.get(0).callBackTriggered = false;
-        assertEquals(1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
+        assertEquals(buildExceptionMessage("Expected desired properties to be size 1, but was size " + deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size(), internalClient), 1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
         Set<Pair> dp = new HashSet<>();
         Pair p = deviceUnderTest.sCDeviceForTwin.getDesiredProperties().iterator().next();
         p.setValue(PROPERTY_VALUE_UPDATE2 + UUID.randomUUID());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -241,7 +241,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
 
         // Assert
         IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
-        deviceUnderTest.dCDeviceForTwin.propertyStateList.get(0).callBackTriggered = false;
+        deviceUnderTest.dCDeviceForTwin.propertyStateList[0].callBackTriggered = false;
         assertEquals(buildExceptionMessage("Expected desired properties to be size 1, but was size " + deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size(), internalClient), 1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
         Set<Pair> dp = new HashSet<>();
         Pair p = deviceUnderTest.sCDeviceForTwin.getDesiredProperties().iterator().next();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -35,7 +35,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -227,7 +227,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     public void errorInjectionSubscribeToDesiredPropertiesFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         subscribeToDesiredPropertiesAndVerify(1);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -35,8 +35,6 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -31,7 +32,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
 {
-    public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.Test;
 
@@ -33,6 +34,8 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
@@ -35,7 +36,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
+        System.out.println(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -252,7 +253,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     public void errorInjectionTestFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         invokeMethodSucceed();
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -263,7 +263,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, this.testInstance.deviceTestManager.client);
         invokeMethodSucceed();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
-import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
-import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -32,7 +29,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class DeviceMethodErrInjTests extends DeviceMethodCommon
 {
-    public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -39,7 +39,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
         System.out.println(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -47,7 +47,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -60,7 +60,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -73,7 +73,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -92,7 +92,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -111,7 +111,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -124,7 +124,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -144,7 +144,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -164,7 +164,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -184,7 +184,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -204,7 +204,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -224,7 +224,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromGracefulShutdownAmqp() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -237,7 +237,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromGracefulShutdownMqtt() throws Exception
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -37,7 +37,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionGetDeviceTwinFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -45,7 +45,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -58,7 +58,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -71,7 +71,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -90,7 +90,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -109,7 +109,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -122,7 +122,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -143,7 +143,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -163,7 +163,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -183,7 +183,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -203,7 +203,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -223,7 +223,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromGracefulShutdownAmqp() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -236,7 +236,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromGracefulShutdownMqtt() throws Exception
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -266,8 +266,9 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
 
         // Assert
         IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
-        for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
+        for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
+            PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];
             propertyState.callBackTriggered = false;
             propertyState.propertyNewVersion = -1;
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -34,7 +34,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -252,7 +252,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public void errorInjectionGetDeviceTwinFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         testGetDeviceTwin();
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -33,6 +33,8 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -30,7 +31,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class GetTwinErrInjTests extends DeviceTwinCommon
 {
-    public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -264,7 +264,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
         for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
         {
             propertyState.callBackTriggered = false;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -34,8 +34,6 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper.DefaultDelayInSec;
 import static com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper.DefaultDurationInSec;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
@@ -272,7 +273,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         try
         {
             IotHubServicesCommon.openClientWithRetry(testInstance.client);
-            IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000);
+            IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000, testInstance.client);
 
             //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
             // we ensure that error injection message isn't resent to service too many times. The message will still likely
@@ -282,7 +283,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 
             //wait to send the message because we want to ensure that the tcp connection drop happens beforehand and we
             // want the connection to be re-established before sending anything from service client
-            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT);
+            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT, testInstance.client);
 
             if (testInstance.client instanceof DeviceClient)
             {
@@ -302,6 +303,6 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
             testInstance.client.closeNow();
         }
 
-        assertTrue(testInstance.protocol + ", " + testInstance.authenticationType + ": Error Injection message did not cause service to drop TCP connection", connectionStatusUpdates.contains(IotHubConnectionStatus.DISCONNECTED_RETRYING));
+        assertTrue(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Error Injection message did not cause service to drop TCP connection", testInstance.client), connectionStatusUpdates.contains(IotHubConnectionStatus.DISCONNECTED_RETRYING));
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -43,7 +43,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         System.out.println(clientType + " ReceiveMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithTCPConnectionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol == HTTPS)
@@ -55,7 +55,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsConnectionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -67,7 +67,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsConnectionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsSessionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -79,7 +79,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsSessionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsCBSReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -97,7 +97,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsCBSRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -115,7 +115,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsD2CLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -127,7 +127,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsD2CTelemetryLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsC2DLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -145,7 +145,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsC2DLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsMethodReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -164,7 +164,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsMethodRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -183,7 +183,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsTwinReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -202,7 +202,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsTwinReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsTwinRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -221,7 +221,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsTwinRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithGracefulShutdownAmqp() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -233,7 +233,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsGracefulShutdownErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithGracefulShutdownMqtt() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != MQTT && testInstance.protocol != MQTT_WS)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -37,6 +37,8 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
     public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " ReceiveMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
-import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
-import com.microsoft.azure.sdk.iot.common.helpers.EventCallback;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.Success;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.ReceiveMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
@@ -36,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 {
-    public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -36,7 +36,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionSendReportedPropertiesFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -44,7 +44,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -57,7 +57,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -70,7 +70,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -89,7 +89,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -108,7 +108,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -121,7 +121,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -141,7 +141,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -161,7 +161,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -181,7 +181,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -201,7 +201,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -33,7 +33,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -224,7 +224,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public void errorInjectionSendReportedPropertiesFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         sendReportedPropertiesAndVerify(1);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -33,8 +33,6 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -236,7 +236,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
         // add one new reported property
         deviceUnderTest.dCDeviceForTwin.createNewReportedProperties(1);
         internalClient.sendReportedProperties(deviceUnderTest.dCDeviceForTwin.getReportedProp());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -29,7 +30,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -32,6 +32,8 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -42,7 +42,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " SendMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
+        System.out.println(clientType + " SendMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -42,7 +42,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithTcpConnectionDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
@@ -55,7 +55,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, TCP_CONNECTION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithConnectionDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -67,7 +67,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CONNECTION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithSessionDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -79,7 +79,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_SESSION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithCbsRequestLinkDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -97,7 +97,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CBS_REQUEST_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithCbsResponseLinkDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -115,7 +115,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CBS_RESPONSE_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithD2CLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -127,7 +127,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_D2C_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithC2DLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -146,7 +146,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_C2D_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithMethodReqLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -165,7 +165,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_METHOD_REQ_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithMethodRespLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -184,7 +184,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_METHOD_RESP_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithTwinReqLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -203,7 +203,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_TWIN_REQ_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithTwinRespLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -222,7 +222,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithThrottling() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -239,7 +239,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     }
 
     @Ignore
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -255,7 +255,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithAuthenticationError() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -270,7 +270,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 false);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithQuotaExceeded() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -285,7 +285,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 false);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverAmqpWithGracefulShutdown() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -297,7 +297,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesOverMqttWithGracefulShutdown() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))
@@ -309,7 +309,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test
+    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
     public void sendMessagesWithTcpConnectionDropNotifiesUserIfRetryExpires() throws IOException, InterruptedException
     {
         if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Ignore;
@@ -40,6 +41,8 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     public SendMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " SendMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -45,7 +45,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         System.out.println(clientType + " SendMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithTcpConnectionDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
@@ -58,7 +58,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, TCP_CONNECTION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithConnectionDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -70,7 +70,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CONNECTION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithSessionDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -82,7 +82,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_SESSION_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithCbsRequestLinkDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -100,7 +100,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CBS_REQUEST_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithCbsResponseLinkDrop() throws IOException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -118,7 +118,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_CBS_RESPONSE_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithD2CLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -130,7 +130,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_D2C_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithC2DLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
@@ -149,7 +149,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_C2D_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithMethodReqLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -168,7 +168,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_METHOD_REQ_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithMethodRespLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -187,7 +187,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_METHOD_RESP_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithTwinReqLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -206,7 +206,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_TWIN_REQ_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithTwinRespLinkDrop() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -225,7 +225,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithThrottling() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -242,7 +242,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     }
 
     @Ignore
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -258,7 +258,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithAuthenticationError() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -273,7 +273,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 false);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithQuotaExceeded() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -288,7 +288,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 false);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpWithGracefulShutdown() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -300,7 +300,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesOverMqttWithGracefulShutdown() throws IOException, InterruptedException
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))
@@ -312,7 +312,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
-    @Test (timeout=ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendMessagesWithTcpConnectionDropNotifiesUserIfRetryExpires() throws IOException, InterruptedException
     {
         if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -329,7 +329,6 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         testInstance.client.setRetryPolicy(new ExponentialBackoffWithJitter());
     }
 
-    //TODO this only tests DEVICE CLIENT, needs to accomodate module client as well
     private void errorInjectionTestFlowNoDisconnect(Message errorInjectionMessage, IotHubStatusCode expectedStatus, boolean noRetry) throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
     {
         // Arrange
@@ -337,7 +336,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         // introduced by injected errors
         String uuid = UUID.randomUUID().toString();
         String deviceId = "java-device-client-e2e-test-send-messages".concat("-" + uuid);
-        String moduleId = "java-device-client-e2e-test-send-messages-module".concat("-" + uuid);
+        String moduleId = "java-module-client-e2e-test-send-messages".concat("-" + uuid);
 
         Device targetDevice;
         Module targetModule;
@@ -368,7 +367,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 targetModule.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
                 registryManager.addDevice(targetDevice);
                 registryManager.addModule(targetModule);
-                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice) + "ModuleId=" + targetModule.getId(), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
+                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
             }
             else
             {
@@ -376,7 +375,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 targetModule = Module.createModule(deviceId, moduleId, AuthenticationType.SAS);
                 registryManager.addDevice(targetDevice);
                 registryManager.addModule(targetModule);
-                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice) + "ModuleId=" + targetModule.getId(), this.testInstance.protocol);
+                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol);
             }
         }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceEmulator;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class DeviceMethodTests extends DeviceMethodCommon
 {
-    public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -37,7 +37,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
+        System.out.println(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -70,9 +71,9 @@ public class DeviceMethodTests extends DeviceMethodCommon
         for (RunnableInvoke run:runs)
         {
             MethodResult result = run.getResult();
-            assertNotNull((run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage()), result);
-            assertEquals((long)DeviceEmulator.METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(run.getExpectedPayload(), result.getPayload().toString());
+            assertNotNull(buildExceptionMessage(run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage(), testInstance.deviceTestManager.client), result);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but was " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS,(long)result.getStatus());
+            assertEquals(buildExceptionMessage("Expected payload " + run.getExpectedPayload() + " but got " + result.getPayload().toString(), testInstance.deviceTestManager.client), run.getExpectedPayload(), result.getPayload().toString());
         }
     }
 
@@ -96,10 +97,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING + " but got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -121,10 +122,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":null", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_LOOPBACK + ":null" + " but got " + result.getPayload(), deviceTestManger.client), DeviceEmulator.METHOD_LOOPBACK + ":null", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -146,10 +147,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -171,10 +172,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_THROWS, (long)result.getStatus());
-        assertEquals("java.lang.NumberFormatException: For input string: \"" + PAYLOAD_STRING + "\"", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_THROWS + " but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_THROWS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected NumberFormatException, but got " + result.getPayload(), testInstance.deviceTestManager.client), "java.lang.NumberFormatException: For input string: \"" + PAYLOAD_STRING + "\"", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -196,10 +197,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_NOT_DEFINED, (long)result.getStatus());
-        Assert.assertEquals("unknown:" + DeviceEmulator.METHOD_UNKNOWN, result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected METHOD_NOT_DEFINED but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_NOT_DEFINED, (long)result.getStatus());
+        Assert.assertEquals(buildExceptionMessage("Expected " + "unknown:" + DeviceEmulator.METHOD_UNKNOWN + " but got " + result.getPayload(), testInstance.deviceTestManager.client), "unknown:" + DeviceEmulator.METHOD_UNKNOWN, result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -238,10 +239,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -263,10 +264,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -288,10 +289,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubGatewayTimeoutException.class)
@@ -342,7 +343,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
                 deviceTestManger.restartDevice(registryManager.getDeviceConnectionString((Device) testInstance.identity), testInstance.protocol, testInstance.publicKeyCert, testInstance.privateKey);
             }
 
-            throw new Exception("Reset identity do not affect the method invoke on the service");
+            Assert.fail(buildExceptionMessage("Reset identity do not affect the method invoke on the service", testInstance.deviceTestManager.client));
         }
         catch (IotHubNotFoundException expected)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -36,6 +36,8 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -40,13 +40,13 @@ public class DeviceMethodTests extends DeviceMethodCommon
         System.out.println(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodSucceed() throws Exception
     {
         super.invokeMethodSucceed();
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodInvokeParallelSucceed() throws Exception
     {
         // Arrange
@@ -79,7 +79,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodStandardTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -105,7 +105,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodNullPayloadSucceed() throws Exception
     {
         // Arrange
@@ -130,7 +130,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodNumberSucceed() throws Exception
     {
         // Arrange
@@ -155,7 +155,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodThrowsNumberFormatExceptionFailed() throws Exception
     {
         // Arrange
@@ -180,7 +180,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodUnknownFailed() throws Exception
     {
         // Arrange
@@ -205,7 +205,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodRecoverFromTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -247,7 +247,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodDefaultResponseTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -272,7 +272,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodDefaultConnectionTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -297,7 +297,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubGatewayTimeoutException.class)
+    @Test (expected = IotHubGatewayTimeoutException.class)
     public void invokeMethodResponseTimeoutFailed() throws Exception
     {
         // Arrange
@@ -312,7 +312,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubNotFoundException.class)
+    @Test(expected = IotHubNotFoundException.class)
     public void invokeMethodUnknownDeviceFailed() throws Exception
     {
         if (testInstance.identity instanceof Module)
@@ -325,7 +325,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodResetDeviceFailed() throws Exception
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test class containing all non error injection tests to be run on JVM and android pertaining to receiving messages on a device/module. Class needs to be extended
@@ -141,14 +141,14 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
             }
             catch (ExecutionException e)
             {
-                Assert.fail("Exception : " + e.getMessage());
+                Assert.fail(buildExceptionMessage("Exception : " + e.getMessage(), testInstance.client));
             }
         }
 
         // Now wait for messages to be received in the device client
         waitForBackToBackC2DMessagesToBeReceived();
         testInstance.client.closeNow(); //close the device client connection
-        assertTrue(testInstance.protocol + ", " + testInstance.authenticationType + ": Received messages don't match up with sent messages", messageIdListStoredOnReceive.containsAll(messageIdListStoredOnC2DSend)); // check if the received list is same as the actual list that was created on sending the messages
+        Assert.assertTrue(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Received messages don't match up with sent messages", testInstance.client), messageIdListStoredOnReceive.containsAll(messageIdListStoredOnC2DSend)); // check if the received list is same as the actual list that was created on sending the messages
         messageIdListStoredOnReceive.clear();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -39,7 +39,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
         System.out.println(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesOverIncludingProperties() throws Exception
     {
         if (testInstance.protocol == HTTPS)
@@ -82,7 +82,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
         testInstance.client.closeNow();
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveBackToBackUniqueC2DCommandsOverAmqpsUsingSendAsync() throws Exception
     {
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -36,7 +36,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
+        System.out.println(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -35,6 +35,8 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
     public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.Success;
 import com.microsoft.azure.sdk.iot.common.setup.ReceiveMessagesCommon;
@@ -32,7 +33,7 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
  */
 public class ReceiveMessagesTests extends ReceiveMessagesCommon
 {
-    public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -41,7 +41,7 @@ public class SendMessagesTests extends SendMessagesCommon
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
+        System.out.println(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -37,7 +37,7 @@ import static junit.framework.TestCase.fail;
  */
 public class SendMessagesTests extends SendMessagesCommon
 {
-    public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.common.setup.SendMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Test;
@@ -39,6 +40,8 @@ public class SendMessagesTests extends SendMessagesCommon
     public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -54,7 +54,7 @@ public class SendMessagesTests extends SendMessagesCommon
         IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test (timeout = 4 * DEFAULT_TEST_TIMEOUT)
     public void tokenRenewalWorks() throws InterruptedException
     {
         if (testInstance.authenticationType != SAS)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -44,7 +44,7 @@ public class SendMessagesTests extends SendMessagesCommon
         System.out.println(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void sendMessages() throws IOException, InterruptedException
     {
 
@@ -57,7 +57,7 @@ public class SendMessagesTests extends SendMessagesCommon
         IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
     }
 
-    @Test (timeout = 4 * DEFAULT_TEST_TIMEOUT)
+    @Test
     public void tokenRenewalWorks() throws InterruptedException
     {
         if (testInstance.authenticationType != SAS)
@@ -96,7 +96,7 @@ public class SendMessagesTests extends SendMessagesCommon
         }
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpsMultithreaded() throws InterruptedException, IOException, IotHubException
     {
         if (!(testInstance.protocol == AMQPS && testInstance.authenticationType == SAS && testInstance.clientType.equals(ClientType.DEVICE_CLIENT)))
@@ -147,7 +147,7 @@ public class SendMessagesTests extends SendMessagesCommon
         }
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void tokenExpiredAfterOpenButBeforeSendHttp() throws InvalidKeyException, IOException, InterruptedException, URISyntaxException
     {
         if (testInstance.protocol != HTTPS || testInstance.authenticationType != SAS)
@@ -167,7 +167,7 @@ public class SendMessagesTests extends SendMessagesCommon
         client.closeNow();
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void expiredMessagesAreNotSent() throws IOException
     {
         IotHubServicesCommon.sendExpiredMessageExpectingMessageExpiredCallback(testInstance.client, testInstance.protocol, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, testInstance.authenticationType);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Test;
 
@@ -48,6 +49,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public void testSubscribeToDesiredPropertiesWithVersion() throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.sCDeviceForTwin.clearTwin();
         deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertiesCB = new HashMap<>();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
@@ -84,6 +86,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         ExecutorService executor = Executors.newFixedThreadPool(MAX_PROPERTIES_TO_TEST);
 
         deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
+        deviceUnderTest.sCDeviceForTwin.clearTwin();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             PropertyState propertyState = new PropertyState();
@@ -130,7 +133,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
+        if (!executor.awaitTermination(1, TimeUnit.MINUTES))
         {
             executor.shutdownNow();
         }
@@ -144,6 +147,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public void testSubscribeToDesiredPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.sCDeviceForTwin.clearTwin();
         deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
@@ -175,6 +179,9 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     @Test
     public void setDesiredPropertiesAtMaxDepthAllowed() throws IOException, IotHubException
     {
+        deviceUnderTest.sCDeviceForTwin.clearTwin();
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
+
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
 
         //Update twin Tags and Desired Properties
@@ -204,6 +211,8 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         addMultipleDevices(MAX_DEVICES);
 
         // Add desired properties for multiple devices
+        deviceUnderTest.sCDeviceForTwin.clearTwin();
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < MAX_DEVICES; i++)
         {
             Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -35,6 +35,8 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -129,7 +131,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -32,7 +33,7 @@ import static org.junit.Assert.*;
  */
 public class DesiredPropertiesTests extends DeviceTwinCommon
 {
-    public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
@@ -108,6 +109,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
                     {
                         Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
                         desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(PROPERTY_KEY + index, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
+                        //TODO need synch block here?
                         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
                         sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
                     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -36,8 +36,6 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -121,7 +121,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
@@ -221,11 +222,11 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 
             for (com.microsoft.azure.sdk.iot.service.devicetwin.Pair dp : devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties())
             {
-                assertEquals(dp.getKey(), PROPERTY_KEY + i);
-                assertEquals(dp.getValue(), PROPERTY_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + PROPERTY_KEY + i + " but was " + dp.getKey(), internalClient), PROPERTY_KEY + i, dp.getKey());
+                assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + PROPERTY_VALUE_UPDATE + i + " but was " + dp.getValue(), internalClient), PROPERTY_VALUE_UPDATE + i, dp.getValue());
             }
             Integer version = devicesUnderTest[i].sCDeviceForTwin.getDesiredPropertiesVersion();
-            assertNotNull(version);
+            assertNotNull(buildExceptionMessage("Version was null", internalClient), version);
         }
 
         // Remove desired properties
@@ -247,7 +248,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         {
             sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
-            assertEquals("Desired properties were not deleted by setting to null", 0, devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties().size());
+            assertEquals(buildExceptionMessage("Desired properties were not deleted by setting to null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties().size());
         }
 
         removeMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -48,6 +48,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public void testSubscribeToDesiredPropertiesWithVersion() throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertiesCB = new HashMap<>();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
@@ -55,7 +56,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
             propertyState.callBackTriggered = false;
             propertyState.propertyNewVersion = -1;
             propertyState.property = new Property(PROPERTY_KEY + i, PROPERTY_VALUE);
-            deviceUnderTest.dCDeviceForTwin.propertyStateList.add(propertyState);
+            deviceUnderTest.dCDeviceForTwin.propertyStateList[i] = propertyState;
             desiredPropertiesCB.put(propertyState.property, new com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<TwinPropertyCallBack, Object>(deviceUnderTest.dCOnProperty, propertyState));
         }
 
@@ -82,12 +83,13 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         // arrange
         ExecutorService executor = Executors.newFixedThreadPool(MAX_PROPERTIES_TO_TEST);
 
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             PropertyState propertyState = new PropertyState();
             propertyState.callBackTriggered = false;
             propertyState.property = new Property(PROPERTY_KEY + i, PROPERTY_VALUE);
-            deviceUnderTest.dCDeviceForTwin.propertyStateList.add(propertyState);
+            deviceUnderTest.dCDeviceForTwin.propertyStateList[i] = propertyState;
             deviceUnderTest.dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, deviceUnderTest.dCDeviceForTwin, propertyState);
         }
 
@@ -142,12 +144,13 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public void testSubscribeToDesiredPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange
+        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             PropertyState propertyState = new PropertyState();
             propertyState.callBackTriggered = false;
             propertyState.property = new Property(PROPERTY_KEY + i, PROPERTY_VALUE);
-            deviceUnderTest.dCDeviceForTwin.propertyStateList.add(propertyState);
+            deviceUnderTest.dCDeviceForTwin.propertyStateList[i] = propertyState;
             deviceUnderTest.dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, deviceUnderTest.dCDeviceForTwin, propertyState);
         }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -36,7 +36,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -39,13 +39,13 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredProperties() throws IOException, InterruptedException, IotHubException
     {
         subscribeToDesiredPropertiesAndVerify(MAX_PROPERTIES_TO_TEST);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredPropertiesWithVersion() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -77,7 +77,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, true);
     }
 
-    @Test(timeout = 240000) //4 minutes
+    @Test
     public void testSubscribeToDesiredPropertiesMultiThreaded() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -162,7 +162,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    @Test (timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void setDesiredPropertiesAtMaxDepthAllowed() throws IOException, IotHubException
     {
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
@@ -188,7 +188,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateDesiredProperties() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -243,7 +243,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         testDevice = null;
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesWithoutVersionSucceed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -281,7 +281,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         assertSetEquals(PROPERTIES, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithVersionSucceed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -356,7 +356,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         assertSetEquals(newValues, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithLowerVersionFailed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -429,7 +429,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         assertSetEquals(PROPERTIES, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithHigherVersionFailed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
@@ -83,14 +84,14 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         Integer reportedPropertyVersion;
     }
 
-    private static void assertSetEquals(Set<Property> expected, Set<Pair> actual)
+    private void assertSetEquals(Set<Property> expected, Set<Pair> actual)
     {
-        assertEquals(expected.size(), actual.size());
+        assertEquals(buildExceptionMessage("Expected size " + expected.size() + " but was size " + actual.size(), testDevice.deviceClient), expected.size(), actual.size());
         for(Pair actualProperty: actual)
         {
             Property expectedProperty = fetchProperty(expected, actualProperty.getKey());
-            assertNotNull("Expected Set of Properties do no contain " + actualProperty.getKey(), expectedProperty);
-            assertEquals(expectedProperty.getValue(), actualProperty.getValue());
+            assertNotNull(buildExceptionMessage("Expected Set of Properties to not contain " + actualProperty.getKey(), testDevice.deviceClient), expectedProperty);
+            assertEquals(buildExceptionMessage("Expected value " + expectedProperty.getValue() + " but got " + actualProperty.getValue(), testDevice.deviceClient), expectedProperty.getValue(), actualProperty.getValue());
         }
     }
 
@@ -270,12 +271,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }
@@ -305,7 +306,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -351,8 +352,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(3, (int)deviceOnServiceClient.getReportedPropertiesVersion());
-        Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
+        assertEquals(buildExceptionMessage("Expected reported properties version 3 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 3, (int)deviceOnServiceClient.getReportedPropertiesVersion());        Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(newValues, reported);
     }
 
@@ -381,7 +381,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -419,12 +419,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }
@@ -454,7 +454,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -492,12 +492,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -19,7 +20,7 @@ import java.io.IOException;
  */
 public class GetTwinTests extends DeviceTwinCommon
 {
-    public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -22,6 +22,8 @@ public class GetTwinTests extends DeviceTwinCommon
     public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -23,8 +23,6 @@ public class GetTwinTests extends DeviceTwinCommon
     public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -26,7 +26,7 @@ public class GetTwinTests extends DeviceTwinCommon
         System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException
     {
         super.testGetDeviceTwin();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -23,7 +23,7 @@ public class GetTwinTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -37,8 +37,6 @@ public class QueryTwinTests extends DeviceTwinCommon
     public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -37,7 +37,7 @@ public class QueryTwinTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
@@ -203,8 +204,8 @@ public class QueryTwinTests extends DeviceTwinCommon
 
                 for (Pair dp : d.getDesiredProperties())
                 {
-                    assertEquals(dp.getKey(), queryProperty);
-                    assertEquals(dp.getValue(), queryPropertyValue);
+                    assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + queryProperty + " but was " + dp.getKey(), internalClient), queryProperty, dp.getKey());
+                    assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + queryPropertyValue + " but was " + dp.getValue(), internalClient), queryPropertyValue, dp.getValue());
                 }
             }
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -172,7 +172,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         });
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }
@@ -416,7 +416,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         });
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -36,6 +36,8 @@ public class QueryTwinTests extends DeviceTwinCommon
     public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -33,7 +34,7 @@ import static org.junit.Assert.*;
  */
 public class QueryTwinTests extends DeviceTwinCommon
 {
-    public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -40,7 +40,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testRawQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -74,7 +74,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testRawQueryMultipleInParallelTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -180,7 +180,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -215,7 +215,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testQueryTwinWithContinuationToken() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(PAGE_SIZE + 1);
@@ -281,7 +281,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         }
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void queryCollectionCanReturnEmptyQueryResults() {
         try
         {
@@ -300,7 +300,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         }
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testMultipleQueryTwinInParallel() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -298,7 +298,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         }
     }
 
-    @Test
+    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
     public void testMultipleQueryTwinInParallel() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -60,7 +61,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
                     {
                         fail(e.getMessage());
                     }
-                    assertEquals(deviceUnderTest.deviceTwinStatus, DeviceTwinCommon.STATUS.SUCCESS);
+                    assertEquals(buildExceptionMessage("Expected SUCCESS but twin status was " + deviceUnderTest.deviceTwinStatus, internalClient), DeviceTwinCommon.STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
                 }
             });
         }
@@ -141,7 +142,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
                     }
                     catch (IOException | InterruptedException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + e.getMessage(), internalClient));
                     }
                 }
             });
@@ -154,7 +155,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         }
 
         // assert
-        assertEquals(deviceUnderTest.deviceTwinStatus, STATUS.SUCCESS);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but twin status was " + deviceUnderTest.deviceTwinStatus, internalClient), DeviceTwinCommon.STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
 
         // verify if they are received by SC
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -33,13 +33,13 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedProperties() throws IOException, IotHubException, InterruptedException
     {
         sendReportedPropertiesAndVerify(MAX_PROPERTIES_TO_TEST);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesMultiThreaded() throws IOException, IotHubException, InterruptedException
     {
         // arrange
@@ -94,7 +94,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedProperties() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -115,7 +115,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesMultiThreaded() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -163,7 +163,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesSequential() throws IOException, InterruptedException, IotHubException
     {
         // arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -30,8 +30,6 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -30,7 +30,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -26,7 +27,7 @@ import static org.junit.Assert.fail;
  */
 public class ReportedPropertiesTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -68,7 +68,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
             });
         }
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }
@@ -151,7 +151,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         }
         Thread.sleep(DELAY_BETWEEN_OPERATIONS);
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -29,6 +29,8 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -75,7 +77,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -36,7 +36,7 @@ public class TwinTagsTests extends DeviceTwinCommon
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
-        System.out.print(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
+        System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class TwinTagsTests extends DeviceTwinCommon
 {
-    public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -36,8 +36,6 @@ public class TwinTagsTests extends DeviceTwinCommon
     public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
@@ -34,6 +35,8 @@ public class TwinTagsTests extends DeviceTwinCommon
     public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.print(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -39,7 +39,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testGetTwinUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -103,7 +103,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testAddTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -134,7 +134,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -200,7 +200,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test (timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void setTagsAtMaxDepthAllowed() throws IOException, IotHubException
     {
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -84,17 +85,17 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE_UPDATE + i + " but was " + t.getValue(), internalClient), TAG_VALUE_UPDATE + i, t.getValue());
             }
 
             for (Pair dp : devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties())
             {
-                assertEquals(dp.getKey(), PROPERTY_KEY + i);
-                assertEquals(dp.getValue(), PROPERTY_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + PROPERTY_KEY + i + " but was " + dp.getKey(), internalClient), PROPERTY_KEY + i, dp.getKey());
+                assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + PROPERTY_VALUE_UPDATE + i + " but was " + dp.getValue(), internalClient), PROPERTY_VALUE_UPDATE + i, dp.getValue());
             }
             Integer version = devicesUnderTest[i].sCDeviceForTwin.getDesiredPropertiesVersion();
-            assertNotNull(version);
+            assertNotNull(buildExceptionMessage("Version was null", internalClient), version);
         }
         removeMultipleDevices(MAX_DEVICES);
     }
@@ -123,8 +124,8 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE + i + " but was " + t.getValue(), internalClient), TAG_VALUE + i, t.getValue());
             }
         }
         removeMultipleDevices(MAX_DEVICES);
@@ -166,8 +167,8 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE + i + " but was " + t.getValue(), internalClient), TAG_VALUE_UPDATE + i, t.getValue());
             }
         }
 
@@ -190,7 +191,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         {
             sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
-            assertEquals("Tags were not deleted by being set null", 0, devicesUnderTest[i].sCDeviceForTwin.getTags().size());
+            assertEquals(buildExceptionMessage("Tags were not deleted by being set null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getTags().size());
         }
 
         removeMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
@@ -174,13 +174,14 @@ public class JobClientTests
             device.stop();
         }
 
-        if (registryManager != null){
+        if (registryManager != null)
+        {
             registryManager.close();
             registryManager = null;
         }
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void scheduleUpdateTwinSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -267,7 +268,7 @@ public class JobClientTests
         }
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void scheduleDeviceMethodSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -353,7 +354,7 @@ public class JobClientTests
         assertEquals(0, deviceTestManger.getStatusError());
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void mixScheduleInFutureSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -475,7 +476,7 @@ public class JobClientTests
         assertEquals(0, deviceTestManger.getStatusError());
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void cancelScheduleDeviceMethodSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
@@ -36,6 +36,8 @@ public class RegistryManagerTests
     private static final String primaryThumbprint2 =   "2222222222222222222222222222222222222222";
     private static final String secondaryThumbprint2 = "3333333333333333333333333333333333333333";
 
+    private static final long MAX_TEST_MILLISECONDS = 1 * 60 * 1000;
+    
     public static void setUp() throws IOException
     {
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
@@ -52,7 +54,7 @@ public class RegistryManagerTests
         }
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e() throws Exception
     {
         // Arrange
@@ -80,7 +82,7 @@ public class RegistryManagerTests
         assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e_X509_CA_signed() throws Exception
     {
         // Arrange
@@ -113,7 +115,7 @@ public class RegistryManagerTests
         assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e_X509_self_signed() throws Exception
     {
         // Arrange
@@ -149,14 +151,14 @@ public class RegistryManagerTests
         assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void getDeviceStatisticsTest() throws Exception
     {
         RegistryManager registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         registryManager.getStatistics();
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e() throws Exception
     {
         // Arrange
@@ -192,7 +194,7 @@ public class RegistryManagerTests
         assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e_X509_CA_signed() throws Exception
     {
         // Arrange
@@ -225,7 +227,7 @@ public class RegistryManagerTests
         assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e_X509_self_signed() throws Exception
     {
         // Arrange
@@ -266,7 +268,7 @@ public class RegistryManagerTests
         assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceId, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_adm_configuration_e2e() throws Exception
     {
         // Arrange
@@ -332,7 +334,7 @@ public class RegistryManagerTests
         assertTrue(configWasDeletedSuccessfully(registryManager, configId));
     }
 
-    @Test(expected = IotHubBadFormatException.class)
+    @Test (timeout=MAX_TEST_MILLISECONDS, expected = IotHubBadFormatException.class)
     public void apply_configuration_e2e() throws Exception
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
@@ -31,6 +31,8 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
     private static String deviceId = "java-service-client-e2e-test";
     private static String content = "abcdefghijklmnopqrstuvwxyz1234567890";
 
+    private static final long MAX_TEST_MILLISECONDS = 1 * 60 * 1000;
+
     public ServiceClientTests(IotHubServiceClientProtocol protocol)
     {
         this.testInstance = new ServiceClientITRunner(protocol);
@@ -67,7 +69,7 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         return inputs;
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void cloudToDeviceTelemetry() throws Exception
     {
         // Arrange
@@ -115,7 +117,7 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         registryManager.close();
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenSendingTelemetry() throws IOException
     {
         boolean expectedExceptionWasCaught = false;
@@ -139,7 +141,7 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         assertTrue("Expected an exception due to service presenting invalid certificate", expectedExceptionWasCaught);
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenGettingFeedbackReceiver() throws IOException
     {
         boolean expectedExceptionWasCaught = false;
@@ -165,7 +167,7 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         assertTrue("Expected an exception due to service presenting invalid certificate", expectedExceptionWasCaught);
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenGettingFileUploadFeedbackReceiver() throws IOException
     {
         boolean expectedExceptionWasCaught = false;

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesErrInjDeviceJVMRunner extends ReceiveMessagesErrInjT
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesErrInjModuleJVMRunner extends ReceiveMessagesErrInjT
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesErrInjDeviceJVMRunner extends SendMessagesErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesErrInjModuleJVMRunner extends SendMessagesErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodErrInjDeviceJVMRunner extends DeviceMethodErrInjTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodErrInjDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodErrInjModuleJVMRunner extends DeviceMethodErrInjTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodErrInjModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
@@ -26,7 +26,7 @@ public class DesiredPropertiesErrInjDeviceJVMRunner extends DesiredPropertiesErr
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class DesiredPropertiesErrInjModuleJVMRunner extends DesiredPropertiesErr
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
@@ -26,7 +26,7 @@ public class GetTwinErrInjJVMRunner extends GetTwinErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinErrInjJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class GetTwinErrInjModuleJVMRunner extends GetTwinErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
@@ -26,7 +26,7 @@ public class ReportedPropertiesErrInjDeviceJVMRunner extends ReportedPropertiesE
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class ReportedPropertiesErrInjModuleJVMRunner extends ReportedPropertiesE
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesDeviceJVMRunner extends ReceiveMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesModuleJVMRunner extends ReceiveMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesDeviceJVMRunner extends SendMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesModuleJVMRunner extends SendMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodDeviceJVMRunner extends DeviceMethodTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodModuleJVMRunner extends DeviceMethodTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class DesiredPropertiesDeviceJVMRunner extends DesiredPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class DesiredPropertiesModuleJVMRunner extends DesiredPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class GetTwinDeviceJVMRunner extends GetTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class GetTwinModuleJVMRunner extends GetTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class QueryTwinDeviceJVMRunner extends QueryTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public QueryTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class QueryTwinModuleJVMRunner extends QueryTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public QueryTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReportedPropertiesDeviceJVMRunner extends ReportedPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReportedPropertiesModuleJVMRunner extends ReportedPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class TwinTagsDeviceJVMRunner extends TwinTagsTests
 {
     static Collection<BaseDevice> identities;
 
-    public TwinTagsDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class TwinTagsModuleJVMRunner extends TwinTagsTests
 {
     static Collection<BaseDevice> identities;
 
-    public TwinTagsModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -7,10 +7,7 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.provisioning;
 
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
-import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -43,7 +40,7 @@ import static junit.framework.TestCase.fail;
 import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
-public class ProvisioningClientJVMRunner
+public class ProvisioningClientJVMRunner extends MethodNameLoggingIntegrationTest
 {
     private final IotHubClientProtocol [] iotHubClientProtocols = {IotHubClientProtocol.MQTT, IotHubClientProtocol.MQTT_WS, IotHubClientProtocol.AMQPS, IotHubClientProtocol.AMQPS_WS, IotHubClientProtocol.HTTPS};
     private final ProvisioningDeviceClientTransportProtocol [] provisioningDeviceClientTransportProtocols = {MQTT, MQTT_WS, AMQPS, AMQPS_WS, HTTPS};
@@ -69,7 +66,7 @@ public class ProvisioningClientJVMRunner
     private static final String TPM_SIMULATOR_IP_ADDRESS_ENV_NAME = "IOT_DPS_TPM_SIMULATOR_IP_ADDRESS"; // ip address of TPM simulator
     private static String tpmSimulatorIpAddress = "";
 
-    private static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 20 * 60 * 1000; // one registration could take up to 20 mins
+    private static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 2 * 60 * 1000; // one registration could take up to 2 mins
 
     private static final long TPM_CONNECTION_TIMEOUT = 1 * 60 * 1000;
 
@@ -92,7 +89,7 @@ public class ProvisioningClientJVMRunner
     private RegistryManager registryManager = null;
 
     private static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
-    private static final int OVERALL_TEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+    private static final int OVERALL_TEST_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection inputs()


### PR DESCRIPTION
# Description of the problem
The e2e tests in this codebase don't always have output that correlates the test device id, hub name, etc. to it's failure logs. This PR adds in these details

# Description of the solution
All device/module-centric tests now include correlation details in all of their assertions/exceptions. Tests with just a service client don't have a big need for these correlation details as the hubs are static, and the timestamp is a part of the VSTS build already

I also added timeouts to all e2e tests that were missing a timeout