### PR TITLE
E2E correlation details logging + E2E fixes

### DIFF
--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -8,8 +8,8 @@ package com.microsoft.azure.sdk.iot.android.iothubservices;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
-import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
+import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
 import com.microsoft.azure.sdk.iot.deps.util.Base64;
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
@@ -10,6 +10,7 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests;
+
 import org.junit.BeforeClass;
 import org.junit.Rule;
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -42,7 +42,7 @@ public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErr
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -42,7 +42,7 @@ public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErr
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -42,7 +42,7 @@ public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -42,7 +42,7 @@ public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
@@ -44,7 +44,7 @@ public class DeviceMethodErrInjDeviceAndroidRunner extends DeviceMethodErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodErrInjDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
@@ -44,7 +44,7 @@ public class DeviceMethodErrInjModuleAndroidRunner extends DeviceMethodErrInjTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodErrInjModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
@@ -38,7 +38,7 @@ public class DesiredPropertiesErrInjDeviceAndroidRunner extends DesiredPropertie
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertie
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
@@ -38,7 +38,7 @@ public class GetTwinErrInjDeviceAndroidRunner extends GetTwinErrInjTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class GetTwinErrInjModuleAndroidRunner extends GetTwinErrInjTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
@@ -38,7 +38,7 @@ public class ReportedPropertiesErrInjDeviceAndroidRunner extends ReportedPropert
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class ReportedPropertiesErrInjModuleAndroidRunner extends ReportedPropert
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -41,7 +41,7 @@ public class ReceiveMessagesDeviceAndroidRunner extends ReceiveMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.messaging;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
-import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -43,7 +43,7 @@ public class ReceiveMessagesModuleAndroidRunner extends ReceiveMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReceiveMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -41,7 +41,7 @@ public class SendMessagesDeviceAndroidRunner extends SendMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesDeviceAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
@@ -42,7 +42,7 @@ public class SendMessagesModuleAndroidRunner extends SendMessagesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public SendMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesModuleAndroidRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -43,7 +43,7 @@ public class DeviceMethodDeviceAndroidRunner extends DeviceMethodTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodDeviceAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
@@ -44,7 +44,7 @@ public class DeviceMethodModuleAndroidRunner extends DeviceMethodTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DeviceMethodModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodModuleAndroidRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class DesiredPropertiesDeviceAndroidRunner extends DesiredPropertiesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class DesiredPropertiesModuleAndroidRunner extends DesiredPropertiesTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public DesiredPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
@@ -10,6 +10,7 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DeviceTwinWithVersionTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class GetTwinDeviceAndroidRunner extends GetTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class GetTwinModuleAndroidRunner extends GetTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public GetTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class QueryTwinDeviceAndroidRunner extends QueryTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public QueryTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class QueryTwinModuleAndroidRunner extends QueryTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public QueryTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class ReportedPropertiesDeviceAndroidRunner extends ReportedPropertiesTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class ReportedPropertiesModuleAndroidRunner extends ReportedPropertiesTes
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public ReportedPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -37,7 +37,7 @@ public class TwinTagsDeviceAndroidRunner extends TwinTagsTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public TwinTagsDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsDeviceAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
@@ -36,7 +36,7 @@ public class TwinTagsModuleAndroidRunner extends TwinTagsTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public TwinTagsModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsModuleAndroidRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
@@ -10,6 +10,7 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ExportImportTests;
 import com.microsoft.azure.storage.StorageException;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
@@ -10,6 +10,7 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.JobClientTests;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.RegistryManagerTests;
+
 import org.junit.BeforeClass;
 import org.junit.Rule;
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
@@ -13,6 +13,7 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -23,7 +24,7 @@ public class ServiceClientAndroidRunner extends ServiceClientTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{0}")
-    public static Collection inputsCommon()
+    public static Collection inputsCommon() throws IOException
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         invalidCertificateServerConnectionString = BuildConfig.IotHubInvalidCertConnectionString;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ServiceClientTests;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/CorrelationDetailsLoggingAssert.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/CorrelationDetailsLoggingAssert.java
@@ -1,0 +1,275 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.common.helpers;
+
+import com.microsoft.azure.sdk.iot.device.InternalClient;
+import org.junit.ComparisonFailure;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+
+public class CorrelationDetailsLoggingAssert
+{
+    String hostname;
+    Collection<String> deviceIds;
+    String protocol;
+    Collection<String> moduleIds;
+
+    public CorrelationDetailsLoggingAssert(String hostname, String deviceId, String protocol, String moduleId)
+    {
+        this.hostname = hostname;
+        this.deviceIds = new ArrayList<>();
+        this.deviceIds.add(deviceId);
+        this.protocol = protocol;
+
+        if (moduleId != null && !moduleId.isEmpty())
+        {
+            this.moduleIds = new ArrayList<>();
+            this.moduleIds.add(moduleId);
+        }
+    }
+
+    public CorrelationDetailsLoggingAssert(String hostname, Collection<String> deviceIds, String protocol, Collection<String> moduleIds)
+    {
+        this.hostname = hostname;
+        this.deviceIds = deviceIds;
+        this.protocol = protocol;
+        this.moduleIds = moduleIds;
+    }
+
+    public CorrelationDetailsLoggingAssert(InternalClient internalClient)
+    {
+        this(internalClient.getConfig().getIotHubHostname(),
+                internalClient.getConfig().getDeviceId(),
+                internalClient.getConfig().getProtocol().toString(),
+                internalClient.getConfig().getModuleId());
+    }
+
+    public static String buildExceptionMessage(String baseMessage, Collection<String> deviceIds, String protocol, String hostname, Collection<String> moduleIds)
+    {
+        String timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss").format(new Date());
+        String correlationString = "Hostname: " + hostname;
+        if (deviceIds != null && deviceIds.size() > 0)
+        {
+            correlationString += " Device id: ";
+            boolean isFirstDevice = true;
+            for (String deviceId : deviceIds)
+            {
+                if (isFirstDevice)
+                {
+                    correlationString += deviceId;
+                }
+                else
+                {
+                    correlationString += ", " + deviceId;
+                }
+
+                isFirstDevice = false;
+            }
+        }
+
+        if (moduleIds != null && moduleIds.size() > 0)
+        {
+            correlationString += " Module id: ";
+            boolean isFirstModule = true;
+            for (String moduleId : moduleIds)
+            {
+                if (isFirstModule)
+                {
+                    correlationString += moduleId;
+                }
+                else
+                {
+                    correlationString += ", " + moduleId;
+                }
+
+                isFirstModule = false;
+            }
+        }
+
+        if (protocol != null && !protocol.isEmpty())
+        {
+            correlationString += " Protocol: " + protocol;
+        }
+        
+        correlationString += " Timestamp: " + timeStamp;
+
+        return baseMessage + "\n(Correlation details: <" + correlationString + ">)";
+    }
+
+    public static String buildExceptionMessage(String baseMessage, String deviceId, String protocol, String hostname, String moduleId)
+    {
+        Collection<String> deviceIds = new ArrayList<>();
+        deviceIds.add(deviceId);
+
+        Collection<String> moduleIds = new ArrayList<>();
+        if (moduleId != null && !moduleId.isEmpty())
+        {
+            moduleIds.add(moduleId);
+        }
+
+        return buildExceptionMessage(baseMessage, deviceIds, protocol, hostname, moduleIds);
+    }
+
+    public static String buildExceptionMessage(String baseMessage, InternalClient client)
+    {
+        if (client == null || client.getConfig() == null)
+        {
+            throw new IllegalArgumentException("client and config must not be null");
+        }
+
+        return buildExceptionMessage(
+                baseMessage,
+                client.getConfig().getDeviceId(),
+                client.getConfig().getProtocol().toString(),
+                client.getConfig().getIotHubHostname(),
+                client.getConfig().getModuleId());
+    }
+
+    public static String buildExceptionMessage(String baseMessage, Collection<InternalClient> clients)
+    {
+        String hostname = "";
+        String protocol = "";
+        Collection<String> deviceIds = new ArrayList<>();
+        Collection<String> moduleIds = new ArrayList<>();
+
+        for (InternalClient client : clients)
+        {
+            hostname = client.getConfig().getIotHubHostname();
+            protocol = client.getConfig().getProtocol().toString();
+            deviceIds.add(client.getConfig().getDeviceId());
+
+            if (client.getConfig().getModuleId() != null && !client.getConfig().getModuleId().isEmpty())
+            {
+                moduleIds.add(client.getConfig().getModuleId());
+            }
+        }
+
+        return buildExceptionMessage(
+                baseMessage,
+                deviceIds,
+                protocol,
+                hostname,
+                moduleIds);
+    }
+
+    public static String buildExceptionMessage(String baseMessage, String hostname)
+    {
+        return buildExceptionMessage(
+                baseMessage,
+                new ArrayList<>(),
+                null,
+                hostname,
+                new ArrayList<>());
+    }
+
+    public void assertTrue(String message, boolean condition)
+    {
+        if (!condition)
+        {
+            fail(message);
+        }
+    }
+
+    public void assertTrue(boolean condition)
+    {
+        assertTrue(null, condition);
+    }
+
+    public void assertFalse(String message, boolean condition)
+    {
+        assertTrue(message, !condition);
+    }
+
+    public void assertFalse(boolean condition)
+    {
+        assertFalse(null, condition);
+    }
+
+    public void fail(String message)
+    {
+        if (message == null)
+        {
+            throw new AssertionError(buildExceptionMessage("", this.deviceIds, this.protocol, this.hostname, this.moduleIds));
+        }
+
+        throw new AssertionError(buildExceptionMessage(message, this.deviceIds, this.protocol, this.hostname, this.moduleIds));
+    }
+
+    public void fail()
+    {
+        fail(null);
+    }
+
+    public void assertEquals(String message, Object expected, Object actual)
+    {
+        if (equalsRegardingNull(expected, actual))
+        {
+            return;
+        }
+        else if (expected instanceof String && actual instanceof String)
+        {
+            String cleanMessage = message == null ? "" : message;
+            throw new ComparisonFailure(cleanMessage, (String) expected, (String) actual);
+        }
+        else
+        {
+            failNotEquals(message, expected, actual);
+        }
+    }
+
+    public void assertEquals(Object expected, Object actual)
+    {
+        assertEquals(null, expected, actual);
+    }
+
+    private boolean equalsRegardingNull(Object expected, Object actual)
+    {
+        if (expected == null)
+        {
+            return actual == null;
+        }
+
+        return isEquals(expected, actual);
+    }
+
+    private void failNotEquals(String message, Object expected, Object actual)
+    {
+        fail(format(message, expected, actual));
+    }
+
+    String format(String message, Object expected, Object actual)
+    {
+        String formatted = "";
+        if (message != null && !message.equals(""))
+        {
+            formatted = message + " ";
+        }
+        String expectedString = String.valueOf(expected);
+        String actualString = String.valueOf(actual);
+        if (expectedString.equals(actualString))
+        {
+            return formatted + "expected: " + formatClassAndValue(expected, expectedString) + " but was: " + formatClassAndValue(actual, actualString);
+        }
+        else
+        {
+            return formatted + "expected:<" + expectedString + "> but was:<" + actualString + ">";
+        }
+    }
+
+    private String formatClassAndValue(Object value, String valueString)
+    {
+        String className = value == null ? "null" : value.getClass().getName();
+        return className + "<" + valueString + ">";
+    }
+
+    private boolean isEquals(Object expected, Object actual)
+    {
+        return expected.equals(actual);
+    }
+}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
@@ -9,13 +9,10 @@ import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Device;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
-import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
@@ -294,11 +294,9 @@ public class DeviceEmulator  implements Runnable
                 case OK:
                 case OK_EMPTY:
                     deviceStatus.statusOk++;
-                    System.out.println("status ok received");
                     break;
                 default:
                     deviceStatus.statusError++;
-                    System.out.println("status error received");
                     break;
             }
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class DeviceTestManager
 {
-    private static final int OPEN_CONNECTION_TIMEOUT_IN_SECONDS = 10;
     private static final int STOP_DEVICE_TIMEOUT_IN_MILLISECONDS = 10000;
     private static final int SECOND_IN_MILLISECONDS = 1000;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
@@ -10,7 +10,7 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
-public class MethodNameLoggingIntegrationTest
+public class IntegrationTest
 {
     @Rule
     public TestRule watcher = new TestWatcher()
@@ -18,6 +18,11 @@ public class MethodNameLoggingIntegrationTest
         protected void starting(Description description)
         {
             System.out.println("Starting test: " + description.getMethodName());
+        }
+
+        protected void finished(Description description)
+        {
+            System.out.println("Finished test: " + description.getMethodName());
         }
     };
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.common.helpers;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 
 public class IntegrationTest
@@ -25,4 +26,10 @@ public class IntegrationTest
             System.out.println("Finished test: " + description.getMethodName());
         }
     };
+
+    public static final int E2E_TEST_TIMEOUT_MS = 15 * 60 * 1000;
+
+    //This timeout applies to all individual tests in classes that inherit from this class
+    @Rule
+    public Timeout timeout = new Timeout(E2E_TEST_TIMEOUT_MS);
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
@@ -448,17 +448,4 @@ public class IotHubServicesCommon
 
         return false;
     }
-
-    public static String actualStatusUpdatesToString(List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
-    {
-        String statusString = "";
-        for (int i = 0; i < actualStatusUpdates.size(); i++)
-        {
-            IotHubConnectionStatus status = actualStatusUpdates.get(i).getKey();
-            Throwable cause = actualStatusUpdates.get(i).getValue();
-            statusString += i + "th status update: " + status + ((cause == null) ? "" : " with throwable " + Tools.getStackTraceFromThrowable(cause) + "\n");
-        }
-
-        return statusString;
-    }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Rerun.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Rerun.java
@@ -37,7 +37,7 @@ public class Rerun implements TestRule
                         return;
                     } catch (Throwable t) {
                         lastThrowable = t;
-                        System.err.println(description.getDisplayName() + ": Failed run " + (i+1));
+                        System.err.println(description.getDisplayName() + ": Failed run " + (i+1) + " with throwable " + Tools.getStackTraceFromThrowable(t));
                     }
                 }
                 System.err.println(description.getDisplayName() + ": Test failed after " + count + " failures");

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
@@ -6,16 +6,22 @@
 package com.microsoft.azure.sdk.iot.common.helpers;
 
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
+import com.microsoft.azure.sdk.iot.service.Device;
 import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Collection;
 
 public class Tools
 {
+    private static final long RETRY_TIMEOUT_ON_NETWORK_FAILURE = 60 * 1000;
+    private static final long WAIT_FOR_RETRY = 2000;
+
     public static String retrieveEnvironmentVariableValue(String environmentVariableName)
     {
         String environmentVariableValue = System.getenv().get(environmentVariableName);
@@ -77,6 +83,133 @@ public class Tools
                 e.printStackTrace();
             }
         }
+    }
+
+    public static Device addDeviceWithRetry(RegistryManager registryManager, Device device) throws IotHubException, IOException, InterruptedException
+    {
+        long startTime = System.currentTimeMillis();
+        Device ret = null;
+        while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+        {
+            try
+            {
+                ret = registryManager.addDevice(device);
+                break;
+            }
+            catch (UnknownHostException | SocketException e)
+            {
+                System.out.println("Failed to add device " + device.getDeviceId());
+                e.printStackTrace();
+                Thread.sleep(WAIT_FOR_RETRY);
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+                {
+                    throw e;
+                }
+            }
+
+        }
+
+        return ret;
+    }
+
+    public static Module addModuleWithRetry(RegistryManager registryManager, Module module) throws IotHubException, IOException, InterruptedException
+    {
+        long startTime = System.currentTimeMillis();
+        Module ret = null;
+        while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+        {
+            try
+            {
+                ret = registryManager.addModule(module);
+                break;
+            }
+            catch (UnknownHostException | SocketException e)
+            {
+                System.out.println("Failed to add module " + module.getId());
+                e.printStackTrace();
+                Thread.sleep(WAIT_FOR_RETRY);
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+                {
+                    throw e;
+                }
+            }
+        }
+        return ret;
+    }
+
+    public static void getStatisticsWithRetry(RegistryManager registryManager) throws IotHubException, IOException, InterruptedException
+    {
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+        {
+            try
+            {
+                registryManager.getStatistics();
+                break;
+            }
+            catch (UnknownHostException | SocketException e)
+            {
+                System.out.println("Failed to get statistics ");
+                e.printStackTrace();
+                Thread.sleep(WAIT_FOR_RETRY);
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+                {
+                    throw e;
+                }
+            }
+        }
+
+
+    }
+
+    public static Device getDeviceWithRetry(RegistryManager registryManager, String id) throws IotHubException, IOException, InterruptedException
+    {
+        long startTime = System.currentTimeMillis();
+        Device ret = null;
+        while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+        {
+            try
+            {
+                ret = registryManager.getDevice(id);
+                break;
+            }
+            catch (UnknownHostException | SocketException e)
+            {
+                System.out.println("Failed to get device ");
+                e.printStackTrace();
+                Thread.sleep(WAIT_FOR_RETRY);
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+                {
+                    throw e;
+                }
+            }
+        }
+        return ret;
+    }
+
+    public static Module getModuleWithRetry(RegistryManager registryManager, String deviceid, String moduleid) throws IotHubException, IOException, InterruptedException
+    {
+        long startTime = System.currentTimeMillis();
+        Module ret = null;
+        while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+        {
+            try
+            {
+                ret = registryManager.getModule(deviceid, moduleid);
+                break;
+            }
+            catch (UnknownHostException | SocketException e)
+            {
+                System.out.println("Failed to get module ");
+                e.printStackTrace();
+                Thread.sleep(WAIT_FOR_RETRY);
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_ON_NETWORK_FAILURE)
+                {
+                    throw e;
+                }
+            }
+        }
+        return ret;
     }
 
     public static String getStackTraceFromThrowable(Throwable throwable)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/Tools.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -40,7 +41,6 @@ public class Tools
     {
         return possibleExceptionCause.isInstance(exceptionToSearch) || (exceptionToSearch != null && isCause(possibleExceptionCause, exceptionToSearch.getCause()));
     }
