### PR TITLE
fix(e2e): Fixed flakey query e2e test

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -51,6 +51,8 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static final long DELAY_BETWEEN_OPERATIONS = 200; // 0.2 sec
     public static final long MULTITHREADED_WAIT_TIMEOUT_MS  = 5 * 60 * 1000; // 5 minutes
 
+    public static final long DESIRED_PROPERTIES_PROPAGATION_TIME_MILLIS = 5 * 1000; //5 seconds
+
     protected static final long MAXIMUM_TIME_FOR_IOTHUB_PROPAGATION_BETWEEN_DEVICE_SERVICE_CLIENTS = 5000; // 5 sec
 
     // Max reported properties to be tested

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -52,6 +52,8 @@ public class QueryTwinTests extends DeviceTwinCommon
 
         setDesiredProperties(queryProperty, queryPropertyValue, MAX_DEVICES);
 
+        Thread.sleep(DESIRED_PROPERTIES_PROPAGATION_TIME_MILLIS);
+
         // Raw Query for multiple devices having same property
         final String select = "properties.desired." + queryProperty + " AS " + queryProperty + "," + " COUNT() AS numberOfDevices";
         final String groupBy = "properties.desired." + queryProperty;


### PR DESCRIPTION
desired properties for n devices were set, and then immediately queried. Often this test would report only finding 1 or 2 of the expected devices due to some propagation time needed. By adding the delay, the query will be more reliable in finding the full set of expected devices with the expected property