### PR TITLE
fix(iot-dev): Fix issue where amqps connection did not refresh token …

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -35,7 +35,7 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
     protected IotHubSasToken sasToken;
 
     public abstract boolean canRefreshToken();
-    public abstract String getRenewedSasToken(boolean proactivelyRenew) throws IOException, TransportException;
+    public abstract String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException;
 
     public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
@@ -72,9 +72,9 @@ public class IotHubSasTokenHardwareAuthenticationProvider extends IotHubSasToken
      * @throws IOException if generating the sas token from the TPM fails
      * @return The value of SasToken
      */
-    public String getRenewedSasToken(boolean proactivelyRenew) throws IOException
+    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException
     {
-        if (this.shouldRefreshToken(proactivelyRenew))
+        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
         {
             //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_035: [If the saved sas token has expired and there is a security provider, the saved sas token shall be refreshed with a new token from the security provider.]
             //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_036: [If the saved sas token has not expired and there is a security provider, but the sas token should be proactively renewed, the saved sas token shall be refreshed with a new token from the security provider.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -104,9 +104,9 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      * @return The value of SasToken
      */
     @Override
-    public String getRenewedSasToken(boolean proactivelyRenew) throws IOException, TransportException
+    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException
     {
-        if (this.shouldRefreshToken(proactivelyRenew))
+        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
         {
             if (this.deviceKey != null)
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
@@ -79,9 +79,9 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * @throws TransportException If a TransportException is encountered while refreshing the sas token
      */
     @Override
-    public String getRenewedSasToken(boolean proactivelyRenew) throws IOException, TransportException
+    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException
     {
-        if (this.shouldRefreshToken(proactivelyRenew))
+        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
         {
             // Codes_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_004: [This function shall invoke shouldRefreshSasToken, and if it should refresh, this function shall refresh the sas token.]
             this.refreshSasToken();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBS.java
@@ -305,7 +305,7 @@ public final class AmqpsDeviceAuthenticationCBS extends AmqpsDeviceAuthenticatio
         Section section = null;
         try
         {
-            section = new AmqpValue(deviceClientConfig.getSasTokenAuthentication().getRenewedSasToken(true));
+            section = new AmqpValue(deviceClientConfig.getSasTokenAuthentication().getRenewedSasToken(true, true));
             outgoingMessage.setBody(section);
         }
         catch (IOException e)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
@@ -31,7 +31,7 @@ public class AmqpsSessionDeviceOperation
 
     private static final int MAX_WAIT_TO_AUTHENTICATE = 10*1000;
     private static final double PERCENTAGE_FACTOR = 0.75;
-    private static final int SEC_IN_MILLISEC = 1000;
+    private static final int MILLISECECONDS_PER_SECOND = 1000;
 
     private final CountDownLatch authenticationLatch = new CountDownLatch(1);
 
@@ -517,7 +517,7 @@ public class AmqpsSessionDeviceOperation
      */
     private void scheduleRenewalThread()
     {
-        long renewalPeriod = calculateRenewalTimeInMilliseconds(this.deviceClientConfig.getSasTokenAuthentication().getTokenValidSecs());
+        long renewalPeriod = calculateRenewalPeriodInMilliseconds(this.deviceClientConfig.getSasTokenAuthentication().getTokenValidSecs());
         if (renewalPeriod > 0)
         {
             this.tokenRenewalPeriodInMilliseconds = renewalPeriod;
@@ -568,13 +568,13 @@ public class AmqpsSessionDeviceOperation
      * @return 75% of the given time
      * @throws IllegalArgumentException if validInSecs is less than 0
      */
-    private long calculateRenewalTimeInMilliseconds(long validInSecs) throws IllegalArgumentException
+    private long calculateRenewalPeriodInMilliseconds(long validInSecs) throws IllegalArgumentException
     {
         if (validInSecs < 0)
         {
             throw new IllegalArgumentException("validInSecs cannot be less than 0.");
         }
 
-        return (long)(validInSecs * PERCENTAGE_FACTOR * SEC_IN_MILLISEC);
+        return (long)(validInSecs * PERCENTAGE_FACTOR * MILLISECECONDS_PER_SECOND);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -452,7 +452,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
     {
         try
         {
-            return this.config.getSasTokenAuthentication().getRenewedSasToken(false);
+            return this.config.getSasTokenAuthentication().getRenewedSasToken(false, false);
         }
         catch (IOException e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -124,7 +124,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
                 SSLContext sslContext = this.config.getAuthenticationProvider().getSSLContext();
                 if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN)
                 {
-                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getRenewedSasToken(false);
+                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 }
                 else if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.X509_CERTIFICATE)
                 {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
@@ -78,7 +78,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         }
 
         @Override
-        public String getRenewedSasToken(boolean proactivelyRenew) throws IOException
+        public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException
         {
             return null;
         }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
@@ -133,7 +133,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(false);
+        sasAuth.getRenewedSasToken(false, false);
 
     }
 
@@ -166,7 +166,38 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(true);
+        sasAuth.getRenewedSasToken(true, false);
+    }
+
+    @Test
+    public void getRenewedSasTokenForciblyRenews(@Mocked final System mockSystem) throws IOException, TransportException
+    {
+        new MockUp<IotHubSasTokenAuthenticationProvider>()
+        {
+            @Mock public boolean shouldRefreshToken(boolean proactivelyRenew)
+            {
+                return false;
+            }
+        };
+
+        //assert
+        new Expectations()
+        {
+            {
+                System.currentTimeMillis();
+                result = 0;
+                times = 2;
+                new IotHubSasToken(expectedHostname, expectedDeviceId, expectedDeviceKey, null, expectedModuleId, anyLong);
+                result = mockSasToken;
+                times = 2;
+            }
+        };
+
+        //arrange
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+
+        //act
+        sasAuth.getRenewedSasToken(true, true);
     }
 
     //Tests_SRS_IOTHUBSASTOKENAUTHENTICATION_34_006: [If the saved sas token has not expired and there is a device key present, but this method is called to proactively renew and the token should renew, the saved sas token shall be renewed.]
@@ -196,7 +227,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(true);
+        sasAuth.getRenewedSasToken(true, false);
     }
 
     //Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_005: [This function shall return the saved sas token.]
@@ -219,7 +250,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        String actualSasToken = Deencapsulation.invoke(sasAuth, "getRenewedSasToken", false);
+        String actualSasToken = Deencapsulation.invoke(sasAuth, "getRenewedSasToken", false, false);
 
         //assert
         assertEquals(mockSasToken.toString(), actualSasToken);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -126,7 +126,25 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true);
+        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true, false);
+
+        //assert
+        assertEquals(newSasToken.toString(), actual);
+    }
+
+    @Test
+    public void getRenewedSasTokenForcesRefresh() throws IOException, TransportException
+    {
+        //arrange
+        final IotHubSasToken oldSasToken = Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, "", "", "", "", "", 1);
+        final IotHubSasToken newSasToken = mockedIotHubSasToken;
+        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
+        Deencapsulation.setField(moduleAuthenticationWithTokenRefresh, "sasToken", oldSasToken);
+        moduleAuthenticationWithTokenRefresh.shouldRefresh = false;
+        moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
+
+        //act
+        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true, true);
 
         //assert
         assertEquals(newSasToken.toString(), actual);
@@ -146,7 +164,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(false);
+        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(false, false);
 
         //assert
         assertEquals(oldSasToken.toString(), actual);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -69,7 +69,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result=testSasToken;
             }
         };