-
 
     /**
      * Uses the provided registry manager to delete all the devices and modules specified in the arguments
@@ -77,5 +77,10 @@ public class Tools
                 e.printStackTrace();
             }
         }
+    }
+
+    public static String getStackTraceFromThrowable(Throwable throwable)
+    {
+        return ExceptionUtils.getStackTrace(throwable);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -118,15 +118,15 @@ public class DeviceMethodCommon extends IntegrationTest
                     DeviceClient deviceClient = new DeviceClient(registryManager.getDeviceConnectionString(device), protocol);
                     DeviceTestManager deviceClientSasTestManager = new DeviceTestManager(deviceClient);
                     deviceTestManagers.add(deviceClientSasTestManager);
-                    inputs.add(makeSubArray(deviceClientSasTestManager, protocol, SAS, "DeviceClient", device, publicKeyCert, privateKey, x509Thumbprint));
+                    inputs.add(makeSubArray(deviceClientSasTestManager, protocol, SAS, ClientType.DEVICE_CLIENT, device, publicKeyCert, privateKey, x509Thumbprint));
                 }
                 else if (clientType == ClientType.MODULE_CLIENT)
                 {
                     //sas module client
-                    ModuleClient moduleClient = new ModuleClient(registryManager.getDeviceConnectionString(device) + ";ModuleId=" + module.getId(), protocol);
+                    ModuleClient moduleClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), protocol);
                     DeviceTestManager moduleClientSasTestManager = new DeviceTestManager(moduleClient);
                     deviceTestManagers.add(moduleClientSasTestManager);
-                    inputs.add(makeSubArray(moduleClientSasTestManager, protocol, SAS, "ModuleClient", module, publicKeyCert, privateKey, x509Thumbprint));
+                    inputs.add(makeSubArray(moduleClientSasTestManager, protocol, SAS, ClientType.MODULE_CLIENT, module, publicKeyCert, privateKey, x509Thumbprint));
                 }
 
                 if (protocol != MQTT_WS && protocol != AMQPS_WS)
@@ -137,15 +137,15 @@ public class DeviceMethodCommon extends IntegrationTest
                         DeviceClient deviceClientX509 = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager deviceClientX509TestManager = new DeviceTestManager(deviceClientX509);
                         deviceTestManagers.add(deviceClientX509TestManager);
-                        inputs.add(makeSubArray(deviceClientX509TestManager, protocol, SELF_SIGNED, "DeviceClient", deviceX509, publicKeyCert, privateKey, x509Thumbprint));
+                        inputs.add(makeSubArray(deviceClientX509TestManager, protocol, SELF_SIGNED, ClientType.DEVICE_CLIENT, deviceX509, publicKeyCert, privateKey, x509Thumbprint));
                     }
                     else if (clientType == ClientType.MODULE_CLIENT)
                     {
                         //x509 module client
-                        ModuleClient moduleClientX509 = new ModuleClient(registryManager.getDeviceConnectionString(deviceX509) + ";ModuleId=" + moduleX509.getId(), protocol, publicKeyCert, false, privateKey, false);
+                        ModuleClient moduleClientX509 = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), protocol, publicKeyCert, false, privateKey, false);
                         DeviceTestManager moduleClientX509TestManager = new DeviceTestManager(moduleClientX509);
                         deviceTestManagers.add(moduleClientX509TestManager);
-                        inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, "ModuleClient", moduleX509, publicKeyCert, privateKey, x509Thumbprint));
+                        inputs.add(makeSubArray(moduleClientX509TestManager, protocol, SELF_SIGNED, ClientType.MODULE_CLIENT, moduleX509, publicKeyCert, privateKey, x509Thumbprint));
                     }
                 }
             }
@@ -154,7 +154,7 @@ public class DeviceMethodCommon extends IntegrationTest
         return inputs;
     }
 
-    private static Object[] makeSubArray(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    private static Object[] makeSubArray(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         Object[] inputSubArray = new Object[8];
         inputSubArray[0] = deviceTestManager;
@@ -168,7 +168,7 @@ public class DeviceMethodCommon extends IntegrationTest
         return inputSubArray;
     }
 
-    protected DeviceMethodCommon(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    protected DeviceMethodCommon(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new DeviceMethodTestInstance(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -178,13 +178,13 @@ public class DeviceMethodCommon extends IntegrationTest
         public DeviceTestManager deviceTestManager;
         public IotHubClientProtocol protocol;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public BaseDevice identity;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
 
-        protected DeviceMethodTestInstance(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+        protected DeviceMethodTestInstance(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.deviceTestManager = deviceTestManager;
             this.protocol = protocol;
@@ -405,6 +405,6 @@ public class DeviceMethodCommon extends IntegrationTest
 
     protected String getModuleConnectionString(Module module) throws IotHubException, IOException
     {
-        return registryManager.getDeviceConnectionString(registryManager.getDevice(module.getDeviceId())) + ";ModuleId=" + module.getId();
+        return DeviceConnectionString.get(iotHubConnectionString, registryManager.getDevice(module.getDeviceId()), module);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -36,7 +36,8 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
 import static junit.framework.TestCase.fail;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Utility functions, setup and teardown for all device method integration tests. This class should not contain any tests,
@@ -44,13 +45,10 @@ import static org.junit.Assert.*;
  */
 public class DeviceMethodCommon extends IntegrationTest
 {
-    protected static final String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
     protected static String iotHubConnectionString = "";
 
     protected static DeviceMethod methodServiceClient;
     protected static RegistryManager registryManager;
-
-    protected static final long DEFAULT_TEST_TIMEOUT = 1 * 60 * 1000;
 
     protected static final Long RESPONSE_TIMEOUT = TimeUnit.SECONDS.toSeconds(200);
     protected static final Long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toSeconds(5);
@@ -68,7 +66,6 @@ public class DeviceMethodCommon extends IntegrationTest
 
     protected DeviceMethodTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT = 1 * 60 * 1000; // 1 minute
-    protected static final long ERROR_INJECTION_EXECUTION_TIMEOUT = 2* 60 * 1000; // 2 minute
 
     protected static Collection inputsCommon(ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
     {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -97,13 +97,13 @@ public class DeviceMethodCommon extends IntegrationTest
         Collection<Object[]> inputs = new ArrayList<>();
 
         /* Add devices to the IoTHub */
-        device = registryManager.addDevice(device);
-        deviceX509 = registryManager.addDevice(deviceX509);
+        device = Tools.addDeviceWithRetry(registryManager, device);
+        deviceX509 = Tools.addDeviceWithRetry(registryManager, deviceX509);
 
         if (clientType == ClientType.MODULE_CLIENT)
         {
-            module = registryManager.addModule(module);
-            moduleX509 = registryManager.addModule(moduleX509);
+            module = Tools.addModuleWithRetry(registryManager, module);
+            moduleX509 = Tools.addModuleWithRetry(registryManager, moduleX509);
         }
 
         Thread.sleep(2000);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -53,9 +53,6 @@ public class DeviceTwinCommon extends IntegrationTest
 
     protected static final long MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS = DELAY_BETWEEN_OPERATIONS * 10; // 2 sec
 
-    //Max time to wait before timing out test
-    protected static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = 180000; // 3 min
-
     // Max reported properties to be tested
     protected static final Integer MAX_PROPERTIES_TO_TEST = 5;
 
@@ -90,7 +87,6 @@ public class DeviceTwinCommon extends IntegrationTest
 
     protected DeviceTwinTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT = 1 * 60 * 1000; // 1 minute
-    protected static final long ERROR_INJECTION_EXECUTION_TIMEOUT = 2 * 60 * 1000; // 2 minute
 
     //How many milliseconds between retry
     protected static final Integer RETRY_MILLISECONDS = 100;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -248,7 +248,7 @@ public class DeviceTwinCommon extends IntegrationTest
                 }
                 else
                 {
-                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId + this.testInstance.uuid,
+                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager, deviceState.sCModuleForRegistryManager),
                             this.testInstance.protocol);
                 }
             }
@@ -265,7 +265,7 @@ public class DeviceTwinCommon extends IntegrationTest
                 }
                 else
                 {
-                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager) + ";ModuleId=" + this.testInstance.moduleId,
+                    internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager, deviceState.sCModuleForRegistryManager),
                             this.testInstance.protocol,
                             testInstance.publicKeyCert,
                             false,
@@ -346,14 +346,14 @@ public class DeviceTwinCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token, device client
-                                    {deviceIdAmqps, null, AMQPS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, null, MQTT, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqps, null, AMQPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqtt, null, MQTT, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509, device client
-                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
                             }
             );
         }
@@ -363,10 +363,10 @@ public class DeviceTwinCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token, module client
-                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }
@@ -374,7 +374,7 @@ public class DeviceTwinCommon extends IntegrationTest
         return inputs;
     }
 
-    public DeviceTwinCommon(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceTwinCommon(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new DeviceTwinTestInstance(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -390,7 +390,7 @@ public class DeviceTwinCommon extends IntegrationTest
         public String x509Thumbprint;
         public String uuid;
 
-        public DeviceTwinTestInstance(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public DeviceTwinTestInstance(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.deviceId = deviceId;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -48,6 +48,7 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static final long PERIODIC_WAIT_TIME_FOR_VERIFICATION = 100; // 0.1 sec
     protected static final long MAX_WAIT_TIME_FOR_VERIFICATION = 180000; // 180 sec
     protected static final long DELAY_BETWEEN_OPERATIONS = 200; // 0.2 sec
+    public static final long MULTITHREADED_WAIT_TIMEOUT_MS  = 5 * 60 * 1000; // 5 minutes
 
     protected static final long MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS = DELAY_BETWEEN_OPERATIONS * 10; // 2 sec
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -581,8 +581,18 @@ public class DeviceTwinCommon extends IntegrationTest
     protected void subscribeToDesiredPropertiesAndVerify(int numOfProp) throws IOException, InterruptedException, IotHubException
     {
         // arrange
-        deviceUnderTest.sCDeviceForTwin.clearDesiredProperties();
-        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
+        if (deviceUnderTest != null)
+        {
+            if (deviceUnderTest.sCDeviceForTwin != null)
+            {
+                deviceUnderTest.sCDeviceForTwin.clearDesiredProperties();
+            }
+
+            if (deviceUnderTest.dCDeviceForTwin != null && deviceUnderTest.dCDeviceForTwin.getReportedProp() != null)
+            {
+                deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
+            }
+        }
         deviceUnderTest.dCDeviceForTwin.propertyStateList = new PropertyState[numOfProp];
         for (int i = 0; i < numOfProp; i++)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -29,6 +29,7 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
@@ -41,7 +42,7 @@ import static org.junit.Assert.*;
  * Utility functions, setup and teardown for all device twin integration tests. This class should not contain any tests,
  * but any child class should.
  */
-public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
+public class DeviceTwinCommon extends IntegrationTest
 {
     // Max time to wait to see it on Hub
     protected static final long PERIODIC_WAIT_TIME_FOR_VERIFICATION = 100; // 0.1 sec
@@ -78,12 +79,12 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
 
     // States of SDK
     protected static RegistryManager registryManager;
-    protected static InternalClient internalClient;
+    protected InternalClient internalClient;
     protected static RawTwinQuery scRawTwinQueryClient;
     protected static DeviceTwin sCDeviceTwin;
-    protected static DeviceState deviceUnderTest = null;
+    protected DeviceState deviceUnderTest = null;
 
-    protected static DeviceState[] devicesUnderTest;
+    protected DeviceState[] devicesUnderTest;
 
     protected DeviceTwinTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT = 1 * 60 * 1000; // 1 minute
@@ -299,7 +300,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         }
     }
 
-    protected static void tearDownTwin(DeviceState deviceState) throws IOException
+    protected void tearDownTwin(DeviceState deviceState) throws IOException
     {
         // tear down twin on device client
         if (deviceState.sCDeviceForTwin != null)
@@ -457,7 +458,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         catch (InterruptedException e)
         {
             e.printStackTrace();
-            fail("Unexpected exception encountered");
+            fail(buildExceptionMessage("Unexpected exception encountered", internalClient));
         }
     }
 
@@ -477,7 +478,6 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
 
         registryManager = null;
         sCDeviceTwin = null;
-        internalClient = null;
     }
 
     protected void readReportedPropertiesAndVerify(DeviceState deviceState, String startsWithKey, String startsWithValue, int expectedReportedPropCount) throws IOException, IotHubException, InterruptedException
@@ -509,7 +509,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 }
             }
         }
-        assertEquals(expectedReportedPropCount, actualCount);
+        assertEquals(buildExceptionMessage("Expected " + expectedReportedPropCount + " but had " + actualCount, internalClient), expectedReportedPropCount, actualCount);
     }
 
     protected void waitAndVerifyTwinStatusBecomesSuccess() throws InterruptedException
@@ -526,7 +526,7 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                 break;
             }
         }
-        assertEquals(STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but was " + deviceUnderTest.deviceTwinStatus, internalClient), STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
     }
 
     protected void sendReportedPropertiesAndVerify(int numOfProp) throws IOException, IotHubException, InterruptedException
@@ -559,11 +559,11 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
                     break;
                 }
             }
-            assertTrue("Callback was not triggered for one or more properties", propertyState.callBackTriggered);
-            assertTrue(((String) propertyState.propertyNewValue).startsWith(propPrefix));
+            assertTrue(buildExceptionMessage("Callback was not triggered for one or more properties", internalClient), propertyState.callBackTriggered);
+            assertTrue(buildExceptionMessage("Missing the expected prefix, was " + propertyState.propertyNewValue, internalClient), ((String) propertyState.propertyNewValue).startsWith(propPrefix));
             if (withVersion)
             {
-                assertNotEquals("Version was not set in the callback", (int) propertyState.propertyNewVersion, -1);
+                assertNotEquals(buildExceptionMessage("Version was not set in the callback", internalClient), (int) propertyState.propertyNewVersion, -1);
             }
         }
     }
@@ -597,14 +597,14 @@ public class DeviceTwinCommon extends MethodNameLoggingIntegrationTest
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    protected void setConnectionStatusCallBack(final List actualStatusUpdates)
+    protected void setConnectionStatusCallBack(final List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
     {
         IotHubConnectionStatusChangeCallback connectionStatusUpdateCallback = new IotHubConnectionStatusChangeCallback()
         {
             @Override
             public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
             {
-                actualStatusUpdates.add(status);
+                actualStatusUpdates.add(new com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<>(status, throwable));
             }
         };
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -216,8 +216,8 @@ public class DeviceTwinCommon extends IntegrationTest
             String id = "java-device-twin-e2e-test-" + this.testInstance.protocol.toString() + UUID.randomUUID().toString();
             devicesUnderTest[i].sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(id, null, null);
             devicesUnderTest[i].sCModuleForRegistryManager = com.microsoft.azure.sdk.iot.service.Module.createFromId(id, "module", null);
-            devicesUnderTest[i].sCDeviceForRegistryManager = registryManager.addDevice(devicesUnderTest[i].sCDeviceForRegistryManager);
-            devicesUnderTest[i].sCModuleForRegistryManager = registryManager.addModule(devicesUnderTest[i].sCModuleForRegistryManager);
+            devicesUnderTest[i].sCDeviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, devicesUnderTest[i].sCDeviceForRegistryManager);
+            devicesUnderTest[i].sCModuleForRegistryManager = Tools.addModuleWithRetry(registryManager, devicesUnderTest[i].sCModuleForRegistryManager);
             Thread.sleep(2000);
             setUpTwin(devicesUnderTest[i]);
         }
@@ -445,11 +445,11 @@ public class DeviceTwinCommon extends IntegrationTest
         }
 
 
-        deviceUnderTest.sCDeviceForRegistryManager = registryManager.addDevice(deviceUnderTest.sCDeviceForRegistryManager);
+        deviceUnderTest.sCDeviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, deviceUnderTest.sCDeviceForRegistryManager);
 
         if (deviceUnderTest.sCModuleForRegistryManager != null)
         {
-            registryManager.addModule(deviceUnderTest.sCModuleForRegistryManager);
+            Tools.addModuleWithRetry(registryManager, deviceUnderTest.sCModuleForRegistryManager);
         }
 
         Thread.sleep(2000);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.fail;
  */
 public class ReceiveMessagesCommon extends IntegrationTest
 {
-    protected static final long DEFAULT_TEST_TIMEOUT = 3 * 60 * 1000;
     protected static Map<String, String> messageProperties = new HashMap<>(3);
 
     protected final static String SET_MINIMUM_POLLING_INTERVAL = "SetMinimumPollingInterval";
@@ -46,7 +45,6 @@ public class ReceiveMessagesCommon extends IntegrationTest
     protected static final List messageIdListStoredOnC2DSend = new ArrayList(); // store the message id list on sending C2D commands using service client
     protected static final List messageIdListStoredOnReceive = new ArrayList(); // store the message id list on receiving C2D commands using device client
 
-    protected static String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
     protected static String iotHubConnectionString = "";
     protected static RegistryManager registryManager;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
@@ -32,7 +33,7 @@ import static org.junit.Assert.fail;
  * Utility functions, setup and teardown for all C2D telemetry integration tests. This class should not contain any tests,
  * but any child class should.
  */
-public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
+public class ReceiveMessagesCommon extends IntegrationTest
 {
     protected static final long DEFAULT_TEST_TIMEOUT = 3 * 60 * 1000;
     protected static Map<String, String> messageProperties = new HashMap<>(3);
@@ -342,18 +343,18 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
 
                 if (System.currentTimeMillis() - startTime > RECEIVE_TIMEOUT)
                 {
-                    fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Timed out waiting to receive message");
+                    Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Timed out waiting to receive message", testInstance.client));
                 }
             }
 
             if (!messageReceived.getResult())
             {
-                Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Received message was missing expected properties");
+                Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Received message was missing expected properties", testInstance.client));
             }
         }
         catch (InterruptedException e)
         {
-            Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Unexpected interrupted exception occurred");
+            Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message over " + protocolName + " protocol failed. Unexpected interrupted exception occurred", testInstance.client));
         }
     }
 
@@ -368,17 +369,15 @@ public class ReceiveMessagesCommon extends MethodNameLoggingIntegrationTest
             {
                 Thread.sleep(100);
 
-                System.out.println(messageIdListStoredOnReceive.size());
-
                 if (System.currentTimeMillis() - startTime > RECEIVE_TIMEOUT)
                 {
-                    Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving messages timed out.");
+                    Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving messages timed out.", testInstance.client));
                 }
             }
         }
         catch (InterruptedException e)
         {
-            Assert.fail(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message failed. Unexpected interrupted exception occurred.");
+            Assert.fail(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Receiving message failed. Unexpected interrupted exception occurred.", testInstance.client));
         }
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -128,13 +128,13 @@ public class ReceiveMessagesCommon extends IntegrationTest
         deviceX509.setThumbprint(x509Thumbprint, x509Thumbprint);
         moduleX509.setThumbprint(x509Thumbprint, x509Thumbprint);
 
-        registryManager.addDevice(device);
-        registryManager.addDevice(deviceX509);
+        Tools.addDeviceWithRetry(registryManager, device);
+        Tools.addDeviceWithRetry(registryManager, deviceX509);
 
         if (clientType == ClientType.MODULE_CLIENT)
         {
-            registryManager.addModule(module);
-            registryManager.addModule(moduleX509);
+            Tools.addModuleWithRetry(registryManager, module);
+            Tools.addModuleWithRetry(registryManager, moduleX509);
         }
 
         Thread.sleep(2000);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -68,7 +68,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
 
     public ReceiveMessagesTestInstance testInstance;
 
-    public ReceiveMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new ReceiveMessagesTestInstance(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -154,16 +154,16 @@ public class ReceiveMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }
@@ -173,14 +173,14 @@ public class ReceiveMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}                           }
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}                           }
             );
         }
 
@@ -193,12 +193,12 @@ public class ReceiveMessagesCommon extends IntegrationTest
         public IotHubClientProtocol protocol;
         public BaseDevice identity;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
 
-        public ReceiveMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public ReceiveMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.client = client;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -50,8 +50,6 @@ public class SendMessagesCommon extends IntegrationTest
     //How many milliseconds between retry
     protected static final Integer RETRY_MILLISECONDS = 100;
 
-    protected static final long DEFAULT_TEST_TIMEOUT = 1 * 60 * 1000;
-    protected static final long ERROR_INJECTION_EXECUTION_TIMEOUT = 2 * 60 * 1000; // 2 minutes
     protected static String iotHubConnectionString = "";
     protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -33,7 +33,7 @@ import static junit.framework.TestCase.fail;
  * Utility functions, setup and teardown for all D2C telemetry integration tests. This class should not contain any tests,
  * but any child class should.
  */
-public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
+public class SendMessagesCommon extends IntegrationTest
 {
     //How much sequential connections each device will open and close in the multithreaded test.
     protected static final Integer NUM_CONNECTIONS_PER_DEVICE = 5;
@@ -189,6 +189,7 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
+        public CorrelationDetailsLoggingAssert correlationDetailsLoggingAssert;
 
         public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
@@ -200,6 +201,20 @@ public class SendMessagesCommon extends MethodNameLoggingIntegrationTest
             this.publicKeyCert = publicKeyCert;
             this.privateKey = privateKey;
             this.x509Thumbprint = x509Thumbprint;
+
+            String deviceId = "";
+            String moduleId = "";
+            if (identity instanceof Module)
+            {
+                deviceId = identity.getDeviceId();
+                moduleId = ((Module) identity).getId();
+            }
+            else if (identity instanceof Device)
+            {
+                deviceId = identity.getDeviceId();
+            }
+
+            this.correlationDetailsLoggingAssert = new CorrelationDetailsLoggingAssert(this.client.getConfig().getIotHubHostname(), deviceId, protocol.toString(), moduleId);
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -87,7 +87,7 @@ public class SendMessagesCommon extends IntegrationTest
 
     protected static RegistryManager registryManager;
 
-    public SendMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesCommon(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         this.testInstance = new SendMessagesTestInstance(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -144,16 +144,16 @@ public class SendMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, "DeviceClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                             }
             );
         }
@@ -163,14 +163,14 @@ public class SendMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, "ModuleClient", publicKeyCert, privateKey, x509Thumbprint}
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
                     }
             );
         }
