### PR TITLE
fix(iot-deps, iot-device-client): Fixed #334 and #378

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
@@ -5,14 +5,19 @@ package com.microsoft.azure.sdk.iot.deps.serializer;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinMetadata;
 
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
@@ -506,5 +511,64 @@ public class ParserUtility
         }
 
         return json;
+    }
+
+    public static Object resolveJsonElement(JsonElement jsonElement)
+    {
+        if (jsonElement == null || jsonElement.isJsonNull()) {
+            return null;
+        }
+        else if (jsonElement.isJsonPrimitive())
+        {
+            return getJsonPrimitiveValue(jsonElement.getAsJsonPrimitive());
+        }
+        else if (jsonElement.isJsonObject())
+        {
+            return getJsonObjectValue(jsonElement.getAsJsonObject());
+        }
+        else if (jsonElement.isJsonArray())
+        {
+            return getJsonArrayValue(jsonElement.getAsJsonArray());
+        }
+        else
+        {
+            // shouldn't be here
+            throw new IllegalArgumentException("Invalid DeviceMethodResponse payload: unknown payload type: " + jsonElement.getClass());
+        }
+    }
+
+    public static Object getJsonPrimitiveValue(JsonPrimitive jsonPrimitive)
+    {
+        if (jsonPrimitive.isNumber())
+        {
+            return jsonPrimitive.getAsNumber();
+        }
+        else if (jsonPrimitive.isBoolean())
+        {
+            return jsonPrimitive.getAsBoolean();
+        }
+        else {
+            return jsonPrimitive.getAsString();
+        }
+    }
+
+    public static Map<String, Object> getJsonObjectValue(JsonObject jsonObject)
+    {
+        Map<String, Object> map = new HashMap<>();
+        for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet())
+        {
+            map.put(entry.getKey(), resolveJsonElement(entry.getValue()));
+        }
+        return map;
+    }
+
+    public static List<Object> getJsonArrayValue(JsonArray jsonArray)
+    {
+        List<Object> list = new ArrayList<>();
+        for (JsonElement element : jsonArray.getAsJsonArray())
+        {
+            list.add(resolveJsonElement(element));
+        }
+        return list;
     }
 }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
@@ -5,8 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.deps.transport.mqtt;
 
-import com.microsoft.azure.sdk.iot.deps.util.ObjectLock;
-import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
@@ -23,8 +23,8 @@ public class MqttConnection implements MqttCallback
     private static final String WS_SSL_URL_FORMAT = "wss://%s:443";
     private static final String SSL_URL_FORMAT = "ssl://%s:8883";
 
-    private MqttAsyncClient mqttAsyncClient = null;
-    private MqttConnectOptions connectionOptions = null;
+    private MqttAsyncClient mqttAsyncClient;
+    private MqttConnectOptions connectionOptions;
 
     //mqtt connection options
     private static final int KEEP_ALIVE_INTERVAL = 230;
@@ -33,11 +33,6 @@ public class MqttConnection implements MqttCallback
     static final int MAX_WAIT_TIME = 1000;
 
     private MqttListener mqttListener;
-
-    private final ObjectLock openLock = new ObjectLock();
-
-    // paho mqtt only supports 10 messages in flight at the same time
-    static final int MAX_IN_FLIGHT_COUNT = 10;
 
     /**
      * Constructor to create MqttAsync Client with Paho

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/Helpers.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/Helpers.java
@@ -10,11 +10,18 @@ import com.microsoft.azure.sdk.iot.deps.twin.TwinMetadata;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test helpers.
@@ -309,7 +316,7 @@ public class Helpers
             }
             else
             {
-                assertEquals(actual, expected);
+                assertEquals(expected,actual);
             }
         }
     }
@@ -407,16 +414,26 @@ public class Helpers
     /**
      * Asserts when list contents are not equal
      * @param expected expected list to verify
-     * @param test  list to test
+     * @param actual  list to actual
      */
