### PR TITLE
refactor(android e2e) split test groups into 38

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpSasTokenRenewalHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpSasTokenRenewalHandler.java
@@ -12,13 +12,13 @@ import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
 
-public class SasTokenRenewalHandler extends BaseHandler
+public class AmqpSasTokenRenewalHandler extends BaseHandler
 {
     AmqpsSessionManager amqpsSessionManager;
     CustomLogger logger;
     DeviceClientConfig config;
 
-    public SasTokenRenewalHandler(AmqpsSessionManager amqpsSessionManager, DeviceClientConfig config)
+    public AmqpSasTokenRenewalHandler(AmqpsSessionManager amqpsSessionManager, DeviceClientConfig config)
     {
         this.amqpsSessionManager = amqpsSessionManager;
         this.logger = new CustomLogger(this.getClass());

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpSasTokenRenewalHandlerTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpSasTokenRenewalHandlerTest.java
@@ -9,7 +9,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubSasTokenAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpsSessionManager;
-import com.microsoft.azure.sdk.iot.device.transport.amqps.SasTokenRenewalHandler;
+import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpSasTokenRenewalHandler;
 import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
 
-public class SasTokenRenewalHandlerTest
+public class AmqpSasTokenRenewalHandlerTest
 {
     @Mocked
     AmqpsSessionManager mockedAmqpsSessionManager;
@@ -41,7 +41,7 @@ public class SasTokenRenewalHandlerTest
     public void constructorSavesArguments()
     {
         //act
-        SasTokenRenewalHandler sasTokenRenewalHandler = new SasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
+        AmqpSasTokenRenewalHandler sasTokenRenewalHandler = new AmqpSasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
 
         //assert
         assertEquals(mockedConfig, Deencapsulation.getField(sasTokenRenewalHandler, "config"));
@@ -52,7 +52,7 @@ public class SasTokenRenewalHandlerTest
     public void timerTaskSchedulesNextTimerTask()
     {
         //arrange
-        final SasTokenRenewalHandler sasTokenRenewalHandler = new SasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
+        final AmqpSasTokenRenewalHandler sasTokenRenewalHandler = new AmqpSasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
 
         final int renewalPeriod = 1234;
 
@@ -85,7 +85,7 @@ public class SasTokenRenewalHandlerTest
     public void timerTaskAuthenticatesUsingSessionManager() throws TransportException
     {
         //arrange
-        final SasTokenRenewalHandler sasTokenRenewalHandler = new SasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
+        final AmqpSasTokenRenewalHandler sasTokenRenewalHandler = new AmqpSasTokenRenewalHandler(mockedAmqpsSessionManager, mockedConfig);
 
         final int renewalPeriod = 1234;
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -64,7 +64,7 @@ public class AmqpsIotHubConnectionTest {
     final String amqpWebSocketPort = "443";
 
     @Mocked
-    SasTokenRenewalHandler mockSasTokenRenewalHandler;
+    AmqpSasTokenRenewalHandler mockAmqpSasTokenRenewalHandler;
 
     @Mocked
     ProtocolException mockedProtocolException;
@@ -1094,7 +1094,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
-        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockSasTokenRenewalHandler);
+        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockAmqpSasTokenRenewalHandler);
 
 
         connection.onReactorInit(mockEvent);
@@ -1104,7 +1104,7 @@ public class AmqpsIotHubConnectionTest {
             {
                 mockEvent.getReactor();
                 mockReactor.schedule(sendPeriod, connection);
-                mockReactor.schedule(expectedSasTokenRenewalPeriod, mockSasTokenRenewalHandler);
+                mockReactor.schedule(expectedSasTokenRenewalPeriod, mockAmqpSasTokenRenewalHandler);
                 mockReactor.connectionToHost(anyString, anyInt, connection);
             }
         };
@@ -1134,7 +1134,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
-        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockSasTokenRenewalHandler);
+        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockAmqpSasTokenRenewalHandler);
 
 
         connection.onReactorInit(mockEvent);
@@ -1145,7 +1145,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getReactor();
                 mockReactor.schedule(sendPeriod, connection);
 
-                mockReactor.schedule(expectedSasTokenRenewalPeriod, mockSasTokenRenewalHandler);
+                mockReactor.schedule(expectedSasTokenRenewalPeriod, mockAmqpSasTokenRenewalHandler);
                 times = 0;
 
                 mockReactor.connectionToHost(anyString, anyInt, connection);
@@ -3032,7 +3032,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
-        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockSasTokenRenewalHandler);
+        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockAmqpSasTokenRenewalHandler);
 
 
         connection.onTimerTask(mockEvent);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.*;
 
 /**
  * Unit tests for DeviceClient.
- * Methods: 100%
- * Lines: 97%
+ * Methods: 88%
+ * Lines: 91%
  */
 public class AmqpsSessionDeviceOperationTest
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/DummyAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/DummyAndroidRunner.java
@@ -39,6 +39,32 @@ public class DummyAndroidRunner
     @TestGroup10
     @TestGroup11
     @TestGroup12
+    @TestGroup13
+    @TestGroup14
+    @TestGroup15
+    @TestGroup16
+    @TestGroup17
+    @TestGroup18
+    @TestGroup19
+    @TestGroup20
+    @TestGroup21
+    @TestGroup22
+    @TestGroup23
+    @TestGroup24
+    @TestGroup25
+    @TestGroup26
+    @TestGroup27
+    @TestGroup28
+    @TestGroup29
+    @TestGroup30
+    @TestGroup31
+    @TestGroup32
+    @TestGroup33
+    @TestGroup34
+    @TestGroup35
+    @TestGroup36
+    @TestGroup37
+    @TestGroup38
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = BasicTierOnlyRule.class)
     public void dummyTest()

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup13.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup13.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup13
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup14.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup14.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup14
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup15.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup15.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup15
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup16.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup16.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup16
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup17.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup17.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup17
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup18.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup18.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup18
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup19.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup19.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup19
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup20.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup20.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup20
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup21.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup21.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup21
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup22.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup22.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup22
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup23.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup23.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup23
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup24.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup24.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup24
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup25.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup25.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup25
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup26.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup26.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup26
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup27.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup27.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup27
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup28.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup28.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup28
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup29.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup29.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup29
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup30.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup30.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup30
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup31.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup31.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup31
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup32.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup32.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup32
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup33.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup33.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup33
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup34.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup34.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup34
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup35.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup35.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup35
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup36.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup36.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup36
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup37.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup37.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup37
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup38.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup38.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup38
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/FileUploadAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup30;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup6;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.FileUploadTests;
@@ -21,7 +22,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-@TestGroup6
+@TestGroup30
 public class FileUploadAndroidRunner extends FileUploadTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/HubTierConnectionAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/HubTierConnectionAndroidRunner.java