@@ -186,13 +186,13 @@ public class SendMessagesCommon extends IntegrationTest
         public IotHubClientProtocol protocol;
         public BaseDevice identity;
         public AuthenticationType authenticationType;
-        public String clientType;
+        public ClientType clientType;
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
         public CorrelationDetailsLoggingAssert correlationDetailsLoggingAssert;
 
-        public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+        public SendMessagesTestInstance(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
         {
             this.client = client;
             this.protocol = protocol;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -124,13 +124,13 @@ public class SendMessagesCommon extends IntegrationTest
         deviceX509.setThumbprint(x509Thumbprint, x509Thumbprint);
         moduleX509.setThumbprint(x509Thumbprint, x509Thumbprint);
 
-        registryManager.addDevice(device);
-        registryManager.addDevice(deviceX509);
+        Tools.addDeviceWithRetry(registryManager, device);
+        Tools.addDeviceWithRetry(registryManager, deviceX509);
 
         if (clientType == ClientType.MODULE_CLIENT)
         {
-            registryManager.addModule(module);
-            registryManager.addModule(moduleX509);
+            Tools.addModuleWithRetry(registryManager, module);
+            Tools.addModuleWithRetry(registryManager, moduleX509);
         }
 
         buildMessageLists();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -51,6 +51,7 @@ public class SendMessagesCommon extends IntegrationTest
     protected static final Integer RETRY_MILLISECONDS = 100;
 
     protected static final long DEFAULT_TEST_TIMEOUT = 1 * 60 * 1000;
+    protected static final long ERROR_INJECTION_EXECUTION_TIMEOUT = 2 * 60 * 1000; // 2 minutes
     protected static String iotHubConnectionString = "";
     protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -61,7 +61,6 @@ public class FileUploadTests extends IntegrationTest
     private static final String REMOTE_FILE_NAME = "File";
     private static final String REMOTE_FILE_NAME_EXT = ".txt";
 
-    private static final String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
     protected static String iotHubConnectionString = "";
 
     // States of SDK

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.*;
 public class FileUploadTests extends IntegrationTest
 {
     // Max time to wait to see it on Hub
-    private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 10000; // 10 sec
+    private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 20000; // 20 sec
 
     //Max time to wait before timing out test
     private static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB + 50000; // 50 secs

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
 import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
@@ -152,12 +153,12 @@ public class FileUploadTests extends IntegrationTest
     {
         String deviceId = "java-file-upload-e2e-test".concat(UUID.randomUUID().toString());
         scDevice = com.microsoft.azure.sdk.iot.service.Device.createFromId(deviceId, null, null);
-        scDevice = registryManager.addDevice(scDevice);
+        scDevice = Tools.addDeviceWithRetry(registryManager, scDevice);
 
         String deviceIdX509 = "java-file-upload-e2e-test-x509".concat(UUID.randomUUID().toString());
         scDevicex509 = com.microsoft.azure.sdk.iot.service.Device.createDevice(deviceIdX509, AuthenticationType.SELF_SIGNED);
         scDevicex509.setThumbprint(x509Thumbprint, x509Thumbprint);
-        scDevicex509 = registryManager.addDevice(scDevicex509);
+        scDevicex509 = Tools.addDeviceWithRetry(registryManager, scDevicex509);
 
         // flush pending notifications before every test to prevent random test failures
         // because of notifications received from other failed test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -122,7 +122,7 @@ public class TransportClientTests extends IntegrationTest
             String deviceId = "java-device-client-e2e-test-multiplexing".concat(i + "-" + uuid);
 
             deviceListAmqps[i] = Device.createFromId(deviceId, null, null);
-            registryManager.addDevice(deviceListAmqps[i]);
+            Tools.addDeviceWithRetry(registryManager, deviceListAmqps[i]);
             clientConnectionStringArrayList[i] = registryManager.getDeviceConnectionString(deviceListAmqps[i]);
         }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices;
 
 import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -89,7 +90,7 @@ public class TransportClientTests extends IntegrationTest
 
     private static final Integer MAX_FILES_TO_UPLOAD = 1;
 
-    private static ArrayList<String> clientConnectionStringArrayList = new ArrayList<>();
+    private static String[] clientConnectionStringArrayList = new String[MAX_DEVICE_MULTIPLEX];
 
     private static DeviceMethod methodServiceClient;
 
@@ -98,7 +99,7 @@ public class TransportClientTests extends IntegrationTest
     private static final String METHOD_NAME = "methodName";
     private static final String METHOD_PAYLOAD = "This is a good payload";
 
-    private static ArrayList<DeviceState> devicesUnderTest = new ArrayList<>();
+    private static DeviceState[] devicesUnderTest = new DeviceState[MAX_DEVICE_MULTIPLEX];
     private static DeviceTwin sCDeviceTwin;
 
     private static final String PROPERTY_KEY = "Key";
@@ -122,7 +123,7 @@ public class TransportClientTests extends IntegrationTest
 
             deviceListAmqps[i] = Device.createFromId(deviceId, null, null);
             registryManager.addDevice(deviceListAmqps[i]);
-            clientConnectionStringArrayList.add(registryManager.getDeviceConnectionString(deviceListAmqps[i]));
+            clientConnectionStringArrayList[i] = registryManager.getDeviceConnectionString(deviceListAmqps[i]);
         }
 
         Thread.sleep(MAX_DEVICE_MULTIPLEX * REGISTRY_MANAGER_DEVICE_CREATION_DELAY_MILLISECONDS);
@@ -165,16 +166,12 @@ public class TransportClientTests extends IntegrationTest
             registryManager.close();
 
             registryManager = null;
-
-            clientConnectionStringArrayList.clear();
         }
 
         if (serviceClient != null)
         {
             serviceClient.close();
         }
-
-        clientConnectionStringArrayList.clear();
     }
 
     @After
@@ -199,7 +196,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         openTransportClientWithRetry(transportClient, clientArrayList);
@@ -220,7 +217,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         openTransportClientWithRetry(transportClient, clientArrayList);
@@ -241,7 +238,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -269,7 +266,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -297,7 +294,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
 
@@ -328,7 +325,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
@@ -362,7 +359,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -436,7 +433,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -509,7 +506,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -540,7 +537,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -581,7 +578,7 @@ public class TransportClientTests extends IntegrationTest
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -608,11 +605,12 @@ public class TransportClientTests extends IntegrationTest
     public void invokeMethodAMQPSWSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
+        transportClient.open();
         ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
-            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
+            clientArrayList.add(new DeviceClient(clientConnectionStringArrayList[i], transportClient));
         }
 
         IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
@@ -648,24 +646,27 @@ public class TransportClientTests extends IntegrationTest
     @Test
     public void testTwin() throws IOException, InterruptedException, IotHubException, URISyntaxException
     {
-        TransportClient transportClient = setUpTwin();
+        TransportClient transportClient = null;
+
+        transportClient = setUpTwin();
 
         ExecutorService executor = Executors.newFixedThreadPool(MAX_PROPERTIES_TO_TEST);
 
-        System.out.println("Testing subscribing to desired properties...");
+        //Testing subscribing to desired properties.
         for (int i = 0; i < MAX_DEVICES; i++)
         {
+            devicesUnderTest[i].dCDeviceForTwin.getDesiredProp().clear();
             for (int j = 0; j < MAX_PROPERTIES_TO_TEST; j++)
             {
                 PropertyState propertyState = new PropertyState();
                 propertyState.callBackTriggered = false;
                 propertyState.property = new Property(PROPERTY_KEY + j, PROPERTY_VALUE);
-                devicesUnderTest.get(i).dCDeviceForTwin.propertyStateList.add(propertyState);
-                devicesUnderTest.get(i).dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, devicesUnderTest.get(i).dCDeviceForTwin, propertyState);
+                devicesUnderTest[i].dCDeviceForTwin.propertyStateList.add(propertyState);
+                devicesUnderTest[i].dCDeviceForTwin.setDesiredPropertyCallback(propertyState.property, devicesUnderTest[i].dCDeviceForTwin, propertyState);
             }
 
             // act
-            devicesUnderTest.get(i).deviceClient.subscribeToDesiredProperties(devicesUnderTest.get(i).dCDeviceForTwin.getDesiredProp());
+            devicesUnderTest[i].deviceClient.subscribeToDesiredProperties(devicesUnderTest[i].dCDeviceForTwin.getDesiredProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             Set<Pair> desiredProperties = new HashSet<>();
@@ -673,46 +674,45 @@ public class TransportClientTests extends IntegrationTest
             {
                 desiredProperties.add(new Pair(PROPERTY_KEY + j, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
             }
-            devicesUnderTest.get(i).sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(devicesUnderTest.get(i).sCDeviceForTwin);
+            devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
+            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            Assert.assertEquals(buildExceptionMessage("Device twin status expected to be SUCCESS, but was: " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
-            for (PropertyState propertyState : devicesUnderTest.get(i).dCDeviceForTwin.propertyStateList)
+            Assert.assertEquals(buildExceptionMessage("Device twin status expected to be SUCCESS, but was: " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
+            for (PropertyState propertyState : devicesUnderTest[i].dCDeviceForTwin.propertyStateList)
             {
-                Assert.assertTrue(buildExceptionMessage("One or more property callbacks were not triggered", devicesUnderTest.get(i).deviceClient), propertyState.callBackTriggered);
-                Assert.assertTrue(buildExceptionMessage("Property new value did not start with " + PROPERTY_VALUE_UPDATE, devicesUnderTest.get(i).deviceClient), ((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
-                Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but device twin status was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+                Assert.assertTrue(buildExceptionMessage("One or more property callbacks were not triggered", devicesUnderTest[i].deviceClient), propertyState.callBackTriggered);
+                Assert.assertTrue(buildExceptionMessage("Property new value did not start with " + PROPERTY_VALUE_UPDATE, devicesUnderTest[i].deviceClient), ((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
+                Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but device twin status was " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
             }
         }
 
-        System.out.println("Testing updating reported properties...");
+        //Testing updating reported properties
         for (int i = 0; i < MAX_DEVICES; i++)
         {
             // act
             // send max_prop RP all at once
-            devicesUnderTest.get(i).dCDeviceForTwin.createNewReportedProperties(MAX_PROPERTIES_TO_TEST);
-            devicesUnderTest.get(i).deviceClient.sendReportedProperties(devicesUnderTest.get(i).dCDeviceForTwin.getReportedProp());
+            devicesUnderTest[i].dCDeviceForTwin.createNewReportedProperties(MAX_PROPERTIES_TO_TEST);
+            devicesUnderTest[i].deviceClient.sendReportedProperties(devicesUnderTest[i].dCDeviceForTwin.getReportedProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // act
             // Update RP
-            devicesUnderTest.get(i).dCDeviceForTwin.updateAllExistingReportedProperties();
-            devicesUnderTest.get(i).deviceClient.sendReportedProperties(devicesUnderTest.get(i).dCDeviceForTwin.getReportedProp());
+            devicesUnderTest[i].dCDeviceForTwin.updateAllExistingReportedProperties();
+            devicesUnderTest[i].deviceClient.sendReportedProperties(devicesUnderTest[i].dCDeviceForTwin.getReportedProp());
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            Assert.assertEquals(buildExceptionMessage("Expected status SUCCESS but was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+            Assert.assertEquals(buildExceptionMessage("Expected status SUCCESS but was " + devicesUnderTest[i].deviceTwinStatus, devicesUnderTest[i].deviceClient), SUCCESS, devicesUnderTest[i].deviceTwinStatus);
 
             // verify if they are received by SC
             Thread.sleep(MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS);
-            int actualReportedPropFound = readReportedProperties(devicesUnderTest.get(i), PROPERTY_KEY, PROPERTY_VALUE_UPDATE);
-            Assert.assertEquals(buildExceptionMessage("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX,devicesUnderTest.get(i).deviceClient), MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
+            int actualReportedPropFound = readReportedProperties(devicesUnderTest[i], PROPERTY_KEY, PROPERTY_VALUE_UPDATE);
+            Assert.assertEquals(buildExceptionMessage("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX,devicesUnderTest[i].deviceClient), MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
         }
 
-        // send max_prop RP one at a time in parallel
-        System.out.println("Testing sending reported properties...");
+        //Testing sending reported properties, send max_prop RP one at a time in parallel
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             final int finalI = i;
@@ -724,37 +724,37 @@ public class TransportClientTests extends IntegrationTest
                     // testSendReportedPropertiesMultiThreaded
                     try
                     {
-                        devicesUnderTest.get(finalI).dCDeviceForTwin.createNewReportedProperties(1);
-                        devicesUnderTest.get(finalI).deviceClient.sendReportedProperties(devicesUnderTest.get(finalI).dCDeviceForTwin.getReportedProp());
+                        devicesUnderTest[finalI].dCDeviceForTwin.createNewReportedProperties(1);
+                        devicesUnderTest[finalI].deviceClient.sendReportedProperties(devicesUnderTest[finalI].dCDeviceForTwin.getReportedProp());
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest[finalI].deviceClient));
                     }
-                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest[finalI].deviceTwinStatus, devicesUnderTest[finalI].deviceClient), SUCCESS, devicesUnderTest[finalI].deviceTwinStatus);
 
                     // testUpdateReportedPropertiesMultiThreaded
                     try
                     {
-                        devicesUnderTest.get(finalI).dCDeviceForTwin.updateExistingReportedProperty(finalI);
-                        devicesUnderTest.get(finalI).deviceClient.sendReportedProperties(devicesUnderTest.get(finalI).dCDeviceForTwin.getReportedProp());
+                        devicesUnderTest[finalI].dCDeviceForTwin.updateExistingReportedProperty(finalI);
+                        devicesUnderTest[finalI].deviceClient.sendReportedProperties(devicesUnderTest[finalI].dCDeviceForTwin.getReportedProp());
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest[finalI].deviceClient));
                     }
-                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest[finalI].deviceTwinStatus, devicesUnderTest[finalI].deviceClient), SUCCESS, devicesUnderTest[finalI].deviceTwinStatus);
                 }
             });
         }
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
         executor.shutdown();
-        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) //4 minutes
         {
             executor.shutdownNow();
+            fail(buildExceptionMessage("Test threads did not finish before timeout", devicesUnderTest[0].deviceClient));
         }
 
-        System.out.println("Tearing down twin status...");
         tearDownTwin(transportClient);
     }
     
@@ -1151,48 +1151,65 @@ public class TransportClientTests extends IntegrationTest
         }
     }
 
-    private TransportClient setUpTwin() throws IOException, IotHubException, InterruptedException, URISyntaxException
+    private TransportClient setUpTwin()
     {
-        sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
-
-        for (int i = 0; i < MAX_DEVICES; i++)
+        TransportClient transportClient = null;
+        try
         {
-            DeviceState deviceState = new DeviceState();
-            deviceState.sCDeviceForRegistryManager = deviceListAmqps[i];
-            deviceState.connectionString = registryManager.getDeviceConnectionString(deviceState.sCDeviceForRegistryManager);
-            devicesUnderTest.add(deviceState);
+            sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
 
-            Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
+            for (int i = 0; i < MAX_DEVICES; i++)
+            {
+                DeviceState deviceState = new DeviceState();
+                deviceState.sCDeviceForRegistryManager = deviceListAmqps[i];
+                deviceState.connectionString = registryManager.getDeviceConnectionString(deviceState.sCDeviceForRegistryManager);
+                devicesUnderTest[i] = deviceState;
+
+                Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
+            }
+
+            transportClient = new TransportClient(IotHubClientProtocol.AMQPS);
+
+            ArrayList<InternalClient> clientArrayList = new ArrayList<>();
+            for (int i = 0; i < MAX_DEVICES; i++)
+            {
+                DeviceState deviceState = devicesUnderTest[i];
+                deviceState.deviceClient = new DeviceClient(deviceState.connectionString, transportClient);
+                devicesUnderTest[i].dCDeviceForTwin = new DeviceExtension();
+                clientArrayList.add(deviceState.deviceClient);
+            }
+
+            IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
+
+            for (int i = 0; i < MAX_DEVICES; i++)
+            {
+                devicesUnderTest[i].deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), devicesUnderTest[i], devicesUnderTest[i].dCDeviceForTwin, devicesUnderTest[i]);
+                devicesUnderTest[i].deviceTwinStatus = SUCCESS;
+                devicesUnderTest[i].sCDeviceForTwin = new DeviceTwinDevice(devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
+                sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+                Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
+            }
         }
-
-        TransportClient transportClient = new TransportClient(IotHubClientProtocol.AMQPS);
-
-        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
-        for (int i = 0; i < MAX_DEVICES; i++)
+        catch (Exception e)
         {
-            DeviceState deviceState = devicesUnderTest.get(i);
-            deviceState.deviceClient = new DeviceClient(deviceState.connectionString, transportClient);
-            devicesUnderTest.get(i).dCDeviceForTwin = new DeviceExtension();
-            clientArrayList.add(deviceState.deviceClient);
-        }
-
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
-
-        for (int i = 0; i < MAX_DEVICES; i++)
-        {
-            devicesUnderTest.get(i).deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), devicesUnderTest.get(i), devicesUnderTest.get(i).dCDeviceForTwin, devicesUnderTest.get(i));
-            devicesUnderTest.get(i).deviceTwinStatus = SUCCESS;
-            devicesUnderTest.get(i).sCDeviceForTwin = new DeviceTwinDevice(devicesUnderTest.get(i).sCDeviceForRegistryManager.getDeviceId());
-            sCDeviceTwin.getTwin(devicesUnderTest.get(i).sCDeviceForTwin);
-            Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
+            fail("Encountered exception during setUpTwin: " + Tools.getStackTraceFromThrowable(e));
         }
 
         return transportClient;
     }
 
-    private void tearDownTwin(TransportClient transportClient) throws IOException
+    private void tearDownTwin(TransportClient transportClient)
     {
-        transportClient.closeNow();
+        try
+        {
+            transportClient.closeNow();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            fail("Encountered exception during tearDownTwin: " + Tools.getStackTraceFromThrowable(e));
+        }
+
         sCDeviceTwin = null;
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -61,7 +61,7 @@ public class TransportClientTests extends IntegrationTest
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION = 500; // .5 seconds
     private static final long RESPONSE_TIMEOUT_SECONDS = 200; // 200 seconds
     private static final long CONNECTION_TIMEOUT_SECONDS = 5; //5 seconds
-    private static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = 2 * 60 * 1000; // 2 minutes
+    private static final long MULTITHREADED_WAIT_TIMEOUT_MS  = 5 * 60 * 1000; // 5 minutes
     private static final long MAX_MILLISECS_TIMEOUT_FLUSH_NOTIFICATION = 10 * 1000; // 10 secs
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_PER_CALL_MS = 1000; // 1 second
     private static final long MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS = MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION * 10; // 2 sec
@@ -191,7 +191,7 @@ public class TransportClientTests extends IntegrationTest
         }
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void sendMessagesOverAmqps() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -212,7 +212,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void sendMessagesOverAmqpsWs() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -233,7 +233,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void receiveMessagesOverAmqpsIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -261,7 +261,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void receiveMessagesOverAmqpWSIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -352,7 +352,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void uploadToBlobAsyncSingleFileAndTelemetryOnAMQP() throws Exception
     {
         // arrange
@@ -412,7 +412,7 @@ public class TransportClientTests extends IntegrationTest
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }
@@ -426,7 +426,7 @@ public class TransportClientTests extends IntegrationTest
         tearDownFileUploadState();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void uploadToBlobAsyncSingleFileAndTelemetryOnAMQPWS() throws Exception
     {
         // arrange
@@ -487,7 +487,7 @@ public class TransportClientTests extends IntegrationTest
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }
@@ -501,7 +501,7 @@ public class TransportClientTests extends IntegrationTest
         tearDownFileUploadState();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -532,7 +532,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
@@ -573,7 +573,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSWSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -604,7 +604,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void invokeMethodAMQPSWSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
@@ -645,7 +645,7 @@ public class TransportClientTests extends IntegrationTest
         transportClient.closeNow();
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testTwin() throws IOException, InterruptedException, IotHubException, URISyntaxException
     {
         TransportClient transportClient = setUpTwin();
@@ -749,7 +749,7 @@ public class TransportClientTests extends IntegrationTest
         }
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices;
 
-import com.microsoft.azure.sdk.iot.common.helpers.EventCallback;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MethodNameLoggingIntegrationTest;
-import com.microsoft.azure.sdk.iot.common.helpers.Success;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -33,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon.openTransportClientWithRetry;
 import static com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon.sendMessagesMultiplex;
 import static com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests.STATUS.FAILURE;
@@ -42,13 +40,12 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
 import static junit.framework.TestCase.fail;
-import static org.junit.Assert.*;
 
 /**
  * Test class containing all tests to be run on JVM and android pertaining to multiplexing with the TransportClient class.
  * Class needs to be extended in order to run these tests as that extended class handles setting connection strings and certificate generation
  */
-public class TransportClientTests extends MethodNameLoggingIntegrationTest
+public class TransportClientTests extends IntegrationTest
 {
     //how many devices to test multiplexing with
     private static final int MAX_DEVICE_MULTIPLEX = 3;
@@ -117,6 +114,8 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         String uuid = UUID.randomUUID().toString();
 
+        System.out.print("TransportClientTests UUID: " + uuid);
+
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             String deviceId = "java-device-client-e2e-test-multiplexing".concat(i + "-" + uuid);
@@ -137,7 +136,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         serviceClient.open();
 
         fileUploadNotificationReceiver = serviceClient.getFileUploadNotificationReceiver();
-        assertNotNull(fileUploadNotificationReceiver);
+        Assert.assertNotNull(fileUploadNotificationReceiver);
 
         // flush pending notifications before every test to prevent random test failures
         // because of notifications received from other failed test
@@ -152,7 +151,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public static void tearDown() throws IOException, IotHubException, InterruptedException
     {
         // flush all the notifications caused by this test suite to avoid failures running on different test suite attempt
-        assertNotNull(fileUploadNotificationReceiver);
+        Assert.assertNotNull(fileUploadNotificationReceiver);
         fileUploadNotificationReceiver.open();
         fileUploadNotificationReceiver.receive(MAX_MILLISECS_TIMEOUT_FLUSH_NOTIFICATION);
         fileUploadNotificationReceiver.close();
@@ -196,14 +195,14 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void sendMessagesOverAmqps() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        openTransportClientWithRetry(transportClient);
+        openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
@@ -217,14 +216,14 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void sendMessagesOverAmqpsWs() throws URISyntaxException, IOException, InterruptedException
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        openTransportClientWithRetry(transportClient);
+        openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
@@ -238,23 +237,23 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void receiveMessagesOverAmqpsIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        final ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        final ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
             Success messageReceived = new Success();
             com.microsoft.azure.sdk.iot.device.MessageCallback callback = new MessageCallback();
-            clientArrayList.get(i).setMessageCallback(callback, messageReceived);
+            ((DeviceClient)clientArrayList.get(i)).setMessageCallback(callback, messageReceived);
 
             sendMessageToDevice(deviceListAmqps[i].getDeviceId(), "AMQPS");
-            waitForMessageToBeReceived(messageReceived, "AMQPS");
+            waitForMessageToBeReceived(messageReceived, "AMQPS", clientArrayList.get(i));
 
             Thread.sleep(200);
         }
@@ -266,23 +265,23 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void receiveMessagesOverAmqpWSIncludingProperties() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        final ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        final ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
             Success messageReceived = new Success();
             com.microsoft.azure.sdk.iot.device.MessageCallback callback = new MessageCallback();
-            clientArrayList.get(i).setMessageCallback(callback, messageReceived);
+            ((DeviceClient)clientArrayList.get(i)).setMessageCallback(callback, messageReceived);
 
             sendMessageToDevice(deviceListAmqps[i].getDeviceId(), "AMQPS_WS");
-            waitForMessageToBeReceived(messageReceived, "AMQPS_WS");
+            waitForMessageToBeReceived(messageReceived, "AMQPS_WS", clientArrayList.get(i));
 
             Thread.sleep(200);
         }
@@ -294,7 +293,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void sendMessagesOverAmqpsMultithreaded() throws InterruptedException, URISyntaxException, IOException
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
@@ -302,7 +301,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
@@ -315,7 +314,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         if(!succeed.get())
         {
-            Assert.fail("Sending message over AMQP protocol in parallel failed");
+            Assert.fail(CorrelationDetailsLoggingAssert.buildExceptionMessage("Sending message over AMQP protocol in parallel failed", clientArrayList));
         }
 
         transportClient.closeNow();
@@ -325,7 +324,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void sendMessagesOverAmqpsWsMultithreaded() throws InterruptedException, URISyntaxException, IOException
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
@@ -334,7 +333,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         CountDownLatch cdl = new CountDownLatch(clientArrayList.size());
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
@@ -347,7 +346,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         if(!succeed.get())
         {
-            Assert.fail("Sending message over AMQP protocol in parallel failed");
+            Assert.fail(CorrelationDetailsLoggingAssert.buildExceptionMessage("Sending message over AMQP protocol in parallel failed", clientArrayList));
         }
 
         transportClient.closeNow();
@@ -359,14 +358,14 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         // arrange
         setUpFileUploadState();
         TransportClient transportClient = new TransportClient(AMQPS);
-        final ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        final ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -384,10 +383,11 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     {
                         try
                         {
-                            clientArrayList.get(indexJ).uploadToBlobAsync(fileUploadState[indexI].blobName, fileUploadState[indexI].fileInputStream, fileUploadState[indexI].fileLength, new FileUploadCallback(), fileUploadState[indexI]);
-                        } catch (IOException e)
+                            ((DeviceClient)clientArrayList.get(indexJ)).uploadToBlobAsync(fileUploadState[indexI].blobName, fileUploadState[indexI].fileInputStream, fileUploadState[indexI].fileLength, new FileUploadCallback(), fileUploadState[indexI]);
+                        }
+                        catch (IOException e)
                         {
-                            Assert.fail(e.getMessage());
+                            Assert.fail(buildExceptionMessage(e.getMessage(), clientArrayList.get(indexJ)));
                         }
                     }
                 });