-    public static void assertListEquals(List expected, List test)
+    public static void assertListEquals(List expected, List actual)
     {
         assertNotNull(expected);
-        assertNotNull(test);
-        assertTrue(expected.size() == test.size());
-        for(Object o : expected)
+        assertNotNull(actual);
+        int size = expected.size();
+        assertEquals(size, actual.size());
+        for(int i = 0; i < size; i++)
         {
-            assertTrue(test.contains(o));
+            Object expectedObject = expected.get(i);
+            Object actualObject = actual.get(i);
+            if (expectedObject instanceof Number && actualObject instanceof Number)
+            {
+                assertEquals(((Number) expectedObject).doubleValue(), ((Number) actualObject).doubleValue(), 1e-10);
+            }
+            else
+            {
+                assertEquals(expectedObject, actualObject);
+            }
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -12,7 +12,11 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.mqtt.exceptions.PahoExceptionTranslator;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -29,8 +33,9 @@ abstract public class Mqtt implements MqttCallback
     private MqttConnection mqttConnection;
     private MqttMessageListener messageListener;
     ConcurrentLinkedQueue<Pair<String, byte[]>> allReceivedMessages;
-    Object mqttLock;
-    Object publishLock;
+    private final Object stateLock;
+    protected final Object incomingLock;
+    private final Object publishLock;
 
     private static Map<Integer, Message> unacknowledgedSentMessages = new ConcurrentHashMap<>();
 
@@ -85,7 +90,8 @@ abstract public class Mqtt implements MqttCallback
         //Codes_SRS_Mqtt_25_003: [The constructor shall retrieve lock, queue from the provided connection information and save the connection.]
         this.mqttConnection = mqttConnection;
         this.allReceivedMessages = mqttConnection.getAllReceivedMessages();
-        this.mqttLock = mqttConnection.getMqttLock();
+        this.stateLock = mqttConnection.getMqttLock();
+        this.incomingLock = new Object();
         this.publishLock = new Object();
         this.userSpecifiedSASTokenExpiredOnRetry = false;
         this.listener = listener;
@@ -100,7 +106,7 @@ abstract public class Mqtt implements MqttCallback
      */
     protected void connect() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.stateLock)
         {
             try
             {
@@ -162,7 +168,7 @@ abstract public class Mqtt implements MqttCallback
      */
     protected void publish(String publishTopic, Message message) throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.publishLock)
         {
             try
             {
@@ -220,12 +226,9 @@ abstract public class Mqtt implements MqttCallback
 
                 mqttMessage.setQos(MqttConnection.QOS);
 
-                synchronized (this.publishLock)
-                {
-                    //Codes_SRS_Mqtt_25_014: [The function shall publish message payload on the publishTopic specified to the IoT Hub given in the configuration.]
-                    IMqttDeliveryToken publishToken = this.mqttConnection.getMqttAsyncClient().publish(publishTopic, mqttMessage);
-                    this.unacknowledgedSentMessages.put(publishToken.getMessageId(), message);
-                }
+                //Codes_SRS_Mqtt_25_014: [The function shall publish message payload on the publishTopic specified to the IoT Hub given in the configuration.]
+                IMqttDeliveryToken publishToken = this.mqttConnection.getMqttAsyncClient().publish(publishTopic, mqttMessage);
+                unacknowledgedSentMessages.put(publishToken.getMessageId(), message);
             }
             catch (MqttException e)
             {
@@ -248,7 +251,7 @@ abstract public class Mqtt implements MqttCallback
      */
     protected void subscribe(String topic) throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.stateLock)
         {
             try
             {
@@ -293,7 +296,7 @@ abstract public class Mqtt implements MqttCallback
      */
     public IotHubTransportMessage receive() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.incomingLock)
         {
             if (this.mqttConnection == null)
             {
@@ -406,31 +409,28 @@ abstract public class Mqtt implements MqttCallback
     {
         synchronized (this.publishLock)
         {
-            if (this.listener != null)
+            if (this.listener != null&& unacknowledgedSentMessages.containsKey(iMqttDeliveryToken.getMessageId()))
             {
-                if (this.unacknowledgedSentMessages.containsKey(iMqttDeliveryToken.getMessageId()))
+                Message deliveredMessage = unacknowledgedSentMessages.remove(iMqttDeliveryToken.getMessageId());
+
+                if (deliveredMessage instanceof IotHubTransportMessage)
                 {
-                    Message deliveredMessage = this.unacknowledgedSentMessages.remove(iMqttDeliveryToken.getMessageId());
-
-                    if (deliveredMessage instanceof IotHubTransportMessage)
+                    DeviceOperations deviceOperation = ((IotHubTransportMessage) deliveredMessage).getDeviceOperationType();
+                    if (deviceOperation == DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST
+                            || deviceOperation == DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST
+                            || deviceOperation == DeviceOperations.DEVICE_OPERATION_TWIN_UNSUBSCRIBE_DESIRED_PROPERTIES_REQUEST)
                     {
-                        DeviceOperations deviceOperation = ((IotHubTransportMessage) deliveredMessage).getDeviceOperationType();
-                        if (deviceOperation == DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST
-                                || deviceOperation == DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST
-                                || deviceOperation == DeviceOperations.DEVICE_OPERATION_TWIN_UNSUBSCRIBE_DESIRED_PROPERTIES_REQUEST)
-                        {
-                            //Codes_SRS_Mqtt_34_056: [If the acknowledged message is of type
-                            // DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST, DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST,
-                            // or DEVICE_OPERATION_TWIN_UNSUBSCRIBE_DESIRED_PROPERTIES_REQUEST, this function shall not notify the saved
-                            // listener that the message was sent.]
-                            //no need to alert the IotHubTransport layer about these messages as they are not tracked in the inProgressQueue
-                            return;
-                        }
+                        //Codes_SRS_Mqtt_34_056: [If the acknowledged message is of type
+                        // DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST, DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST,
+                        // or DEVICE_OPERATION_TWIN_UNSUBSCRIBE_DESIRED_PROPERTIES_REQUEST, this function shall not notify the saved
+                        // listener that the message was sent.]
+                        //no need to alert the IotHubTransport layer about these messages as they are not tracked in the inProgressQueue
+                        return;
                     }
-
-                    //Codes_SRS_Mqtt_34_042: [If this object has a saved listener, that listener shall be notified of the successfully delivered message.]
-                    this.listener.onMessageSent(deliveredMessage, null);
                 }
+
+                //Codes_SRS_Mqtt_34_042: [If this object has a saved listener, that listener shall be notified of the successfully delivered message.]
+                this.listener.onMessageSent(deliveredMessage, null);
             }
         }
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
@@ -144,7 +144,7 @@ public class MqttDeviceMethod extends Mqtt
     @Override
     public IotHubTransportMessage receive() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.incomingLock)
         {
             IotHubTransportMessage message = null;
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwin.java
@@ -275,7 +275,7 @@ public class MqttDeviceTwin extends Mqtt
     @Override
     public IotHubTransportMessage receive() throws TransportException
     {
-        synchronized (this.mqttLock)
+        synchronized (this.incomingLock)
         {
             IotHubTransportMessage messsage = null;
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
@@ -6,9 +6,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.device.transport.mqtt;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.MessageType;
-import com.microsoft.azure.sdk.iot.device.exceptions.ProtocolException;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
-import com.microsoft.azure.sdk.iot.device.exceptions.IotHubServiceException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt;
 import com.microsoft.azure.sdk.iot.device.transport.mqtt.MqttConnection;
@@ -19,6 +17,7 @@ import mockit.NonStrictExpectations;
 import mockit.Verifications;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,8 +26,13 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.*;
-import static org.junit.Assert.*;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SEND_RESPONSE;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST;
+import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_UNKNOWN;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /* Unit tests for MqttDeviceMethod
  * Code coverage: 100% methods, 97% lines
@@ -38,13 +42,17 @@ public class MqttDeviceMethodTest
     @Mocked
     MqttConnection mockedMqttConnection;
 
-    private void baseConstructorExpectation()
+    private ConcurrentLinkedQueue<Pair<String, byte[]>> testAllReceivedMessages;
+
+    @Before
+    public void baseConstructorExpectation()
     {
+        testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         new NonStrictExpectations()
         {
             {
                 Deencapsulation.invoke(mockedMqttConnection, "getAllReceivedMessages");
-                result = new ConcurrentLinkedQueue<>();
+                result = testAllReceivedMessages;
                 Deencapsulation.invoke(mockedMqttConnection, "getMqttLock");
                 result = new Object();
             }
@@ -285,7 +293,6 @@ public class MqttDeviceMethodTest
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
         Map<String, DeviceOperations> testRequestMap = new HashMap<>();
         testRequestMap.put("ReqId", DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST);
-        Deencapsulation.setField(testMethod, "requestMap", testRequestMap);
         testMethod.start();
 
         //act
@@ -304,11 +311,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -330,8 +334,6 @@ public class MqttDeviceMethodTest
         //arrange
         Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -352,8 +354,6 @@ public class MqttDeviceMethodTest
         Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -370,11 +370,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
         testMethod.start();
 
         //act
@@ -390,11 +387,8 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/";
         byte[] actualPayload = "TestPayload".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
 
         testMethod.start();
 
@@ -408,13 +402,9 @@ public class MqttDeviceMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "".getBytes();
-        Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
         testAllReceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod(mockedMqttConnection, "");
-        Deencapsulation.setField(testMethod, "mqttLock", new Object());
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
         testMethod.start();
-        Deencapsulation.setField(testMethod, "allReceivedMessages", testAllReceivedMessages);
 
         //act
         Message testMessage = testMethod.receive();

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
@@ -646,7 +646,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -676,7 +676,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -717,7 +717,7 @@ public class MqttDeviceTwinTest
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
             Deencapsulation.setField(testTwin, "requestMap", requestMap);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -828,7 +828,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
@@ -883,7 +883,7 @@ public class MqttDeviceTwinTest
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_UPDATE_REPORTED_PROPERTIES_REQUEST);
             Deencapsulation.setField(testTwin, "requestMap", requestMap);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1003,10 +1003,10 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
-            receivedMessage = (IotHubTransportMessage) testTwin.receive();
+            receivedMessage = testTwin.receive();
         }
         finally
         {
@@ -1044,7 +1044,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1073,7 +1073,7 @@ public class MqttDeviceTwinTest
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             testAllReceivedMessages.add(new MutablePair<>(insertTopic, actualPayload));
             Deencapsulation.setField(testTwin, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
 
             //act
             receivedMessage = (IotHubTransportMessage) testTwin.receive();
@@ -1099,10 +1099,11 @@ public class MqttDeviceTwinTest
             MqttDeviceTwin testTwin = new MqttDeviceTwin(mockedMqttConnection, "");
             Queue<Pair<String, byte[]>> testAllReceivedMessages = new ConcurrentLinkedQueue<>();
             Deencapsulation.setField(mockMqtt, "allReceivedMessages", testAllReceivedMessages);
-            Deencapsulation.setField(testTwin, "mqttLock", new Object());
+            Deencapsulation.setField(testTwin, "stateLock", new Object());
+            Deencapsulation.setField(testTwin, "incomingLock", new Object());
 
             //act
-            receivedMessage = (IotHubTransportMessage) testTwin.receive();
+            receivedMessage = testTwin.receive();
         }
         finally
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
@@ -276,12 +276,12 @@ public class MqttTest
         Mqtt mockMqtt1 = instantiateMqtt(true);
         MqttConnection actualInfoInstance1 = Deencapsulation.getField(mockMqtt1, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue1 = Deencapsulation.getField(mockMqtt1, "allReceivedMessages");
-        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "mqttLock");
+        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "stateLock");
 
         Mqtt mockMqtt2 = instantiateMqtt(false);
         MqttConnection actualInfoInstance2 = Deencapsulation.getField(mockMqtt2, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue2 = Deencapsulation.getField(mockMqtt2, "allReceivedMessages");
-        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "mqttLock");
+        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "stateLock");
 
         //assert
         assertEquals(actualInfoInstance1, actualInfoInstance2);
@@ -331,8 +331,8 @@ public class MqttTest
         Object actualInfoInstance2 = Deencapsulation.getField(mockMqtt2, "mqttConnection");
         Queue<Pair<String, byte[]>> actualQueue2 = Deencapsulation.getField(mockMqtt2, "allReceivedMessages");
 
-        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "mqttLock");
-        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "mqttLock");
+        Object actualLock1 = Deencapsulation.getField(mockMqtt1, "stateLock");
+        Object actualLock2 = Deencapsulation.getField(mockMqtt2, "stateLock");
 
         assertEquals(actualInfoInstance1, actualInfoInstance2);
         assertEquals(actualQueue1, actualQueue2);
@@ -1543,7 +1543,7 @@ public class MqttTest
         //arrange
         final Mqtt mockMqtt = instantiateMqtt(true);
         Deencapsulation.setField(mockMqtt, "mqttConnection", mockedMqttConnection);
-        Deencapsulation.setField(mockMqtt, "mqttLock", new Object());
+        Deencapsulation.setField(mockMqtt, "stateLock", new Object());
 
         final MqttException mqttException = new MqttException(new Throwable());
         new NonStrictExpectations()

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -148,7 +148,7 @@ public class DeviceMethod
         }
 
         long  responseTimeout, connectTimeout;
-        
+
         if (responseTimeoutInSeconds == null)
         {
             responseTimeout  = DEFAULT_RESPONSE_TIMEOUT; // If timeout is not set, it defaults to 30 seconds


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/334
https://github.com/Azure/azure-iot-sdk-java/issues/378
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-java/issues/334 Device Client connect timeout with MQTT if there are 10~ messages stack on IoT Hub.
https://github.com/Azure/azure-iot-sdk-java/issues/378 DeviceMethodCallback message contains backslashes

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
https://github.com/Azure/azure-iot-sdk-java/issues/334 Deadlock was cased by sharing the same lock in different threads when subscribe is called. Separating locks helped to avoid deadlock during this process. Next step we should look closer to the sync locks and avoid hold lock during I/O operation.

https://github.com/Azure/azure-iot-sdk-java/issues/378 Fixed the issue by modifying MethodParser class

`Gson` is a tool class used for serialize/deserialize known class type. In this case, payload is send/received as String. `Gson.toJsonTree`  will just json escape `payload`. We'd like to parse `payload` to a `JsonElement` and send as `payload` attribute which is `JsonParser`'s functionality.  For example, if Service client invoke `methodName` as `test` and payload as `{"a":"A"}`, `payload` will be escaped by `Gson` as `"{\"a\": \"A\"}` and be sent as:
```
{
     "methodName": "test",
     "payload": "{\"a\": \"A\"}"
}
```
`JsonParser` will convert it to a `JsonObject`, serialize as `{"abc":"XYZ"}` and sent as
```
{
	"methodName": "test",
	"payload": {
		"a": "A"
	}
}
```
IoT Hub does a good job and just convert `payload` as `JsonElement` to `String`, which will be `"{\"a\": \"A\"}"` with former `Gson` code and `{"a":"A"}` with the fix. 

Once device client receives the `payload`, it will pass the `payload` as `String` to Application `DeviceMethodCallback` API. 

**Caution** Application will get `payload` as it is sent out now if it's a valid json string. Ideally `payload` is required to be json string but for back compatible, any invalid string will be accepted, json escaped and received. For example if `payload` is `abc` will is invalid, it will be received as `"abc"` on `DeviceMethodCallback` API. 
For Java specific, `Map<String,Object>` will be converted as `JsonObject`, e.g. following map
```
{"boolean"=true, "string"="STRING", "int"=123, "map"= { "internal": 1.3}}
```
will be sent and received as:
```
{
     "boolean": true,
     "string": "STRING",
     "int": 123
     "map": {
          "internal": 1.3
     }
}
```
  Basic class type `Number` and `Boolean will be received as it's value. Any other `Object` will be called `toString()` and follow the process above. 

After `DeviceMethodCallback` process, when `DeviceMethodCallback` send back `payload` as `String`, it will reverse the process above, Json `String` will be converted to `Map`. 