### PR TITLE
Bump package versions for release 2019-4-19

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client</artifactId>
     <name>IoT Hub Java Device Client</name>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <description>The Microsoft Azure IoT Device SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.2</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.17.0";
+    private static final String CLIENT_VERSION = "1.17.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.17.0'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.17.1'
 }
 
 repositories {

--- a/device/iot-device-samples/device-method-sample/pom.xml
+++ b/device/iot-device-samples/device-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/device-twin-sample/pom.xml
+++ b/device/iot-device-samples/device-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/file-upload-sample/pom.xml
+++ b/device/iot-device-samples/file-upload-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/handle-messages/pom.xml
+++ b/device/iot-device-samples/handle-messages/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-invoke-method-sample/pom.xml
+++ b/device/iot-device-samples/module-invoke-method-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-method-sample/pom.xml
+++ b/device/iot-device-samples/module-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-twin-sample/pom.xml
+++ b/device/iot-device-samples/module-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-device-samples</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>IoT Hub Java Device SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/device/iot-device-samples/send-event-x509/pom.xml
+++ b/device/iot-device-samples/send-event-x509/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-event/pom.xml
+++ b/device/iot-device-samples/send-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-module-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-module-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-receive-x509-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-x509-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-serialized-event/pom.xml
+++ b/device/iot-device-samples/send-serialized-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/pom.xml
+++ b/device/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client-parent</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>IoT Hub Java Device Client Parent </name>
     <packaging>pom</packaging>
     <developers>

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.16.2</version>
+            <version>1.16.3</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.16.2</version>
+            <version>1.16.3</version>
         </dependency>
     </dependencies>
 

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -46,13 +46,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.16.2</version>
+            <version>1.16.3</version>
             <scope>test</scope>
         </dependency>
         <!-- test dependencies -->

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.2</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.2</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/security/pom.xml
+++ b/provisioning/security/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>security</artifactId>
     <name>Provisioning Security Provider</name>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
     <description>The Microsoft Azure IoT Provisioning Security SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>security-provider</artifactId>
     <name>Provisioning Security Provider</name>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security Provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client</artifactId>
     <name>Iot Hub Java Service SDK</name>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <description>The Microsoft Azure IoT Service SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.16.2";
+    public static String serviceVersion = "1.16.3";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-manager-sample</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>Device Manager Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-method-sample</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>Device Method Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-twin-sample</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>Device Twin Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>job-client-sample</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>Job Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/pom.xml
+++ b/service/iot-service-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-service-samples</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>IoT Hub Service SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.16.2</version>
+            <version>1.16.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>service-client-sample</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>Service Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client-parent</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
     <name>IoT Hub Java Service SDK Parent</name>
     <packaging>pom</packaging>
     <developers>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.17.1)
**Bug Fixes**
•             Fix an issue where connection status callback reports BAD_CREDENTIALS.
•             Fix an issue where device client using amqp occasionally dropped acks.
•             Fix an issue where amqps connection did not refresh token appropriately.
•             Fix for AMQP connection with Basic SKU (#485)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.16.3)
**Bug Fixes**
•             Fix an issue where delivery tag in amqp could wrap around to negative int.

## Java Provisioning Security Provider (com.microsoft.azure.sdk.iot.provisioning:security-provider:1.3.0)
**Bug Fixes**
•             Add API to securityProviderSymmetricKey to accept primary and secondary key as strings.

## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.8.2)
**Bug Fixes**
•             Fix an issue where delivery tag in amqp could wrap around to negative int.

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.17.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.16.3/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.6.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.5.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/security-provider/1.3.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/tpm-provider/1.1.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/x509-provider/1.1.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.8.2/jar