@@ -403,11 +403,11 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
                 // assert
                 FileUploadNotification fileUploadNotification = fileUploadNotificationReceiver.receive(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
-                assertNotNull(fileUploadNotification);
-                verifyNotification(fileUploadNotification, fileUploadState[i]);
-                assertTrue(fileUploadState[i].isCallBackTriggered);
-                assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-                assertEquals(messageStates[i].messageStatus, SUCCESS);
+                Assert.assertNotNull(buildExceptionMessage("file upload notification was null", clientArrayList.get(indexJ)), fileUploadNotification);
+                verifyNotification(fileUploadNotification, fileUploadState[i], clientArrayList.get(indexJ));
+                Assert.assertTrue(buildExceptionMessage("File upload callback was not triggered for file upload attempt " + i, clientArrayList.get(indexJ)), fileUploadState[i].isCallBackTriggered);
+                Assert.assertEquals(buildExceptionMessage("File upload status was not successful on attempt " + i + ", status was: " + fileUploadState[i].fileUploadStatus, clientArrayList.get(indexJ)), fileUploadState[i].fileUploadStatus, SUCCESS);
+                Assert.assertEquals(buildExceptionMessage("Message status was not successful on attempt " + i + ", status was: " + messageStates[i].messageStatus, clientArrayList.get(indexJ)), messageStates[i].messageStatus, SUCCESS);
             }
         }
 
@@ -419,7 +419,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("File" + i + " has no notification", clientArrayList), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         transportClient.closeNow();
@@ -432,14 +432,14 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         // arrange
         setUpFileUploadState();
         TransportClient transportClient = new TransportClient(AMQPS_WS);
-        final ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        final ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -457,10 +457,11 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     {
                         try
                         {
-                            clientArrayList.get(indexJ).uploadToBlobAsync(fileUploadState[indexI].blobName, fileUploadState[indexI].fileInputStream, fileUploadState[indexI].fileLength, new FileUploadCallback(), fileUploadState[indexI]);
-                        } catch (IOException e)
+                            ((DeviceClient)clientArrayList.get(indexJ)).uploadToBlobAsync(fileUploadState[indexI].blobName, fileUploadState[indexI].fileInputStream, fileUploadState[indexI].fileLength, new FileUploadCallback(), fileUploadState[indexI]);
+                        }
+                        catch (IOException e)
                         {
-                            Assert.fail(e.getMessage());
+                            Assert.fail(buildExceptionMessage(e.getMessage(), clientArrayList.get(indexJ)));
                         }
                     }
                 });
@@ -476,11 +477,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
                 // assert
                 FileUploadNotification fileUploadNotification = fileUploadNotificationReceiver.receive(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
-                assertNotNull(fileUploadNotification);
-                verifyNotification(fileUploadNotification, fileUploadState[i]);
-                assertTrue(fileUploadState[i].isCallBackTriggered);
-                assertEquals(fileUploadState[i].fileUploadStatus, SUCCESS);
-                assertEquals(messageStates[i].messageStatus, SUCCESS);
+                Assert.assertNotNull(buildExceptionMessage("File upload notification was null", clientArrayList.get(j)), fileUploadNotification);
+                verifyNotification(fileUploadNotification, fileUploadState[i], clientArrayList.get(indexJ));
+                Assert.assertTrue(buildExceptionMessage("file upload state callback was not triggered", clientArrayList.get(j)), fileUploadState[i].isCallBackTriggered);
+                Assert.assertEquals(buildExceptionMessage("File upload status was not successful on attempt " + i + ", status was: " + fileUploadState[i].fileUploadStatus, clientArrayList.get(indexJ)), fileUploadState[i].fileUploadStatus, SUCCESS);
+                Assert.assertEquals(buildExceptionMessage("Message status was not successful on attempt " + i + ", status was: " + messageStates[i].messageStatus, clientArrayList.get(indexJ)), messageStates[i].messageStatus, SUCCESS);
+
             }
         }
 
@@ -492,7 +494,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         for (int i = 1; i < MAX_FILES_TO_UPLOAD; i++)
         {
-            assertEquals("File" + i + " has no notification", fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("File" + i + " has no notification", clientArrayList), fileUploadState[i].fileUploadNotificationReceived, SUCCESS);
         }
 
         transportClient.closeNow();
@@ -503,18 +505,18 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void invokeMethodAMQPSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
-            clientArrayList.get(i).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            ((DeviceClient)clientArrayList.get(i)).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
 
             CountDownLatch countDownLatch = new CountDownLatch(1);
             RunnableInvoke runnableInvoke = new RunnableInvoke(methodServiceClient, deviceListAmqps[i].getDeviceId(), METHOD_NAME, METHOD_PAYLOAD, countDownLatch);
@@ -522,9 +524,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             countDownLatch.await();
 
             MethodResult result = runnableInvoke.getResult();
-            assertNotNull((runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage()), result);
-            assertEquals((long)METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
+            Assert.assertNotNull(buildExceptionMessage(runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage(), clientArrayList.get(i)), result);
+            Assert.assertEquals(buildExceptionMessage("result was not success, but was: " + result.getStatus(), clientArrayList.get(i)), (long)METHOD_SUCCESS,(long)result.getStatus());
+            Assert.assertEquals(buildExceptionMessage("Received unexpected payload", clientArrayList.get(i)), runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
         }
 
         transportClient.closeNow();
@@ -534,18 +536,18 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void invokeMethodAMQPSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
-            clientArrayList.get(i).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            ((DeviceClient)clientArrayList.get(i)).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
         }
 
         List<RunnableInvoke> runs = new LinkedList<>();
@@ -560,12 +562,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_PER_CALL_MS * MAX_DEVICE_MULTIPLEX);
 
-        for (RunnableInvoke run:runs)
+        for (RunnableInvoke runnableInvoke:runs)
         {
-            MethodResult result = run.getResult();
-            assertNotNull((run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage()), result);
-            assertEquals((long)METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(run.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
+            MethodResult result = runnableInvoke.getResult();
+            Assert.assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessage(runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage(), clientArrayList), result);
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("result was not success, but was: " + result.getStatus(), clientArrayList), (long)METHOD_SUCCESS,(long)result.getStatus());
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Received unexpected payload", clientArrayList), runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
         }
 
         transportClient.closeNow();
@@ -575,18 +577,18 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void invokeMethodAMQPSWSSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
-            clientArrayList.get(i).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            ((DeviceClient)clientArrayList.get(i)).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
 
             CountDownLatch countDownLatch = new CountDownLatch(1);
             RunnableInvoke runnableInvoke = new RunnableInvoke(methodServiceClient, deviceListAmqps[i].getDeviceId(), METHOD_NAME, METHOD_PAYLOAD, countDownLatch);
@@ -594,9 +596,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             countDownLatch.await();
 
             MethodResult result = runnableInvoke.getResult();
-            assertNotNull((runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage()), result);
-            assertEquals((long)METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
+            Assert.assertNotNull(buildExceptionMessage(runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage(), clientArrayList.get(i)), result);
+            Assert.assertEquals(buildExceptionMessage("result was not success, but was: " + result.getStatus(), clientArrayList.get(i)), (long)METHOD_SUCCESS,(long)result.getStatus());
+            Assert.assertEquals(buildExceptionMessage("Received unexpected payload", clientArrayList.get(i)), runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
         }
 
         transportClient.closeNow();
@@ -606,18 +608,18 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
     public void invokeMethodAMQPSWSInvokeParallelSucceed() throws Exception
     {
         TransportClient transportClient = new TransportClient(AMQPS_WS);
-        ArrayList<DeviceClient> clientArrayList = new ArrayList<>();
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
 
         for (int i = 0; i < MAX_DEVICE_MULTIPLEX; i++)
         {
             clientArrayList.add(new DeviceClient(clientConnectionStringArrayList.get(i), transportClient));
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < clientArrayList.size(); i++)
         {
-            clientArrayList.get(i).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            ((DeviceClient)clientArrayList.get(i)).subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
         }
 
         List<RunnableInvoke> runs = new LinkedList<>();
@@ -632,12 +634,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_PER_CALL_MS * MAX_DEVICE_MULTIPLEX);
 
-        for (RunnableInvoke run:runs)
+        for (RunnableInvoke runnableInvoke:runs)
         {
-            MethodResult result = run.getResult();
-            assertNotNull((run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage()), result);
-            assertEquals((long)METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(run.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
+            MethodResult result = runnableInvoke.getResult();
+            Assert.assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessage(runnableInvoke.getException() == null ? "Runnable returns null without exception information" : runnableInvoke.getException().getMessage(), clientArrayList), result);
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("result was not success, but was: " + result.getStatus(), clientArrayList), (long)METHOD_SUCCESS,(long)result.getStatus());
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Received unexpected payload", clientArrayList), runnableInvoke.getExpectedPayload(), METHOD_NAME + ":" + result.getPayload().toString());
         }
 
         transportClient.closeNow();
@@ -676,12 +678,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            assertEquals(SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+            Assert.assertEquals(buildExceptionMessage("Device twin status expected to be SUCCESS, but was: " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
             for (PropertyState propertyState : devicesUnderTest.get(i).dCDeviceForTwin.propertyStateList)
             {
-                assertTrue("One or more property callbacks were not triggered", propertyState.callBackTriggered);
-                assertTrue(((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
-                assertEquals(SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
+                Assert.assertTrue(buildExceptionMessage("One or more property callbacks were not triggered", devicesUnderTest.get(i).deviceClient), propertyState.callBackTriggered);
+                Assert.assertTrue(buildExceptionMessage("Property new value did not start with " + PROPERTY_VALUE_UPDATE, devicesUnderTest.get(i).deviceClient), ((String) propertyState.propertyNewValue).startsWith(PROPERTY_VALUE_UPDATE));
+                Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but device twin status was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
             }
         }
 
@@ -701,12 +703,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION);
 
             // assert
-            assertEquals(devicesUnderTest.get(i).deviceTwinStatus, SUCCESS);
+            Assert.assertEquals(buildExceptionMessage("Expected status SUCCESS but was " + devicesUnderTest.get(i).deviceTwinStatus, devicesUnderTest.get(i).deviceClient), SUCCESS, devicesUnderTest.get(i).deviceTwinStatus);
 
             // verify if they are received by SC
             Thread.sleep(MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS);
             int actualReportedPropFound = readReportedProperties(devicesUnderTest.get(i), PROPERTY_KEY, PROPERTY_VALUE_UPDATE);
-            assertEquals("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX, MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
+            Assert.assertEquals(buildExceptionMessage("Missing reported properties on the " + (i+1) + " device out of " + MAX_DEVICE_MULTIPLEX,devicesUnderTest.get(i).deviceClient), MAX_PROPERTIES_TO_TEST.intValue(), actualReportedPropFound);
         }
 
         // send max_prop RP one at a time in parallel
@@ -727,9 +729,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(e.getMessage());
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
                     }
-                    assertEquals(devicesUnderTest.get(finalI).deviceTwinStatus, SUCCESS);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
 
                     // testUpdateReportedPropertiesMultiThreaded
                     try
@@ -739,9 +741,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     }
                     catch (IOException e)
                     {
-                        Assert.fail(e.getMessage());
+                        Assert.fail(buildExceptionMessage(e.getMessage(), devicesUnderTest.get(finalI).deviceClient));
                     }
-                    assertEquals(devicesUnderTest.get(finalI).deviceTwinStatus, SUCCESS);
+                    Assert.assertEquals(buildExceptionMessage("Expected SUCCESS but was " + devicesUnderTest.get(finalI).deviceTwinStatus, devicesUnderTest.get(finalI).deviceClient), SUCCESS, devicesUnderTest.get(finalI).deviceTwinStatus);
                 }
             });
         }
@@ -756,9 +758,9 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         tearDownTwin(transportClient);
     }
     
-    private void verifyNotification(FileUploadNotification fileUploadNotification, FileUploadState fileUploadState) throws IOException
+    private void verifyNotification(FileUploadNotification fileUploadNotification, FileUploadState fileUploadState, InternalClient client) throws IOException
     {
-        assertTrue(fileUploadNotification.getBlobSizeInBytes() == fileUploadState.fileLength);
+        Assert.assertTrue(buildExceptionMessage("Wrong file upload notification length", client), fileUploadNotification.getBlobSizeInBytes() == fileUploadState.fileLength);
 
         URL u = new URL(fileUploadNotification.getBlobUri());
         try (InputStream inputStream = u.openStream())
@@ -768,11 +770,11 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
             byte[] actualBuf = new byte[(int)fileUploadState.fileLength];
             fileUploadState.fileInputStream.reset();
             int actualLen = (fileUploadState.fileLength == 0) ? (int) fileUploadState.fileLength : fileUploadState.fileInputStream.read(actualBuf, 0, (int) fileUploadState.fileLength);
-            assertEquals(testLen, actualLen);
-            assertTrue(Arrays.equals(testBuf, actualBuf));
+            Assert.assertEquals(buildExceptionMessage("Incorrect file length", client), testLen, actualLen);
+            Assert.assertTrue(buildExceptionMessage("Arrays are not equal", client), Arrays.equals(testBuf, actualBuf));
         }
 
-        assertTrue(fileUploadNotification.getBlobName().contains(fileUploadState.blobName));
+        Assert.assertTrue(buildExceptionMessage("Incorrect blob name", client), fileUploadNotification.getBlobName().contains(fileUploadState.blobName));
         fileUploadState.fileUploadNotificationReceived = SUCCESS;
     }
 
@@ -833,7 +835,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         serviceClient.send(deviceId, serviceMessage);
     }
 