@@ -4,6 +4,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup12;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup31;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.HubTierConnectionTests;
 import com.microsoft.azure.sdk.iot.deps.util.Base64;
@@ -25,7 +26,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup12
+@TestGroup31
 @RunWith(Parameterized.class)
 public class HubTierConnectionAndroidRunner extends HubTierConnectionTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/TransportClientAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup32;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup7;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests;
@@ -16,7 +17,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 
-@TestGroup7
+@TestGroup32
 public class TransportClientAndroidRunner extends TransportClientTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjDeviceAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup1;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup33;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
@@ -31,7 +32,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup1
+@TestGroup33
 @RunWith(Parameterized.class)
 public class ReceiveMessagesErrInjDeviceAndroidRunner extends ReceiveMessagesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/ReceiveMessagesErrInjModuleAndroidRunner.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.errorinjection.messag
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
-import com.microsoft.azure.sdk.iot.android.helper.TestGroup2;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup34;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.ReceiveMessagesErrInjTests;
@@ -32,7 +32,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup2
+@TestGroup34
 @RunWith(Parameterized.class)
 public class ReceiveMessagesErrInjModuleAndroidRunner extends ReceiveMessagesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjDeviceAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.errorinjection.messag
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup15;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup3;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -31,7 +32,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup3
+@TestGroup15
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjDeviceAndroidRunner extends SendMessagesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/messaging/SendMessagesErrInjModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.errorinjection.messag
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup16;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup4;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -32,7 +33,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup4
+@TestGroup16
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjModuleAndroidRunner extends SendMessagesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/errorinjection/twin/DesiredPropertiesErrInjModuleAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup10;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup8;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.errorinjection.DesiredPropertiesErrInjTests;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup10
+@TestGroup8
 @RunWith(Parameterized.class)
 public class DesiredPropertiesErrInjModuleAndroidRunner extends DesiredPropertiesErrInjTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesDeviceAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup1;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup13;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.ReceiveMessagesTests;
