### PR TITLE
Dps symmetric key AMQP and MQTT support

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslHandler.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslHandler.java
@@ -65,4 +65,11 @@ public interface SaslHandler
      * @throws Exception if sasl negotiation fails
      */
     void handleOutcome(SaslOutcome outcome) throws Exception;
+
+    String plainUsername();
+
+    String plainPassword();
+
+    void setSasToken(String sasToken);
+
 }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslListenerImpl.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslListenerImpl.java
@@ -42,9 +42,19 @@ public class SaslListenerImpl implements SaslListener
                 chosenMechanism = this.saslHandler.chooseSaslMechanism(mechanisms);
                 sasl.setMechanisms(chosenMechanism);
 
-                // Codes_SRS_SASLLISTENERIMPL_34_003: [This function shall ask the saved saslHandler object to create the init payload for the chosen sasl mechanism and then send that payload.]
+                if (chosenMechanism.equalsIgnoreCase("PLAIN"))
+                {
+                    //Codes_SRS_SASLLISTENERIMPL_34_015: [If the chosen mechanism is PLAIN, this function shall call sasl.plain(...) with the inputs given by the saslhandler.]
+                    sasl.plain(this.saslHandler.plainUsername(), this.saslHandler.plainPassword());
+                }
+
+                // Codes_SRS_SASLLISTENERIMPL_34_003: [This function shall ask the saved saslHandler object to create the init payload for the chosen sasl mechanism and then send that payload if the init payload is larger than 0 bytes.]
                 byte[] initMessage = this.saslHandler.getInitPayload(chosenMechanism);
-                sasl.send(initMessage, 0, initMessage.length);
+
+                if (initMessage.length > 0)
+                {
+                    sasl.send(initMessage, 0, initMessage.length);
+                }
             }
             catch (Exception e)
             {

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslListenerImplTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/SaslListenerImplTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * Unit tests for SaslListenerImpl.java
- * Coverage : 75% method, 95% line
+ * Coverage : 75% method, 89% line
  * (Two methods currently have no implementation)
  */
 @RunWith(JMockit.class)
@@ -52,7 +52,7 @@ public class SaslListenerImplTest
     }
 
     // Tests_SRS_SASLLISTENERIMPL_34_002: [This function shall retrieve the remote mechanisms and give them to the saved saslHandler object to decide which mechanism to use.]
