### PR TITLE
refactor(e2e): Generate all certificates on the fly for android now

### DIFF
--- a/iot-e2e-tests/android/app/build.gradle
+++ b/iot-e2e-tests/android/app/build.gradle
@@ -1,10 +1,7 @@
 apply plugin: 'com.android.application'
 
 //***********************************************************************************************//
-def IOTHUB_E2E_X509_PRIVATE_KEY_BASE64 = project.hasProperty('IotHubPrivateKeyBase64') ? '"'+project.property('IotHubPrivateKeyBase64')+'"' : '"Define IotHub Private Key"'
-def IOTHUB_E2E_X509_CERT_BASE64 = project.hasProperty('IotHubPublicCertBase64') ? '"'+project.property('IotHubPublicCertBase64')+'"': '"Define IotHub Public Cert"'
 def IOTHUB_CONNECTION_STRING_ENV_VAR_NAME = project.hasProperty('IotHubConnectionString') ? '"'+project.property('IotHubConnectionString')+'"' : '"Define IotHub Connection"'
-def IOTHUB_E2E_X509_THUMBPRINT = project.hasProperty('IotHubThumbprint') ? '"'+project.property('IotHubThumbprint')+'"': '"Define IotHub Cert Thumbprint"'
 def IOTHUB_CONN_STRING_INVALIDCERT = project.hasProperty('IotHubInvalidCertConnectionString') ? '"'+project.property('IotHubInvalidCertConnectionString')+'"': '"Define IotHub Invalid Cert Connection"'
 def APPCENTER_APP_SECRET = project.hasProperty('AppCenterAppSecret') ? '"'+project.property('AppCenterAppSecret')+'"': '"Define AppCenter App Secret"'
 def STORAGE_ACCOUNT_CONNECTION_STRING = project.hasProperty('StorageAccountConnectionString') ? '"'+project.property('StorageAccountConnectionString')+'"': '"Define Storage Account Connection String"'
