### PR TITLE
fix(iot-deps,iot-device-client): introduced separate locks for status change and incoming/publishing message

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
@@ -5,8 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.deps.transport.mqtt;
 
-import com.microsoft.azure.sdk.iot.deps.util.ObjectLock;
-import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
@@ -23,8 +23,8 @@ public class MqttConnection implements MqttCallback
     private static final String WS_SSL_URL_FORMAT = "wss://%s:443";
     private static final String SSL_URL_FORMAT = "ssl://%s:8883";
 
-    private MqttAsyncClient mqttAsyncClient = null;
-    private MqttConnectOptions connectionOptions = null;
+    private MqttAsyncClient mqttAsyncClient;
+    private MqttConnectOptions connectionOptions;
 
     //mqtt connection options
     private static final int KEEP_ALIVE_INTERVAL = 230;
@@ -33,11 +33,6 @@ public class MqttConnection implements MqttCallback
     static final int MAX_WAIT_TIME = 1000;
 
     private MqttListener mqttListener;
-
-    private final ObjectLock openLock = new ObjectLock();
-
-    // paho mqtt only supports 10 messages in flight at the same time
-    static final int MAX_IN_FLIGHT_COUNT = 10;
 
     /**
      * Constructor to create MqttAsync Client with Paho

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
@@ -144,7 +144,7 @@ public class MqttDeviceMethod extends Mqtt
     @Override
     public IotHubTransportMessage receive() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.incomingLock)
         {
             IotHubTransportMessage message = null;
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwin.java
@@ -275,7 +275,7 @@ public class MqttDeviceTwin extends Mqtt
     @Override
     public IotHubTransportMessage receive() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.incomingLock)
         {
             IotHubTransportMessage messsage = null;
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
@@ -6,9 +6,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.device.transport.mqtt;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.MessageType;
-import com.microsoft.azure.sdk.iot.device.exceptions.ProtocolException;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
-import com.microsoft.azure.sdk.iot.device.exceptions.IotHubServiceException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt;
 import com.microsoft.azure.sdk.iot.device.transport.mqtt.MqttConnection;
@@ -19,6 +17,7 @@ import mockit.NonStrictExpectations;
 import mockit.Verifications;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,8 +26,13 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.*;
-import static org.junit.Assert.*;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SEND_RESPONSE;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_UNKNOWN;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /* Unit tests for MqttDeviceMethod
  * Code coverage: 100% methods, 97% lines
@@ -38,13 +42,17 @@ public class MqttDeviceMethodTest
     @Mocked
     MqttConnection mockedMqttConnection;
 
-    private void baseConstructorExpectation()
+    private ConcurrentLinkedQueue<Pair<String, byte[]>> testAllReceivedMessages;
+
+    @Before
+    public void baseConstructorExpectation()
     {
+        testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         new NonStrictExpectations()
         {
             {
                 Deencapsulation.invoke(mockedMqttConnection, "getAllReceivedMessages");
-                result = new ConcurrentLinkedQueue<>();
+                result = testAllReceivedMessages;
                 Deencapsulation.invoke(mockedMqttConnection, "getMqttLock");
                 result = new Object();
             }
@@ -285,7 +293,6 @@ public class MqttDeviceMethodTest
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
         Map<String, DeviceOperations> testRequestMap = new HashMap<>();
         testRequestMap.put("ReqId", DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST);
-        Deencapsulation.setField(testMethod, "requestMap", testRequestMap);
         testMethod.start();
 
         //act
@@ -304,11 +311,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -330,8 +334,6 @@ public class MqttDeviceMethodTest
         //arrange
         Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -352,8 +354,6 @@ public class MqttDeviceMethodTest
         Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -370,11 +370,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -390,11 +387,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
 
         testMethod.start();
 
@@ -408,13 +402,9 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
         testMethod.start();
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
 
         //act
         Message testMessage = testMethod.receive();

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
@@ -646,7 +646,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -676,7 +676,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -717,7 +717,7 @@ public class MqttDeviceTwinTest
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
             Deencapsulation.setField(testTwin, "requestMap", requestMap);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -828,7 +828,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
@@ -883,7 +883,7 @@ public class MqttDeviceTwinTest
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_UPDATE_REPORTED_PROPERTIES_REQUEST);
             Deencapsulation.setField(testTwin, "requestMap", requestMap);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1003,10 +1003,10 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
-            receivedMessage = (IotHubTransportMessage) testTwin.receive();
+            receivedMessage = testTwin.receive();
         }
         finally
         {
@@ -1044,7 +1044,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1073,7 +1073,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1099,10 +1099,11 @@ public class MqttDeviceTwinTest
             MqttDeviceTwin testTwin = new MqttDeviceTwin(mockedMqttConnection, "");
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             Deencapsulation.setField(mockMqtt, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
+            Deencapsulation.setField(testTwin, "incomingLock", new Object());
 
             //act
-            receivedMessage = (IotHubTransportMessage) testTwin.receive();
+            receivedMessage = testTwin.receive();
         }
         finally
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
@@ -276,12 +276,12 @@ public class MqttTest
         Mqtt mockMqtt1 = instantiateMqtt(true);
         MqttConnection actualInfoInstance1 = Deencapsulation.getField(mockMqtt1, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue1 = Deencapsulation.getField(mockMqtt1, "allReceivedMessages");
-        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "mqttLock");
+        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "stateLock");
 
         Mqtt mockMqtt2 = instantiateMqtt(false);
         MqttConnection actualInfoInstance2 = Deencapsulation.getField(mockMqtt2, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue2 = Deencapsulation.getField(mockMqtt2, "allReceivedMessages");
-        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "mqttLock");
+        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "stateLock");
 
         //assert
         assertEquals(actualInfoInstance1, actualInfoInstance2);
@@ -331,8 +331,8 @@ public class MqttTest
         Object actualInfoInstance2 = Deencapsulation.getField(mockMqtt2, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue2 = Deencapsulation.getField(mockMqtt2, "allReceivedMessages");
 
-        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "mqttLock");
-        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "mqttLock");
+        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "stateLock");
+        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "stateLock");
 
         assertEquals(actualInfoInstance1, actualInfoInstance2);
         assertEquals(actualQueue1, actualQueue2);
@@ -1543,7 +1543,7 @@ public class MqttTest
         //arrange
         final Mqtt mockMqtt = instantiateMqtt(true);
         Deencapsulation.setField(mockMqtt, "mqttConnection", mockedMqttConnection);
-        Deencapsulation.setField(mockMqtt, "mqttLock", new Object());
+        Deencapsulation.setField(mockMqtt, "stateLock", new Object());
 
         final MqttException mqttException = new MqttException(new Throwable());
         new NonStrictExpectations()


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/334

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
[Device Client] Device Client connect timeout with MQTT if there are 10~ messages stack on IoT Hub.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
It was cased by sharing the same lock in different threads when subscribe is called. Separating locks helped to avoid deadlock during this process. Next step we should look closer to the sync locks and avoid hold lock during I/O operation.