-    // Tests_SRS_SASLLISTENERIMPL_34_003: [This function shall ask the saved saslHandler object to create the init payload for the chosen sasl mechanism and then send that payload.]
+    // Tests_SRS_SASLLISTENERIMPL_34_003: [This function shall ask the saved saslHandler object to create the init payload for the chosen sasl mechanism and then send that payload if the init payload is larger than 0 bytes.]
     @Test
     public void onSaslMechanismsTest() throws Exception
     {
@@ -89,6 +89,102 @@ public class SaslListenerImplTest
                 times = 1;
 
                 mockedSasl.send(initPayload, 0, initPayload.length);
+                times = 1;
+            }
+        };
+    }
+
+    // Tests_SRS_SASLLISTENERIMPL_34_003: [This function shall ask the saved saslHandler object to create the init payload for the chosen sasl mechanism and then send that payload if the init payload is larger than 0 bytes.]
+    @Test
+    public void onSaslMechanismsTestWithoutInit() throws Exception
+    {
+        //arrange
+        final String[] remoteMechanisms = new String[] {"1", "2"};
+        final String chosenMechanism = "1";
+        final byte[] initPayload = new byte[0];
+        SaslListener saslListener = new SaslListenerImpl(mockedSaslHandler);
+        new NonStrictExpectations()
+        {
+            {
+                mockedSasl.getRemoteMechanisms();
+                result = remoteMechanisms;
+
+                mockedSaslHandler.chooseSaslMechanism(remoteMechanisms);
+                result = chosenMechanism;
+
+                mockedSaslHandler.getInitPayload(chosenMechanism);
+                result = initPayload;
+            }
+        };
+
+        //act
+        saslListener.onSaslMechanisms(mockedSasl, mockedTransport);
+
+        //assert
+        new Verifications()
+        {
+            {
+                mockedSaslHandler.chooseSaslMechanism(remoteMechanisms);
+                times = 1;
+
+                mockedSaslHandler.getInitPayload(chosenMechanism);
+                times = 1;
+
+                mockedSasl.send(initPayload, 0, initPayload.length);
+                times = 0;
+            }
+        };
+    }
+
+    //Tests_SRS_SASLLISTENERIMPL_34_015: [If the chosen mechanism is PLAIN, this function shall call sasl.plain(...) with the inputs given by the saslhandler.]
+    @Test
+    public void onSaslMechanismsWithPlainMechanism() throws Exception
+    {
+        //arrange
+        final String[] remoteMechanisms = new String[] {"PLAIN"};
+        final String chosenMechanism = "PLAIN";
+        final byte[] initPayload = new byte[0];
+        SaslListener saslListener = new SaslListenerImpl(mockedSaslHandler);
+        final String expectedUsername = "1234";
+        final String expectedPass = "5678";
+
+        new NonStrictExpectations()
+        {
+            {
+                mockedSasl.getRemoteMechanisms();
+                result = remoteMechanisms;
+
+                mockedSaslHandler.chooseSaslMechanism(remoteMechanisms);
+                result = chosenMechanism;
+
+                mockedSaslHandler.getInitPayload(chosenMechanism);
+                result = initPayload;
+
+                mockedSaslHandler.plainUsername();
+                result = expectedUsername;
+
+                mockedSaslHandler.plainPassword();
+                result = expectedPass;
+            }
+        };
+
+        //act
+        saslListener.onSaslMechanisms(mockedSasl, mockedTransport);
+
+        //assert
+        new Verifications()
+        {
+            {
+                mockedSaslHandler.chooseSaslMechanism(remoteMechanisms);
+                times = 1;
+
+                mockedSaslHandler.getInitPayload(chosenMechanism);
+                times = 1;
+
+                mockedSasl.send(initPayload, 0, initPayload.length);
+                times = 0;
+
+                mockedSasl.plain(expectedUsername, expectedPass);
                 times = 1;
             }
         };

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -16,12 +16,16 @@ import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.provisioning.device.*;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
+import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
+import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderTpm;
+import com.microsoft.azure.sdk.iot.provisioning.security.exceptions.SecurityProviderException;
 import com.microsoft.azure.sdk.iot.provisioning.security.hsm.SecurityProviderTPMEmulator;
 import com.microsoft.azure.sdk.iot.provisioning.security.hsm.SecurityProviderX509Cert;
 import com.microsoft.azure.sdk.iot.provisioning.service.ProvisioningServiceClient;
 import com.microsoft.azure.sdk.iot.provisioning.service.configs.*;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientException;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
+import com.microsoft.azure.sdk.iot.service.auth.SymmetricKey;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.After;
 import org.junit.Before;
@@ -30,8 +34,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_ASSIGNED;
@@ -42,6 +53,19 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class ProvisioningClientJVMRunner extends IntegrationTest
 {
+    private enum AttestationType
+    {
+        X509,
+        TPM,
+        SYMMETRIC_KEY
+    };
+
+    private enum EnrollmentType
+    {
+        INDIVIDUAL,
+        GROUP
+    };
+
     private final IotHubClientProtocol [] iotHubClientProtocols = {IotHubClientProtocol.MQTT, IotHubClientProtocol.MQTT_WS, IotHubClientProtocol.AMQPS, IotHubClientProtocol.AMQPS_WS, IotHubClientProtocol.HTTPS};
 
     private static final String IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
@@ -78,6 +102,8 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     //How many milliseconds between retry
     private static final Integer IOTHUB_RETRY_MILLISECONDS = 100;
 
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
     private static final String REGISTRATION_ID_TPM_PREFIX = "java-tpm-registration-id-";
     private static final String DEVICE_ID_TPM_PREFIX = "java-tpm-device-id-";
     private static final String REGISTRATION_ID_X509_PREFIX = "java-x509-registration-id-";
@@ -89,24 +115,38 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     private static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
     private static final int OVERALL_TEST_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameterized.Parameters(name = "{0} using {1}")
     public static Collection inputs()
     {
         return Arrays.asList(
                 new Object[][]
                 {
-                    {HTTPS},
-                    {MQTT},
-                    {MQTT_WS},
-                    {AMQPS},
-                    {AMQPS_WS},
+                        {HTTPS, AttestationType.SYMMETRIC_KEY},
+                        //{HTTPS, AttestationType.TPM}, disabled: missing test infrastructure on VSTS
+                        {HTTPS, AttestationType.X509},
+
+                        {MQTT, AttestationType.SYMMETRIC_KEY},
+                        //{MQTT, AttestationType.TPM}, NOT SUPPORTED BY SERVICE
+                        {MQTT, AttestationType.X509},
+
+                        {MQTT_WS, AttestationType.SYMMETRIC_KEY},
+                        //{MQTT_WS, AttestationType.TPM}, NOT SUPPORTED BY SERVICE
+                        {MQTT_WS, AttestationType.X509},
+
+                        {AMQPS, AttestationType.SYMMETRIC_KEY},
+                        //{AMQPS, AttestationType.TPM}, //disabled: missing test infrastructure on VSTS
+                        {AMQPS, AttestationType.X509},
+
+                        {AMQPS_WS, AttestationType.SYMMETRIC_KEY},
+                        //{AMQPS_WS, AttestationType.TPM}, //disabled: missing test infrastructure on VSTS
+                        {AMQPS_WS, AttestationType.X509},
                 }
         );
     }
 
-    public ProvisioningClientJVMRunner(ProvisioningDeviceClientTransportProtocol protocol)
+    public ProvisioningClientJVMRunner(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
     {
-        this.testInstance = new ProvisioningClientITRunner(protocol);
+        this.testInstance = new ProvisioningClientITRunner(protocol, attestationType);
     }
 
     private ProvisioningClientITRunner testInstance;
@@ -114,10 +154,19 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     private class ProvisioningClientITRunner
     {
         private ProvisioningDeviceClientTransportProtocol protocol;
+        private AttestationType attestationType;
+        private String groupId;
+        private IndividualEnrollment individualEnrollment;
+        private EnrollmentGroup enrollmentGroup;
+        private String registrationId;
+        private String provisionedDeviceId;
 
-        public ProvisioningClientITRunner(ProvisioningDeviceClientTransportProtocol protocol)
+        public ProvisioningClientITRunner(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
         {
             this.protocol = protocol;
+            this.attestationType = attestationType;
+            this.groupId = "";// by default, assume individual enrollment which has no group id
+            this.registrationId = "java-provisioning-test-" + this.attestationType.toString().toLowerCase().replace("_", "-") + "-" + UUID.randomUUID().toString();
         }
     }
 
@@ -242,107 +291,100 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
         return null;
     }
 
-    private IndividualEnrollment createIndividualEnrollmentTPM(String endorsementKey, String registrationId, String deviceId, TwinState twinState) throws ProvisioningServiceClientException
+    private SecurityProvider getSecurityProviderInstance(EnrollmentType enrollmentType) throws ProvisioningServiceClientException, GeneralSecurityException, IOException, SecurityProviderException, InterruptedException
     {
-        System.out.println("Creating Individual Enrollment For TPM with Registration ID " + registrationId);
-        Attestation attestation = new TpmAttestation(endorsementKey);
-        IndividualEnrollment individualEnrollment =
-                new IndividualEnrollment(
-                        registrationId,
-                        attestation);
+        SecurityProvider securityProvider = null;
+        TwinCollection tags = new TwinCollection();
+        final String TEST_KEY_TAG = "testTag";
+        final String TEST_VALUE_TAG = "testValue";
+        tags.put(TEST_KEY_TAG, TEST_VALUE_TAG);
 
-        individualEnrollment.setDeviceIdFinal(deviceId);
-        if (twinState != null)
+        final String TEST_KEY_DP = "testDP";
+        final String TEST_VALUE_DP = "testDPValue";
+        TwinCollection desiredProperties = new TwinCollection();
+        desiredProperties.put(TEST_KEY_DP, TEST_VALUE_DP);
+
+        TwinState twinState = new TwinState(tags, desiredProperties);
+
+        if (enrollmentType == EnrollmentType.GROUP)
         {
-            individualEnrollment.setInitialTwin(twinState);
+            if (testInstance.attestationType == AttestationType.TPM)
+            {
+                throw new UnsupportedOperationException("Group enrollments cannot use tpm attestation");
+            }
+            else if (testInstance.attestationType == AttestationType.X509)
+            {
+                throw new UnsupportedOperationException("Test code hasn't been written to test Group x509 enrollments yet");
+            }
+            else if (testInstance.attestationType == AttestationType.SYMMETRIC_KEY)
+            {
+                testInstance.groupId = "java-provisioning-test-group-id-" + testInstance.attestationType.toString().toLowerCase().replace("_", "-") + "-" + UUID.randomUUID().toString();
+
+                testInstance.enrollmentGroup = new EnrollmentGroup(testInstance.groupId, new SymmetricKeyAttestation(null, null));
+                testInstance.enrollmentGroup.setInitialTwinFinal(twinState);
+
+                testInstance.enrollmentGroup = provisioningServiceClient.createOrUpdateEnrollmentGroup(testInstance.enrollmentGroup);
+                Attestation attestation = testInstance.enrollmentGroup.getAttestation();
+                assertTrue(attestation instanceof SymmetricKeyAttestation);
+
+                assertNotNull(testInstance.enrollmentGroup.getInitialTwin());
+                assertEquals(TEST_VALUE_TAG, testInstance.enrollmentGroup.getInitialTwin().getTags().get(TEST_KEY_TAG));
+                assertEquals(TEST_VALUE_DP, testInstance.enrollmentGroup.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
+
+                SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) attestation;
+                byte[] derivedPrimaryKey = ComputeDerivedSymmetricKey(symmetricKeyAttestation.getPrimaryKey(), testInstance.registrationId);
+                securityProvider = new SecurityProviderSymmetricKey(derivedPrimaryKey, testInstance.registrationId);
+            }
+        }
+        else if (enrollmentType == EnrollmentType.INDIVIDUAL)
+        {
+            testInstance.provisionedDeviceId = "Some-Provisioned-Device-" + testInstance.attestationType + "-" +UUID.randomUUID().toString();
+            if (testInstance.attestationType == AttestationType.TPM)
+            {
+                securityProvider = connectToTpmEmulator();
+                Attestation attestation = new TpmAttestation(new String(Base64.encodeBase64Local(((SecurityProviderTpm) securityProvider).getEndorsementKey())));
+                testInstance.individualEnrollment = new IndividualEnrollment(testInstance.registrationId, attestation);
+                testInstance.individualEnrollment.setDeviceIdFinal(testInstance.provisionedDeviceId);
+                testInstance.individualEnrollment.setInitialTwin(twinState);
+                testInstance.individualEnrollment =  provisioningServiceClient.createOrUpdateIndividualEnrollment(testInstance.individualEnrollment);
+            }
+            else if (testInstance.attestationType == AttestationType.X509)
+            {
+                X509Cert certs = new X509Cert(0, false, testInstance.registrationId, null);
+                final String leafPublicPem =  certs.getPublicCertLeafPem();
+                String leafPrivateKey = certs.getPrivateKeyLeafPem();
+                Collection<String> signerCertificates = new LinkedList<>();
+                Attestation attestation = X509Attestation.createFromClientCertificates(leafPublicPem);
+                testInstance.individualEnrollment = new IndividualEnrollment(testInstance.registrationId, attestation);
+                testInstance.individualEnrollment.setDeviceIdFinal(testInstance.provisionedDeviceId);
+                testInstance.individualEnrollment.setInitialTwin(twinState);
+                testInstance.individualEnrollment = provisioningServiceClient.createOrUpdateIndividualEnrollment(testInstance.individualEnrollment);
+                securityProvider = new SecurityProviderX509Cert(leafPublicPem, leafPrivateKey, signerCertificates);
+            }
+            else if (testInstance.attestationType == AttestationType.SYMMETRIC_KEY)
+            {
+                Attestation attestation = new SymmetricKeyAttestation(null, null);
+                testInstance.individualEnrollment = new IndividualEnrollment(testInstance.registrationId, attestation);
+                testInstance.individualEnrollment.setDeviceIdFinal(testInstance.provisionedDeviceId);
+                testInstance.individualEnrollment =  provisioningServiceClient.createOrUpdateIndividualEnrollment(testInstance.individualEnrollment);
+                testInstance.individualEnrollment.setInitialTwin(twinState);
+                assertTrue(testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
+                SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) testInstance.individualEnrollment.getAttestation();
+                securityProvider = new SecurityProviderSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(), testInstance.registrationId);
+            }
+
+            assertEquals(testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());
+            assertNotNull(testInstance.individualEnrollment.getInitialTwin());
+            assertEquals(TEST_VALUE_TAG, testInstance.individualEnrollment.getInitialTwin().getTags().get(TEST_KEY_TAG));
+            assertEquals(TEST_VALUE_DP, testInstance.individualEnrollment.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
         }
 
-        IndividualEnrollment individualEnrollmentResult =  provisioningServiceClient.createOrUpdateIndividualEnrollment(individualEnrollment);
-        assertNotNull(individualEnrollmentResult);
-        assertNotNull(individualEnrollmentResult.getRegistrationId()); // Registration ID
-        assertEquals(registrationId, individualEnrollmentResult.getRegistrationId()); // Registration ID
-        assertNotNull((individualEnrollmentResult.getAttestation())); // Endorsement key
-        assertNotNull(((TpmAttestation)individualEnrollmentResult.getAttestation()).getEndorsementKey()); // Endorsement key
-        assertEquals(endorsementKey, ((TpmAttestation)individualEnrollmentResult.getAttestation()).getEndorsementKey()); // Endorsement key
-        assertNotNull(individualEnrollmentResult.getEtag()); //
-        assertNotNull(individualEnrollmentResult.getCreatedDateTimeUtc()); //
-        assertNotNull(individualEnrollmentResult.getLastUpdatedDateTimeUtc()); //
-        assertNotNull(individualEnrollmentResult.getDeviceId()); // expected identity ID
-        assertEquals(deviceId, individualEnrollmentResult.getDeviceId()); // expected identity ID
-        if (twinState == null)
-        {
-            assertNull(individualEnrollmentResult.getInitialTwin()); // expected null
-        }
-        else
-        {
-            assertNotNull(individualEnrollmentResult.getInitialTwin()); // expected not null
-        }
-        System.out.println("Successfully created Individual Enrollment for TPM");
-        return individualEnrollmentResult;
+        return securityProvider;
     }
 
-    private IndividualEnrollment createIndividualEnrollmentX509(String clientCertPem, String registrationId, String deviceId, TwinState twinState) throws ProvisioningServiceClientException
+    private SecurityProviderTPMEmulator connectToTpmEmulator() throws InterruptedException
     {
-        System.out.println("Creating Individual Enrollment for X509 with Registration ID " + registrationId);
-        Attestation attestation = X509Attestation.createFromClientCertificates(clientCertPem);
-        IndividualEnrollment individualEnrollment =
-                new IndividualEnrollment(
-                        registrationId,
-                        attestation);
-
-        individualEnrollment.setDeviceIdFinal(deviceId);
-        if (twinState != null)
-        {
-            individualEnrollment.setInitialTwin(twinState);
-        }
-
-        IndividualEnrollment individualEnrollmentResult =  provisioningServiceClient.createOrUpdateIndividualEnrollment(individualEnrollment);
-        assertNotNull(individualEnrollmentResult);
-        assertNotNull(individualEnrollmentResult.getRegistrationId()); // Registration ID
-        assertEquals(registrationId, individualEnrollmentResult.getRegistrationId()); // Registration ID
-        assertNotNull((individualEnrollmentResult.getAttestation())); // ?
-        assertNotNull(((X509Attestation)individualEnrollmentResult.getAttestation()).getPrimaryX509CertificateInfo()); // Client Cert Info
-        assertNotNull(individualEnrollmentResult.getEtag()); //
-        assertNotNull(individualEnrollmentResult.getCreatedDateTimeUtc()); //
-        assertNotNull(individualEnrollmentResult.getLastUpdatedDateTimeUtc()); //
-        assertNotNull(individualEnrollmentResult.getDeviceId()); // expected identity ID
-        assertEquals(deviceId, individualEnrollmentResult.getDeviceId()); // expected identity ID
-        if (twinState == null)
-        {
-            assertNull(individualEnrollmentResult.getInitialTwin()); // expected null
-        }
-        else
-        {
-            assertNotNull(individualEnrollmentResult.getInitialTwin()); // expected not null
-        }
-        System.out.println("Successfully created Individual Enrollment for X509");
-        return individualEnrollmentResult;
-    }
-
-    private void deleteEnrollment(String registrationId) throws ProvisioningServiceClientException
-    {
-        provisioningServiceClient.deleteIndividualEnrollment(registrationId);
-    }
-
-    private void deleteDeviceFromIotHub(String deviceId) throws IotHubException, IOException
-    {
-        registryManager.removeDevice(deviceId);
-    }
-
-    // disable this test due to stability issue off TPM simulator on linux.
-    @Ignore
-    @Test (timeout = OVERALL_TEST_TIMEOUT)
-    public void individualEnrollmentTPMSimulator() throws Exception
-    {
-        if (testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS)
-        {
-            // MQTT and MQTT_WS are not supported for TPM from service
-            return;
-        }
-
-        String registrationId = REGISTRATION_ID_TPM_PREFIX + UUID.randomUUID().toString();
-
-        SecurityProvider securityProviderTPMEmulator = null;
+        SecurityProviderTPMEmulator securityProviderTPMEmulator = null;
         long startTime = System.currentTimeMillis();
         while (securityProviderTPMEmulator == null)
         {
@@ -353,7 +395,8 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
                     fail("Timed out trying to reach TPM emulator");
                 }
 
-                securityProviderTPMEmulator = new SecurityProviderTPMEmulator(registrationId, tpmSimulatorIpAddress);
+                securityProviderTPMEmulator = new SecurityProviderTPMEmulator(testInstance.registrationId, tpmSimulatorIpAddress);
+                return securityProviderTPMEmulator;
             }
             catch (Exception e)
             {
@@ -365,103 +408,33 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
             }
         }
 
+        return null;
+    }
 
-        String deviceID = DEVICE_ID_TPM_PREFIX + UUID.randomUUID().toString();
-
-        // setup service client with a unique registration id
-        assertEquals(registrationId, securityProviderTPMEmulator.getRegistrationId());
-
-        //
-        TwinCollection tags = new TwinCollection();
-        final String TEST_KEY_TAG = "testTag";
-        final String TEST_VALUE_TAG = "testValue";
-        tags.put(TEST_KEY_TAG, TEST_VALUE_TAG);
-
-        final String TEST_KEY_DP = "testDP";
-        final String TEST_VALUE_DP = "testDPValue";
-        TwinCollection desiredProperties = new TwinCollection();
-        desiredProperties.put(TEST_KEY_DP, TEST_VALUE_DP);
-
-        TwinState twinState = new TwinState(tags, desiredProperties);
-        IndividualEnrollment individualEnrollmentResult = createIndividualEnrollmentTPM(new String(Base64.encodeBase64Local(((SecurityProviderTPMEmulator) securityProviderTPMEmulator).getEndorsementKey())),
-                                      registrationId, deviceID, twinState);
-
-        assertNotNull(individualEnrollmentResult.getInitialTwin());
-        assertEquals(TEST_VALUE_TAG, individualEnrollmentResult.getInitialTwin().getTags().get(TEST_KEY_TAG));
-        assertEquals(TEST_VALUE_DP, individualEnrollmentResult.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
-
-        // Register identity
-        ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProviderTPMEmulator, provisioningServiceGlobalEndpoint);
-        waitForRegistrationCallback(provisioningStatus);
-        provisioningStatus.provisioningDeviceClient.closeNow();
-
-        assertEquals(deviceID, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
-
-        // Tests will not pass if the linked iothub to provisioning service and iothub setup to send/receive messages isn't same.
-        assertEquals("Iothub Linked to provisioning service and IotHub in connection String are not same", getHostName(iotHubConnectionString),
-                     provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri());
-
-        // send messages over all protocols
-        for (IotHubClientProtocol iotHubClientProtocol: iotHubClientProtocols)
-        {
-            DeviceClient deviceClient = DeviceClient.createFromSecurityProvider(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri(),
-                                                                                provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId(),
-                                                                                securityProviderTPMEmulator, iotHubClientProtocol);
-            IotHubServicesCommon.sendMessages(deviceClient, iotHubClientProtocol, messagesToSendAndResultsExpected, IOTHUB_RETRY_MILLISECONDS, IOTHUB_MAX_SEND_TIMEOUT, 200, null);
-
-            System.out.println("Send Messages over " + iotHubClientProtocol + " for TPM registration over " + testInstance.protocol + " succeeded");
-        }
-
-        // delete enrollment
-        deleteEnrollment(registrationId);
-        deleteDeviceFromIotHub(deviceID);
-        ((SecurityProviderTPMEmulator) securityProviderTPMEmulator).shutDown();
-        System.out.println("Running TPM registration over " + testInstance.protocol + " succeeded");
+    private static byte[] ComputeDerivedSymmetricKey(String masterKey, String registrationId) throws InvalidKeyException, NoSuchAlgorithmException
+    {
+        byte[] masterKeyBytes = Base64.decodeBase64Local(masterKey.getBytes(StandardCharsets.UTF_8));
+        SecretKeySpec secretKey = new SecretKeySpec(masterKeyBytes, HMAC_SHA256);
+        Mac hMacSha256 = Mac.getInstance(HMAC_SHA256);
+        hMacSha256.init(secretKey);
+        return Base64.encodeBase64Local(hMacSha256.doFinal(registrationId.getBytes()));
     }
 
     @Test (timeout = OVERALL_TEST_TIMEOUT)
-    public void individualEnrollmentX509() throws Exception
+    public void IndividualEnrollmentProvisioningFlow() throws Exception
     {
-        String registrationId = REGISTRATION_ID_X509_PREFIX + UUID.randomUUID().toString();
-        X509Cert certs = new X509Cert(0, false, registrationId, null);
-        final String leafPublicPem =  certs.getPublicCertLeafPem();
-        String leafPrivateKey = certs.getPrivateKeyLeafPem();
-        Collection<String> signerCertificates = new LinkedList<>();
-        SecurityProvider securityProviderX509 = new SecurityProviderX509Cert(leafPublicPem, leafPrivateKey, signerCertificates);
-
-        // Create a identity with Zero Root, Zero Intermediate and 1 leaf
-        String deviceID = String.format(DEVICE_ID_X509_PREFIX, "R0-I0-L1") + UUID.randomUUID().toString();
-
-        // setup service client with a unique registration id
-        assertEquals(registrationId, securityProviderX509.getRegistrationId());
-
-        //
-        TwinCollection tags = new TwinCollection();
-        final String TEST_KEY_TAG = "testTag";
-        final String TEST_VALUE_TAG = "testValue";
-        tags.put(TEST_KEY_TAG, TEST_VALUE_TAG);
-
-        final String TEST_KEY_DP = "testDP";
-        final String TEST_VALUE_DP = "testDPValue";
-        TwinCollection desiredProperties = new TwinCollection();
-        desiredProperties.put(TEST_KEY_DP, TEST_VALUE_DP);
-
-        TwinState twinState = new TwinState(tags, desiredProperties);
-        IndividualEnrollment individualEnrollmentResult = createIndividualEnrollmentX509(leafPublicPem, registrationId, deviceID, twinState);
-
-        assertNotNull(individualEnrollmentResult.getInitialTwin());
-        assertEquals(TEST_VALUE_TAG, individualEnrollmentResult.getInitialTwin().getTags().get(TEST_KEY_TAG));
-        assertEquals(TEST_VALUE_DP, individualEnrollmentResult.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
+        SecurityProvider securityProvider = getSecurityProviderInstance(EnrollmentType.INDIVIDUAL);
 
         // Register identity
-        ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProviderX509, provisioningServiceGlobalEndpoint);
+        ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProvider, provisioningServiceGlobalEndpoint);
         waitForRegistrationCallback(provisioningStatus);
         provisioningStatus.provisioningDeviceClient.closeNow();
 
-        assertEquals(deviceID, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
+        assertEquals(testInstance.provisionedDeviceId, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
+
         // Tests will not pass if the linked iothub to provisioning service and iothub setup to send/receive messages isn't same.
         assertEquals("Iothub Linked to provisioning service and IotHub in connection String are not same", getHostName(iotHubConnectionString),
-                     provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri());
+                provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri());
 
         // send messages over all protocols
         for (IotHubClientProtocol iotHubClientProtocol: iotHubClientProtocols)
@@ -473,59 +446,84 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
             }
 
             DeviceClient deviceClient = DeviceClient.createFromSecurityProvider(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri(),
-                                                                                provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId(),
-                                                                                securityProviderX509, iotHubClientProtocol);
+                    provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId(),
+                    securityProvider, iotHubClientProtocol);
             IotHubServicesCommon.sendMessages(deviceClient, iotHubClientProtocol, messagesToSendAndResultsExpected, IOTHUB_RETRY_MILLISECONDS, IOTHUB_MAX_SEND_TIMEOUT, 200, null);
-
-            System.out.println("Send Messages over " + iotHubClientProtocol + " for X509 registration over " + testInstance.protocol + " succeeded");
         }
 
         // delete enrollment