-    private void waitForMessageToBeReceived(Success messageReceived, String protocolName)
+    private void waitForMessageToBeReceived(Success messageReceived, String protocolName, InternalClient client)
     {
         try
         {
@@ -850,12 +852,12 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
             if (!messageReceived.getResult())
             {
-                Assert.fail("Receiving message over " + protocolName + " protocol failed. Received message was missing one or more properties");
+                Assert.fail(buildExceptionMessage("Receiving message over " + protocolName + " protocol failed. Received message was missing one or more properties", client));
             }
         }
         catch (InterruptedException e)
         {
-            Assert.fail("Receiving message over " + protocolName + " protocol failed");
+            Assert.fail(buildExceptionMessage("Receiving message over " + protocolName + " protocol failed", client));
         }
     }
 
@@ -1001,7 +1003,7 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
     protected static class MultiplexRunnable implements Runnable
     {
-        private DeviceClient client;
+        private InternalClient client;
         private String messageString;
 
         private long numMessagesPerDevice;
@@ -1029,13 +1031,13 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
         }
 
         private MultiplexRunnable(Device deviceAmqps,
-                                 DeviceClient deviceClient,
+                                 InternalClient client,
                                  long numMessagesPerConnection,
                                  long numKeys,
                                  long sendTimeout,
                                  CountDownLatch latch)
         {
-            this.client = deviceClient;
+            this.client = client;
             this.numMessagesPerDevice = numMessagesPerConnection;
             this.sendTimeout = sendTimeout;
             this.numKeys = numKeys;
@@ -1067,13 +1069,13 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
                     Thread.sleep(RETRY_MILLISECONDS);
                     if ((System.currentTimeMillis() - startTime) > sendTimeout)
                     {
-                        throw new Exception("Timed out waiting for OK_EMPTY response for sent message");
+                        fail(buildExceptionMessage("Timed out waiting for OK_EMPTY response for sent message", client));
                     }
                 }
 
                 if (messageSent.getCallbackStatusCode() != IotHubStatusCode.OK_EMPTY)
                 {
-                    throw new Exception("Unexpected iot hub status code! Expected OK_EMPTY but got " + messageSent.getCallbackStatusCode());
+                    fail(buildExceptionMessage("Unexpected iot hub status code! Expected OK_EMPTY but got " + messageSent.getCallbackStatusCode(), client));
                 }
             }
         }
@@ -1165,14 +1167,16 @@ public class TransportClientTests extends MethodNameLoggingIntegrationTest
 
         TransportClient transportClient = new TransportClient(IotHubClientProtocol.AMQPS);
 
+        ArrayList<InternalClient> clientArrayList = new ArrayList<>();
         for (int i = 0; i < MAX_DEVICES; i++)
         {
             DeviceState deviceState = devicesUnderTest.get(i);
             deviceState.deviceClient = new DeviceClient(deviceState.connectionString, transportClient);
             devicesUnderTest.get(i).dCDeviceForTwin = new DeviceExtension();
+            clientArrayList.add(deviceState.deviceClient);
         }
 
-        IotHubServicesCommon.openTransportClientWithRetry(transportClient);
+        IotHubServicesCommon.openTransportClientWithRetry(transportClient, clientArrayList);
 
         for (int i = 0; i < MAX_DEVICES; i++)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -71,7 +71,6 @@ public class TransportClientTests extends IntegrationTest
     private static Device[] deviceListAmqps = new Device[MAX_DEVICE_MULTIPLEX];
     private static final AtomicBoolean succeed = new AtomicBoolean();
 
-    private static final String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
     protected static String iotHubConnectionString = "";
 
     private static Map<String, String> messageProperties = new HashMap<>(3);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -38,7 +38,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionSubscribeToDesiredPropertiesFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -46,7 +46,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -59,7 +59,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -72,7 +72,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsCBSReqLinkrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -91,7 +91,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -110,7 +110,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsD2CDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -123,7 +123,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromC2DDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -143,7 +143,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -163,7 +163,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -183,7 +183,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -203,7 +203,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void subscribeToDesiredPropertiesRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -31,7 +32,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
 {
-    public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -241,7 +241,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
 
         // Assert
         IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
-        deviceUnderTest.dCDeviceForTwin.propertyStateList.get(0).callBackTriggered = false;
+        deviceUnderTest.dCDeviceForTwin.propertyStateList[0].callBackTriggered = false;
         assertEquals(buildExceptionMessage("Expected desired properties to be size 1, but was size " + deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size(), internalClient), 1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
         Set<Pair> dp = new HashSet<>();
         Pair p = deviceUnderTest.sCDeviceForTwin.getDesiredProperties().iterator().next();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DesiredPropertiesErrInjTests.java
@@ -34,8 +34,6 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     public DesiredPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " DesiredPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -10,10 +10,12 @@ import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.Test;
 
@@ -33,6 +35,8 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -249,7 +253,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     public void errorInjectionTestFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         invokeMethodSucceed();
 
@@ -263,7 +267,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, this.testInstance.deviceTestManager.client);
         invokeMethodSucceed();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
-import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
-import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -32,7 +29,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class DeviceMethodErrInjTests extends DeviceMethodCommon
 {
-    public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/DeviceMethodErrInjTests.java
@@ -39,7 +39,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
         System.out.println(clientType + " DeviceMethodErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -47,7 +47,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -60,7 +60,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -73,7 +73,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -92,7 +92,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -111,7 +111,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -124,7 +124,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -144,7 +144,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -164,7 +164,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -184,7 +184,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -204,7 +204,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -224,7 +224,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromGracefulShutdownAmqp() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -237,7 +237,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void invokeMethodRecoveredFromGracefulShutdownMqtt() throws Exception
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -33,8 +33,6 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -37,7 +37,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionGetDeviceTwinFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -45,7 +45,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -58,7 +58,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -71,7 +71,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -90,7 +90,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -109,7 +109,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -122,7 +122,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -143,7 +143,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -163,7 +163,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -183,7 +183,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -203,7 +203,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -223,7 +223,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromGracefulShutdownAmqp() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -236,7 +236,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void getDeviceTwinRecoveredFromGracefulShutdownMqtt() throws Exception
     {
         if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -30,7 +31,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class GetTwinErrInjTests extends DeviceTwinCommon
 {
-    public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -266,8 +266,9 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
 
         // Assert
         IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
-        for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
+        for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
+            PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];
             propertyState.callBackTriggered = false;
             propertyState.propertyNewVersion = -1;
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/GetTwinErrInjTests.java
@@ -33,6 +33,8 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public GetTwinErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " GetTwinErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -250,7 +252,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     public void errorInjectionGetDeviceTwinFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         testGetDeviceTwin();
 
@@ -264,7 +266,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
         for (PropertyState propertyState : deviceUnderTest.dCDeviceForTwin.propertyStateList)
         {
             propertyState.callBackTriggered = false;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -43,7 +43,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         System.out.println(clientType + " ReceiveMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithTCPConnectionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol == HTTPS)
@@ -55,7 +55,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsConnectionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -67,7 +67,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsConnectionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsSessionDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -79,7 +79,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsSessionDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsCBSReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -97,7 +97,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsCBSRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -115,7 +115,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsD2CLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -127,7 +127,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsD2CTelemetryLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsC2DLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -145,7 +145,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsC2DLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsMethodReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -164,7 +164,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsMethodRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -183,7 +183,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsTwinReqLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -202,7 +202,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsTwinReqLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithAmqpsTwinRespLinkDrop() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -221,7 +221,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsTwinRespLinkDropErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithGracefulShutdownAmqp() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
@@ -233,7 +233,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsGracefulShutdownErrorInjectionMessage(DefaultDelayInSec, DefaultDurationInSec));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesWithGracefulShutdownMqtt() throws IOException, IotHubException, InterruptedException
     {
         if (testInstance.protocol != MQTT && testInstance.protocol != MQTT_WS)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
-import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
-import com.microsoft.azure.sdk.iot.common.helpers.EventCallback;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.Success;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.ReceiveMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
@@ -36,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 {
-    public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.Success;
 import com.microsoft.azure.sdk.iot.common.setup.ReceiveMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Module;
@@ -20,7 +21,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper.DefaultDelayInSec;
 import static com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper.DefaultDurationInSec;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
@@ -36,6 +39,8 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
     public ReceiveMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " ReceiveMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)
@@ -242,13 +247,13 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 
     public void errorInjectionTestFlow(com.microsoft.azure.sdk.iot.device.Message errorInjectionMessage) throws IOException, IotHubException, InterruptedException
     {
-        final ArrayList<IotHubConnectionStatus> connectionStatusUpdates = new ArrayList<>();
+        List<Pair<IotHubConnectionStatus, Throwable>> connectionStatusUpdates = new ArrayList<>();
         testInstance.client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeCallback()
         {
             @Override
             public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
             {
-                connectionStatusUpdates.add(status);
+                connectionStatusUpdates.add(new Pair<>(status, throwable));
             }
         }, null);
 
@@ -272,7 +277,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         try
         {
             IotHubServicesCommon.openClientWithRetry(testInstance.client);
-            IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000);
+            IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000, testInstance.client);
 
             //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
             // we ensure that error injection message isn't resent to service too many times. The message will still likely
@@ -282,7 +287,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 
             //wait to send the message because we want to ensure that the tcp connection drop happens beforehand and we
             // want the connection to be re-established before sending anything from service client
-            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT);
+            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT, testInstance.client);
 
             if (testInstance.client instanceof DeviceClient)
             {
@@ -302,6 +307,6 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
             testInstance.client.closeNow();
         }
 
-        assertTrue(testInstance.protocol + ", " + testInstance.authenticationType + ": Error Injection message did not cause service to drop TCP connection", connectionStatusUpdates.contains(IotHubConnectionStatus.DISCONNECTED_RETRYING));
+        assertTrue(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Error Injection message did not cause service to drop TCP connection", testInstance.client), IotHubServicesCommon.actualStatusUpdatesContainsStatus(connectionStatusUpdates, IotHubConnectionStatus.DISCONNECTED_RETRYING));
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -36,7 +36,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
         System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromTcpConnectionDrop() throws Exception
     {
         this.errorInjectionSendReportedPropertiesFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
@@ -44,7 +44,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsConnectionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -57,7 +57,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsSessionDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -70,7 +70,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsCBSReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -89,7 +89,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsCBSRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -108,7 +108,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsD2CLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -121,7 +121,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsC2DLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -141,7 +141,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsTwinReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -161,7 +161,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsTwinRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -181,7 +181,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsMethodReqLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
@@ -201,7 +201,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void sendReportedPropertiesRecoveredFromAmqpsMethodRespLinkDrop() throws Exception
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -32,8 +32,6 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -32,6 +32,8 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " ReportedPropertiesErrInjTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
@@ -222,7 +224,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     public void errorInjectionSendReportedPropertiesFlow(Message errorInjectionMessage) throws Exception
     {
         // Arrange
-        final List<IotHubConnectionStatus> actualStatusUpdates = new ArrayList<>();
+        List<com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
         setConnectionStatusCallBack(actualStatusUpdates);
         sendReportedPropertiesAndVerify(1);
 
@@ -236,7 +238,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT, internalClient);
         // add one new reported property
         deviceUnderTest.dCDeviceForTwin.createNewReportedProperties(1);
         internalClient.sendReportedProperties(deviceUnderTest.dCDeviceForTwin.getReportedProp());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReportedPropertiesErrInjTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
@@ -29,7 +30,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Ignore;
@@ -40,6 +41,8 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     public SendMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " SendMessagesErrInjTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -350,13 +350,13 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
             {
                 targetDevice = Device.createDevice(deviceId, SELF_SIGNED);
                 targetDevice.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
-                registryManager.addDevice(targetDevice);
+                Tools.addDeviceWithRetry(registryManager, targetDevice);
                 client = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
             }
             else
             {
                 targetDevice = Device.createFromId(deviceId, null, null);
-                registryManager.addDevice(targetDevice);
+                Tools.addDeviceWithRetry(registryManager, targetDevice);
                 client = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice), this.testInstance.protocol);
             }
         }
@@ -368,16 +368,16 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 targetModule = Module.createModule(deviceId, moduleId, SELF_SIGNED);
                 targetDevice.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
                 targetModule.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
-                registryManager.addDevice(targetDevice);
-                registryManager.addModule(targetModule);
+                Tools.addDeviceWithRetry(registryManager, targetDevice);
+                Tools.addModuleWithRetry(registryManager, targetModule);
                 client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
             }
             else
             {
                 targetDevice = Device.createFromId(deviceId, null, null);
                 targetModule = Module.createModule(deviceId, moduleId, AuthenticationType.SAS);
-                registryManager.addDevice(targetDevice);
-                registryManager.addModule(targetModule);
+                Tools.addDeviceWithRetry(registryManager, targetDevice);
+                Tools.addModuleWithRetry(registryManager, targetModule);
                 client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol);
             }
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
 import com.microsoft.azure.sdk.iot.common.setup.SendMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
@@ -226,7 +227,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     }
 
     @Test
-    public void sendMessagesWithThrottling() throws URISyntaxException, IOException, IotHubException, InterruptedException
+    public void sendMessagesWithThrottling() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
@@ -241,7 +242,6 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     }
 
-    @Ignore
     @Test
     public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -5,10 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection;
 
-import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
-import com.microsoft.azure.sdk.iot.common.helpers.ErrorInjectionHelper;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.SendMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -39,7 +36,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
  */
 public class SendMessagesErrInjTests extends SendMessagesCommon
 {
-    public SendMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 
@@ -259,7 +256,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     }
 
     @Test
-    public void sendMessagesWithAuthenticationError() throws URISyntaxException, IOException, IotHubException, InterruptedException
+    public void sendMessagesWithAuthenticationError() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
@@ -274,7 +271,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     }
 
     @Test
-    public void sendMessagesWithQuotaExceeded() throws URISyntaxException, IOException, IotHubException, InterruptedException
+    public void sendMessagesWithQuotaExceeded() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
@@ -331,40 +328,66 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         testInstance.client.setRetryPolicy(new ExponentialBackoffWithJitter());
     }
 
-    private void errorInjectionTestFlowNoDisconnect(Message errorInjectionMessage, IotHubStatusCode expectedStatus, boolean noRetry) throws IOException, IotHubException, URISyntaxException, InterruptedException
+    private void errorInjectionTestFlowNoDisconnect(Message errorInjectionMessage, IotHubStatusCode expectedStatus, boolean noRetry) throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
     {
         // Arrange
         // This test case creates a device instead of re-using the one in this.testInstance due to state changes
         // introduced by injected errors
         String uuid = UUID.randomUUID().toString();
         String deviceId = "java-device-client-e2e-test-send-messages".concat("-" + uuid);
+        String moduleId = "java-module-client-e2e-test-send-messages".concat("-" + uuid);
 
-        Device target;
-        DeviceClient dc;
-        if (this.testInstance.authenticationType == SELF_SIGNED)
+        Device targetDevice;
+        Module targetModule;
+        InternalClient client;
+        if (this.testInstance.clientType == ClientType.DEVICE_CLIENT)
         {
-            target = Device.createDevice(deviceId, SELF_SIGNED);
-            target.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
-            registryManager.addDevice(target);
-            dc = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, target), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
+            if (this.testInstance.authenticationType == SELF_SIGNED)
+            {
+                targetDevice = Device.createDevice(deviceId, SELF_SIGNED);
+                targetDevice.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
+                registryManager.addDevice(targetDevice);
+                client = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
+            }
+            else
+            {
+                targetDevice = Device.createFromId(deviceId, null, null);
+                registryManager.addDevice(targetDevice);
+                client = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice), this.testInstance.protocol);
+            }
         }
         else
         {
-            target = Device.createFromId(deviceId, null, null);
-            registryManager.addDevice(target);
-            dc = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, target), this.testInstance.protocol);
+            if (this.testInstance.authenticationType == SELF_SIGNED)
+            {
+                targetDevice = Device.createDevice(deviceId, SELF_SIGNED);
+                targetModule = Module.createModule(deviceId, moduleId, SELF_SIGNED);
+                targetDevice.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
+                targetModule.setThumbprint(testInstance.x509Thumbprint, testInstance.x509Thumbprint);
+                registryManager.addDevice(targetDevice);
+                registryManager.addModule(targetModule);
+                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol, testInstance.publicKeyCert, false, testInstance.privateKey, false);
+            }
+            else
+            {
+                targetDevice = Device.createFromId(deviceId, null, null);
+                targetModule = Module.createModule(deviceId, moduleId, AuthenticationType.SAS);
+                registryManager.addDevice(targetDevice);
+                registryManager.addModule(targetModule);
+                client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, targetDevice, targetModule), this.testInstance.protocol);
+            }
         }
 
         if (noRetry)
         {
-            dc.setRetryPolicy(new NoRetry());
+            client.setRetryPolicy(new NoRetry());
         }
-        IotHubServicesCommon.openClientWithRetry(dc);
+        IotHubServicesCommon.openClientWithRetry(client);
 
         // Act
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage,null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(
-                dc,
+                client,
                 errorInjectionMsgAndRet,
                 RETRY_MILLISECONDS,
                 SEND_TIMEOUT_MILLISECONDS,
@@ -375,15 +398,15 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
         MessageAndResult normalMessageAndExpectedResult = new MessageAndResult(new Message("test message"), expectedStatus);
         IotHubServicesCommon.sendMessageAndWaitForResponse(
-                dc,
+                client,
                 normalMessageAndExpectedResult,
                 RETRY_MILLISECONDS,
                 SEND_TIMEOUT_MILLISECONDS,
                 this.testInstance.protocol);
 
-        dc.closeNow();
+        client.closeNow();
 
         //cleanup
-        registryManager.removeDevice(target.getDeviceId());
+        registryManager.removeDevice(targetDevice.getDeviceId());
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -242,7 +242,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     @Ignore
     @Test
-    public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException
+    public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
         if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -223,6 +223,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         sendMessagesExpectingConnectionStatusChangeUpdate(testInstance.client, testInstance.protocol, AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, IotHubConnectionStatus.DISCONNECTED_RETRYING, 100, testInstance.authenticationType);
     }
 
+    @Ignore
     @Test
     public void sendMessagesWithThrottling() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
@@ -239,6 +240,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     }
 
+    @Ignore
     @Test
     public void sendMessagesWithThrottlingNoRetry() throws URISyntaxException, IOException, IotHubException, InterruptedException
     {
@@ -255,6 +257,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
 
     }
 
+    @Ignore
     @Test
     public void sendMessagesWithAuthenticationError() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {
@@ -270,6 +273,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
                 false);
     }
 