@@ -31,7 +32,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup1
+@TestGroup13
 @RunWith(Parameterized.class)
 public class ReceiveMessagesDeviceAndroidRunner extends ReceiveMessagesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/ReceiveMessagesModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.messaging;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup14;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup2;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -32,7 +33,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup2
+@TestGroup14
 @RunWith(Parameterized.class)
 public class ReceiveMessagesModuleAndroidRunner extends ReceiveMessagesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesDeviceAndroidRunner.java
@@ -9,6 +9,8 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup11;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup15;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup3;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.telemetry.SendMessagesTests;
@@ -31,7 +33,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup11
+@TestGroup3
 @RunWith(Parameterized.class)
 public class SendMessagesDeviceAndroidRunner extends SendMessagesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/messaging/SendMessagesModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.messaging;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup16;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup4;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodDeviceAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.methods;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup17;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup5;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
@@ -32,7 +33,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-@TestGroup5
+@TestGroup17
 @RunWith(Parameterized.class)
 public class DeviceMethodDeviceAndroidRunner extends DeviceMethodTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/methods/DeviceMethodModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.methods;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup18;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup6;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.DeviceTestManager;
@@ -33,7 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup6
+@TestGroup18
 @RunWith(Parameterized.class)
 public class DeviceMethodModuleAndroidRunner extends DeviceMethodTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesDeviceAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup19;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup7;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup7
+@TestGroup19
 @RunWith(Parameterized.class)
 public class DesiredPropertiesDeviceAndroidRunner extends DesiredPropertiesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DesiredPropertiesModuleAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup10;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup20;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DesiredPropertiesTests;
@@ -28,7 +29,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup10
+@TestGroup20
 @RunWith(Parameterized.class)
 public class DesiredPropertiesModuleAndroidRunner extends DesiredPropertiesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/DeviceTwinWithVersionAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup21;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup9;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.DeviceTwinWithVersionTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
@@ -20,7 +21,7 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.util.Collection;
 
-@TestGroup9
+@TestGroup21
 @RunWith(Parameterized.class)
 public class DeviceTwinWithVersionAndroidRunner extends DeviceTwinWithVersionTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinDeviceAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup22;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup8;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup8
+@TestGroup22
 @RunWith(Parameterized.class)
 public class GetTwinDeviceAndroidRunner extends GetTwinTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/GetTwinModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup23;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup3;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -28,7 +29,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup3
+@TestGroup23
 @RunWith(Parameterized.class)
 public class GetTwinModuleAndroidRunner extends GetTwinTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinDeviceAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup12;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup24;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup12
+@TestGroup24
 @RunWith(Parameterized.class)
 public class QueryTwinDeviceAndroidRunner extends QueryTwinTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/QueryTwinModuleAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup1;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup25;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.QueryTwinTests;
