### PR TITLE
refactor(e2e): Add vsts yaml files for windows, linux, android and sdl

### DIFF
--- a/vsts/android_build_repo.ps1
+++ b/vsts/android_build_repo.ps1
@@ -1,0 +1,1 @@
+﻿./jenkins/android_java.cmd

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -1,0 +1,1 @@
+﻿mvn install -DskipITs=false -T 2C #parallelized to use 2 threads per core

--- a/vsts/echo_inputs.ps1
+++ b/vsts/echo_inputs.ps1
@@ -1,0 +1,10 @@
+﻿$pr = $false
+if ($env:COMMIT_FROM -match "^[\d]+$") 
+{
+    Write-Host -ForegroundColor Cyan "PR #$($env:COMMIT_FROM)"
+    $pr = $true
+}
+else
+{
+    Write-Host -ForegroundColor Cyan "BRANCH $($env:COMMIT_FROM)"
+}

--- a/vsts/manual_checkout.ps1
+++ b/vsts/manual_checkout.ps1
@@ -1,0 +1,45 @@
+﻿Function Invoke-Git
+{
+    & git $Args
+    if ($LASTEXITCODE) 
+    {
+        throw "Git error: $LASTEXITCODE"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($env:COMMIT_FROM))
+{
+    Write-Host -ForegroundColor Cyan "COMMIT_FROM empty - preserving VSTS repository state:"
+    Invoke-Git status -vv
+    Invoke-Git log -1
+    return
+}
+
+$pr = $false
+if ($env:COMMIT_FROM -match "^[\d]+$") 
+{
+    Write-Host -ForegroundColor Cyan "Verifying PR #$($env:COMMIT_FROM)"
+    $pr = $true
+}
+else
+{
+    Write-Host -ForegroundColor Cyan "Verifying BRANCH $($env:COMMIT_FROM)"
+}
+
+if ($pr)
+{
+    Write-Host -ForegroundColor Cyan "Fetching PR #$($env:COMMIT_FROM)"
+    Invoke-Git fetch origin pull/$env:COMMIT_FROM/head:pr$env:COMMIT_FROM
+    Invoke-Git checkout pr$env:COMMIT_FROM
+    Invoke-Git status
+}
+else
+{
+    Write-Host -ForegroundColor Cyan "Fetching BRANCH $($env:COMMIT_FROM)"
+    Invoke-Git fetch origin $env:COMMIT_FROM:$env:COMMIT_FROM
+    Invoke-Git checkout $env:COMMIT_FROM
+    Invoke-Git status
+}
+
+Write-Host -ForegroundColor Cyan "Last 5 from log:"
+Invoke-Git log -5

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -1,0 +1,90 @@
+name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+resources:
+- repo: self
+  clean: true
+phases:
+
+### SDL Tasks ###
+- phase: SDL
+  displayName: SDL Tasks
+
+  condition: succeeded()
+  queue:
+    name: sdl-java
+    timeoutInMinutes: 60
+  steps:
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+    displayName: CredScan
+    inputs:
+      debugMode: false
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
+    displayName: AutoApplicability
+    inputs:
+      ApplyRules: All
+      VerboseWriter: true
+      ExternalRelease: true
+      InternalRelease: true
+      UsesHSM: true
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-vulnerabilityassessment.VulnerabilityAssessment@0
+    displayName: 'Vulnerability Assessment'
+
+  - task: fortifyvsts.hpe-security-fortify-vsts.build-task-fortify-sca.FortifySCA@1
+    displayName: Fortify
+    inputs:
+      applicationType: java
+      buildClasspath: '$(Build.SourcesDirectory)'
+      buildSourceVersion: 1.8
+      buildSourcePath: '$(Build.SourcesDirectory)'
+      buildAnalyzerParams: '-exclude "$(Build.SourcesDirectory)\**\test\**\*" -exclude "$(Build.SourcesDirectory)\**\*sample*\**\*" -exclude "$(Build.SourcesDirectory)\edge-e2e\**\*" -exclude "$(Build.SourcesDirectory)\iot-e2e-tests\**\*" -exclude "$(Build.SourcesDirectory)\provisioning\provisioning-tools\**\*"'
+      fortifyBuildId: 12345
+      scaVerbose: true
+      scaDebug: true
+      additionalScanParams: '-filter "$(Build.SourcesDirectory)\vsts\fortify\filter.txt"'
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: PoliCheck
+    inputs:
+      targetType: F
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+    displayName: 'AntiMalware Scanner'
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+    displayName: 'Publish Security Analysis Logs'
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+    displayName: 'Post Analysis'
+    inputs:
+      CredScan: true
+      FortifySCA: true
+
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+    displayName: 'TSA upload'
+    inputs:
+      tsaVersion: TsaV2
+      codebase: NewOrUpdate
+      tsaEnvironment: Production
+      codeBaseName: 'Azure-Iot-SDK-Java-Master'
+      notificationAlias: 'timtay@microsoft.com, prmathur@microsoft.com, jasminel@microsoft.com'
+      codeBaseAdmins: 'REDMOND\timtay;REDMOND\prmathur;REDMOND\jasminel'
+      instanceUrlForTsaV2: MSAZURE
+      projectNameMSAZURE: One
+      areaPath: 'One\IoT\Platform\Clients\java'
+      iterationPath: 'One\IoT\Backlog'
+      uploadAPIScan: false
+      uploadBinSkim: false
+      uploadFxCop: false
+      uploadModernCop: false
+      uploadPREfast: false
+      uploadRoslyn: false
+      uploadTSLint: false

--- a/vsts/start_tpm_windows.ps1
+++ b/vsts/start_tpm_windows.ps1
@@ -1,0 +1,2 @@
+﻿#Note this script only works for windows. Linux builds must use the docker container instead
+Start provisioning\provisioning-tools\tpm-simulator\Simulator.exe

--- a/vsts/windowsLinuxAndAndroidBuild.yaml
+++ b/vsts/windowsLinuxAndAndroidBuild.yaml
@@ -1,0 +1,346 @@
+name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+resources:
+- repo: self
+  clean: true
+phases:
+
+### Windows build ###
+
+- phase: WINDOWS
+  displayName: Windows
+
+  condition: succeeded()
+  queue:
+    name: Hosted VS2017
+    timeoutInMinutes: 180
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/start_tpm_windows.ps1
+    displayName: 'Start TPM Simulator'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/build_repo.ps1
+    displayName: 'Build and Test'
+    env:
+      IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
+      IOTHUB_EVENTHUB_CONNECTION_STRING: $(WINDOWS-IOTHUB-EVENTHUB-CONNECTION-STRING)
+      IOT_DPS_ID_SCOPE: $(WINDOWS-IOT-DPS-ID-SCOPE)
+      IOTHUB_CONNECTION_STRING: $(WINDOWS-IOTHUB-CONNECTION-STRING)
+      IOT_DPS_TPM_SIMULATOR_IP_ADDRESS: $(WINDOWS-IOT-DPS-TPM-SIMULATOR-IP-ADDRESS)
+      IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(WINDOWS-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+
+  - task: CopyFiles@2
+    displayName: 'Copy Test Results to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+       **/*.trx
+       **/*.xml
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    continueOnError: true
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact Staging Directory'
+    continueOnError: true
+    condition: always()
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      mergeTestResults: true
+    continueOnError: true
+    condition: always()
+
+### Android build Other ###
+- phase: ANDROID
+  displayName: Android Other
+  
+  condition: succeeded()
+  queue:
+    name: Hosted VS2017
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./jenkins/android_java.cmd
+    displayName: 'GIT checkout'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+  
+  - task: AppCenterTest@1
+    displayName: 'E2E with Visual Studio App Center'
+    inputs:
+      appFile: 'iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      frameworkOption: espresso
+      espressoBuildDirectory: 'iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      serverEndpoint: 'AppCenter connection aziotclb'
+      appSlug: 'Azure-Iot-Sdk/androide2e'
+      devices: 'Azure-Iot-Sdk/api28'
+      runOptions: '--test-parameter notAnnotation=com.microsoft.azure.sdk.iot.android.helper.TestGroupA,com.microsoft.azure.sdk.iot.android.helper.TestGroupB,com.microsoft.azure.sdk.iot.android.helper.TestGroupC'
+      showDebugOutput: true
+
+### Android build A ###
+- phase: ANDROID
+  displayName: Android A
+  
+  condition: succeeded()
+  queue:
+    name: Hosted VS2017
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./jenkins/android_java.cmd
+    displayName: 'GIT checkout'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+  
+  - task: AppCenterTest@1
+    displayName: 'E2E with Visual Studio App Center A'
+    inputs:
+      appFile: 'iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      frameworkOption: espresso
+      espressoBuildDirectory: 'iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      serverEndpoint: 'AppCenter connection aziotclb'
+      appSlug: 'Azure-Iot-Sdk/androide2e'
+      devices: 'Azure-Iot-Sdk/api28'
+      runOptions: '--test-parameter annotation=com.microsoft.azure.sdk.iot.android.helper.TestGroupA'
+      showDebugOutput: true
+
+### Android build B ###
+- phase: ANDROID
+  displayName: Android B
+  
+  condition: succeeded()
+  queue:
+    name: Hosted VS2017
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./jenkins/android_java.cmd
+    displayName: 'GIT checkout'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+  
+  - task: AppCenterTest@1
+    displayName: 'E2E with Visual Studio App Center B'
+    inputs:
+      appFile: 'iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      frameworkOption: espresso
+      espressoBuildDirectory: 'iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      serverEndpoint: 'AppCenter connection aziotclb'
+      appSlug: 'Azure-Iot-Sdk/androide2e'
+      devices: 'Azure-Iot-Sdk/api28'
+      runOptions: '--test-parameter annotation=com.microsoft.azure.sdk.iot.android.helper.TestGroupB'
+      showDebugOutput: true
+
+### Android build C ###
+- phase: ANDROID
+  displayName: Android C
+  
+  condition: succeeded()
+  queue:
+    name: Hosted VS2017
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./jenkins/android_java.cmd
+    displayName: 'GIT checkout'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+  
+  - task: AppCenterTest@1
+    displayName: 'E2E with Visual Studio App Center C'
+    inputs:
+      appFile: 'iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      frameworkOption: espresso
+      espressoBuildDirectory: 'iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      serverEndpoint: 'AppCenter connection aziotclb'
+      appSlug: 'Azure-Iot-Sdk/androide2e'
+      devices: 'Azure-Iot-Sdk/api28'
+      runOptions: '--test-parameter annotation=com.microsoft.azure.sdk.iot.android.helper.TestGroupC'
+      showDebugOutput: true
+      
+### Linux build ###
+- phase: LINUX
+  displayName: Linux
+
+  condition: succeeded()
+  queue:
+    name: Hosted Ubuntu 1604
+    timeoutInMinutes: 180
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+
+  - task: Docker@1
+    displayName: 'Start TPM Simulator'
+    inputs:
+      containerregistrytype: 'Container Registry'
+      command: 'Run an image'
+      imageName: aziotbld/testtpm
+      containerName: 'testtpm-instance'
+      ports: |
+       127.0.0.1:2321:2321
+       127.0.0.1:2322:2322
+      restartPolicy: unlessStopped      
+      
+  - powershell: ./vsts/build_repo.ps1
+    displayName: 'Build and Test'
+    env:
+      IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
+      IOTHUB_EVENTHUB_CONNECTION_STRING: $(LINUX-IOTHUB-EVENTHUB-CONNECTION-STRING)
+      IOT_DPS_ID_SCOPE: $(LINUX-IOT-DPS-ID-SCOPE)
+      IOTHUB_CONNECTION_STRING: $(LINUX-IOTHUB-CONNECTION-STRING)
+      IOT_DPS_TPM_SIMULATOR_IP_ADDRESS: $(LINUX-IOT-DPS-TPM-SIMULATOR-IP-ADDRESS)
+      IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(LINUX-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+    condition: always()
+
+  - task: CopyFiles@2
+    displayName: 'Copy Test Results to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+       **/*.trx
+       **/*.xml
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    continueOnError: true
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact Staging Directory'
+    continueOnError: true
+    condition: always()
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      mergeTestResults: true
+    continueOnError: true
+    condition: always()
+    
+    
+    


### PR DESCRIPTION
Keeping the sdl yaml separate since it only needs to be run once, regardless of iot hub region, basic vs standard tier, etc.