+    @Ignore
     @Test
     public void sendMessagesWithQuotaExceeded() throws URISyntaxException, IOException, IotHubException, InterruptedException, ModuleClientException
     {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceEmulator;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceMethodCommon;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class DeviceMethodTests extends DeviceMethodCommon
 {
-    public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -35,6 +36,8 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public DeviceMethodTests(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -70,9 +73,9 @@ public class DeviceMethodTests extends DeviceMethodCommon
         for (RunnableInvoke run:runs)
         {
             MethodResult result = run.getResult();
-            assertNotNull((run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage()), result);
-            assertEquals((long)DeviceEmulator.METHOD_SUCCESS,(long)result.getStatus());
-            assertEquals(run.getExpectedPayload(), result.getPayload().toString());
+            assertNotNull(buildExceptionMessage(run.getException() == null ? "Runnable returns null without exception information" : run.getException().getMessage(), testInstance.deviceTestManager.client), result);
+            assertEquals(buildExceptionMessage("Expected SUCCESS but was " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS,(long)result.getStatus());
+            assertEquals(buildExceptionMessage("Expected payload " + run.getExpectedPayload() + " but got " + result.getPayload().toString(), testInstance.deviceTestManager.client), run.getExpectedPayload(), result.getPayload().toString());
         }
     }
 
@@ -96,10 +99,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING + " but got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -121,10 +124,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":null", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_LOOPBACK + ":null" + " but got " + result.getPayload(), deviceTestManger.client), DeviceEmulator.METHOD_LOOPBACK + ":null", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -146,10 +149,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -171,10 +174,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_THROWS, (long)result.getStatus());
-        assertEquals("java.lang.NumberFormatException: For input string: \"" + PAYLOAD_STRING + "\"", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_THROWS + " but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_THROWS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected NumberFormatException, but got " + result.getPayload(), testInstance.deviceTestManager.client), "java.lang.NumberFormatException: For input string: \"" + PAYLOAD_STRING + "\"", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -196,10 +199,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_NOT_DEFINED, (long)result.getStatus());
-        Assert.assertEquals("unknown:" + DeviceEmulator.METHOD_UNKNOWN, result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected METHOD_NOT_DEFINED but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_NOT_DEFINED, (long)result.getStatus());
+        Assert.assertEquals(buildExceptionMessage("Expected " + "unknown:" + DeviceEmulator.METHOD_UNKNOWN + " but got " + result.getPayload(), testInstance.deviceTestManager.client), "unknown:" + DeviceEmulator.METHOD_UNKNOWN, result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -238,10 +241,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -263,10 +266,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT)
@@ -288,10 +291,10 @@ public class DeviceMethodTests extends DeviceMethodCommon
         deviceTestManger.waitIotHub(1, 10);
 
         // Assert
-        assertNotNull(result);
-        assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
-        assertEquals(DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
-        Assert.assertEquals(0, deviceTestManger.getStatusError());
+        assertNotNull(buildExceptionMessage("method result was null", testInstance.deviceTestManager.client), result);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but got " + result.getStatus(), testInstance.deviceTestManager.client), (long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
+        assertEquals(buildExceptionMessage("Expected " + DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed" + " But got " + result.getPayload(), testInstance.deviceTestManager.client), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS + ":succeed", result.getPayload());
+        Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
     @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubGatewayTimeoutException.class)
@@ -342,7 +345,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
                 deviceTestManger.restartDevice(registryManager.getDeviceConnectionString((Device) testInstance.identity), testInstance.protocol, testInstance.publicKeyCert, testInstance.privateKey);
             }
 
-            throw new Exception("Reset identity do not affect the method invoke on the service");
+            Assert.fail(buildExceptionMessage("Reset identity do not affect the method invoke on the service", testInstance.deviceTestManager.client));
         }
         catch (IotHubNotFoundException expected)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -40,13 +40,13 @@ public class DeviceMethodTests extends DeviceMethodCommon
         System.out.println(clientType + " DeviceMethodTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodSucceed() throws Exception
     {
         super.invokeMethodSucceed();
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodInvokeParallelSucceed() throws Exception
     {
         // Arrange
@@ -79,7 +79,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodStandardTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -105,7 +105,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodNullPayloadSucceed() throws Exception
     {
         // Arrange
@@ -130,7 +130,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodNumberSucceed() throws Exception
     {
         // Arrange
@@ -155,7 +155,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodThrowsNumberFormatExceptionFailed() throws Exception
     {
         // Arrange
@@ -180,7 +180,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodUnknownFailed() throws Exception
     {
         // Arrange
@@ -205,7 +205,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodRecoverFromTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -247,7 +247,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodDefaultResponseTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -272,7 +272,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodDefaultConnectionTimeoutSucceed() throws Exception
     {
         // Arrange
@@ -297,7 +297,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         Assert.assertEquals(buildExceptionMessage("Unexpected status errors occurred", testInstance.deviceTestManager.client), 0, deviceTestManger.getStatusError());
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubGatewayTimeoutException.class)
+    @Test (expected = IotHubGatewayTimeoutException.class)
     public void invokeMethodResponseTimeoutFailed() throws Exception
     {
         // Arrange
@@ -312,7 +312,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT, expected = IotHubNotFoundException.class)
+    @Test(expected = IotHubNotFoundException.class)
     public void invokeMethodUnknownDeviceFailed() throws Exception
     {
         if (testInstance.identity instanceof Module)
@@ -325,7 +325,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
         }
     }
 
-    @Test(timeout=DEFAULT_TEST_TIMEOUT)
+    @Test
     public void invokeMethodResetDeviceFailed() throws Exception
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -39,7 +39,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
         System.out.println(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveMessagesOverIncludingProperties() throws Exception
     {
         if (testInstance.protocol == HTTPS)
@@ -82,7 +82,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
         testInstance.client.closeNow();
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void receiveBackToBackUniqueC2DCommandsOverAmqpsUsingSendAsync() throws Exception
     {
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test class containing all non error injection tests to be run on JVM and android pertaining to receiving messages on a device/module. Class needs to be extended
@@ -35,6 +35,8 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
     public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " ReceiveMessagesTests UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)
@@ -141,14 +143,14 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
             }
             catch (ExecutionException e)
             {
-                Assert.fail("Exception : " + e.getMessage());
+                Assert.fail(buildExceptionMessage("Exception : " + e.getMessage(), testInstance.client));
             }
         }
 
         // Now wait for messages to be received in the device client
         waitForBackToBackC2DMessagesToBeReceived();
         testInstance.client.closeNow(); //close the device client connection
-        assertTrue(testInstance.protocol + ", " + testInstance.authenticationType + ": Received messages don't match up with sent messages", messageIdListStoredOnReceive.containsAll(messageIdListStoredOnC2DSend)); // check if the received list is same as the actual list that was created on sending the messages
+        Assert.assertTrue(buildExceptionMessage(testInstance.protocol + ", " + testInstance.authenticationType + ": Received messages don't match up with sent messages", testInstance.client), messageIdListStoredOnReceive.containsAll(messageIdListStoredOnC2DSend)); // check if the received list is same as the actual list that was created on sending the messages
         messageIdListStoredOnReceive.clear();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.Success;
 import com.microsoft.azure.sdk.iot.common.setup.ReceiveMessagesCommon;
@@ -32,7 +33,7 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
  */
 public class ReceiveMessagesTests extends ReceiveMessagesCommon
 {
-    public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -37,7 +37,7 @@ import static junit.framework.TestCase.fail;
  */
 public class SendMessagesTests extends SendMessagesCommon
 {
-    public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -113,7 +113,7 @@ public class SendMessagesTests extends SendMessagesCommon
             String deviceIdAmqps = "java-device-client-e2e-test-amqps".concat(i + "-" + uuid);
             deviceIds.add(deviceIdAmqps);
             deviceListAmqps[i] = Device.createFromId(deviceIdAmqps, null, null);
-            registryManager.addDevice(deviceListAmqps[i]);
+            Tools.addDeviceWithRetry(registryManager, deviceListAmqps[i]);
         }
 
         List<Thread> threads = new ArrayList<>(deviceListAmqps.length);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -44,7 +44,7 @@ public class SendMessagesTests extends SendMessagesCommon
         System.out.println(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void sendMessages() throws IOException, InterruptedException
     {
 
@@ -57,7 +57,7 @@ public class SendMessagesTests extends SendMessagesCommon
         IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void tokenRenewalWorks() throws InterruptedException
     {
         if (testInstance.authenticationType != SAS)
@@ -96,7 +96,7 @@ public class SendMessagesTests extends SendMessagesCommon
         }
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void sendMessagesOverAmqpsMultithreaded() throws InterruptedException, IOException, IotHubException
     {
         if (!(testInstance.protocol == AMQPS && testInstance.authenticationType == SAS && testInstance.clientType.equals(ClientType.DEVICE_CLIENT)))
@@ -147,7 +147,7 @@ public class SendMessagesTests extends SendMessagesCommon
         }
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void tokenExpiredAfterOpenButBeforeSendHttp() throws InvalidKeyException, IOException, InterruptedException, URISyntaxException
     {
         if (testInstance.protocol != HTTPS || testInstance.authenticationType != SAS)
@@ -167,7 +167,7 @@ public class SendMessagesTests extends SendMessagesCommon
         client.closeNow();
     }
 
-    @Test (timeout = DEFAULT_TEST_TIMEOUT)
+    @Test
     public void expiredMessagesAreNotSent() throws IOException
     {
         IotHubServicesCommon.sendExpiredMessageExpectingMessageExpiredCallback(testInstance.client, testInstance.protocol, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, testInstance.authenticationType);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -5,27 +5,27 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry;
 
-import com.microsoft.azure.sdk.iot.common.helpers.EventCallback;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.Success;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.SendMessagesCommon;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.helpers.SasTokenGenerator.generateSasTokenForIotDevice;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.*;
@@ -40,6 +40,8 @@ public class SendMessagesTests extends SendMessagesCommon
     public SendMessagesTests(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " SendMessagesTest UUID: " + (identity instanceof Module ? ((Module) identity).getId() : identity.getDeviceId()));
     }
 
     @Test (timeout = DEFAULT_TEST_TIMEOUT)
@@ -97,17 +99,19 @@ public class SendMessagesTests extends SendMessagesCommon
     @Test (timeout = DEFAULT_TEST_TIMEOUT)
     public void sendMessagesOverAmqpsMultithreaded() throws InterruptedException, IOException, IotHubException
     {
-        if (!(testInstance.protocol == AMQPS && testInstance.authenticationType == SAS))
+        if (!(testInstance.protocol == AMQPS && testInstance.authenticationType == SAS && testInstance.clientType.equals(ClientType.DEVICE_CLIENT)))
         {
-            //this test only applicable for AMQPS with SAS auth
+            //this test only applicable for AMQPS with SAS auth using device client
             return;
         }
 
         Device[] deviceListAmqps = new Device[MAX_DEVICE_PARALLEL];
+        Collection<String> deviceIds = new ArrayList<>();
         String uuid = UUID.randomUUID().toString();
         for (int i = 0; i < MAX_DEVICE_PARALLEL; i++)
         {
             String deviceIdAmqps = "java-device-client-e2e-test-amqps".concat(i + "-" + uuid);
+            deviceIds.add(deviceIdAmqps);
             deviceListAmqps[i] = Device.createFromId(deviceIdAmqps, null, null);
             registryManager.addDevice(deviceListAmqps[i]);
         }
@@ -139,7 +143,7 @@ public class SendMessagesTests extends SendMessagesCommon
 
         if(!succeed.get())
         {
-            Assert.fail("Sending message over AMQP protocol in parallel failed");
+            fail(CorrelationDetailsLoggingAssert.buildExceptionMessage("Sending message over AMQP protocol in parallel failed", deviceIds, "amqp", hostName, new ArrayList<>()));
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.common.helpers.SasTokenGenerator.generateSasTokenForIotDevice;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.*;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -32,7 +33,7 @@ import static org.junit.Assert.*;
  */
 public class DesiredPropertiesTests extends DeviceTwinCommon
 {
-    public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -106,6 +107,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
                     {
                         Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
                         desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(PROPERTY_KEY + index, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
+                        //TODO need synch block here?
                         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
                         sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
                     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
@@ -34,6 +35,8 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -128,7 +131,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -221,11 +224,11 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 
             for (com.microsoft.azure.sdk.iot.service.devicetwin.Pair dp : devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties())
             {
-                assertEquals(dp.getKey(), PROPERTY_KEY + i);
-                assertEquals(dp.getValue(), PROPERTY_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + PROPERTY_KEY + i + " but was " + dp.getKey(), internalClient), PROPERTY_KEY + i, dp.getKey());
+                assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + PROPERTY_VALUE_UPDATE + i + " but was " + dp.getValue(), internalClient), PROPERTY_VALUE_UPDATE + i, dp.getValue());
             }
             Integer version = devicesUnderTest[i].sCDeviceForTwin.getDesiredPropertiesVersion();
-            assertNotNull(version);
+            assertNotNull(buildExceptionMessage("Version was null", internalClient), version);
         }
 
         // Remove desired properties
@@ -247,7 +250,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         {
             sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
-            assertEquals("Desired properties were not deleted by setting to null", 0, devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties().size());
+            assertEquals(buildExceptionMessage("Desired properties were not deleted by setting to null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties().size());
         }
 
         removeMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -39,13 +39,13 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredProperties() throws IOException, InterruptedException, IotHubException
     {
         subscribeToDesiredPropertiesAndVerify(MAX_PROPERTIES_TO_TEST);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSubscribeToDesiredPropertiesWithVersion() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -77,7 +77,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, true);
     }
 
-    @Test(timeout = 240000) //4 minutes
+    @Test
     public void testSubscribeToDesiredPropertiesMultiThreaded() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -121,7 +121,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         }
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(5 * 60 * 1000, TimeUnit.MILLISECONDS)) //5 minutes
         {
             executor.shutdownNow();
         }
@@ -162,7 +162,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, false);
     }
 
-    @Test (timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void setDesiredPropertiesAtMaxDepthAllowed() throws IOException, IotHubException
     {
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
@@ -188,7 +188,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateDesiredProperties() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -35,8 +35,6 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     public DesiredPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " DesiredPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -13,7 +13,6 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Test;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
@@ -34,6 +35,7 @@ import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Test class containing all tests to be run on JVM and android pertaining to twin with version. Class needs to be extended
@@ -43,6 +45,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
 {
     private static final long BREATHE_TIME = 100; // 0.1 sec
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 1000; // 1 sec
+    private static final long EXPECTED_PROPERTIES_MAX_WAIT_MS = 60 * 1000; //1 minute
     private static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB + 50000; // 50 secs
     protected static String iotHubConnectionString = "";
 
@@ -243,7 +246,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         testDevice = null;
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesWithoutVersionSucceed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -263,8 +266,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         }
 
         testDevice.deviceClient.getDeviceTwin();
+        long startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.BAD_ANSWER)
             {
@@ -281,7 +290,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         assertSetEquals(PROPERTIES, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithVersionSucceed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -294,8 +303,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
 
         testDevice.deviceClient.getDeviceTwin();
+        long startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.IOTHUB_FAILURE)
             {
@@ -339,8 +354,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
             testDevice.reportedPropertyVersion = null;
             testDevice.receivedProperties = new HashSet<>();
             testDevice.deviceClient.getDeviceTwin();
+            startTime = System.currentTimeMillis();
             while(!testDevice.expectedProperties.isEmpty())
             {
+                if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+                {
+                    fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+                }
+
                 Thread.sleep(BREATHE_TIME);
                 if(testDevice.deviceTwinStatus == STATUS.BAD_ANSWER)
                 {
@@ -356,7 +377,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         assertSetEquals(newValues, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithLowerVersionFailed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -369,8 +390,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
 
         testDevice.deviceClient.getDeviceTwin();
+        long startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.IOTHUB_FAILURE)
             {
@@ -411,8 +438,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         testDevice.reportedPropertyVersion = null;
         testDevice.receivedProperties = new HashSet<>();
         testDevice.deviceClient.getDeviceTwin();
+        startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.BAD_ANSWER)
             {
@@ -429,7 +462,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         assertSetEquals(PROPERTIES, reported);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesWithHigherVersionFailed() throws IOException, InterruptedException, URISyntaxException, IotHubException
     {
         // arrange
@@ -442,8 +475,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB);
 
         testDevice.deviceClient.getDeviceTwin();
+        long startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.IOTHUB_FAILURE)
             {
@@ -484,8 +523,14 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         testDevice.reportedPropertyVersion = null;
         testDevice.receivedProperties = new HashSet<>();
         testDevice.deviceClient.getDeviceTwin();
+        startTime = System.currentTimeMillis();
         while(!testDevice.expectedProperties.isEmpty())
         {
+            if (System.currentTimeMillis() - startTime > EXPECTED_PROPERTIES_MAX_WAIT_MS)
+            {
+                fail(buildExceptionMessage("Timed out waiting for expected property change", testDevice.deviceClient));
+            }
+
             Thread.sleep(BREATHE_TIME);
             if(testDevice.deviceTwinStatus == STATUS.BAD_ANSWER)
             {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAsser
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
@@ -228,7 +229,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         testDevice.receivedProperties = new HashSet<>();
 
         deviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(testDevice.deviceId, null, null);
-        deviceForRegistryManager = registryManager.addDevice(deviceForRegistryManager);
+        deviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, deviceForRegistryManager);
 
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -7,8 +7,8 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
 import com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -34,9 +34,7 @@ import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggi
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Test class containing all tests to be run on JVM and android pertaining to twin with version. Class needs to be extended
@@ -47,7 +45,6 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
     private static final long BREATHE_TIME = 100; // 0.1 sec
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 1000; // 1 sec
     private static final long EXPECTED_PROPERTIES_MAX_WAIT_MS = 60 * 1000; //1 minute
-    private static final long MAX_MILLISECS_TIMEOUT_KILL_TEST = MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB + 50000; // 50 secs
     protected static String iotHubConnectionString = "";
 
     private static final String PROPERTY_KEY_1 = "Key1";

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
 import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MethodNameLoggingIntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK;
 import static com.microsoft.azure.sdk.iot.device.IotHubStatusCode.OK_EMPTY;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
  * Test class containing all tests to be run on JVM and android pertaining to twin with version. Class needs to be extended
  * in order to run these tests as that extended class handles setting connection strings and certificate generation
  */
-public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
+public class DeviceTwinWithVersionTests extends IntegrationTest
 {
     private static final long BREATHE_TIME = 100; // 0.1 sec
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 1000; // 1 sec
@@ -83,14 +84,14 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         Integer reportedPropertyVersion;
     }
 
-    private static void assertSetEquals(Set<Property> expected, Set<Pair> actual)
+    private void assertSetEquals(Set<Property> expected, Set<Pair> actual)
     {
-        assertEquals(expected.size(), actual.size());
+        assertEquals(buildExceptionMessage("Expected size " + expected.size() + " but was size " + actual.size(), testDevice.deviceClient), expected.size(), actual.size());
         for(Pair actualProperty: actual)
         {
             Property expectedProperty = fetchProperty(expected, actualProperty.getKey());
-            assertNotNull("Expected Set of Properties do no contain " + actualProperty.getKey(), expectedProperty);
-            assertEquals(expectedProperty.getValue(), actualProperty.getValue());
+            assertNotNull(buildExceptionMessage("Expected Set of Properties to not contain " + actualProperty.getKey(), testDevice.deviceClient), expectedProperty);
+            assertEquals(buildExceptionMessage("Expected value " + expectedProperty.getValue() + " but got " + actualProperty.getValue(), testDevice.deviceClient), expectedProperty.getValue(), actualProperty.getValue());
         }
     }
 
@@ -270,12 +271,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }
@@ -305,7 +306,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -351,8 +352,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(3, (int)deviceOnServiceClient.getReportedPropertiesVersion());
-        Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
+        assertEquals(buildExceptionMessage("Expected reported properties version 3 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 3, (int)deviceOnServiceClient.getReportedPropertiesVersion());        Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(newValues, reported);
     }
 
@@ -381,7 +381,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -419,12 +419,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }
@@ -454,7 +454,7 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // New values for the reported properties
         final Set<Property> newValues = new HashSet<Property>()
@@ -492,12 +492,12 @@ public class DeviceTwinWithVersionTests extends MethodNameLoggingIntegrationTest
                 throw new IOException(testDevice.exception);
             }
         }
-        assertEquals(2, (int)testDevice.reportedPropertyVersion);
+        assertEquals(buildExceptionMessage("Expected 2, but reported properties version was " + testDevice.reportedPropertyVersion, testDevice.deviceClient), 2, (int)testDevice.reportedPropertyVersion);
 
         // test service client
         DeviceTwinDevice deviceOnServiceClient = new DeviceTwinDevice(testDevice.deviceId);
         sCDeviceTwin.getTwin(deviceOnServiceClient);
-        assertEquals(2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
+        assertEquals(buildExceptionMessage("Expected reported properties version 2 but was " + deviceOnServiceClient.getReportedPropertiesVersion(), testDevice.deviceClient), 2, (int)deviceOnServiceClient.getReportedPropertiesVersion());
         Set<Pair> reported = deviceOnServiceClient.getReportedProperties();
         assertSetEquals(PROPERTIES, reported);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -22,8 +22,6 @@ public class GetTwinTests extends DeviceTwinCommon
     public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -19,7 +20,7 @@ import java.io.IOException;
  */
 public class GetTwinTests extends DeviceTwinCommon
 {
-    public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -26,7 +26,7 @@ public class GetTwinTests extends DeviceTwinCommon
         System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException
     {
         super.testGetDeviceTwin();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -22,6 +22,8 @@ public class GetTwinTests extends DeviceTwinCommon
     public GetTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " GetTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
@@ -35,6 +36,8 @@ public class QueryTwinTests extends DeviceTwinCommon
     public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -203,8 +206,8 @@ public class QueryTwinTests extends DeviceTwinCommon
 
                 for (Pair dp : d.getDesiredProperties())
                 {
-                    assertEquals(dp.getKey(), queryProperty);
-                    assertEquals(dp.getValue(), queryPropertyValue);
+                    assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + queryProperty + " but was " + dp.getKey(), internalClient), queryProperty, dp.getKey());
+                    assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + queryPropertyValue + " but was " + dp.getValue(), internalClient), queryPropertyValue, dp.getValue());
                 }
             }
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -36,8 +36,6 @@ public class QueryTwinTests extends DeviceTwinCommon
     public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -33,7 +34,7 @@ import static org.junit.Assert.*;
  */
 public class QueryTwinTests extends DeviceTwinCommon
 {
-    public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -40,7 +40,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         System.out.println(clientType + " QueryTwinTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testRawQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -74,7 +74,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testRawQueryMultipleInParallelTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -172,7 +172,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         });
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }
@@ -180,7 +180,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -215,7 +215,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testQueryTwinWithContinuationToken() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(PAGE_SIZE + 1);
@@ -281,7 +281,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         }
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void queryCollectionCanReturnEmptyQueryResults() {
         try
         {
@@ -416,7 +416,7 @@ public class QueryTwinTests extends DeviceTwinCommon
         });
 
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -33,13 +33,13 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedProperties() throws IOException, IotHubException, InterruptedException
     {
         sendReportedPropertiesAndVerify(MAX_PROPERTIES_TO_TEST);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesMultiThreaded() throws IOException, IotHubException, InterruptedException
     {
         // arrange
@@ -68,7 +68,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
             });
         }
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }
@@ -94,7 +94,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedProperties() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -115,7 +115,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesMultiThreaded() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -151,7 +151,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         }
         Thread.sleep(DELAY_BETWEEN_OPERATIONS);
         executor.shutdown();
-        if (!executor.awaitTermination(10000, TimeUnit.MILLISECONDS))
+        if (!executor.awaitTermination(MULTITHREADED_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         {
             executor.shutdownNow();
         }
@@ -163,7 +163,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateReportedPropertiesSequential() throws IOException, InterruptedException, IotHubException
     {
         // arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -28,6 +29,8 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -60,7 +63,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
                     {
                         fail(e.getMessage());
                     }
-                    assertEquals(deviceUnderTest.deviceTwinStatus, DeviceTwinCommon.STATUS.SUCCESS);
+                    assertEquals(buildExceptionMessage("Expected SUCCESS but twin status was " + deviceUnderTest.deviceTwinStatus, internalClient), DeviceTwinCommon.STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
                 }
             });
         }
@@ -74,7 +77,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST.intValue());
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testSendReportedPropertiesSequentially() throws IOException, InterruptedException, IotHubException
     {
         // arrange
@@ -141,7 +144,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
                     }
                     catch (IOException | InterruptedException e)
                     {
-                        fail(e.getMessage());
+                        fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + e.getMessage(), internalClient));
                     }
                 }
             });
@@ -154,7 +157,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         }
 
         // assert
-        assertEquals(deviceUnderTest.deviceTwinStatus, STATUS.SUCCESS);
+        assertEquals(buildExceptionMessage("Expected SUCCESS but twin status was " + deviceUnderTest.deviceTwinStatus, internalClient), DeviceTwinCommon.STATUS.SUCCESS, deviceUnderTest.deviceTwinStatus);
 
         // verify if they are received by SC
         readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST.intValue());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -26,7 +27,7 @@ import static org.junit.Assert.fail;
  */
 public class ReportedPropertiesTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -29,8 +29,6 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     public ReportedPropertiesTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " ReportedPropertiesTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -35,8 +35,6 @@ public class TwinTagsTests extends DeviceTwinCommon
     public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-
-        System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class TwinTagsTests extends DeviceTwinCommon
 {
-    public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
@@ -21,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -33,6 +35,8 @@ public class TwinTagsTests extends DeviceTwinCommon
     public TwinTagsTests(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+
+        System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
     @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
@@ -84,17 +88,17 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE_UPDATE + i + " but was " + t.getValue(), internalClient), TAG_VALUE_UPDATE + i, t.getValue());
             }
 
             for (Pair dp : devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties())
             {
-                assertEquals(dp.getKey(), PROPERTY_KEY + i);
-                assertEquals(dp.getValue(), PROPERTY_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("Unexpected desired property key, expected " + PROPERTY_KEY + i + " but was " + dp.getKey(), internalClient), PROPERTY_KEY + i, dp.getKey());
+                assertEquals(buildExceptionMessage("Unexpected desired property value, expected " + PROPERTY_VALUE_UPDATE + i + " but was " + dp.getValue(), internalClient), PROPERTY_VALUE_UPDATE + i, dp.getValue());
             }
             Integer version = devicesUnderTest[i].sCDeviceForTwin.getDesiredPropertiesVersion();