@@ -29,7 +30,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup1
+@TestGroup25
 @RunWith(Parameterized.class)
 public class QueryTwinModuleAndroidRunner extends QueryTwinTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesDeviceAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup2;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup26;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.ReportedPropertiesTests;
@@ -28,7 +29,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup2
+@TestGroup26
 @RunWith(Parameterized.class)
 public class ReportedPropertiesDeviceAndroidRunner extends ReportedPropertiesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/ReportedPropertiesModuleAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup27;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup3;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -28,7 +29,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup3
+@TestGroup27
 @RunWith(Parameterized.class)
 public class ReportedPropertiesModuleAndroidRunner extends ReportedPropertiesTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsDeviceAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothubservices.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup28;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup4;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 
-@TestGroup4
+@TestGroup28
 @RunWith(Parameterized.class)
 public class TwinTagsDeviceAndroidRunner extends TwinTagsTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothubservices/twin/TwinTagsModuleAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup12;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup29;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin.TwinTagsTests;
@@ -28,7 +29,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Collections;
 
-@TestGroup12
+@TestGroup29
 @RunWith(Parameterized.class)
 public class TwinTagsModuleAndroidRunner extends TwinTagsTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/provisioning/ProvisioningClientSymmetricKeyAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/provisioning/ProvisioningClientSymmetricKeyAndroidRunner.java
@@ -8,6 +8,8 @@ package com.microsoft.azure.sdk.iot.android.provisioning;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup1;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup33;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup8;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.setup.ProvisioningCommon;
@@ -21,7 +23,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
-@TestGroup8
+@TestGroup1
 @RunWith(Parameterized.class)
 public class ProvisioningClientSymmetricKeyAndroidRunner extends ProvisioningTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/provisioning/ProvisioningClientX509AndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/provisioning/ProvisioningClientX509AndroidRunner.java
@@ -8,6 +8,8 @@ package com.microsoft.azure.sdk.iot.android.provisioning;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup2;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup34;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup9;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.setup.ProvisioningCommon;
@@ -21,7 +23,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
-@TestGroup9
+@TestGroup2
 @RunWith(Parameterized.class)
 public class ProvisioningClientX509AndroidRunner extends ProvisioningTests
 {

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ExportImportAndroidRunner.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.android.serviceclient;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup35;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup8;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ExportImportTests;
 import com.microsoft.azure.storage.StorageException;
@@ -22,7 +23,7 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 
 @Ignore
-@TestGroup8
+@TestGroup35
 public class ExportImportAndroidRunner extends ExportImportTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/JobClientAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup11;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup36;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.JobClientTests;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 
@@ -21,7 +22,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 @Ignore
-@TestGroup11
+@TestGroup36
 public class JobClientAndroidRunner extends JobClientTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/RegistryManagerAndroidRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup12;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup37;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.RegistryManagerTests;
 
 import org.junit.BeforeClass;
@@ -17,7 +18,7 @@ import org.junit.After;
 
 import java.io.IOException;
 
-@TestGroup12
+@TestGroup37
 public class RegistryManagerAndroidRunner extends RegistryManagerTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/serviceclient/ServiceClientAndroidRunner.java
@@ -8,6 +8,7 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup1;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup38;
 import com.microsoft.azure.sdk.iot.common.tests.serviceclient.ServiceClientTests;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 
@@ -19,7 +20,7 @@ import org.junit.After;
 import java.io.IOException;
 import java.util.Collection;
 
-@TestGroup1
+@TestGroup38
 @RunWith(Parameterized.class)
 public class ServiceClientAndroidRunner extends ServiceClientTests
 {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -360,9 +360,9 @@ public class ProvisioningCommon extends IntegrationTest
         }
     }
 