@@ -26,10 +23,7 @@ android {
         //********** We can define variables here **********
         each {
             //buildTypes.mBuildConfigFields 'DATATYPE','VARIABLE',|"GRADLE VARIABLE|"'
-            buildConfigField STRING, 'IotHubPrivateKeyBase64', IOTHUB_E2E_X509_PRIVATE_KEY_BASE64
-            buildConfigField STRING, 'IotHubPublicCertBase64', IOTHUB_E2E_X509_CERT_BASE64
             buildConfigField STRING, 'IotHubConnectionString', IOTHUB_CONNECTION_STRING_ENV_VAR_NAME
-            buildConfigField STRING, 'IotHubThumbprint', IOTHUB_E2E_X509_THUMBPRINT
             buildConfigField STRING, 'IotHubInvalidCertConnectionString', IOTHUB_CONN_STRING_INVALIDCERT
             buildConfigField STRING, 'AppCenterAppSecret', APPCENTER_APP_SECRET
             buildConfigField STRING, 'StorageAccountConnectionString', STORAGE_ACCOUNT_CONNECTION_STRING

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -11,14 +11,10 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
-
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.IOException;
 
 @TestGroupB
 public class FileUploadAndroidRunner extends FileUploadTests
@@ -30,15 +26,10 @@ public class FileUploadAndroidRunner extends FileUploadTests
     public ReportHelper reportHelper = Factory.getReportHelper();
 
     @BeforeClass
-    public static void setup() throws IOException
+    public static void setup() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
+        FileUploadTests.setUp();
     }
 
     @Ignore

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -15,6 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.After;
 
 @TestGroupB
 public class FileUploadAndroidRunner extends FileUploadTests
@@ -37,5 +38,11 @@ public class FileUploadAndroidRunner extends FileUploadTests
     @Test
     public void uploadToBlobAsyncSingleFileZeroLength()
     {
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests;
-
 import org.junit.BeforeClass;
 import org.junit.Rule;
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.After;
 
 public class TransportClientAndroidRunner extends TransportClientTests
 {
@@ -26,5 +27,11 @@ public class TransportClientAndroidRunner extends TransportClientTests
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         setUpCommon();
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,5 +55,11 @@ public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErr
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
@@ -49,18 +42,11 @@ public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErr
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
+import org.junit.After;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
@@ -54,5 +55,11 @@ public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErr
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupB
@@ -49,18 +42,11 @@ public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErr
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,5 +55,11 @@ public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTes
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
@@ -49,18 +42,11 @@ public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,6 +55,12 @@ public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTes
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupB
@@ -49,18 +42,11 @@ public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,6 +67,12 @@ public class DeviceMethodErrInjDeviceAndroidRunner extends DeviceMethodErrInjTes
     public static void cleanUpResources()
     {
         tearDown(identities, testManagers);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceAndroidRunner.java
@@ -13,21 +13,14 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -51,22 +44,16 @@ public class DeviceMethodErrInjDeviceAndroidRunner extends DeviceMethodErrInjTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,5 +67,11 @@ public class DeviceMethodErrInjModuleAndroidRunner extends DeviceMethodErrInjTes
     public static void cleanUpResources()
     {
         tearDown(identities, testManagers);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleAndroidRunner.java
@@ -13,21 +13,14 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -51,22 +44,16 @@ public class DeviceMethodErrInjModuleAndroidRunner extends DeviceMethodErrInjTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class DesiredPropertiesErrInjDeviceAndroidRunner extends DesiredPropertie
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,19 +41,11 @@ public class DesiredPropertiesErrInjDeviceAndroidRunner extends DesiredPropertie
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertie
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertie
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,19 +41,11 @@ public class GetTwinErrInjDeviceAndroidRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class GetTwinErrInjDeviceAndroidRunner extends GetTwinErrInjTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class GetTwinErrInjModuleAndroidRunner extends GetTwinErrInjTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/GetTwinErrInjModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class GetTwinErrInjModuleAndroidRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,18 +41,11 @@ public class ReportedPropertiesErrInjDeviceAndroidRunner extends ReportedPropert
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class ReportedPropertiesErrInjDeviceAndroidRunner extends ReportedPropert
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class ReportedPropertiesErrInjModuleAndroidRunner extends ReportedPropert
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,18 +39,11 @@ public class ReportedPropertiesErrInjModuleAndroidRunner extends ReportedPropert
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,5 +56,11 @@ public class ReceiveMessagesDeviceAndroidRunner extends ReceiveMessagesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
@@ -50,18 +43,11 @@ public class ReceiveMessagesDeviceAndroidRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupB;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupB
@@ -49,18 +42,11 @@ public class ReceiveMessagesModuleAndroidRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,5 +55,11 @@ public class ReceiveMessagesModuleAndroidRunner extends ReceiveMessagesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,5 +55,11 @@ public class SendMessagesDeviceAndroidRunner extends SendMessagesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
@@ -49,18 +42,11 @@ public class SendMessagesDeviceAndroidRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
@@ -12,22 +12,15 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupA
@@ -49,18 +42,11 @@ public class SendMessagesModuleAndroidRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
+    public static Collection inputs() throws Exception
+    {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,5 +55,11 @@ public class SendMessagesModuleAndroidRunner extends SendMessagesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -13,21 +13,14 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -51,22 +44,16 @@ public class DeviceMethodDeviceAndroidRunner extends DeviceMethodTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,5 +67,11 @@ public class DeviceMethodDeviceAndroidRunner extends DeviceMethodTests
     public static void cleanUpResources()
     {
         tearDown(identities, testManagers);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
@@ -13,21 +13,14 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -51,22 +44,16 @@ public class DeviceMethodModuleAndroidRunner extends DeviceMethodTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,6 +67,12 @@ public class DeviceMethodModuleAndroidRunner extends DeviceMethodTests
     public static void cleanUpResources()
     {
         tearDown(identities, testManagers);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -43,22 +39,13 @@ public class DesiredPropertiesDeviceAndroidRunner extends DesiredPropertiesTests
         super(deviceId, moduleId, protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class DesiredPropertiesDeviceAndroidRunner extends DesiredPropertiesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class DesiredPropertiesModuleAndroidRunner extends DesiredPropertiesTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class DesiredPropertiesModuleAndroidRunner extends DesiredPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DeviceTwinWithVersionTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import org.junit.Rule;
+import org.junit.After;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -34,5 +35,11 @@ public class DeviceTwinWithVersionAndroidRunner extends DeviceTwinWithVersionTes
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         return inputsCommon();
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DeviceTwinWithVersionTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class GetTwinDeviceAndroidRunner extends GetTwinTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,19 +41,11 @@ public class GetTwinDeviceAndroidRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class GetTwinModuleAndroidRunner extends GetTwinTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class GetTwinModuleAndroidRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class QueryTwinDeviceAndroidRunner extends QueryTwinTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,19 +41,11 @@ public class QueryTwinDeviceAndroidRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class QueryTwinModuleAndroidRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class QueryTwinModuleAndroidRunner extends QueryTwinTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,18 +41,11 @@ public class ReportedPropertiesDeviceAndroidRunner extends ReportedPropertiesTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class ReportedPropertiesDeviceAndroidRunner extends ReportedPropertiesTes
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,18 +39,11 @@ public class ReportedPropertiesModuleAndroidRunner extends ReportedPropertiesTes
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class ReportedPropertiesModuleAndroidRunner extends ReportedPropertiesTes
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,5 +54,11 @@ public class TwinTagsDeviceAndroidRunner extends TwinTagsTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -12,18 +12,14 @@ import com.microsoft.azure.sdk.iot.android.helper.TestGroupC;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @TestGroupC
@@ -45,19 +41,11 @@ public class TwinTagsDeviceAndroidRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
@@ -11,18 +11,14 @@ import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -43,19 +39,11 @@ public class TwinTagsModuleAndroidRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,5 +52,11 @@ public class TwinTagsModuleAndroidRunner extends TwinTagsTests
     public static void cleanUpResources()
     {
         tearDown(identities);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.storage.StorageException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.After;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -31,5 +32,11 @@ public class ExportImportAndroidRunner extends ExportImportTests
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         storageAccountConnectionString = BuildConfig.StorageAccountConnectionString;
         ExportImportTests.setUp();
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.After;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -29,5 +30,11 @@ public class JobClientAndroidRunner extends JobClientTests
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         JobClientTests.setUp();
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.common.tests.serviceclient.RegistryManagerTes
 
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.After;
 
 import java.io.IOException;
 
@@ -25,5 +26,11 @@ public class RegistryManagerAndroidRunner extends RegistryManagerTests
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
         RegistryManagerTests.setUp();
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.After;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -35,5 +36,11 @@ public class ServiceClientAndroidRunner extends ServiceClientTests
     public ServiceClientAndroidRunner(IotHubServiceClientProtocol protocol)
     {
         super(protocol);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
     }
 }

--- a/iot-e2e-tests/android/things/build.gradle
+++ b/iot-e2e-tests/android/things/build.gradle
@@ -1,10 +1,7 @@
 apply plugin: 'com.android.application'
 
 //***********************************************************************************************//
-def IOTHUB_E2E_X509_PRIVATE_KEY_BASE64 = project.hasProperty('IotHubPrivateKeyBase64') ? '"'+project.property('IotHubPrivateKeyBase64')+'"' : '"Define IotHub Private Key"'
-def IOTHUB_E2E_X509_CERT_BASE64 = project.hasProperty('IotHubPublicCertBase64') ? '"'+project.property('IotHubPublicCertBase64')+'"': '"Define IotHub Public Cert"'
 def IOTHUB_CONNECTION_STRING_ENV_VAR_NAME = project.hasProperty('IotHubConnectionString') ? '"'+project.property('IotHubConnectionString')+'"' : '"Define IotHub Connection"'
-def IOTHUB_E2E_X509_THUMBPRINT = project.hasProperty('IotHubThumbprint') ? '"'+project.property('IotHubThumbprint')+'"': '"Define IotHub Cert Thumbprint"'
 def IOTHUB_CONN_STRING_INVALIDCERT = project.hasProperty('IotHubInvalidCertConnectionString') ? '"'+project.property('IotHubInvalidCertConnectionString')+'"': '"Define IotHub Invalid Cert Connection"'
 def STORAGE_ACCOUNT_CONNECTION_STRING = project.hasProperty('StorageAccountConnectionString') ? '"'+project.property('StorageAccountConnectionString')+'"': '"Define Storage Account Connection String"'
 
@@ -25,10 +22,7 @@ android {
         //********** We can define variables here **********
         each {
             //buildTypes.mBuildConfigFields 'DATATYPE','VARIABLE',|"GRADLE VARIABLE|"'
-            buildConfigField STRING, 'IotHubPrivateKeyBase64', IOTHUB_E2E_X509_PRIVATE_KEY_BASE64
-            buildConfigField STRING, 'IotHubPublicCertBase64', IOTHUB_E2E_X509_CERT_BASE64
             buildConfigField STRING, 'IotHubConnectionString', IOTHUB_CONNECTION_STRING_ENV_VAR_NAME
-            buildConfigField STRING, 'IotHubThumbprint', IOTHUB_E2E_X509_THUMBPRINT
             buildConfigField STRING, 'IotHubInvalidCertConnectionString', IOTHUB_CONN_STRING_INVALIDCERT
             buildConfigField STRING, 'StorageAccountConnectionString', STORAGE_ACCOUNT_CONNECTION_STRING
         }

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/FileUploadThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/FileUploadThingsRunner.java
@@ -8,14 +8,19 @@ package com.microsoft.azure.sdk.iot.androidthings.iothubservices;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
 
 public class FileUploadThingsRunner extends FileUploadTests
 {
@@ -23,15 +28,10 @@ public class FileUploadThingsRunner extends FileUploadTests
     public Rerun count = new Rerun(3);
 
     @BeforeClass
-    public static void setup() throws IOException
+    public static void setup() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
+        FileUploadTests.setUp();
     }
 
     @Ignore

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/TransportClientThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/TransportClientThingsRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.androidthings.iothubservices;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests;
+
 import org.junit.BeforeClass;
 import org.junit.Rule;
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceThingsRunner.java
@@ -6,12 +6,10 @@
 package com.microsoft.azure.sdk.iot.androidthings.iothubservices.errorinjection.messaging;
 
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
-
 import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -19,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -45,19 +44,11 @@ public class ReceiveMessagesErrInjDeviceThingsRunner extends ReceiveMessagesErrI
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class ReceiveMessagesErrInjModuleThingsRunner extends ReceiveMessagesErrI
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class SendMessagesErrInjDeviceThingsRunner extends SendMessagesErrInjTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class SendMessagesErrInjModuleThingsRunner extends SendMessagesErrInjTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceThingsRunner.java
@@ -11,13 +11,13 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -46,22 +46,16 @@ public class DeviceMethodErrInjDeviceThingsRunner extends DeviceMethodErrInjTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleThingsRunner.java
@@ -11,13 +11,13 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -46,22 +46,17 @@ public class DeviceMethodErrInjModuleThingsRunner extends DeviceMethodErrInjTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
 
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class DesiredPropertiesErrInjDeviceThingsRunner extends DesiredProperties
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class DesiredPropertiesErrInjModuleThingsRunner extends DesiredProperties
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/GetTwinErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/GetTwinErrInjDeviceThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class GetTwinErrInjDeviceThingsRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/GetTwinErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/GetTwinErrInjModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class GetTwinErrInjModuleThingsRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,18 +38,11 @@ public class ReportedPropertiesErrInjDeviceThingsRunner extends ReportedProperti
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,18 +38,11 @@ public class ReportedPropertiesErrInjModuleThingsRunner extends ReportedProperti
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/ReceiveMessagesDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/ReceiveMessagesDeviceThingsRunner.java
@@ -5,12 +5,11 @@
 
 package com.microsoft.azure.sdk.iot.androidthings.iothubservices.messaging;
 
-import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
+import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -45,19 +45,11 @@ public class ReceiveMessagesDeviceThingsRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/ReceiveMessagesModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/ReceiveMessagesModuleThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class ReceiveMessagesModuleThingsRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/SendMessagesDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/SendMessagesDeviceThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class SendMessagesDeviceThingsRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/SendMessagesModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/messaging/SendMessagesModuleThingsRunner.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.sdk.iot.androidthings.helper.TestGroupA;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -18,6 +17,7 @@ import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -44,19 +44,11 @@ public class SendMessagesModuleThingsRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{3}_{4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/methods/DeviceMethodDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/methods/DeviceMethodDeviceThingsRunner.java
@@ -11,12 +11,13 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -45,22 +46,16 @@ public class DeviceMethodDeviceThingsRunner extends DeviceMethodTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/methods/DeviceMethodModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/methods/DeviceMethodModuleThingsRunner.java
@@ -11,13 +11,13 @@ import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -46,22 +46,16 @@ public class DeviceMethodModuleThingsRunner extends DeviceMethodTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1}_{2}_{3}")
-    public static Collection inputsCommons() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();
         for (int i = 0; i < inputsArray.length; i++)
         {
-            Object[] inputCollection = (Object[])inputsArray[i];
+            Object[] inputCollection = (Object[]) inputsArray[i];
             testManagers.add((DeviceTestManager) inputCollection[0]);
         }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DesiredPropertiesDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DesiredPropertiesDeviceThingsRunner.java
@@ -9,10 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -37,19 +38,11 @@ public class DesiredPropertiesDeviceThingsRunner extends DesiredPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DesiredPropertiesModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DesiredPropertiesModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class DesiredPropertiesModuleThingsRunner extends DesiredPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DeviceTwinWithVersionThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/DeviceTwinWithVersionThingsRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DeviceTwinWithVersionTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/GetTwinDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/GetTwinDeviceThingsRunner.java
@@ -9,10 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -37,19 +38,11 @@ public class GetTwinDeviceThingsRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/GetTwinModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/GetTwinModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class GetTwinModuleThingsRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/QueryTwinDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/QueryTwinDeviceThingsRunner.java
@@ -9,10 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -37,19 +38,11 @@ public class QueryTwinDeviceThingsRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/QueryTwinModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/QueryTwinModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class QueryTwinModuleThingsRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/ReportedPropertiesDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/ReportedPropertiesDeviceThingsRunner.java
@@ -9,10 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -37,18 +38,11 @@ public class ReportedPropertiesDeviceThingsRunner extends ReportedPropertiesTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/ReportedPropertiesModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/ReportedPropertiesModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,18 +38,11 @@ public class ReportedPropertiesModuleThingsRunner extends ReportedPropertiesTest
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/TwinTagsDeviceThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/TwinTagsDeviceThingsRunner.java
@@ -9,10 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -37,19 +38,11 @@ public class TwinTagsDeviceThingsRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/TwinTagsModuleThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/iothubservices/twin/TwinTagsModuleThingsRunner.java
@@ -9,11 +9,11 @@ import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
-import com.microsoft.azure.sdk.iot.deps.util.Base64;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -38,19 +38,11 @@ public class TwinTagsModuleThingsRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2}_{3}_{4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
-        String privateKeyBase64Encoded = BuildConfig.IotHubPrivateKeyBase64;
-        String publicKeyCertBase64Encoded = BuildConfig.IotHubPublicCertBase64;
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        String x509Thumbprint = BuildConfig.IotHubThumbprint;
-        String privateKey = new String(Base64.decodeBase64Local(privateKeyBase64Encoded.getBytes()));
-        String publicKeyCert = new String(Base64.decodeBase64Local(publicKeyCertBase64Encoded.getBytes()));
-
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/ExportImportThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/ExportImportThingsRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.androidthings.serviceclient;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ExportImportTests;
 import com.microsoft.azure.storage.StorageException;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/JobClientThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/JobClientThingsRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.androidthings.serviceclient;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.JobClientTests;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/RegistryManagerThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/RegistryManagerThingsRunner.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.androidthings.serviceclient;
 
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.RegistryManagerTests;
+
 import org.junit.BeforeClass;
 
 import java.io.IOException;

--- a/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/ServiceClientThingsRunner.java
+++ b/iot-e2e-tests/android/things/src/androidTest/java/com/microsoft/azure/sdk/iot/androidthings/serviceclient/ServiceClientThingsRunner.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.androidthings.serviceclient;
 import com.microsoft.azure.sdk.iot.androidthings.BuildConfig;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ServiceClientTests;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IntegrationTest.java
@@ -27,7 +27,7 @@ public class IntegrationTest
         }
     };
 
-    public static final int E2E_TEST_TIMEOUT_MS = 15 * 60 * 1000;
+    public static final int E2E_TEST_TIMEOUT_MS = 4 * 60 * 1000;
 
     //This timeout applies to all individual tests in classes that inherit from this class
     @Rule

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/X509CertificateGenerator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/X509CertificateGenerator.java
@@ -36,24 +36,38 @@ public class X509CertificateGenerator
      * Constructor that generates a new self signed x509 certificate. Public certificate, private key, thumbprint, and the complete
      * certificate can be accessed by getters. No common name is given to the certificate.
      */
-    public X509CertificateGenerator() throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    public X509CertificateGenerator()
     {
-        this.generateCertificate();
+        try
+        {
+            this.generateCertificate();
+        }
+        catch (Exception e)
+        {
+            System.out.println(Tools.getStackTraceFromThrowable(e));
+        }
     }
 
     /**
      * Constructor that generates a new self signed x509 certificate. Public certificate, private key, thumbprint, and the complete
      * certificate can be accessed by getters. The created certificate will have the provided common name.
      */
-    public X509CertificateGenerator(String commonName) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    public X509CertificateGenerator(String commonName)
     {
-        this.generateCertificate(commonName);
+        try
+        {
+            this.generateCertificate(commonName);
+        }
+        catch (Exception e)
+        {
+            System.out.println(Tools.getStackTraceFromThrowable(e));
+        }
     }
 
     /**
      * generate a new certificate
      */
-    public void generateCertificate() throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    private void generateCertificate() throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
     {
         generateCertificate(null);
     }
@@ -61,7 +75,7 @@ public class X509CertificateGenerator
     /**
      * generate a new certificate using the provided common name
      */
-    public void generateCertificate(String commonName) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    private void generateCertificate(String commonName) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
     {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(1024, new SecureRandom());

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/X509CertificateGenerator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/X509CertificateGenerator.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.common.helpers;
+
+import com.microsoft.azure.sdk.iot.deps.util.Base64;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+/**
+ * Utility class for generating self signed certificates, and computing their thumprints
+ */
+public class X509CertificateGenerator
+{
+    private String x509Thumbprint;
+    private X509Certificate x509Certificate;
+    private String publicCertificate;
+    private String privateKey;
+
+    /**
+     * Constructor that generates a new self signed x509 certificate. Public certificate, private key, thumbprint, and the complete
+     * certificate can be accessed by getters. No common name is given to the certificate.
+     */
+    public X509CertificateGenerator() throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    {
+        this.generateCertificate();
+    }
+
+    /**
+     * Constructor that generates a new self signed x509 certificate. Public certificate, private key, thumbprint, and the complete
+     * certificate can be accessed by getters. The created certificate will have the provided common name.
+     */
+    public X509CertificateGenerator(String commonName) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    {
+        this.generateCertificate(commonName);
+    }
+
+    /**
+     * generate a new certificate
+     */
+    public void generateCertificate() throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    {
+        generateCertificate(null);
+    }
+
+    /**
+     * generate a new certificate using the provided common name
+     */
+    public void generateCertificate(String commonName) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(1024, new SecureRandom());
+        KeyPair keypair = keyGen.generateKeyPair();
+        this.x509Certificate = createX509CertificateFromKeyPair(keypair, commonName);
+        this.x509Thumbprint = new String(Hex.encodeHex(DigestUtils.sha(x509Certificate.getEncoded())));
+        this.publicCertificate = getPublicCertificatePem(x509Certificate);
+        this.privateKey = getPrivateKeyPem(keypair.getPrivate());
+    }
+
+    /**
+     * @return the thumbprint for the the generated x509 certificate
+     */
+    public String getX509Thumbprint()
+    {
+        return x509Thumbprint;
+    }
+
+    /**
+     * @return the complete x509 certificate that was generated
+     */
+    public X509Certificate getX509Certificate()
+    {
+        return x509Certificate;
+    }
+
+    /**
+     * @return the Pem formatted public certificate for the generated certificate key pair
+     */
+    public String getPublicCertificate()
+    {
+        return publicCertificate;
+    }
+
+    /**
+     * @return the Pem formatted private key for the generated certificate key pair
+     */
+    public String getPrivateKey()
+    {
+        return privateKey;
+    }
+
+    /**
+     * Create a new self signed x509 certificate without specifying a common name
+     */
+    private static X509Certificate createX509CertificateFromKeyPair(KeyPair keyPair) throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
+    {
+        return createX509CertificateFromKeyPair(keyPair, null);
+    }
+
+    /**
+     * Create a new self signed x509 certificate with the specified common name
+     */
+    private static X509Certificate createX509CertificateFromKeyPair(KeyPair keyPair, String commonName)
+            throws OperatorCreationException, CertificateException, InvalidKeyException, NoSuchAlgorithmException,
+            NoSuchProviderException, SignatureException
+    {
+        String issuerString = "C=US, O=Microsoft, L=Redmond, OU=Azure";
+        // subjects name - the same as we are self signed.
+        String subjectString = "C=US, O=Microsoft, L=Redmond, OU=Azure";
+
+        if (commonName != null && !commonName.isEmpty())
+        {
+            issuerString += ", CN=" +commonName;
+            subjectString += ", CN=" +commonName;
+        }
+
+        X500Name issuer = new X500Name( issuerString );
+        BigInteger serial = BigInteger.ONE;
+        Date notBefore = new Date();
+        Date notAfter = new Date( System.currentTimeMillis() + ( 60*60*1000 ) );
+        X500Name subject = new X500Name( subjectString );
+        PublicKey publicKey = keyPair.getPublic();
+        JcaX509v3CertificateBuilder v3Bldr = new JcaX509v3CertificateBuilder(issuer,
+                serial,
+                notBefore,
+                notAfter,
+                subject,
+                publicKey);
+        X509CertificateHolder certHldr = v3Bldr
+                .build( new JcaContentSignerBuilder( "SHA1WithRSA" ).build( keyPair.getPrivate() ) );
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certHldr );
+        cert.checkValidity(new Date());
+        cert.verify(keyPair.getPublic());
+        return cert;
+    }
+
+    private static String getPrivateKeyPem(PrivateKey privateKey)
+    {
+        return "-----BEGIN PRIVATE KEY-----\n" +
+                Base64.encodeBase64StringLocal(privateKey.getEncoded()) +
+                "\n-----END PRIVATE KEY-----\n";
+    }
+
+    private static String getPublicCertificatePem(X509Certificate certificate) throws CertificateEncodingException {
+        return "-----BEGIN CERTIFICATE-----\n" +
+                Base64.encodeBase64StringLocal(certificate.getEncoded()) +
+                "\n-----END CERTIFICATE-----\n";
+    }
+}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -20,14 +20,18 @@ import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.devicetwin.RawTwinQuery;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubNotFoundException;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
 import java.util.*;
 
 import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
@@ -321,7 +325,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    protected static Collection inputsCommon(ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
+    protected static Collection inputsCommon(ClientType clientType) throws IOException, CertificateException, NoSuchAlgorithmException, OperatorCreationException, SignatureException, NoSuchProviderException, InvalidKeyException
     {
         sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
@@ -340,6 +344,11 @@ public class DeviceTwinCommon extends IntegrationTest
         String moduleIdMqtt = "java-device-client-e2e-test-mqtt-module-";
         String moduleIdMqttWs = "java-device-client-e2e-test-mqttws-module-";
 
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator();
+        String publicCertificate = certificateGenerator.getPublicCertificate();
+        String privateKey = certificateGenerator.getPrivateKey();
+        String thumbprint = certificateGenerator.getX509Thumbprint();
+
         List inputs;
         if (clientType == ClientType.DEVICE_CLIENT)
         {
@@ -347,14 +356,14 @@ public class DeviceTwinCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token, device client
-                                    {deviceIdAmqps, null, AMQPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, null, MQTT, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqps, null, AMQPS, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdAmqpsWs, null, AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdMqtt, null, MQTT, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdMqttWs,  null, MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
 
                                     //x509, device client
-                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {deviceIdAmqpsX509, null, AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdMqttX509, null, MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
                             }
             );
         }
@@ -364,10 +373,10 @@ public class DeviceTwinCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token, module client
-                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
+                                    {deviceIdAmqps, moduleIdAmqps, AMQPS, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdAmqpsWs, moduleIdAmqpsWs, AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdMqtt, moduleIdMqtt, MQTT, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {deviceIdMqttWs,  moduleIdMqttWs, MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint}
                             }
             );
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.service.*;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import junit.framework.TestCase;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -101,7 +102,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
         }
     }
 
-    protected static Collection inputsCommon(ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    protected static Collection inputsCommon(ClientType clientType) throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException, OperatorCreationException
     {
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         String uuid = UUID.randomUUID().toString();
@@ -111,20 +112,25 @@ public class ReceiveMessagesCommon extends IntegrationTest
         String moduleId = "java-module-client-e2e-test-receive-messages".concat("-" + uuid);
         String moduleIdX509 = "java-module-client-e2e-test-receive-messages-X509".concat("-" + uuid);
 
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator();
+        String publicCertificate = certificateGenerator.getPublicCertificate();
+        String privateKey = certificateGenerator.getPrivateKey();
+        String thumbprint = certificateGenerator.getX509Thumbprint();
+
         device = Device.createFromId(deviceId, null, null);
         deviceX509 = Device.createDevice(deviceIdX509, SELF_SIGNED);
 
         module = Module.createFromId(deviceId, moduleId, null);
         moduleX509 = Module.createModule(deviceIdX509, moduleIdX509, SELF_SIGNED);
 
-        deviceX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
-        moduleX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
+        deviceX509.setThumbprintFinal(thumbprint, thumbprint);
+        moduleX509.setThumbprintFinal(thumbprint, thumbprint);
 
         module = Module.createFromId(deviceId, moduleId, null);
         moduleX509 = Module.createModule(deviceIdX509, moduleIdX509, SELF_SIGNED);
 
-        deviceX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
-        moduleX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
+        deviceX509.setThumbprintFinal(thumbprint, thumbprint);
+        moduleX509.setThumbprintFinal(thumbprint, thumbprint);
 
         Tools.addDeviceWithRetry(registryManager, device);
         Tools.addDeviceWithRetry(registryManager, deviceX509);
@@ -152,16 +158,16 @@ public class ReceiveMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
 
                                     //x509
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicCertificate, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicCertificate, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicCertificate, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint}
                             }
             );
         }
@@ -171,14 +177,14 @@ public class ReceiveMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}                           }
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicCertificate, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicCertificate, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint}                           }
             );
         }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.*;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -99,7 +100,7 @@ public class SendMessagesCommon extends IntegrationTest
         }
     }
 
