### PR TITLE
Amqp dropped ack fix, misc improvements

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -463,7 +463,17 @@ public class AmqpsConnection extends BaseHandler
 
             if (length > 0)
             {
-                byte[] tag = String.valueOf(this.nextTag++).getBytes();
+                byte[] tag = String.valueOf(this.nextTag).getBytes();
+
+                //want to avoid negative delivery tags since -1 is the designated failure value
+                if (this.nextTag == Integer.MAX_VALUE || this.nextTag < 0)
+                {
+                    this.nextTag = 0;
+                }
+                else
+                {
+                    this.nextTag++;
+                }
 
                 amqpDeviceOperations.sendMessage(tag, msgData, length, 0);
                 result = true;

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
-            <version>0.25.0</version>
+            <version>0.31.0</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -603,10 +603,11 @@ public class IotHubTransport implements IotHubListener
                 // retryable and the saved sas token has expired, this function shall return EXPIRED_SAS_TOKEN.]
                 return IotHubConnectionStatusChangeReason.EXPIRED_SAS_TOKEN;
             }
-            else
+            else if (e instanceof UnauthorizedException || e instanceof MqttUnauthorizedException || e instanceof AmqpUnauthorizedAccessException)
             {
                 //Codes_SRS_IOTHUBTRANSPORT_34_035: [If the provided exception is a TransportException that isn't
-                // retryable and the saved sas token has not expired, this function shall return BAD_CREDENTIAL.]
+                // retryable and the saved sas token has not expired, but the exception is an unauthorized exception,
+                // this function shall return BAD_CREDENTIAL.]
                 return IotHubConnectionStatusChangeReason.BAD_CREDENTIAL;
             }
         }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
@@ -115,7 +115,17 @@ public final class AmqpsDeviceAuthenticationCBS extends AmqpsDeviceAuthenticatio
                     }
                 }
                 // Codes_SRS_AMQPSDEVICEAUTHENTICATIONCBS_12_009: [The function shall set the delivery tag for the sender.]
-                byte[] deliveryTag = String.valueOf(this.nextTag++).getBytes();
+                byte[] deliveryTag = String.valueOf(this.nextTag).getBytes();
+
+                //want to avoid negative delivery tags since -1 is the designated failure value
+                if (this.nextTag == Integer.MAX_VALUE || this.nextTag < 0)
+                {
+                    this.nextTag = 0;
+                }
+                else
+                {
+                    this.nextTag++;
+                }
 
                 // Codes_SRS_AMQPSDEVICEAUTHENTICATIONCBS_12_010: [The function shall call the super class sendMessageAndGetDeliveryHash.]
                 this.sendMessageAndGetDeliveryHash(MessageType.CBS_AUTHENTICATION, msgData, 0, length, deliveryTag);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperations.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperations.java
@@ -313,7 +313,7 @@ public class AmqpsDeviceOperations
             // Codes_SRS_AMQPSDEVICEOPERATIONS_12_023: [The function shall advance the sender link.]
             this.senderLink.advance();
             // Codes_SRS_AMQPSDEVICEOPERATIONS_12_024: [The function shall set the delivery hash to the value returned by the sender link.]
