### PR TITLE
Correlation logging for provisioning e2e tests

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -240,7 +240,11 @@ public class DeviceMethodCommon extends IntegrationTest
 
     public void cleanToStart() throws Exception
     {
+        long startTime = System.currentTimeMillis();
         testInstance.setup();
+        long time1 = System.currentTimeMillis();
+        System.out.println("Time taken to testInstance.setup " + ((time1 - startTime) / 1000.0));
+
         actualStatusUpdates = new ArrayList<Pair<IotHubConnectionStatus, Throwable>>();
         setConnectionStatusCallBack(actualStatusUpdates);
 
@@ -257,12 +261,21 @@ public class DeviceMethodCommon extends IntegrationTest
             e.printStackTrace();
         }
 
+        long time2 = System.currentTimeMillis();
+        System.out.println("Time taken to stop " + ((time2 - time1) / 1000.0));
+
         this.testInstance.deviceTestManager.clearDevice();
+
+        long time3 = System.currentTimeMillis();
+        System.out.println("Time taken to clear device " + ((time3 - time2) / 1000.0));
 
         try
         {
             this.testInstance.deviceTestManager.setup(true, false);
             IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
+
+            long time5 = System.currentTimeMillis();
+            System.out.println("Time taken to confirm open stabilized " + ((time5 - time4) / 1000.0));
         }
         catch (IOException | InterruptedException e)
         {
@@ -377,6 +390,7 @@ public class DeviceMethodCommon extends IntegrationTest
     protected void invokeMethodSucceed() throws Exception
     {
         // Arrange
+        long startTime = System.currentTimeMillis();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
@@ -390,13 +404,20 @@ public class DeviceMethodCommon extends IntegrationTest
             result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
 
+        long time2 = System.currentTimeMillis();
+        System.out.println("Time taken to invoke method " + ((time2 - startTime) / 1000.0));
+
         deviceTestManger.waitIotHub(1, 10);
+
+        long time3 = System.currentTimeMillis();
+        System.out.println("Time taken to receive invoked method " + ((time3 - time2) / 1000.0));
 
         // Assert
         assertNotNull(result);
         assertEquals((long)DeviceEmulator.METHOD_SUCCESS, (long)result.getStatus());
         assertEquals(DeviceEmulator.METHOD_LOOPBACK + ":" + PAYLOAD_STRING, result.getPayload());
         Assert.assertEquals(0, deviceTestManger.getStatusError());
+        System.out.println("Time taken to assert " + ((System.currentTimeMillis() - time3) / 1000.0));
     }
 
     protected String getModuleConnectionString(Module module) throws IotHubException, IOException

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/methods/DeviceMethodTests.java
@@ -42,7 +42,9 @@ public class DeviceMethodTests extends DeviceMethodCommon
     @Before
     public void cleanToStart() throws Exception
     {
+        long startTime = System.currentTimeMillis();
         super.cleanToStart();
+        System.out.println("Time taken to cleanToStart " + ((System.currentTimeMillis() - startTime) / 1000.0));
     }
 
     @Test


### PR DESCRIPTION
A few assert statements in our provisioning e2e tests are missing correlation details, so I added them