-        deleteEnrollment(registrationId);
-        deleteDeviceFromIotHub(deviceID);
-        System.out.println("Running X509 registration over " + testInstance.protocol + " succeeded");
+        provisioningServiceClient.deleteIndividualEnrollment(testInstance.registrationId);
+        registryManager.removeDevice(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
+    }
 
+    @Test (timeout = OVERALL_TEST_TIMEOUT)
+    public void EnrollmentGroupProvisioningFlow() throws Exception
+    {
+        if (testInstance.attestationType != AttestationType.SYMMETRIC_KEY)
+        {
+            //tpm doesn't support group, and x509 group test has not been implemented yet
+            return;
+        }
+
+        SecurityProvider securityProvider = getSecurityProviderInstance(EnrollmentType.GROUP);
+
+        // Register identity
+        ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProvider, provisioningServiceGlobalEndpoint);
+        waitForRegistrationCallback(provisioningStatus);
+        provisioningStatus.provisioningDeviceClient.closeNow();
+
+        assertEquals(testInstance.registrationId, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
+
+        // Tests will not pass if the linked iothub to provisioning service and iothub setup to send/receive messages isn't same.
+        assertEquals("Iothub Linked to provisioning service and IotHub in connection String are not same", getHostName(iotHubConnectionString),
+                provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri());
+
+        // send messages over all protocols
+        for (IotHubClientProtocol iotHubClientProtocol: iotHubClientProtocols)
+        {
+            if (iotHubClientProtocol == IotHubClientProtocol.MQTT_WS || iotHubClientProtocol == IotHubClientProtocol.AMQPS_WS)
+            {
+                // MQTT_WS/AMQP_WS does not support X509 because of a bug on service
+                continue;
+            }
+
+            DeviceClient deviceClient = DeviceClient.createFromSecurityProvider(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri(),
+                    provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId(),
+                    securityProvider, iotHubClientProtocol);
+            IotHubServicesCommon.sendMessages(deviceClient, iotHubClientProtocol, messagesToSendAndResultsExpected, IOTHUB_RETRY_MILLISECONDS, IOTHUB_MAX_SEND_TIMEOUT, 200, null);
+        }
+
+        // delete enrollment
+        provisioningServiceClient.deleteEnrollmentGroup(testInstance.groupId);
+        registryManager.removeDevice(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId());
     }
 
     @Test (timeout = OVERALL_TEST_TIMEOUT)
     public void individualEnrollmentWithInvalidRemoteServerCertificateFails() throws Exception
     {
+        enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType.INDIVIDUAL);
+    }
+
+    @Test (timeout = OVERALL_TEST_TIMEOUT)
+    public void groupEnrollmentWithInvalidRemoteServerCertificateFails() throws Exception
+    {
+        enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType.GROUP);
+    }
+
+    public void enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType enrollmentType) throws Exception
+    {
+        if (enrollmentType == EnrollmentType.GROUP && testInstance.attestationType != AttestationType.SYMMETRIC_KEY)
+        {
+            return; // test code not written for the x509 group scenario, and group enrollment does not support tpm attestation
+        }
+
         boolean expectedExceptionEncountered = false;
-        String registrationId = REGISTRATION_ID_X509_PREFIX + UUID.randomUUID().toString();
-        X509Cert certs = new X509Cert(0, false, registrationId, null);
-        final String leafPublicPem =  certs.getPublicCertLeafPem();
-        String leafPrivateKey = certs.getPrivateKeyLeafPem();
-        Collection<String> signerCertificates = new LinkedList<>();
-        SecurityProvider securityProviderX509 = new SecurityProviderX509Cert(leafPublicPem, leafPrivateKey, signerCertificates);
-
-        // Create a identity with Zero Root, Zero Intermediate and 1 leaf
-        String deviceID = String.format(DEVICE_ID_X509_PREFIX, "R0-I0-L1") + UUID.randomUUID().toString();
-
-        // setup service client with a unique registration id
-        assertEquals(registrationId, securityProviderX509.getRegistrationId());
-
-        //
-        TwinCollection tags = new TwinCollection();
-        final String TEST_KEY_TAG = "testTag";
-        final String TEST_VALUE_TAG = "testValue";
-        tags.put(TEST_KEY_TAG, TEST_VALUE_TAG);
-
-        final String TEST_KEY_DP = "testDP";
-        final String TEST_VALUE_DP = "testDPValue";
-        TwinCollection desiredProperties = new TwinCollection();
-        desiredProperties.put(TEST_KEY_DP, TEST_VALUE_DP);
-
-        TwinState twinState = new TwinState(tags, desiredProperties);
-        IndividualEnrollment individualEnrollmentResult = createIndividualEnrollmentX509(leafPublicPem, registrationId, deviceID, twinState);
-
-        assertNotNull(individualEnrollmentResult.getInitialTwin());
-        assertEquals(TEST_VALUE_TAG, individualEnrollmentResult.getInitialTwin().getTags().get(TEST_KEY_TAG));
-        assertEquals(TEST_VALUE_DP, individualEnrollmentResult.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
+        SecurityProvider securityProvider = getSecurityProviderInstance(enrollmentType);
 
         // Register identity
         try
         {
-            ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProviderX509, provisioningServiceGlobalEndpointWithInvalidCert);
+            ProvisioningStatus provisioningStatus = registerDevice(testInstance.protocol, securityProvider, provisioningServiceGlobalEndpointWithInvalidCert);
             waitForRegistrationCallback(provisioningStatus);
         }
         catch (Exception e)

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandler.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandler.java
@@ -237,12 +237,24 @@ public class AmqpsProvisioningSaslHandler implements SaslHandler
         }
     }
 