-            return new AmqpsSendReturnValue(true, delivery.hashCode());
+            return new AmqpsSendReturnValue(true, delivery.hashCode(), deliveryTag);
         }
         catch (Exception e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -396,20 +396,17 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         if (this.amqpsSessionManager != null)
         {
             this.amqpsSessionManager.closeNow();
-            this.amqpsSessionManager = null;
         }
 
         if (this.connection != null)
         {
             this.connection.close();
-            this.connection = null;
         }
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_34_014: [If this object's proton reactor is not null, this function shall stop the Proton reactor.]
         if (this.reactor != null)
         {
             this.reactor.stop();
-            this.reactor = null;
         }
 
         logger.LogInfo("Proton reactor has been stopped, method name is %s ", logger.getMethodName());
@@ -429,22 +426,22 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     {
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
-        Integer deliveryHash = -1;
+        Integer deliveryTag = -1;
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_015: [If the state of the connection is DISCONNECTED or there is not enough
         // credit, the function shall return -1.]
         if (this.state == IotHubConnectionStatus.DISCONNECTED || this.linkCredit <= 0)
         {
-            deliveryHash = -1;
+            deliveryTag = -1;
         }
         else
         {
             // Codes_SRS_AMQPSIOTHUBCONNECTION_12_024: [The function shall call AmqpsSessionManager.sendMessage with the given parameters.]
-            deliveryHash = this.amqpsSessionManager.sendMessage(message, messageType, deviceId);
+            deliveryTag = this.amqpsSessionManager.sendMessage(message, messageType, deviceId);
         }
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_021: [The function shall return the delivery hash.]
-        return deliveryHash;
+        return deliveryTag;
     }
 
     /**
@@ -578,58 +575,38 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     {
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
-        AmqpsMessage amqpsMessage = null;
+        Link link = event.getLink();
 
-        // Codes_SRS_AMQPSIOTHUBCONNECTION_12_015: [The function shall call AmqpsSessionManager.getMessageFromReceiverLink.]
-        try
+        if (link instanceof Sender)
         {
-            String linkName = event.getLink().getName();
-            amqpsMessage = this.amqpsSessionManager.getMessageFromReceiverLink(linkName);
-        }
-        catch (TransportException e)
-        {
-            this.listener.onMessageReceived(null, e);
-        }
+            //ack received for a message that this SDK sent earlier
+            logger.LogInfo("Reading the delivery event in Sender link, method name is %s ", logger.getMethodName());
 
-        if (amqpsMessage != null)
-        {
-            // Codes_SRS_AMQPSIOTHUBCONNECTION_15_050: [All the listeners shall be notified that a message was received from the server.]
-            try
+            // Codes_SRS_AMQPSIOTHUBCONNECTION_15_038: [If this link is the Sender link and the event type is DELIVERY, the event handler shall get the Delivery (Proton) object from the event.]
+            Delivery delivery = event.getDelivery();
+            while (delivery != null && !delivery.isSettled() && delivery.getRemoteState() != null)
             {
-                this.messageReceivedFromServer(amqpsMessage);
-            }
-            catch (TransportException e)
-            {
-                this.listener.onMessageReceived(null, e);
-            }
-        }
-        else
-        {
-            //Sender specific section for dispositions it receives
-            if (event.getType() == Event.Type.DELIVERY)
-            {
-                logger.LogInfo("Reading the delivery event in Sender link, method name is %s ", logger.getMethodName());
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_038: [If this link is the Sender link and the event type is DELIVERY, the event handler shall get the Delivery (Proton) object from the event.]
-                Delivery d = event.getDelivery();
-                DeliveryState remoteState = d.getRemoteState();
+                DeliveryState remoteState = delivery.getRemoteState();
+
+                int deliveryTag = Integer.valueOf(new String(delivery.getTag()));
 
                 logger.LogInfo("Is state of remote Delivery COMPLETE ? %s, method name is %s ", state, logger.getMethodName());
                 logger.LogInfo("Inform listener that a message has been sent to IoT Hub along with remote state, method name is %s ", logger.getMethodName());
 
-                if (!event.getLink().getSource().getAddress().equalsIgnoreCase(AmqpsDeviceAuthenticationCBS.RECEIVER_LINK_ENDPOINT_PATH))
+                if (!link.getSource().getAddress().equalsIgnoreCase(AmqpsDeviceAuthenticationCBS.RECEIVER_LINK_ENDPOINT_PATH))
                 {
-                    if (this.inProgressMessages.containsKey(d.hashCode()))
+                    if (this.inProgressMessages.containsKey(deliveryTag))
                     {
                         if (remoteState instanceof Accepted)
                         {
                             // Codes_SRS_AMQPSIOTHUBCONNECTION_34_064: [If the acknowledgement sent from the service is "Accepted", this function shall notify its listener that the message was successfully sent.]
-                            this.listener.onMessageSent(inProgressMessages.remove(d.hashCode()), null);
+                            this.listener.onMessageSent(inProgressMessages.remove(deliveryTag), null);
                         }
                         else if (remoteState instanceof Rejected)
                         {
                             TransportException transportException;
                             ErrorCondition errorCondition = ((Rejected) remoteState).getError();
-                            if (errorCondition !=  null && errorCondition.getCondition() != null)
+                            if (errorCondition != null && errorCondition.getCondition() != null)
                             {
                                 // Codes_SRS_AMQPSIOTHUBCONNECTION_28_001: [If the acknowledgement sent from the service is "Rejected", this function shall map the error condition if it exists to amqp exceptions.]
                                 String errorCode = errorCondition.getCondition().toString();
@@ -647,16 +624,15 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                                 transportException = new TransportException("IotHub rejected the message");
                             }
 
-                            this.listener.onMessageSent(inProgressMessages.remove(d.hashCode()), transportException);
+                            this.listener.onMessageSent(inProgressMessages.remove(deliveryTag), transportException);
 
                         }
                         else if (remoteState instanceof Modified || remoteState instanceof Released || remoteState instanceof Received)
                         {
                             // Codes_SRS_AMQPSIOTHUBCONNECTION_34_066: [If the acknowledgement sent from the service is "Modified", "Released", or "Received", this function shall notify its listener that the sent message needs to be retried.]
-                            TransportException transportException = new TransportException("IotHub responded to message " +
-                                    "with Modified, Received or Released; message needs to be re-delivered");
+                            TransportException transportException = new TransportException("IotHub responded to message " + "with Modified, Received or Released; message needs to be re-delivered");
                             transportException.setRetryable(true);
-                            this.listener.onMessageSent(inProgressMessages.remove(d.hashCode()), transportException);
+                            this.listener.onMessageSent(inProgressMessages.remove(deliveryTag), transportException);
                         }
                     }
                     else
@@ -665,8 +641,38 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                     }
                 }
 
-                // release the delivery object which created in sendMessage().
-                d.free();
+                delivery.free();
+
+                //get next delivery to handle, or null if there isn't one
+                delivery = link.head();
+            }
+        }
+        else if (link instanceof Receiver)
+        {
+            //receiver link has a message from iot hub to retrieve
+            AmqpsMessage amqpsMessage = null;
+
+            // Codes_SRS_AMQPSIOTHUBCONNECTION_12_015: [The function shall call AmqpsSessionManager.getMessageFromReceiverLink.]
+            try
+            {
+                amqpsMessage = this.amqpsSessionManager.getMessageFromReceiverLink(link.getName());
+            }
+            catch (TransportException e)
+            {
+                this.listener.onMessageReceived(null, e);
+            }
+
+            if (amqpsMessage != null)
+            {
+                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_050: [All the listeners shall be notified that a message was received from the server.]
+                try
+                {
+                    this.messageReceivedFromServer(amqpsMessage);
+                }
+                catch (TransportException e)
+                {
+                    this.listener.onMessageReceived(null, e);
+                }
             }
         }
 
@@ -984,12 +990,12 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
 
         // Codes_SRS_AMQPSTRANSPORT_34_077: [The function shall attempt to send the Proton message to IoTHub using the underlying AMQPS connection.]
-        Integer sendHash = this.sendMessage(amqpsConvertToProtonReturnValue.getMessageImpl(), amqpsConvertToProtonReturnValue.getMessageType(), message.getConnectionDeviceId());
+        Integer deliveryTag = this.sendMessage(amqpsConvertToProtonReturnValue.getMessageImpl(), amqpsConvertToProtonReturnValue.getMessageType(), message.getConnectionDeviceId());
 
-        if (sendHash != -1)
+        if (deliveryTag != -1)
         {
             // Codes_SRS_AMQPSTRANSPORT_34_078: [If the sent message hash is valid, it shall be added to the in progress map and this function shall return OK.]
-            this.inProgressMessages.put(sendHash, message);
+            this.inProgressMessages.put(deliveryTag, message);
             return IotHubStatusCode.OK;
         }
         else

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendReturnValue.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendReturnValue.java
@@ -4,6 +4,9 @@ public class AmqpsSendReturnValue
 {
     private boolean deliverySuccessful;
     private int  deliveryHash;
+    private byte[] deliveryTag;
+
+    private byte[] failedDeliveryTag = "-1".getBytes();
 
     /**
      * Create a return value object containing the delivery status and the delivery hash
@@ -16,6 +19,21 @@ public class AmqpsSendReturnValue
         // Codes_SRS_AMQPSSENDRETURNVALUE_12_001: [The constructor shall initialize deliverySuccessful and deliveryHash private member variables with the given arguments.]
         this.deliverySuccessful = deliverySuccessful;
         this.deliveryHash = deliveryHash;
+        this.deliveryTag = failedDeliveryTag;
+    }
+
+    public AmqpsSendReturnValue(boolean deliverySuccessful, int deliveryHash, byte[] deliveryTag)
+    {
+        // Codes_SRS_AMQPSSENDRETURNVALUE_34_005: [The constructor shall initialize deliverySuccessful, deliveryHash, and deliveryTag private member variables with the given arguments.]
+        this.deliverySuccessful = deliverySuccessful;
+        this.deliveryHash = deliveryHash;
+        this.deliveryTag = deliveryTag;
+    }
+
+    public byte[] getDeliveryTag()
+    {
+        // Codes_SRS_AMQPSSENDRETURNVALUE_34_004: [The function shall return the saved value of the delivery tag.]
+        return this.deliveryTag;
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
@@ -360,22 +360,22 @@ public class AmqpsSessionManager
      */
     Integer sendMessage(org.apache.qpid.proton.message.Message message, MessageType messageType, String deviceId) throws TransportException
     {
-        Integer deliveryHash = -1;
+        Integer deliveryTag = -1;
 
         if (this.session != null)
         {
             for (int i = 0; i < this.amqpsDeviceSessionList.size(); i++)
             {
                 // Codes_SRS_AMQPSESSIONMANAGER_12_032: [The function shall call sendMessage on all session list member and if there is a successful send return with the deliveryHash, otherwise return -1.]
-                deliveryHash = this.amqpsDeviceSessionList.get(i).sendMessage(message, messageType, deviceId);
-                if (deliveryHash != -1)
+                deliveryTag = this.amqpsDeviceSessionList.get(i).sendMessage(message, messageType, deviceId);
+                if (deliveryTag != -1)
                 {
                     break;
                 }
             }
         }
 
-        return deliveryHash;
+        return deliveryTag;
     }
 
     /**

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -728,9 +728,9 @@ public class IotHubTransportTest
         assertEquals(EXPIRED_SAS_TOKEN, reason);
     }
 
-    //Tests_SRS_IOTHUBTRANSPORT_34_035: [If the provided exception is a TransportException that isn't retryable and the saved sas token has not expired, this function shall return BAD_CREDENTIAL.]
+    //Tests_SRS_IOTHUBTRANSPORT_34_035: [If the provided exception is a TransportException that isn't retryable and the saved sas token has not expired, but the exception is an unauthorized exception, this function shall return BAD_CREDENTIAL]
     @Test
-    public void exceptionToStatusChangeReasonBadCredential()
+    public void exceptionToStatusChangeReasonBadCredentialForAmqpUnauthorizedException(@Mocked final AmqpUnauthorizedAccessException mockedUnauthorizedException)
     {
         //arrange
         final IotHubTransport transport = new IotHubTransport(mockedConfig);
@@ -747,7 +747,58 @@ public class IotHubTransportTest
         };
 
         //act
-        IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, mockedTransportException);
+        IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, mockedUnauthorizedException);
+
+        //assert
+        assertEquals(BAD_CREDENTIAL, reason);
+    }
+
+    //Tests_SRS_IOTHUBTRANSPORT_34_035: [If the provided exception is a TransportException that isn't retryable and the saved sas token has not expired, but the exception is an unauthorized exception, this function shall return BAD_CREDENTIAL]
+    @Test
+    public void exceptionToStatusChangeReasonBadCredentialForMqttUnauthorizedException(@Mocked final MqttUnauthorizedException mockedUnauthorizedException)
+    {
+        //arrange
+        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+
+        new NonStrictExpectations(IotHubTransport.class)
+        {
+            {
+                mockedTransportException.isRetryable();
+                result = false;
+
+                Deencapsulation.invoke(transport, "isSasTokenExpired");
+                result = false;
+            }
+        };
+
+        //act
+        IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, mockedUnauthorizedException);
+
+        //assert
+        assertEquals(BAD_CREDENTIAL, reason);
+    }
+
+
+    //Tests_SRS_IOTHUBTRANSPORT_34_035: [If the provided exception is a TransportException that isn't retryable and the saved sas token has not expired, but the exception is an unauthorized exception, this function shall return BAD_CREDENTIAL]
+    @Test
+    public void exceptionToStatusChangeReasonBadCredentialForGenericUnauthorizedException(@Mocked final UnauthorizedException mockedUnauthorizedException)
+    {
+        //arrange
+        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+
+        new NonStrictExpectations(IotHubTransport.class)
+        {
+            {
+                mockedTransportException.isRetryable();
+                result = false;
+
+                Deencapsulation.invoke(transport, "isSasTokenExpired");
+                result = false;
+            }
+        };
+
+        //act
+        IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, mockedUnauthorizedException);
 
         //assert
         assertEquals(BAD_CREDENTIAL, reason);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -1424,7 +1424,7 @@ public class AmqpsIotHubConnectionTest {
                 result = null;
 
                 mockEvent.getLink();
-                result = mockLink;
+                result = mockSender;
 
                 mockLink.getSource();
                 result = mockSource;
@@ -1435,11 +1435,17 @@ public class AmqpsIotHubConnectionTest {
                 mockLink.getName();
                 result = receiverLinkName;
 
-                mockEvent.getType();
-                result = Event.Type.DELIVERY;
-
                 mockEvent.getDelivery();
                 result = mockDelivery;
+
+                mockDelivery.isSettled();
+                result = false;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockDelivery.getRemoteState();
                 result = Accepted.getInstance();
@@ -1461,16 +1467,104 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedIotHubListener.onMessageSent(mockedTransportMessage, null);
                 times = 1;
                 mockDelivery.free();
                 times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void onDeliveryProcessesAllAvailableDeliveries(@Mocked final Map<Integer, com.microsoft.azure.sdk.iot.device.Message> mockInProgressMessages) throws TransportException
+    {
+        baseExpectations();
+        final String receiverLinkName = "receiver";
+
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        Deencapsulation.setField(connection, "inProgressMessages", mockInProgressMessages);
+        Deencapsulation.setField(connection, "amqpsSessionManager", mockAmqpsSessionManager);
+
+        new StrictExpectations()
+        {
+            {
+                mockEvent.getLink();
+                result = mockSender;
+
+                mockEvent.getDelivery();
+                result = mockDelivery;
+
+                mockDelivery.isSettled();
+                result = false;
+
+                mockDelivery.getRemoteState();
+                result = Accepted.getInstance();
+                times = 2;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.getSource();
+                result = mockSource;
+
+                mockSource.getAddress();
+                result = "notACBSLink";
+
+                mockInProgressMessages.containsKey(anyInt);
+                result = true;
+
+                mockInProgressMessages.remove(anyInt);
+                result = mockedTransportMessage;
+
+                mockDelivery.free();
+
+                mockSender.head();
+                result = mockDelivery;
+
+                mockDelivery.isSettled();
+                result = false;
+
+                mockDelivery.getRemoteState();
+                result = Accepted.getInstance();
+                times = 2;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.getSource();
+                result = mockSource;
+
+                mockSource.getAddress();
+                result = "notACBSLink";
+
+                mockInProgressMessages.containsKey(anyInt);
+                result = true;
+
+                mockInProgressMessages.remove(anyInt);
+                result = mockedTransportMessage;
+
+                mockDelivery.free();
+
+                mockSender.head();
+                result = null;
+            }
+        };
+
+        connection.setListener(mockedIotHubListener);
+
+        //act
+        connection.onDelivery(mockEvent);
+
+        //assert
+        new Verifications()
+        {
+            {
+                mockedIotHubListener.onMessageSent((com.microsoft.azure.sdk.iot.device.Message) any, null);
+                times = 2;
             }
         };
     }
@@ -1504,8 +1598,14 @@ public class AmqpsIotHubConnectionTest {
                 mockLink.getName();
                 result = receiverLinkName;
 
-                mockEvent.getType();
-                result = Event.Type.DELIVERY;
+                mockEvent.getLink();
+                result = mockSender;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockEvent.getDelivery();
                 result = mockDelivery;
@@ -1542,12 +1642,10 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedRejected.getError();
                 times = 1;
                 mockedErrorCondition.getCondition();
@@ -1578,7 +1676,13 @@ public class AmqpsIotHubConnectionTest {
                 result = null;
 
                 mockEvent.getLink();
-                result = mockLink;
+                result = mockSender;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockLink.getSource();
                 result = mockSource;
@@ -1624,12 +1728,10 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedIotHubListener.onMessageSent(mockedTransportMessage, mockedTransportException);
                 times = 1;
                 mockDelivery.free();
@@ -1656,7 +1758,13 @@ public class AmqpsIotHubConnectionTest {
                 result = null;
 
                 mockEvent.getLink();
-                result = mockLink;
+                result = mockSender;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockLink.getSource();
                 result = mockSource;
@@ -1672,6 +1780,9 @@ public class AmqpsIotHubConnectionTest {
 
                 mockEvent.getDelivery();
                 result = mockDelivery;
+
+                mockDelivery.isSettled();
+                result = false;
 
                 mockDelivery.getRemoteState();
                 result = mockedModified;
@@ -1699,12 +1810,10 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedIotHubListener.onMessageSent(mockedTransportMessage, mockedTransportException);
                 times = 1;
                 mockDelivery.free();
@@ -1731,7 +1840,13 @@ public class AmqpsIotHubConnectionTest {
                 result = null;
 
                 mockEvent.getLink();
-                result = mockLink;
+                result = mockSender;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockLink.getSource();
                 result = mockSource;
@@ -1774,12 +1889,10 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedIotHubListener.onMessageSent(mockedTransportMessage, mockedTransportException);
                 times = 1;
                 mockDelivery.free();
@@ -1806,7 +1919,13 @@ public class AmqpsIotHubConnectionTest {
                 result = null;
 
                 mockEvent.getLink();
-                result = mockLink;
+                result = mockSender;
+
+                mockDelivery.getTag();
+                result = "12".getBytes();
+
+                mockSender.head();
+                result = null;
 
                 mockLink.getSource();
                 result = mockSource;
@@ -1849,12 +1968,10 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockEvent.getType();
-                times = 1;
                 mockEvent.getDelivery();
                 times = 1;
                 mockDelivery.getRemoteState();
-                times = 1;
+                times = 2;
                 mockedIotHubListener.onMessageSent(mockedTransportMessage, mockedTransportException);
                 times = 1;
                 mockDelivery.free();
@@ -2143,8 +2260,8 @@ public class AmqpsIotHubConnectionTest {
         new NonStrictExpectations()
         {
             {
-                mockEvent.getLink().getName();
-                result = "";
+                mockEvent.getLink();
+                result = mockReceiver;
                 Deencapsulation.invoke(mockAmqpsSessionManager, "getMessageFromReceiverLink", "");
                 result = mockAmqpsMessage;
                 mockAmqpsMessage.getApplicationProperties();

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendReturnValueTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendReturnValueTest.java
@@ -24,15 +24,39 @@ public class AmqpsSendReturnValueTest
         //arrange
         boolean isDeliverySuccessful = false;
         int deliveryHash = 42;
+        byte[] expectedDeliveryTag = "-1".getBytes();
 
         //act
         AmqpsSendReturnValue amqpsSendReturnValue = Deencapsulation.newInstance(AmqpsSendReturnValue.class, isDeliverySuccessful, deliveryHash);
         boolean actualIsDeliverySuccessful = Deencapsulation.getField(amqpsSendReturnValue, "deliverySuccessful");
         int actualDeliveryHash = Deencapsulation.getField(amqpsSendReturnValue, "deliveryHash");
+        byte[] actualDeliveryTag = Deencapsulation.getField(amqpsSendReturnValue, "deliveryTag");
 
         //assert
         assertEquals(isDeliverySuccessful, actualIsDeliverySuccessful);
         assertEquals(deliveryHash, actualDeliveryHash);
+        assertEquals(new String(expectedDeliveryTag), new String(actualDeliveryTag));
+    }
+
+    // Tests_SRS_AMQPSSENDRETURNVALUE_34_005: [The constructor shall initialize deliverySuccessful, deliveryHash, and deliveryTag private member variables with the given arguments.]
+    @Test
+    public void constructorInitializesAllMembersWithDeliveryTag()
+    {
+        //arrange
+        boolean isDeliverySuccessful = false;
+        int deliveryHash = 42;
+        byte[] expectedDeliveryTag = "1234".getBytes();
+
+        //act
+        AmqpsSendReturnValue amqpsSendReturnValue = Deencapsulation.newInstance(AmqpsSendReturnValue.class, isDeliverySuccessful, deliveryHash, expectedDeliveryTag);
+        boolean actualIsDeliverySuccessful = Deencapsulation.getField(amqpsSendReturnValue, "deliverySuccessful");
+        int actualDeliveryHash = Deencapsulation.getField(amqpsSendReturnValue, "deliveryHash");
+        byte[] actualDeliveryTag = Deencapsulation.getField(amqpsSendReturnValue, "deliveryTag");
+
+        //assert
+        assertEquals(isDeliverySuccessful, actualIsDeliverySuccessful);
+        assertEquals(deliveryHash, actualDeliveryHash);
+        assertEquals(expectedDeliveryTag, actualDeliveryTag);
     }
 
     // Tests_SRS_AMQPSSENDRETURNVALUE_12_002: [The function shall return the current value of deliverySuccessful private member.]
@@ -43,6 +67,7 @@ public class AmqpsSendReturnValueTest
         //arrange
         boolean isDeliverySuccessful = true;
         int deliveryHash = 42;
+        byte[] deliveryTag = new byte[] {1,2,3,4};
         AmqpsSendReturnValue amqpsSendReturnValue = Deencapsulation.newInstance(AmqpsSendReturnValue.class, isDeliverySuccessful, deliveryHash);
 
         //act
@@ -52,5 +77,22 @@ public class AmqpsSendReturnValueTest
         //assert
         assertEquals(isDeliverySuccessful, actualIsDeliverySuccessful);
         assertEquals(deliveryHash, actualDeliveryHash);
+    }
+
+    // Tests_SRS_AMQPSSENDRETURNVALUE_34_004: [The function shall return the saved value of the delivery tag.]
+    @Test
+    public void getDeliveryTagWorks()
+    {
+        //arrange
+        boolean isDeliverySuccessful = true;
+        int deliveryHash = 42;
+        byte[] deliveryTag = new byte[] {1,2,3,4};
+        AmqpsSendReturnValue amqpsSendReturnValue = Deencapsulation.newInstance(AmqpsSendReturnValue.class, isDeliverySuccessful, deliveryHash, deliveryTag);
+
+        //act
+        byte[] actualDeliveryTag = amqpsSendReturnValue.getDeliveryTag();
+
+        //assert
+        assertEquals(new String(deliveryTag), new String(actualDeliveryTag));
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
@@ -596,6 +596,8 @@ public class AmqpsSessionDeviceOperationTest
                 result = mockAmqpsSendReturnValue;
                 Deencapsulation.invoke(mockAmqpsSendReturnValue, "isDeliverySuccessful");
                 result = true;
+                mockAmqpsSendReturnValue.getDeliveryTag();
+                result = "12".getBytes();
 
                 mockDeviceClientConfig.getDeviceId();
                 result = "someDeviceId";
@@ -642,6 +644,9 @@ public class AmqpsSessionDeviceOperationTest
 
                 mockDeviceClientConfig.getDeviceId();
                 result = "someDeviceId";
+
+                mockAmqpsSendReturnValue.getDeliveryTag();
+                result = "12".getBytes();
             }
         };
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -314,7 +314,18 @@ public class AmqpSendHandler extends BaseHandler
                     }
                 }
                 // Codes_SRS_SERVICE_SDK_JAVA_AMQPSENDHANDLER_12_020: [The event handler shall set the delivery tag on the Sender (Proton) object]
-                byte[] tag = String.valueOf(nextTag++).getBytes();
+                byte[] tag = String.valueOf(nextTag).getBytes();
+
+                //want to avoid negative delivery tags since -1 is the designated failure value
+                if (this.nextTag == Integer.MAX_VALUE || this.nextTag < 0)
+                {
+                    this.nextTag = 0;
+                }
+                else
+                {
+                    this.nextTag++;
+                }
+
                 Delivery dlv = snd.delivery(tag);
                 // Codes_SRS_SERVICE_SDK_JAVA_AMQPSENDHANDLER_12_021: [The event handler shall send the encoded bytes]
                 snd.send(msgData, 0, length);


### PR DESCRIPTION
This PR fixes the issue where a device client using amqp occasionally drops acks from the service on d2c telemetry. 

It also fixes an issue where tracking outstanding messages used non-unique ids that risked being accidentally overwritten. Using the send tag rather than the send hash fixes this issue.

This PR also fixes a bug in IotHubTransport where BAD_CREDENTIAL is erroneously used as the reason for certain connection status callbacks.