@@ -265,7 +265,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = tokenStr;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
@@ -667,7 +667,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = tokenStr;
             }
         };
@@ -916,7 +916,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = tokenStr;
             }
         };
@@ -1557,7 +1557,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = tokenStr;
             }
         };
@@ -1746,7 +1746,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 times = 1;
             }
         };
@@ -1773,7 +1773,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 times = 1;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
@@ -274,7 +274,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -324,7 +324,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = true;
@@ -369,7 +369,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -437,7 +437,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean);
                 result = mockDeviceMessaging;
@@ -493,7 +493,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean);
                 result = mockDeviceMessaging;
@@ -1074,7 +1074,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1111,7 +1111,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1159,7 +1159,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false);
+                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import static com.microsoft.azure.sdk.iot.common.helpers.SasTokenGenerator.generateSasTokenForIotDevice;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.*;
+import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
 /**
@@ -56,12 +57,24 @@ public class SendMessagesTests extends SendMessagesCommon
         IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
     }
 
+    /**
+     * Note, this test takes at least 10 minutes to run as a token has a 10 minute grace period from the service to stay alive after it has technically expired
+     * This test behaves a bit differently across protocol due to amqp proactively renewing sas tokens, and http not having connection status callback
+     * Amqps/Amqps_ws : Expect the cbs link to send a new sas token before the old token expires
+     * Mqtt/Mqtt_ws   : Expect the connection to be lost briefly, but re-established with a new sas token
+     * Http           : No connection status callback, but should be able to send a message after the first generated sas token has expired
+     */
     @Test
     public void tokenRenewalWorks() throws InterruptedException, IOException
     {
         final long SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL = 60;
         final long DEFAULT_SAS_TOKEN_EXPIRY_TIME = 3600;
-        final long WAIT_BUFFER_FOR_TOKEN_TO_EXPIRE = 15;
+        final long EXPIRED_SAS_TOKEN_GRACE_PERIOD_SECONDS = 600;
+        final long EXTRA_BUFFER_TO_ENSURE_TOKEN_EXPIRED_SECONDS = 30;
+
+        //service grants a 5 minute grace period beyond when sas token expires, this test attempts to send a message after that grace period
+        // to ensure that the first sas token has expired, and that the sas token was renewed successfully.
+        final long WAIT_BUFFER_FOR_TOKEN_TO_EXPIRE = EXPIRED_SAS_TOKEN_GRACE_PERIOD_SECONDS + EXTRA_BUFFER_TO_ENSURE_TOKEN_EXPIRED_SECONDS;
 
         if (testInstance.authenticationType != SAS)
         {
@@ -71,6 +84,15 @@ public class SendMessagesTests extends SendMessagesCommon
 
         //set it so a newly generated sas token only lasts for a small amount of time
         testInstance.client.setOption("SetSASTokenExpiryTime", SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL);
+
+        Success amqpDisconnectDidNotHappen = new Success();
+        Success mqttDisconnectDidHappen = new Success();
+        Success shutdownWasGraceful = new Success();
+        amqpDisconnectDidNotHappen.setResult(true); //assume success until unexpected DISCONNECTED_RETRYING
+        shutdownWasGraceful.setResult(true); //assume success until DISCONNECTED callback without CLIENT_CLOSE
+        mqttDisconnectDidHappen.setResult(false); //assume failure until DISCONNECTED_RETRYING is triggered by token expiring
+        testInstance.client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeTokenRenewalCallbackVerifier(testInstance.protocol, amqpDisconnectDidNotHappen, mqttDisconnectDidHappen, shutdownWasGraceful), null);
+
         IotHubServicesCommon.openClientWithRetry(testInstance.client);
 
         //wait until old sas token has expired, this should force the config to generate a new one from the device key
@@ -98,6 +120,17 @@ public class SendMessagesTests extends SendMessagesCommon
         // resetting the device's option to default
         testInstance.client.close();
         testInstance.client.setOption("SetSASTokenExpiryTime", DEFAULT_SAS_TOKEN_EXPIRY_TIME);
+
+        if (testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS)
+        {
+            assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("MQTT connection was never lost, token renewal was not tested", testInstance.client), mqttDisconnectDidHappen.result);
+        }
+        else if (testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS)
+        {
+            assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("AMQPS connection was lost at least once, token renewal must have failed", testInstance.client), amqpDisconnectDidNotHappen.result);
+        }
+
+        assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("Connection was lost during test, or shutdown was not graceful", testInstance.client), shutdownWasGraceful.result);
     }
 
     @Test


### PR DESCRIPTION
…appropriately

cbs renewal task would wake up before the sas token should be ready to be proactively renewed. Now, when the cbs renewal thread wakes up, it forces a new sas token to be generated.