-    protected static Collection inputsCommon(ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    protected static Collection inputsCommon(ClientType clientType) throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException, OperatorCreationException
     {
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         String uuid = UUID.randomUUID().toString();
@@ -108,14 +109,19 @@ public class SendMessagesCommon extends IntegrationTest
         String moduleId = "java-module-client-e2e-test-send-messages".concat("-" + uuid);
         String moduleIdX509 = "java-module-client-e2e-test-send-messages-X509".concat("-" + uuid);
 
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator();
+        String publicCertificate = certificateGenerator.getPublicCertificate();
+        String privateKey = certificateGenerator.getPrivateKey();
+        String thumbprint = certificateGenerator.getX509Thumbprint();
+
         Device device = Device.createFromId(deviceId, null, null);
         Device deviceX509 = Device.createDevice(deviceIdX509, SELF_SIGNED);
 
         Module module = Module.createFromId(deviceId, moduleId, null);
         Module moduleX509 = Module.createModule(deviceIdX509, moduleIdX509, SELF_SIGNED);
 
-        deviceX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
-        moduleX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
+        deviceX509.setThumbprintFinal(thumbprint, thumbprint);
+        moduleX509.setThumbprintFinal(thumbprint, thumbprint);
 
         Tools.addDeviceWithRetry(registryManager, device);
         Tools.addDeviceWithRetry(registryManager, deviceX509);
@@ -137,16 +143,16 @@ public class SendMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), HTTPS), HTTPS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT), MQTT, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), MQTT_WS), MQTT_WS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS), AMQPS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
 
                                     //x509 device client
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicKeyCert, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), HTTPS, publicCertificate, false, privateKey, false), HTTPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), MQTT, publicCertificate, false, privateKey, false), MQTT, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicCertificate, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicCertificate, privateKey, thumbprint}
                             }
             );
         }