-            assertNotNull(version);
+            assertNotNull(buildExceptionMessage("Version was null", internalClient), version);
         }
         removeMultipleDevices(MAX_DEVICES);
     }
@@ -123,8 +127,8 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE + i + " but was " + t.getValue(), internalClient), TAG_VALUE + i, t.getValue());
             }
         }
         removeMultipleDevices(MAX_DEVICES);
@@ -166,8 +170,8 @@ public class TwinTagsTests extends DeviceTwinCommon
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
-                assertEquals(t.getKey(), TAG_KEY + i);
-                assertEquals(t.getValue(), TAG_VALUE_UPDATE + i);
+                assertEquals(buildExceptionMessage("unexpected tag key, expected " + TAG_KEY + i + " but was " + t.getKey(), internalClient), TAG_KEY + i, t.getKey());
+                assertEquals(buildExceptionMessage("Unexpected tag value, expected " + TAG_VALUE + i + " but was " + t.getValue(), internalClient), TAG_VALUE_UPDATE + i, t.getValue());
             }
         }
 
@@ -190,7 +194,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         {
             sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
-            assertEquals("Tags were not deleted by being set null", 0, devicesUnderTest[i].sCDeviceForTwin.getTags().size());
+            assertEquals(buildExceptionMessage("Tags were not deleted by being set null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getTags().size());
         }
 
         removeMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -39,7 +39,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         System.out.println(clientType + " TwinTagsTests UUID: " + (moduleId != null && !moduleId.isEmpty() ? moduleId : deviceId));
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testGetTwinUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -103,7 +103,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testAddTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -134,7 +134,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test(timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Test
     public void testUpdateTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
@@ -200,7 +200,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         removeMultipleDevices(MAX_DEVICES);
     }
 
-    @Test (timeout = ERROR_INJECTION_EXECUTION_TIMEOUT)
+    @Test
     public void setTagsAtMaxDepthAllowed() throws IOException, IotHubException
     {
         sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -9,7 +9,6 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
-import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.common.tests.serviceclient;
 
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceEmulator;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.deps.serializer.JobsResponseParser;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -121,7 +122,7 @@ public class JobClientTests
         String uuid = UUID.randomUUID().toString();
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            testDevice = registryManager.addDevice(Device.createFromId(DEVICE_ID_NAME.concat("-" + i + "-" + uuid), DeviceStatus.Enabled, null));
+            testDevice = Tools.addDeviceWithRetry(registryManager, Device.createFromId(DEVICE_ID_NAME.concat("-" + i + "-" + uuid), DeviceStatus.Enabled, null));
             DeviceTestManager testManager = new DeviceTestManager(new DeviceClient(registryManager.getDeviceConnectionString(testDevice), IotHubClientProtocol.AMQPS));
             testManager.start();
             devices.add(testManager);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
@@ -174,13 +174,14 @@ public class JobClientTests
             device.stop();
         }
 
-        if (registryManager != null){
+        if (registryManager != null)
+        {
             registryManager.close();
             registryManager = null;
         }
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void scheduleUpdateTwinSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -267,7 +268,7 @@ public class JobClientTests
         }
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void scheduleDeviceMethodSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -353,7 +354,7 @@ public class JobClientTests
         assertEquals(0, deviceTestManger.getStatusError());
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void mixScheduleInFutureSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange
@@ -475,7 +476,7 @@ public class JobClientTests
         assertEquals(0, deviceTestManger.getStatusError());
     }
 
-    @Test
+    @Test (timeout=TEST_TIMEOUT_MS)
     public void cancelScheduleDeviceMethodSucceed() throws IOException, IotHubException, InterruptedException
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.sdk.iot.common.tests.serviceclient;
 
 import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.service.*;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.auth.SymmetricKey;
@@ -66,7 +67,7 @@ public class RegistryManagerTests extends IntegrationTest
 
         //-Create-//
         Device deviceAdded = Device.createFromId(deviceId, DeviceStatus.Enabled, null);
-        registryManager.addDevice(deviceAdded);
+        Tools.addDeviceWithRetry(registryManager, deviceAdded);
 
         //-Read-//
         Device deviceRetrieved = registryManager.getDevice(deviceId);
@@ -94,7 +95,7 @@ public class RegistryManagerTests extends IntegrationTest
 
         //-Create-//
         Device deviceAdded = Device.createDevice(deviceId, AuthenticationType.CERTIFICATE_AUTHORITY);
-        registryManager.addDevice(deviceAdded);
+        Tools.addDeviceWithRetry(registryManager, deviceAdded);
 
         //-Read-//
         Device deviceRetrieved = registryManager.getDevice(deviceId);
@@ -128,7 +129,7 @@ public class RegistryManagerTests extends IntegrationTest
         //-Create-//
         Device deviceAdded = Device.createDevice(deviceId, AuthenticationType.SELF_SIGNED);
         deviceAdded.setThumbprint(primaryThumbprint, secondaryThumbprint);
-        registryManager.addDevice(deviceAdded);
+        Tools.addDeviceWithRetry(registryManager, deviceAdded);
 
         //-Read-//
         Device deviceRetrieved = registryManager.getDevice(deviceId);
@@ -160,7 +161,7 @@ public class RegistryManagerTests extends IntegrationTest
     public void getDeviceStatisticsTest() throws Exception
     {
         RegistryManager registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
-        registryManager.getStatistics();
+        Tools.getStatisticsWithRetry(registryManager);
     }
 
     @Test (timeout=MAX_TEST_MILLISECONDS)
@@ -171,12 +172,12 @@ public class RegistryManagerTests extends IntegrationTest
 
         deleteDeviceIfItExistsAlready(registryManager, deviceForTest);
         Device deviceSetup = Device.createFromId(deviceForTest, DeviceStatus.Enabled, null);
-        registryManager.addDevice(deviceSetup);
+        Tools.addDeviceWithRetry(registryManager, deviceSetup);
         deleteModuleIfItExistsAlready(registryManager, deviceForTest, moduleId);
 
         //-Create-//
         Module moduleAdded = Module.createFromId(deviceForTest, moduleId, null);
-        registryManager.addModule(moduleAdded);
+        Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
         Module moduleRetrieved = registryManager.getModule(deviceForTest, moduleId);
@@ -206,12 +207,12 @@ public class RegistryManagerTests extends IntegrationTest
         deleteDeviceIfItExistsAlready(registryManager, deviceForTest);
         deleteModuleIfItExistsAlready(registryManager, deviceForTest, moduleId);
         Device deviceSetup = Device.createFromId(deviceForTest, DeviceStatus.Enabled, null);
-        registryManager.addDevice(deviceSetup);
+        Tools.addDeviceWithRetry(registryManager, deviceSetup);
         deleteModuleIfItExistsAlready(registryManager, deviceForTest, moduleId);
 
         //-Create-//
         Module moduleAdded = Module.createModule(deviceForTest, moduleId, AuthenticationType.CERTIFICATE_AUTHORITY);
-        registryManager.addModule(moduleAdded);
+        Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
         Module moduleRetrieved = registryManager.getModule(deviceForTest, moduleId);
@@ -238,13 +239,13 @@ public class RegistryManagerTests extends IntegrationTest
         // Arrange
         deleteDeviceIfItExistsAlready(registryManager, deviceForTest);
         Device deviceSetup = Device.createFromId(deviceForTest, DeviceStatus.Enabled, null);
-        registryManager.addDevice(deviceSetup);
+        Tools.addDeviceWithRetry(registryManager, deviceSetup);
         deleteModuleIfItExistsAlready(registryManager, deviceForTest, moduleId);
 
         //-Create-//
         Module moduleAdded = Module.createModule(deviceForTest, moduleId, AuthenticationType.SELF_SIGNED);
         moduleAdded.setThumbprint(primaryThumbprint, secondaryThumbprint);
-        registryManager.addModule(moduleAdded);
+        Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
         Module moduleRetrieved = registryManager.getModule(deviceForTest, moduleId);
@@ -345,7 +346,7 @@ public class RegistryManagerTests extends IntegrationTest
         // Arrange
         deleteDeviceIfItExistsAlready(registryManager, deviceForTest);
         Device deviceSetup = Device.createFromId(deviceForTest, DeviceStatus.Enabled, null);
-        registryManager.addDevice(deviceSetup);
+        Tools.addDeviceWithRetry(registryManager, deviceSetup);
         final HashMap<String, Object> testDeviceContent = new HashMap<String, Object>()
         {
             {
@@ -367,11 +368,11 @@ public class RegistryManagerTests extends IntegrationTest
     }
 
 
-    private void deleteDeviceIfItExistsAlready(RegistryManager registryManager, String deviceId) throws IOException
+    private void deleteDeviceIfItExistsAlready(RegistryManager registryManager, String deviceId) throws IOException, InterruptedException
     {
         try
         {
-            registryManager.getDevice(deviceId);
+            Tools.getDeviceWithRetry(registryManager, deviceId);
 
             //if no exception yet, identity exists so it can be deleted
             try
@@ -388,11 +389,11 @@ public class RegistryManagerTests extends IntegrationTest
         }
     }
 
-    private void deleteModuleIfItExistsAlready(RegistryManager registryManager, String deviceId, String moduleId) throws IOException
+    private void deleteModuleIfItExistsAlready(RegistryManager registryManager, String deviceId, String moduleId) throws IOException, InterruptedException
     {
         try
         {
-            registryManager.getModule(deviceId, moduleId);
+            Tools.getModuleWithRetry(registryManager, deviceId, moduleId);
 
             //if no exception yet, identity exists so it can be deleted
             try

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
@@ -39,6 +39,8 @@ public class RegistryManagerTests extends IntegrationTest
     private static final String primaryThumbprint2 =   "2222222222222222222222222222222222222222";
     private static final String secondaryThumbprint2 = "3333333333333333333333333333333333333333";
 
+    private static final long MAX_TEST_MILLISECONDS = 1 * 60 * 1000;
+    
     public static void setUp() throws IOException
     {
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
@@ -56,7 +58,7 @@ public class RegistryManagerTests extends IntegrationTest
         }
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e() throws Exception
     {
         // Arrange
@@ -84,7 +86,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e_X509_CA_signed() throws Exception
     {
         // Arrange
@@ -117,7 +119,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_device_e2e_X509_self_signed() throws Exception
     {
         // Arrange
@@ -161,7 +163,7 @@ public class RegistryManagerTests extends IntegrationTest
         registryManager.getStatistics();
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e() throws Exception
     {
         // Arrange
@@ -197,7 +199,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e_X509_CA_signed() throws Exception
     {
         // Arrange
@@ -230,7 +232,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_module_e2e_X509_self_signed() throws Exception
     {
         // Arrange
@@ -271,7 +273,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceId, moduleId));
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void crud_adm_configuration_e2e() throws Exception
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.serviceclient;
 
+import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
 import com.microsoft.azure.sdk.iot.service.*;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.auth.SymmetricKey;
@@ -17,19 +18,21 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.UUID;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
  * Test class containing all tests to be run on JVM and android pertaining to identity CRUD. Class needs to be extended
  * in order to run these tests as that extended class handles setting connection strings and certificate generation
  */
-public class RegistryManagerTests
+public class RegistryManagerTests extends IntegrationTest
 {
     protected static String iotHubConnectionString = "";
     private static String deviceId = "java-crud-e2e-test";
     private static String deviceForTest = "deviceForTest";
     private static String moduleId = "java-crud-module-e2e-test";
     private static String configId = "java-crud-adm-e2e-test";
+    private static String hostName;
     private static RegistryManager registryManager;
     private static final String primaryThumbprint =   "0000000000000000000000000000000000000000";
     private static final String secondaryThumbprint = "1111111111111111111111111111111111111111";
@@ -40,6 +43,7 @@ public class RegistryManagerTests
     {
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         deviceId = deviceId.concat("-" + UUID.randomUUID());
+        hostName = IotHubConnectionStringBuilder.createConnectionString(iotHubConnectionString).getHostName();
     }
 
     @AfterClass
@@ -74,10 +78,10 @@ public class RegistryManagerTests
         registryManager.removeDevice(deviceId);
 
         // Assert
-        assertEquals(deviceId, deviceAdded.getDeviceId());
-        assertEquals(deviceId, deviceRetrieved.getDeviceId());
-        assertEquals(DeviceStatus.Disabled, deviceUpdated.getStatus());
-        assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), DeviceStatus.Disabled, deviceUpdated.getStatus());
+        assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
     @Test
@@ -102,15 +106,15 @@ public class RegistryManagerTests
         registryManager.removeDevice(deviceId);
 
         // Assert
-        assertEquals(deviceId, deviceAdded.getDeviceId());
-        assertEquals(deviceId, deviceRetrieved.getDeviceId());
-        assertEquals(AuthenticationType.CERTIFICATE_AUTHORITY, deviceRetrieved.getAuthenticationType());
-        assertEquals(DeviceStatus.Disabled, deviceUpdated.getStatus());
-        assertNull(deviceAdded.getPrimaryThumbprint());
-        assertNull(deviceAdded.getSecondaryKey());
-        assertNull(deviceRetrieved.getPrimaryThumbprint());
-        assertNull(deviceRetrieved.getSecondaryThumbprint());
-        assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), AuthenticationType.CERTIFICATE_AUTHORITY, deviceRetrieved.getAuthenticationType());
+        assertEquals(buildExceptionMessage("", hostName), DeviceStatus.Disabled, deviceUpdated.getStatus());
+        assertNull(buildExceptionMessage("", hostName), deviceAdded.getPrimaryThumbprint());
+        assertNull(buildExceptionMessage("", hostName), deviceAdded.getSecondaryKey());
+        assertNull(buildExceptionMessage("", hostName), deviceRetrieved.getPrimaryThumbprint());
+        assertNull(buildExceptionMessage("", hostName), deviceRetrieved.getSecondaryThumbprint());
+        assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
     @Test
@@ -136,19 +140,20 @@ public class RegistryManagerTests
         registryManager.removeDevice(deviceId);
 
         // Assert
-        assertEquals(deviceId, deviceAdded.getDeviceId());
-        assertEquals(deviceId, deviceRetrieved.getDeviceId());
-        assertEquals(AuthenticationType.SELF_SIGNED, deviceAdded.getAuthenticationType());
-        assertEquals(AuthenticationType.SELF_SIGNED, deviceRetrieved.getAuthenticationType());
-        assertEquals(primaryThumbprint, deviceAdded.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint, deviceAdded.getSecondaryThumbprint());
-        assertEquals(primaryThumbprint, deviceRetrieved.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint, deviceRetrieved.getSecondaryThumbprint());
-        assertEquals(primaryThumbprint2, deviceUpdated.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint2, deviceUpdated.getSecondaryThumbprint());
-        assertTrue(deviceWasDeletedSuccessfully(registryManager, deviceId));
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), deviceId, deviceRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), AuthenticationType.SELF_SIGNED, deviceAdded.getAuthenticationType());
+        assertEquals(buildExceptionMessage("", hostName), AuthenticationType.SELF_SIGNED, deviceRetrieved.getAuthenticationType());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint, deviceAdded.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint, deviceAdded.getSecondaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint, deviceRetrieved.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint, deviceRetrieved.getSecondaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint2, deviceUpdated.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint2, deviceUpdated.getSecondaryThumbprint());
+        assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(registryManager, deviceId));
     }
 