+    @Override
+    public String plainUsername()
+    {
+        throw new UnsupportedOperationException("TPM sasl does not use plain mechanism for authentication");
+    }
+
+    @Override
+    public String plainPassword()
+    {
+        throw new UnsupportedOperationException("TPM sasl does not use plain mechanism for authentication");
+    }
+
     /**
      * Sets the value of this object's saved sas token. Should only be called when that sas token was generated using the
      * nonce retrieved from the Device Provisioning service.
      * @param sasToken The SAS token to be used when finishing Sasl negotiation.
      */
-    void setSasToken(String sasToken)
+    public void setSasToken(String sasToken)
     {
         // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_008: [This function shall save the provided sas token.]
         this.sasToken = sasToken;

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSymmetricKeySaslHandler.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSymmetricKeySaslHandler.java
@@ -1,0 +1,154 @@
+/*
+*  Copyright (c) Microsoft. All rights reserved.
+*  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+package com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.amqp;
+
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.SaslHandler;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.ResponseCallback;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceSecurityException;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ResponseData;
+
+/**
+ * Implementation of a SaslHandler that is designed to handle Sasl negotiation using TPM authentication against the Device Provisioning Service
+ */
+public class AmqpsProvisioningSymmetricKeySaslHandler implements SaslHandler
+{
+    private final static String PLAIN_MECHANISM = "PLAIN";
+    private final static String USERNAME_FORMAT = "%s/registrations/%s";
+    private String idScope;
+    private String registrationId;
+    private String sasToken;
+
+    /**
+     * SaslHandler implementation that handles the TPM flow for Provisioning
+     *
+     * @param idScope idScope of the provisioning service
+     * @param registrationId registration id of this provisioning
+     * @param sasToken sas token for authentication
+     */
+    AmqpsProvisioningSymmetricKeySaslHandler(String idScope, String registrationId, String sasToken)
+    {
+        if (idScope == null || idScope.isEmpty())
+        {
+            // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty other than the autorizationCallbackContext, this function shall throw an IllegalArgumentException.]
+            throw new IllegalArgumentException("IdScope cannot be null or empty");
+        }
+
+        if (registrationId == null || registrationId.isEmpty())
+        {
+            // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty other than the autorizationCallbackContext, this function shall throw an IllegalArgumentException.]
+            throw new IllegalArgumentException("RegistrationId cannot be null or empty");
+        }
+
+        if (sasToken == null || sasToken.length() == 0)
+        {
+            // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+            throw new IllegalArgumentException("sasToken cannot be null or empty");
+        }
+
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_001: [This constructor shall save the provided idScope, registrationId, and sas token.]
+        this.idScope = idScope;
+        this.registrationId = registrationId;
+        this.sasToken = sasToken;
+    }
+
+    /**
+     * Checks to ensure that TPM is an available mechanism and chooses it
+     * @param mechanisms A list of available Sasl Mechanisms offered by the service
+     * @return "TPM" if offered by the service
+     */
+    public String chooseSaslMechanism(String[] mechanisms) throws ProvisioningDeviceSecurityException
+    {
+        boolean plainMechanismOfferedByService = false;
+        for (String mechanism : mechanisms)
+        {
+            plainMechanismOfferedByService |= mechanism.equals(PLAIN_MECHANISM);
+        }
+
+        if (!plainMechanismOfferedByService)
+        {
+            // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_004: [If the provided mechanisms array does not contain "PLAIN" then this function shall throw a ProvisioningDeviceSecurityException.]
+            throw new ProvisioningDeviceSecurityException("Service endpoint does not support TPM authentication");
+        }
+
+        // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_005: [This function shall return "PLAIN".]
+        return PLAIN_MECHANISM;
+    }
+
+    /**
+     * Builds the init payload out of the saved idScope, registrationId, and endorsementKey
+     * @param chosenMechanism The sasl mechanism chosen to be used when doing Sasl negotiation with the service
+     * @return the payload of the init message to be sent to the service
+     */
+    public byte[] getInitPayload(String chosenMechanism)
+    {
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_007: [This function shall return an empty byte array".]
+        return new byte[0];
+    }
+
+    /**
+     * Handles the three expected challenges from the service that happen in Sasl negotiation
+     * @param saslChallenge The bytes from the Sasl challenge received from the service
+     * @return the payload of the challenge response to the given challenge
+     */
+    public byte[] handleChallenge(byte[] saslChallenge) throws ProvisioningDeviceClientException
+    {
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_009: [This function shall return an empty byte array.]
+        return new byte[0];
+    }
+
+    /**
+     * Handles the outcome of the Sasl negotiation
+     * @param outcome The outcome of the sasl negotiation
+     */
+    public void handleOutcome(SaslOutcome outcome) throws ProvisioningDeviceSecurityException
+    {
+        switch (outcome)
+        {
+            case OK:
+                //auth successful
+                break;
+
+            case AUTH:
+                //bad credentials
+                // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a SecurityException.]
+                throw new ProvisioningDeviceSecurityException("Sas token was rejected by the service");
+
+            case SYS_TEMP:
+                // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a SecurityException.]
+                throw new ProvisioningDeviceSecurityException("Sasl negotiation failed due to transient system error");
+                
+            case SYS:
+            case SYS_PERM:
+            default:
+                //some other kind of failure
+                // Codes_SRS_AMQPSPROVISIONINGSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a SecurityException.]
+                throw new ProvisioningDeviceSecurityException("Sasl negotiation with service failed");
+        }
+    }
+
+    @Override
+    public String plainUsername()
+    {
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_023: [This function shall return <idScope>/registrations/<registrationId>.]
+        return String.format(USERNAME_FORMAT, this.idScope, registrationId);
+    }
+
+    @Override
+    public String plainPassword()
+    {
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_023: [This function shall return the saved sas token.]
+        return this.sasToken;
+    }
+
+    @Override
+    public void setSasToken(String sasToken)
+    {
+        // Codes_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_024: [This function shall save the provided sas token.]
+        this.sasToken = sasToken;
+    }
+}

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
@@ -196,8 +196,7 @@ public class RegisterTask implements Callable
 
             //SRS_RegisterTask_25_016: [ If the provided security client is for Key then, this method shall trigger authenticateWithProvisioningService on the contract API using the sasToken generated and wait for response and return it. ]
             ResponseData responseDataForSasTokenAuth = new ResponseData();
-            this.provisioningDeviceClientContract.authenticateWithProvisioningService(requestData, responseCallback,
-                                                                                      responseDataForSasTokenAuth);
+            this.provisioningDeviceClientContract.authenticateWithProvisioningService(requestData, responseCallback, responseDataForSasTokenAuth);
             waitForResponse(responseDataForSasTokenAuth);
 
             if (responseDataForSasTokenAuth.getResponseData() != null &&
@@ -287,7 +286,7 @@ public class RegisterTask implements Callable
 
             if (this.securityProvider instanceof SecurityProviderX509)
             {
-                RequestData requestData = new RequestData(securityProvider.getRegistrationId(),  sslContext, null);
+                RequestData requestData = new RequestData(securityProvider.getRegistrationId(),  sslContext, true);
                 return this.authenticateWithX509(requestData);
             }
             else if (this.securityProvider instanceof SecurityProviderTpm )
@@ -303,7 +302,7 @@ public class RegisterTask implements Callable
 
                 return this.authenticateWithTPM(requestData);
             }
-            else if (this.securityProvider instanceof  SecurityProviderSymmetricKey)
+            else if (this.securityProvider instanceof SecurityProviderSymmetricKey)
             {
                 RequestData requestData = new RequestData(securityProvider.getRegistrationId(),  sslContext, null);
 

--- a/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandlerTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandlerTest.java
@@ -454,7 +454,7 @@ public class AmqpsProvisioningSaslHandlerTest
         AmqpsProvisioningSaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSaslHandler.class, idScope, registrationId, endorsementKey, storageRootKey, mockedResponseCallback, new Object());
 
         //act
-        Deencapsulation.invoke(handler, "setSasToken", sasToken);
+        handler.setSasToken(sasToken);
 
         //assert
         String actualSasToken = Deencapsulation.getField(handler, "sasToken");

--- a/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSymmetricKeySaslHandlerTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSymmetricKeySaslHandlerTest.java
@@ -1,0 +1,241 @@
+/*
+*  Copyright (c) Microsoft. All rights reserved.
+*  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+package tests.unit.com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.amqp;
+
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.SaslHandler;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.amqp.AmqpsProvisioningSymmetricKeySaslHandler;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceSecurityException;
+import mockit.Deencapsulation;
+import mockit.integration.junit4.JMockit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for AmqpsProvisioningSymmetricKeySaslHandler.java
+ * Method: 100%
+ * Lines: 93%
+ */
+@RunWith(JMockit.class)
+public class AmqpsProvisioningSymmetricKeySaslHandlerTest
+{
+    private static final String idScope = "5";
+    private static final String registrationId = "3";
+    private static final String sasToken = "6";
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_001: [This constructor shall save the provided idScope, registrationId, and sas token.]
+    @Test
+    public void constructorSavesArgumentValues()
+    {
+        //act
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //assert
+        String actualIdScope = Deencapsulation.getField(handler, "idScope");
+        String actualRegistrationId = Deencapsulation.getField(handler, "registrationId");
+        String actualSasToken = Deencapsulation.getField(handler, "sasToken");
+
+        assertEquals(idScope, actualIdScope);
+        assertEquals(registrationId, actualRegistrationId);
+        assertEquals(sasToken, actualSasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForNullIdScope()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, null, registrationId, sasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForEmptyIdScope()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, "", registrationId, sasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForNullRegistrationId()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, null, sasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForEmptyRegistrationId()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, "", sasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForNullSasToken()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, null);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_002: [If any of the arguments are null or empty, this function shall throw an IllegalArgumentException.]
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsForEmptySasToken()
+    {
+        //act
+        Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, "");
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_004: [If the provided mechanisms array does not contain "PLAIN" then this function shall throw a ProvisioningDeviceSecurityException.]
+    @Test (expected = ProvisioningDeviceSecurityException.class)
+    public void choseSaslMechanismThrowsIfPlainNotPresent() throws ProvisioningDeviceSecurityException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.chooseSaslMechanism(new String[]{"NotPLAIN"});
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSASLHANDLER_34_005: [This function shall return "PLAIN".]
+    @Test
+    public void choseSaslMechanismReturnsPLAINIfPresent() throws ProvisioningDeviceSecurityException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        String chosenMechanism = handler.chooseSaslMechanism(new String[]{"NotTPM", "PLAIN"});
+
+        //assert
+        String expectedMechanism = Deencapsulation.getField(handler, "PLAIN_MECHANISM");
+        assertEquals(expectedMechanism, chosenMechanism);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_007: [This function shall return an empty byte array.]
+    @Test
+    public void buildInitSuccess() throws ProvisioningDeviceSecurityException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+        handler.chooseSaslMechanism(new String[]{"TPM", "PLAIN"});
+
+        //act
+        byte[] actualInitPayload = handler.getInitPayload("PLAIN");
+
+        //assert
+        assertEquals(0, actualInitPayload.length);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_009: [This function shall return an empty byte array.]
+    @Test
+    public void challengeResponseSuccess() throws ProvisioningDeviceClientException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+        handler.chooseSaslMechanism(new String[]{"TPM", "PLAIN"});
+
+        //act
+        byte[] challengeResponseBytes = handler.handleChallenge(new byte[0]);
+
+        //assert
+        assertEquals(0, challengeResponseBytes.length);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a ProvisioningDeviceSecurityException.]
+    @Test (expected = ProvisioningDeviceSecurityException.class)
+    public void handleOutcomeAuthThrowsProvisioningDeviceSecurityException() throws ProvisioningDeviceClientException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.handleOutcome(SaslHandler.SaslOutcome.AUTH);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a ProvisioningDeviceSecurityException.]
+    @Test (expected = ProvisioningDeviceSecurityException.class)
+    public void handleOutcomeSysTempThrowsProvisioningDeviceSecurityException() throws ProvisioningDeviceClientException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.handleOutcome(SaslHandler.SaslOutcome.SYS_TEMP);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a ProvisioningDeviceSecurityException.]
+    @Test (expected = ProvisioningDeviceSecurityException.class)
+    public void handleOutcomeSysThrowsProvisioningDeviceSecurityException() throws ProvisioningDeviceClientException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.handleOutcome(SaslHandler.SaslOutcome.SYS);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_022: [If the sasl outcome is not OK, this function shall throw a ProvisioningDeviceSecurityException.]
+    @Test (expected = ProvisioningDeviceSecurityException.class)
+    public void handleOutcomeSysPermThrowsProvisioningDeviceSecurityException() throws ProvisioningDeviceClientException
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.handleOutcome(SaslHandler.SaslOutcome.SYS_PERM);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_008: [This function shall save the provided sas token.]
+    @Test
+    public void setSasTokenSets()
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+
+        //act
+        handler.setSasToken(sasToken);
+
+        //assert
+        String actualSasToken = Deencapsulation.getField(handler, "sasToken");
+        assertEquals(sasToken, actualSasToken);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_023: [This function shall return <idScope>/registrations/<registrationId>.]
+    @Test
+    public void plainUsernameSuccess()
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+        String expectedUsername = idScope + "/registrations/" + registrationId;
+
+        //act
+        String actualUsername = handler.plainUsername();
+
+        //assert
+        assertEquals(expectedUsername, actualUsername);
+    }
+
+    // Tests_SRS_AMQPSPROVISIONINGSYMMETRICKEYSASLHANDLER_34_023: [This function shall return the saved sas token.]
+    @Test
+    public void plainPasswordSuccess()
+    {
+        //arrange
+        AmqpsProvisioningSymmetricKeySaslHandler handler = Deencapsulation.newInstance(AmqpsProvisioningSymmetricKeySaslHandler.class, new Class[]{String.class, String.class, String.class}, idScope, registrationId, sasToken);
+        String expectedPassword = sasToken;
+
+        //act
+        String actualPassword = handler.plainPassword();
+
+        //assert
+        assertEquals(expectedPassword, actualPassword);
+    }
+
+}


### PR DESCRIPTION
This PR enables the use of AMQPS/AMQPS_WS/MQTT/MQTT_WS as provisioning device client protocols when using Symmetric key attestation.

This PR includes e2e tests that cover the scenarios around symmetric key attestation for both individual enrollment and group enrollment, and over all protocols