@@ -156,14 +162,14 @@ public class SendMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT), MQTT, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), MQTT_WS), MQTT_WS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS), AMQPS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, device, module), AMQPS_WS), AMQPS_WS, module, SAS, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
 
                                     //x509 module client
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicKeyCert, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
-                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint}
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), MQTT, publicCertificate, false, privateKey, false), MQTT, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint},
+                                    {new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), AMQPS, publicCertificate, false, privateKey, false), AMQPS, moduleX509, SELF_SIGNED, ClientType.MODULE_CLIENT, publicCertificate, privateKey, thumbprint}
                     }
             );
         }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -5,9 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothubservices;
 
-import com.microsoft.azure.sdk.iot.common.helpers.DeviceConnectionString;
-import com.microsoft.azure.sdk.iot.common.helpers.IntegrationTest;
-import com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon;
+import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -134,14 +132,15 @@ public class FileUploadTests extends IntegrationTest
         }
     }
 
-    public static void setUp(String publicK, String privateK, String thumbprint) throws IOException
+    public static void setUp() throws Exception
     {
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator();
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, IotHubServiceClientProtocol.AMQPS);
 
-        publicKeyCertificate = publicK;
-        privateKeyCertificate = privateK;
-        x509Thumbprint = thumbprint;
+        publicKeyCertificate = certificateGenerator.getPublicCertificate();
+        privateKeyCertificate = certificateGenerator.getPrivateKey();
+        x509Thumbprint = certificateGenerator.getX509Thumbprint();
         
         fileUploadNotificationReceiver = serviceClient.getFileUploadNotificationReceiver();
         assertNotNull(fileUploadNotificationReceiver);

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/FileUploadJVMRunner.java
@@ -7,23 +7,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices;
 
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
 import org.junit.BeforeClass;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 
 public class FileUploadJVMRunner extends FileUploadTests
 {
     @BeforeClass
-    public static void setup() throws IOException, GeneralSecurityException
+    public static void setup() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        FileUploadTests.setUp(publicKeyCert, privateKey, x509Thumbprint);
+        FileUploadTests.setUp();
     }
 }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReceiveMessagesErrInjDeviceJVMRunner extends ReceiveMessagesErrInjT
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReceiveMessagesErrInjModuleJVMRunner extends ReceiveMessagesErrInjT
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class SendMessagesErrInjDeviceJVMRunner extends SendMessagesErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.SendMessagesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class SendMessagesErrInjModuleJVMRunner extends SendMessagesErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjDeviceJVMRunner.java
@@ -5,20 +5,18 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinjection.methods;
 