+    //TODO what is this testing?
     @Test
     public void getDeviceStatisticsTest() throws Exception
     {
@@ -184,12 +189,12 @@ public class RegistryManagerTests
         registryManager.removeDevice(deviceForTest);
 
         // Assert
-        assertEquals(deviceForTest, moduleAdded.getDeviceId());
-        assertEquals(moduleId, moduleAdded.getId());
-        assertEquals(deviceForTest, moduleRetrieved.getDeviceId());
-        assertEquals(moduleId, moduleRetrieved.getId());
-        assertEquals(expectedSymmetricKey.getPrimaryKey(), moduleUpdated.getPrimaryKey());
-        assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleAdded.getId());
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleRetrieved.getId());
+        assertEquals(buildExceptionMessage("", hostName), expectedSymmetricKey.getPrimaryKey(), moduleUpdated.getPrimaryKey());
+        assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
     @Test
@@ -214,15 +219,15 @@ public class RegistryManagerTests
         registryManager.removeDevice(deviceForTest);
 
         // Assert
-        assertEquals(deviceForTest, moduleAdded.getDeviceId());
-        assertEquals(moduleId, moduleAdded.getId());
-        assertEquals(deviceForTest, moduleRetrieved.getDeviceId());
-        assertEquals(moduleId, moduleRetrieved.getId());
-        assertNull(moduleAdded.getPrimaryThumbprint());
-        assertNull(moduleAdded.getSecondaryThumbprint());
-        assertNull(moduleRetrieved.getPrimaryThumbprint());
-        assertNull(moduleRetrieved.getSecondaryThumbprint());
-        assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleAdded.getId());
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleRetrieved.getId());
+        assertNull(buildExceptionMessage("", hostName), moduleAdded.getPrimaryThumbprint());
+        assertNull(buildExceptionMessage("", hostName), moduleAdded.getSecondaryThumbprint());
+        assertNull(buildExceptionMessage("", hostName), moduleRetrieved.getPrimaryThumbprint());
+        assertNull(buildExceptionMessage("", hostName), moduleRetrieved.getSecondaryThumbprint());
+        assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceForTest, moduleId));
     }
 
     @Test
@@ -251,19 +256,19 @@ public class RegistryManagerTests
         registryManager.removeModule(deviceForTest, moduleId);
 
         // Assert
-        assertEquals(deviceForTest, moduleAdded.getDeviceId());
-        assertEquals(moduleId, moduleAdded.getId());
-        assertEquals(deviceForTest, moduleRetrieved.getDeviceId());
-        assertEquals(moduleId, moduleRetrieved.getId());
-        assertEquals(AuthenticationType.SELF_SIGNED, moduleAdded.getAuthenticationType());
-        assertEquals(AuthenticationType.SELF_SIGNED, moduleRetrieved.getAuthenticationType());
-        assertEquals(primaryThumbprint, moduleAdded.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint, moduleAdded.getSecondaryThumbprint());
-        assertEquals(primaryThumbprint, moduleRetrieved.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint, moduleRetrieved.getSecondaryThumbprint());
-        assertEquals(primaryThumbprint2, moduleUpdated.getPrimaryThumbprint());
-        assertEquals(secondaryThumbprint2, moduleUpdated.getSecondaryThumbprint());
-        assertTrue(moduleWasDeletedSuccessfully(registryManager, deviceId, moduleId));
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleAdded.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleAdded.getId());
+        assertEquals(buildExceptionMessage("", hostName), deviceForTest, moduleRetrieved.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), moduleId, moduleRetrieved.getId());
+        assertEquals(buildExceptionMessage("", hostName), AuthenticationType.SELF_SIGNED, moduleAdded.getAuthenticationType());
+        assertEquals(buildExceptionMessage("", hostName), AuthenticationType.SELF_SIGNED, moduleRetrieved.getAuthenticationType());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint, moduleAdded.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint, moduleAdded.getSecondaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint, moduleRetrieved.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint, moduleRetrieved.getSecondaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), primaryThumbprint2, moduleUpdated.getPrimaryThumbprint());
+        assertEquals(buildExceptionMessage("", hostName), secondaryThumbprint2, moduleUpdated.getSecondaryThumbprint());
+        assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(registryManager, deviceId, moduleId));
     }
 
     @Test
@@ -309,8 +314,8 @@ public class RegistryManagerTests
         registryManager.removeConfiguration(configId);
 
         // Assert
-        assertEquals(configId, configAdded.getId());
-        assertEquals(configId, configRetrieved.getId());
+        assertEquals(buildExceptionMessage("", hostName), configId, configAdded.getId());
+        assertEquals(buildExceptionMessage("", hostName), configId, configRetrieved.getId());
         String actualString = configRetrieved.getContent().getDeviceContent().get("properties.desired.chiller-water").toString();
         actualString = actualString.substring(1, actualString.length()-1);
         String[] keyValuePairs = actualString.split(",");
@@ -320,19 +325,19 @@ public class RegistryManagerTests
             String[] entry = pair.split("=");
             actualMap.put(entry[0].trim(), entry[1].trim());
         }
-        assertEquals("66.0", actualMap.get("temperature"));
-        assertEquals("28.0", actualMap.get("pressure"));
-        assertEquals("SELECT deviceId FROM devices WHERE properties.reported.chillerWaterSettings.status=\'pending\'",
+        assertEquals(buildExceptionMessage("", hostName), "66.0", actualMap.get("temperature"));
+        assertEquals(buildExceptionMessage("", hostName), "28.0", actualMap.get("pressure"));
+        assertEquals(buildExceptionMessage("", hostName), "SELECT deviceId FROM devices WHERE properties.reported.chillerWaterSettings.status=\'pending\'",
                 configRetrieved.getMetrics().getQueries().get("waterSettingsPending"));
-        assertEquals("properties.reported.chillerProperties.model=\'4000x\'",
+        assertEquals(buildExceptionMessage("", hostName), "properties.reported.chillerProperties.model=\'4000x\'",
                 configRetrieved.getTargetCondition());
-        assertEquals(new Integer(20), configRetrieved.getPriority());
-        assertEquals(configId, configUpdated.getId());
-        assertEquals(new Integer(1), configUpdated.getPriority());
-        assertTrue(configWasDeletedSuccessfully(registryManager, configId));
+        assertEquals(buildExceptionMessage("", hostName), new Integer(20), configRetrieved.getPriority());
+        assertEquals(buildExceptionMessage("", hostName), configId, configUpdated.getId());
+        assertEquals(buildExceptionMessage("", hostName), new Integer(1), configUpdated.getPriority());
+        assertTrue(buildExceptionMessage("", hostName), configWasDeletedSuccessfully(registryManager, configId));
     }
 
-    @Test(expected = IotHubBadFormatException.class)
+    @Test (expected = IotHubBadFormatException.class)
     public void apply_configuration_e2e() throws Exception
     {
         // Arrange

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
@@ -91,7 +91,7 @@ public class ServiceClientTests extends IntegrationTest
         }
 
         Device deviceAdded = Device.createFromId(deviceId, null, null);
-        registryManager.addDevice(deviceAdded);
+        Tools.addDeviceWithRetry(registryManager, deviceAdded);
 
         Device deviceGetBefore = registryManager.getDevice(deviceId);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
@@ -34,6 +34,8 @@ public class ServiceClientTests extends IntegrationTest
     private static String content = "abcdefghijklmnopqrstuvwxyz1234567890";
     private static String hostName;
 
+    private static final long MAX_TEST_MILLISECONDS = 1 * 60 * 1000;
+
     public ServiceClientTests(IotHubServiceClientProtocol protocol)
     {
         this.testInstance = new ServiceClientITRunner(protocol);
@@ -71,7 +73,7 @@ public class ServiceClientTests extends IntegrationTest
         return inputs;
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void cloudToDeviceTelemetry() throws Exception
     {
         // Arrange
@@ -119,7 +121,7 @@ public class ServiceClientTests extends IntegrationTest
         registryManager.close();
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenSendingTelemetry() throws IOException
     {
         boolean expectedExceptionWasCaught = false;
@@ -143,7 +145,7 @@ public class ServiceClientTests extends IntegrationTest
         assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenGettingFeedbackReceiver() throws IOException
     {
         boolean expectedExceptionWasCaught = false;
@@ -169,7 +171,7 @@ public class ServiceClientTests extends IntegrationTest
         assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
-    @Test
+    @Test (timeout=MAX_TEST_MILLISECONDS)
     public void serviceClientValidatesRemoteCertificateWhenGettingFileUploadFeedbackReceiver() throws IOException
     {
         boolean expectedExceptionWasCaught = false;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/ServiceClientTests.java
@@ -5,7 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.serviceclient;
 
-import com.microsoft.azure.sdk.iot.common.helpers.MethodNameLoggingIntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.service.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.Test;
@@ -18,18 +19,20 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
 import static org.junit.Assert.*;
 
 /**
  * Test class containing all tests to be run on JVM and android pertaining to C2D communication using the service client. Class needs to be extended
  * in order to run these tests as that extended class handles setting connection strings and certificate generation
  */
-public class ServiceClientTests extends MethodNameLoggingIntegrationTest
+public class ServiceClientTests extends IntegrationTest
 {
     protected static String iotHubConnectionString = "";
     protected static String invalidCertificateServerConnectionString = "";
     private static String deviceId = "java-service-client-e2e-test";
     private static String content = "abcdefghijklmnopqrstuvwxyz1234567890";
+    private static String hostName;
 
     public ServiceClientTests(IotHubServiceClientProtocol protocol)
     {
@@ -50,10 +53,11 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{0}")
-    public static Collection inputsCommon()
+    public static Collection inputsCommon() throws IOException
     {
         String uuid = UUID.randomUUID().toString();
         deviceId = deviceId.concat("-" + uuid);
+        hostName = IotHubConnectionStringBuilder.createConnectionString(iotHubConnectionString).getHostName();
 
 
         List inputs = Arrays.asList(
@@ -108,9 +112,9 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         registryManager.removeDevice(deviceId);
 
         // Assert
-        assertEquals(deviceGetBefore.getDeviceId(), deviceGetAfter.getDeviceId());
-        assertEquals(0, deviceGetBefore.getCloudToDeviceMessageCount());
-        assertEquals(1, deviceGetAfter.getCloudToDeviceMessageCount());
+        assertEquals(buildExceptionMessage("", hostName), deviceGetBefore.getDeviceId(), deviceGetAfter.getDeviceId());
+        assertEquals(buildExceptionMessage("", hostName), 0, deviceGetBefore.getCloudToDeviceMessageCount());
+        assertEquals(buildExceptionMessage("", hostName), 1, deviceGetAfter.getCloudToDeviceMessageCount());
 
         registryManager.close();
     }
@@ -133,10 +137,10 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         }
         catch (Exception e)
         {
-            fail("Expected IOException, but received: " + e.getMessage());
+            fail(buildExceptionMessage("Expected IOException, but received: " + Tools.getStackTraceFromThrowable(e), hostName));
         }
 
-        assertTrue("Expected an exception due to service presenting invalid certificate", expectedExceptionWasCaught);
+        assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
     @Test
@@ -159,10 +163,10 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         }
         catch (Exception e)
         {
-            fail("Expected IOException, but received: " + e.getMessage());
+            fail(buildExceptionMessage("Expected IOException, but received: " + Tools.getStackTraceFromThrowable(e), hostName));
         }
 
-        assertTrue("Expected an exception due to service presenting invalid certificate", expectedExceptionWasCaught);
+        assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
     @Test
@@ -185,9 +189,9 @@ public class ServiceClientTests extends MethodNameLoggingIntegrationTest
         }
         catch (Exception e)
         {
-            fail("Expected IOException, but received: " + e.getMessage());
+            fail(buildExceptionMessage("Expected IOException, but received: " + Tools.getStackTraceFromThrowable(e), hostName));
         }
 
-        assertTrue("Expected an exception due to service presenting invalid certificate", expectedExceptionWasCaught);
+        assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
@@ -13,8 +13,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateEncodingException;
 
 public class FileUploadJVMRunner extends FileUploadTests
 {

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesErrInjDeviceJVMRunner extends ReceiveMessagesErrInjT
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesErrInjModuleJVMRunner extends ReceiveMessagesErrInjT
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesErrInjDeviceJVMRunner extends SendMessagesErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesErrInjModuleJVMRunner extends SendMessagesErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesErrInjModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodErrInjDeviceJVMRunner extends DeviceMethodErrInjTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodErrInjDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodErrInjModuleJVMRunner extends DeviceMethodErrInjTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodErrInjModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodErrInjModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
@@ -26,7 +26,7 @@ public class DesiredPropertiesErrInjDeviceJVMRunner extends DesiredPropertiesErr
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class DesiredPropertiesErrInjModuleJVMRunner extends DesiredPropertiesErr
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
@@ -26,7 +26,7 @@ public class GetTwinErrInjJVMRunner extends GetTwinErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinErrInjJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class GetTwinErrInjModuleJVMRunner extends GetTwinErrInjTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
@@ -26,7 +26,7 @@ public class ReportedPropertiesErrInjDeviceJVMRunner extends ReportedPropertiesE
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
@@ -26,7 +26,7 @@ public class ReportedPropertiesErrInjModuleJVMRunner extends ReportedPropertiesE
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesDeviceJVMRunner extends ReceiveMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReceiveMessagesModuleJVMRunner extends ReceiveMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReceiveMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReceiveMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesDeviceJVMRunner extends SendMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesDeviceJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class SendMessagesModuleJVMRunner extends SendMessagesTests
 {
     static Collection<BaseDevice> identities;
 
-    public SendMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public SendMessagesModuleJVMRunner(InternalClient client, IotHubClientProtocol protocol, BaseDevice identity, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(client, protocol, identity, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodDeviceJVMRunner extends DeviceMethodTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodDeviceJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
@@ -28,7 +28,7 @@ public class DeviceMethodModuleJVMRunner extends DeviceMethodTests
     static Collection<BaseDevice> identities;
     static ArrayList<DeviceTestManager> testManagers;
 
-    public DeviceMethodModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceMethodModuleJVMRunner(DeviceTestManager deviceTestManager, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, BaseDevice identity, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class DesiredPropertiesDeviceJVMRunner extends DesiredPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class DesiredPropertiesModuleJVMRunner extends DesiredPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public DesiredPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class GetTwinDeviceJVMRunner extends GetTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class GetTwinModuleJVMRunner extends GetTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public GetTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class QueryTwinDeviceJVMRunner extends QueryTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public QueryTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class QueryTwinModuleJVMRunner extends QueryTwinTests
 {
     static Collection<BaseDevice> identities;
 
-    public QueryTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class ReportedPropertiesDeviceJVMRunner extends ReportedPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class ReportedPropertiesModuleJVMRunner extends ReportedPropertiesTests
 {
     static Collection<BaseDevice> identities;
 
-    public ReportedPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
@@ -30,7 +30,7 @@ public class TwinTagsDeviceJVMRunner extends TwinTagsTests
 {
     static Collection<BaseDevice> identities;
 
-    public TwinTagsDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsDeviceJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
@@ -30,7 +30,7 @@ public class TwinTagsModuleJVMRunner extends TwinTagsTests
 {
     static Collection<BaseDevice> identities;
 
-    public TwinTagsModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, String clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsModuleJVMRunner(String deviceId, String moduleId, IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
     {
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.*;
 public class ProvisioningClientJVMRunner extends IntegrationTest
 {
     private final IotHubClientProtocol [] iotHubClientProtocols = {IotHubClientProtocol.MQTT, IotHubClientProtocol.MQTT_WS, IotHubClientProtocol.AMQPS, IotHubClientProtocol.AMQPS_WS, IotHubClientProtocol.HTTPS};
-    private final ProvisioningDeviceClientTransportProtocol [] provisioningDeviceClientTransportProtocols = {MQTT, MQTT_WS, AMQPS, AMQPS_WS, HTTPS};
 
     private static final String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
     private static String iotHubConnectionString = "";
@@ -84,7 +83,6 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     private static final String REGISTRATION_ID_X509_PREFIX = "java-x509-registration-id-";
     private static final String DEVICE_ID_X509_PREFIX = "java-x509-device-id-%s";
 
-    private ProvisioningDeviceClient provisioningDeviceClient = null;
     private ProvisioningServiceClient provisioningServiceClient = null;
     private RegistryManager registryManager = null;
 
@@ -160,7 +158,6 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
 
         provisioningServiceClient = null;
         registryManager = null;
-        provisioningDeviceClient = null;
     }
 
     static class ProvisioningStatus

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -7,10 +7,7 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.provisioning;
 
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
-import com.microsoft.azure.sdk.iot.common.helpers.MessageAndResult;
-import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -43,7 +40,7 @@ import static junit.framework.TestCase.fail;
 import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
-public class ProvisioningClientJVMRunner
+public class ProvisioningClientJVMRunner extends IntegrationTest
 {
     private final IotHubClientProtocol [] iotHubClientProtocols = {IotHubClientProtocol.MQTT, IotHubClientProtocol.MQTT_WS, IotHubClientProtocol.AMQPS, IotHubClientProtocol.AMQPS_WS, IotHubClientProtocol.HTTPS};
     private final ProvisioningDeviceClientTransportProtocol [] provisioningDeviceClientTransportProtocols = {MQTT, MQTT_WS, AMQPS, AMQPS_WS, HTTPS};

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -66,7 +66,7 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     private static final String TPM_SIMULATOR_IP_ADDRESS_ENV_NAME = "IOT_DPS_TPM_SIMULATOR_IP_ADDRESS"; // ip address of TPM simulator
     private static String tpmSimulatorIpAddress = "";
 
-    private static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 20 * 60 * 1000; // one registration could take up to 20 mins
+    private static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 2 * 60 * 1000; // one registration could take up to 2 mins
 
     private static final long TPM_CONNECTION_TIMEOUT = 1 * 60 * 1000;
 
@@ -89,7 +89,7 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     private RegistryManager registryManager = null;
 
     private static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
-    private static final int OVERALL_TEST_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+    private static final int OVERALL_TEST_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection inputs()

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/serviceclient/ServiceClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/serviceclient/ServiceClientJVMRunner.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.Collection;
 
 
@@ -20,7 +21,7 @@ public class ServiceClientJVMRunner extends ServiceClientTests
 {
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{0}")
-    public static Collection inputsCommon()
+    public static Collection inputsCommon() throws IOException
     {
         iotHubConnectionString =
                 Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
@@ -139,7 +139,7 @@ public class ContractAPIMqtt extends ProvisioningDeviceClientContract implements
         catch (IOException ex)
         {
             this.mqttConnection = null;
-            throw new ProvisioningDeviceConnectionException("Exception opening connection amqp", ex);
+            throw new ProvisioningDeviceConnectionException("Exception opening connection", ex);
         }
     }
 


### PR DESCRIPTION
# Description of the problem
e2e tests do not currently log out any device id/hub name correlation details when they fail. This pr adds that functionality

Also, desired properties tests and transport client tests had issues with reruns, so this pr fixes those issues.

This pr also has a few small fixes in misc areas


For an outline of each commit, and why we are adding it see below:

 **Correlation logging details**: We need to log the relevant device id(s) and hub name for any failure

**Adjusting Timeouts**: Removed test timeouts at the individual test level, now all tests inherit a 15 minute timeout which is only for preventing stalled builds. Ideally, these 15 minute timeouts are never hit

**TransportClient test fixes**: Some state was maintained between test reruns since the arraylist was never cleared. Instead, we'll now use arrays so they can't grow over time like they used to

**DesiredProperties test fixes**: Similar to transport client. Some twin state was maintained from previous test runs.

**SendMessageErrInj**: The test class had a test that was hardcoded to use a device client, even when the ClientType given to it was ModuleClient. Also, migrating to using ClientType the enum instead of a string when passing Device vs Module to all test classes.

**Ignore Error Injection Auth/Throttle/Quota**: Disabling due to service side issue