-    protected void assertProvisionedDeviceCapabilitiesAreExpected(DeviceCapabilities expectedDeviceCapabilities) throws IOException, IotHubException
+    protected void assertProvisionedDeviceCapabilitiesAreExpected(DeviceCapabilities expectedDeviceCapabilities, String provisionedHubConnectionString) throws IOException, IotHubException
     {
-        DeviceTwin deviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
+        DeviceTwin deviceTwin = DeviceTwin.createFromConnectionString(provisionedHubConnectionString);
         Query query = deviceTwin.queryTwin("SELECT * FROM devices WHERE deviceId = '" + testInstance.provisionedDeviceId +"'");
         assertTrue(deviceTwin.hasNextDeviceTwin(query));
         DeviceTwinDevice provisionedDevice = deviceTwin.getNextDeviceTwin(query);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -315,7 +315,7 @@ public class ProvisioningCommon extends IntegrationTest
                 {
                     if (((System.currentTimeMillis() - startTime) < timeoutInMillis))
                     {
-                        fail(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Timed out waiting for device to register successfully", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId));
+                        fail(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Timed out waiting for device to register successfully, last exception: " + Tools.getStackTraceFromThrowable(e), getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId));
                     }
                     
                     System.out.println("Encountered an exception while registering device, trying again: " + Tools.getStackTraceFromThrowable(e));

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
@@ -32,6 +32,7 @@ public class ProvisioningTask implements Callable
     private static final int MAX_THREADS_TO_RUN = 2;
     private static final int MAX_TIME_TO_WAIT_FOR_REGISTRATION = 1000000;
     private static final int MAX_TIME_TO_WAIT_FOR_STATUS_UPDATE = 10000;
+    private static final int DEFAULT_DELAY_BETWEEN_STATUS_CHECKS = 2 * 1000; //2 seconds
     private static final String THREAD_NAME = "azure-iot-sdk-ProvisioningTask";
 
     private SecurityProvider securityProvider = null;
@@ -139,7 +140,7 @@ public class ProvisioningTask implements Callable
                                                                                       ProvisioningDeviceClientException
     {
         // To-Do : Add appropriate wait time retrieved from Service
-        Thread.sleep(MAX_TIME_TO_WAIT_FOR_STATUS_UPDATE);
+        Thread.sleep(DEFAULT_DELAY_BETWEEN_STATUS_CHECKS);
         StatusTask statusTask = new StatusTask(securityProvider, provisioningDeviceClientContract, operationId,
                                                this.authorization);
         FutureTask<RegistrationOperationStatusParser> futureStatusTask = new FutureTask<RegistrationOperationStatusParser>(statusTask);

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -143,7 +143,61 @@ jobs:
     condition: always()  
     
  ### Android, Multi configuration build (12 different test groups to cover) ###
-- job: Android
+- job: AndroidBuild
+  timeoutInMinutes: 180
+  pool:
+    name: Hosted VS2017
+  displayName: Android Build
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./vsts/android_java.cmd
+    displayName: 'Android Build'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
+      IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
+      IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+      IS_BASIC_TIER_HUB: $(IS-BASIC-TIER-HUB) 
+    condition: always()
+      
+  - task: CopyFiles@2
+    displayName: 'Copy Test Results to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)\iot-e2e-tests\android\app\build\outputs\apk'
+      Contents: |
+       *.*
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    continueOnError: true
+    condition: always()
+    
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'androidBuildFiles'
+      targetPath: 'iot-e2e-tests\android\app\build\outputs\apk'
+    
+- job: AndroidTest
   timeoutInMinutes: 180
   pool:
     name: Hosted VS2017
@@ -174,53 +228,77 @@ jobs:
         ANDROID_TEST_GROUP_ID: TestGroup11
       TestGroup12:
         ANDROID_TEST_GROUP_ID: TestGroup12
-        
+      TestGroup13:
+        ANDROID_TEST_GROUP_ID: TestGroup13
+      TestGroup14:
+        ANDROID_TEST_GROUP_ID: TestGroup14
+      TestGroup15:
+        ANDROID_TEST_GROUP_ID: TestGroup15
+      TestGroup16:
+        ANDROID_TEST_GROUP_ID: TestGroup16
+      TestGroup17:
+        ANDROID_TEST_GROUP_ID: TestGroup17
+      TestGroup18:
+        ANDROID_TEST_GROUP_ID: TestGroup18
+      TestGroup19:
+        ANDROID_TEST_GROUP_ID: TestGroup19
+      TestGroup20:
+        ANDROID_TEST_GROUP_ID: TestGroup20
+      TestGroup21:
+        ANDROID_TEST_GROUP_ID: TestGroup21
+      TestGroup22:
+        ANDROID_TEST_GROUP_ID: TestGroup22
+      TestGroup23:
+        ANDROID_TEST_GROUP_ID: TestGroup23
+      TestGroup24:
+        ANDROID_TEST_GROUP_ID: TestGroup24
+      TestGroup25:
+        ANDROID_TEST_GROUP_ID: TestGroup25
+      TestGroup26:
+        ANDROID_TEST_GROUP_ID: TestGroup26
+      TestGroup27:
+        ANDROID_TEST_GROUP_ID: TestGroup27
+      TestGroup28:
+        ANDROID_TEST_GROUP_ID: TestGroup28
+      TestGroup29:
+        ANDROID_TEST_GROUP_ID: TestGroup29
+      TestGroup30:
+        ANDROID_TEST_GROUP_ID: TestGroup30
+      TestGroup31:
+        ANDROID_TEST_GROUP_ID: TestGroup31
+      TestGroup32:
+        ANDROID_TEST_GROUP_ID: TestGroup32
+      TestGroup33:
+        ANDROID_TEST_GROUP_ID: TestGroup33
+      TestGroup34:
+        ANDROID_TEST_GROUP_ID: TestGroup34
+      TestGroup35:
+        ANDROID_TEST_GROUP_ID: TestGroup35
+      TestGroup36:
+        ANDROID_TEST_GROUP_ID: TestGroup36
+      TestGroup37:
+        ANDROID_TEST_GROUP_ID: TestGroup37
+      TestGroup38:
+        ANDROID_TEST_GROUP_ID: TestGroup38
       
-  displayName: Android
-  
+  displayName: Android Test
+  dependsOn: AndroidBuild
   steps:
-  - powershell: ./vsts/echo_inputs.ps1
-    displayName: 'Echo Inputs'
-    env:
-      COMMIT_FROM: $(COMMIT_FROM)
-    condition: always()
-    
   - powershell: ./vsts/install_appcenter_cli.ps1
     displayName: 'Install app center cli'
     condition: always()
-    
-  - powershell: ./vsts/manual_checkout.ps1
-    displayName: 'GIT checkout'
-    env:
-      COMMIT_FROM: $(COMMIT_FROM)
-    condition: always()
-
-  - powershell: ./vsts/android_java.cmd
-    displayName: 'Android Build'
-    env:
-      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
-      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
-      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-      IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-      IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-      IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
-      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
-      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
-      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
-      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
-      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
-      IS_BASIC_TIER_HUB: $(IS-BASIC-TIER-HUB) 
-    condition: always()
+   
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: 'androidBuildFiles'
+      targetPath: $(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk
   
   - task: AppCenterTest@1
     displayName: 'E2E with Visual Studio App Center'
     inputs:
-      appFile: 'iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      appFile: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
       frameworkOption: espresso
-      espressoBuildDirectory: 'iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      espressoBuildDirectory: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
       serverEndpoint: 'AppCenter connection aziotclb'
       appSlug: 'Azure-Iot-Sdk/androide2e'
       devices: 'Azure-Iot-Sdk/api28_2'


### PR DESCRIPTION
one test class per group. Still max of 12 running in app center at a time, but this gives better re-run granularity

Yaml file now uses one build agent to do android build, and test agents just pull the artifacts needed from that build agent.