-import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
+import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -35,14 +33,10 @@ public class DeviceMethodErrInjDeviceJVMRunner extends DeviceMethodErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {2} auth using {3}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/methods/DeviceMethodErrInjModuleJVMRunner.java
@@ -5,20 +5,18 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinjection.methods;
 
-import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
+import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DeviceMethodErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -35,14 +33,10 @@ public class DeviceMethodErrInjModuleJVMRunner extends DeviceMethodErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {2} auth using {3}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjDeviceJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class DesiredPropertiesErrInjDeviceJVMRunner extends DesiredPropertiesErr
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class DesiredPropertiesErrInjModuleJVMRunner extends DesiredPropertiesErr
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class GetTwinErrInjJVMRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, GeneralSecurityException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/GetTwinErrInjModuleJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.GetTwinErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class GetTwinErrInjModuleJVMRunner extends GetTwinErrInjTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, GeneralSecurityException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjDeviceJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class ReportedPropertiesErrInjDeviceJVMRunner extends ReportedPropertiesE
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/errorinjection/twin/ReportedPropertiesErrInjModuleJVMRunner.java
@@ -8,7 +8,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.errorinject
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReportedPropertiesErrInjTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
@@ -17,8 +16,6 @@ import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -33,17 +30,11 @@ public class ReportedPropertiesErrInjModuleJVMRunner extends ReportedPropertiesE
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    public static Collection inputsCommons() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.messaging;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReceiveMessagesDeviceJVMRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/ReceiveMessagesModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.messaging;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReceiveMessagesModuleJVMRunner extends ReceiveMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.messaging;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class SendMessagesDeviceJVMRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/messaging/SendMessagesModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.messaging;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class SendMessagesModuleJVMRunner extends SendMessagesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodDeviceJVMRunner.java
@@ -5,20 +5,18 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.methods;
 
-import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
+import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -33,17 +31,13 @@ public class DeviceMethodDeviceJVMRunner extends DeviceMethodTests
         super(deviceTestManager, protocol, authenticationType, clientType, identity, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {2} auth using {3}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+
+        Collection inputs = inputsCommon(ClientType.DEVICE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/methods/DeviceMethodModuleJVMRunner.java
@@ -5,20 +5,18 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.methods;
 
-import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
+import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.methods.DeviceMethodTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -35,14 +33,11 @@ public class DeviceMethodModuleJVMRunner extends DeviceMethodTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{1} with {2} auth using {3}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, InterruptedException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
+
+        Collection inputs = inputsCommon(ClientType.MODULE_CLIENT);
         Object[] inputsArray = inputs.toArray();
 
         testManagers = new ArrayList<>();

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class DesiredPropertiesDeviceJVMRunner extends DesiredPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/DesiredPropertiesModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class DesiredPropertiesModuleJVMRunner extends DesiredPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class GetTwinDeviceJVMRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/GetTwinModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.GetTwinTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class GetTwinModuleJVMRunner extends GetTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class QueryTwinDeviceJVMRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/QueryTwinModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class QueryTwinModuleJVMRunner extends QueryTwinTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReportedPropertiesDeviceJVMRunner extends ReportedPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/ReportedPropertiesModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class ReportedPropertiesModuleJVMRunner extends ReportedPropertiesTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsDeviceJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class TwinTagsDeviceJVMRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothubservices/twin/TwinTagsModuleJVMRunner.java
@@ -8,21 +8,15 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.helpers.X509Cert;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
-import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
@@ -37,17 +31,11 @@ public class TwinTagsModuleJVMRunner extends TwinTagsTests
 
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
     @Parameterized.Parameters(name = "{2} with {3} auth using {4}")
-    public static Collection inputs() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        X509Cert cert = new X509Cert(0,false, "TestLeaf", "TestRoot");
-        String privateKey =  cert.getPrivateKeyLeafPem();
-        String publicKeyCert = cert.getPublicCertLeafPem();
-        String x509Thumbprint = cert.getThumbPrintLeaf();
-        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint);
-
+        Collection inputs = DeviceTwinCommon.inputsCommon(ClientType.MODULE_CLIENT);
         identities = getIdentities(inputs);
-
         return inputs;
     }
 

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningClientJVMRunner.java
@@ -423,9 +423,9 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     public void individualEnrollmentX509() throws Exception
     {
         String registrationId = REGISTRATION_ID_X509_PREFIX + UUID.randomUUID().toString();
-        X509Cert certs = new X509Cert(0, false, registrationId, null);
-        final String leafPublicPem =  certs.getPublicCertLeafPem();
-        String leafPrivateKey = certs.getPrivateKeyLeafPem();
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(registrationId);
+        final String leafPublicPem =  certificateGenerator.getPublicCertificate();
+        String leafPrivateKey = certificateGenerator.getPrivateKey();
         Collection<String> signerCertificates = new LinkedList<>();
         SecurityProvider securityProviderX509 = new SecurityProviderX509Cert(leafPublicPem, leafPrivateKey, signerCertificates);
 
@@ -492,9 +492,9 @@ public class ProvisioningClientJVMRunner extends IntegrationTest
     {
         boolean expectedExceptionEncountered = false;
         String registrationId = REGISTRATION_ID_X509_PREFIX + UUID.randomUUID().toString();
-        X509Cert certs = new X509Cert(0, false, registrationId, null);
-        final String leafPublicPem =  certs.getPublicCertLeafPem();
-        String leafPrivateKey = certs.getPrivateKeyLeafPem();
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(registrationId);
+        final String leafPublicPem =  certificateGenerator.getPublicCertificate();
+        String leafPrivateKey = certificateGenerator.getPrivateKey();
         Collection<String> signerCertificates = new LinkedList<>();
         SecurityProvider securityProviderX509 = new SecurityProviderX509Cert(leafPublicPem, leafPrivateKey, signerCertificates);
 


### PR DESCRIPTION
Currently, Android and Android Things e2e tests use hardcoded certificates for testing x509 authentication. This PR changes that such that all the needed certificates for testing x509 auth are generated on the fly