### PR TITLE
Misc speed improvements to e2e

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Implement a fake device to the end to end test.
  */
-public class DeviceEmulator  implements Runnable
+public class DeviceEmulator
 {
     public static final String METHOD_RESET = "reset";
     public static final String METHOD_LOOPBACK = "loopback";
@@ -31,21 +31,14 @@ public class DeviceEmulator  implements Runnable
     public static final int METHOD_THROWS = 403;
     public static final int METHOD_NOT_DEFINED = 404;
 
-    private static final int STOP_DEVICE_INTERVAL_IN_MILLISECONDS = 10000;
-
-    private enum LIGHTS{ ON, OFF, DISABLED }
-
     private InternalClient client;
     private DeviceStatus deviceStatus = new DeviceStatus();
     private ConcurrentMap<String, ConcurrentLinkedQueue<Object>> twinChanges = new ConcurrentHashMap<>();
-    private Boolean stopDevice = false;
 
     private DeviceMethodCallback deviceMethodCallback;
     private Object deviceMethodCallbackContext;
     private IotHubEventCallback deviceMethodStatusCallback;
     private Object deviceMethodStatusCallbackContext;
-
-    private final static String THREAD_NAME = "azure-iot-sdk-DeviceEmulator";
 
     /**
      * CONSTRUCTOR
@@ -61,25 +54,7 @@ public class DeviceEmulator  implements Runnable
         this.client = client;
     }
 
-    @Override
-    public void run()
-    {
-        Thread.currentThread().setName(THREAD_NAME);
-
-        while(!stopDevice)
-        {
-            try
-            {
-                Thread.sleep(STOP_DEVICE_INTERVAL_IN_MILLISECONDS);
-            }
-            catch (InterruptedException e)
-            {
-
-            }
-        }
-    }
-
-    void start() throws InterruptedException
+    void setup() throws InterruptedException
     {
         try
         {
@@ -105,13 +80,12 @@ public class DeviceEmulator  implements Runnable
      * Ends the DeviceClient connection and destroy the thread.
      * @throws IOException if the DeviceClient cannot close the connection with the IoTHub.
      */
-    void stop() throws IOException
+    void tearDown() throws IOException
     {
         if (this.client != null)
         {
             this.client.closeNow();
         }
-        stopDevice = true;
     }
 
     /**
@@ -330,7 +304,7 @@ public class DeviceEmulator  implements Runnable
                     case METHOD_RESET:
                         result = METHOD_RESET + ":succeed";
                         status = METHOD_SUCCESS;
-                        stop();
+                        tearDown();
                         break;
                     case METHOD_LOOPBACK:
                         result = loopback(methodData);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
@@ -25,7 +25,6 @@ public class DeviceTestManager
 
     /* deviceEmulator is the device definition on the device `End`. */
     private DeviceEmulator deviceEmulator;
-    private Thread deviceThread;
 
     public DeviceTestManager(InternalClient client)
             throws IOException, URISyntaxException, InterruptedException
@@ -34,9 +33,6 @@ public class DeviceTestManager
 
         /* Create a emulator for the device client, and connect it to the IoTHub */
         deviceEmulator = new DeviceEmulator(client);
-
-        deviceThread = new Thread(deviceEmulator);
-        deviceThread.start();
     }
 
     public void waitIotHub(int numberOfEvents, long timeoutInSeconds) throws InterruptedException, IOException
@@ -57,9 +53,9 @@ public class DeviceTestManager
         this.deviceEmulator.clearStatistics();
     }
 
-    public void start(boolean enableMethod, boolean enableTwin) throws IOException, InterruptedException
+    public void setup(boolean enableMethod, boolean enableTwin) throws IOException, InterruptedException
     {
-        this.deviceEmulator.start();
+        this.deviceEmulator.setup();
 
         if (enableMethod)
         {
@@ -72,25 +68,16 @@ public class DeviceTestManager
             /* Enable DeviceTwin on the device client using the callbacks from the DeviceEmulator */
             deviceEmulator.enableDeviceTwin();
         }
-
-        /* Wait until the device complete the connection with the IoTHub. */
-        //waitIotHub(1, OPEN_CONNECTION_TIMEOUT_IN_SECONDS);
     }
 
-    public void stop() throws IOException, InterruptedException
+    public void tearDown() throws IOException, InterruptedException
     {
-        deviceEmulator.stop();
-        int stopDeviceTimeoutInMilliseconds = STOP_DEVICE_TIMEOUT_IN_MILLISECONDS;
-        deviceThread.join(stopDeviceTimeoutInMilliseconds);
+        deviceEmulator.tearDown();
     }
 
     public void restartDevice(String connectionString, IotHubClientProtocol protocol, String publicCert, String privateKey) throws InterruptedException, IOException, URISyntaxException, ModuleClientException
     {
-        if(deviceThread.getState() == Thread.State.RUNNABLE)
-        {
-            deviceEmulator.stop();
-        }
-        deviceThread.join(STOP_DEVICE_TIMEOUT_IN_MILLISECONDS);
+        deviceEmulator.tearDown();
 
         if (this.client instanceof DeviceClient)
         {
@@ -118,19 +105,13 @@ public class DeviceTestManager
         /* Create a emulator for the device client, and connect it to the IoTHub */
         deviceEmulator = new DeviceEmulator(this.client);
 
-        deviceEmulator.start();
+        deviceEmulator.setup();
 
         /* Enable DeviceMethod on the device client using the callbacks from the DeviceEmulator */
         deviceEmulator.enableDeviceMethod();
 
         /* Enable DeviceTwin on the device client using the callbacks from the DeviceEmulator */
         deviceEmulator.enableDeviceTwin();
-
-        deviceThread = new Thread(deviceEmulator);
-        deviceThread.start();
-
-        /* Wait until the device complete the connection with the IoTHub. */
-        //waitIotHub(1, OPEN_CONNECTION_TIMEOUT_IN_SECONDS);
     }
 
     public int getStatusOk()

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
@@ -433,7 +433,7 @@ public class IotHubServicesCommon
             while (numOfUpdates == 0 || numOfUpdates != actualStatusUpdates.size() || actualStatusUpdates.get(actualStatusUpdates.size() - 1).getKey() != IotHubConnectionStatus.CONNECTED)
             {
                 numOfUpdates = actualStatusUpdates.size();
-                Thread.sleep(6 * 1000);
+                Thread.sleep(3 * 1000);
                 timeElapsed = System.currentTimeMillis() - startTime;
 
                 if (timeElapsed > timeout)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -52,7 +52,7 @@ public class DeviceMethodCommon extends IntegrationTest
     protected static final String PAYLOAD_STRING = "This is a valid payload";
 
     protected static final int NUMBER_INVOKES_PARALLEL = 10;
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     // How much to wait until a message makes it to the server, in milliseconds
     protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60000;
 
@@ -212,7 +212,7 @@ public class DeviceMethodCommon extends IntegrationTest
         {
             try
             {
-                this.deviceTestManager.stop();
+                this.deviceTestManager.tearDown();
                 registryManager.removeDevice(this.identity.getDeviceId()); //removes all modules associated with this device, too
             }
             catch (Exception e)
@@ -246,7 +246,7 @@ public class DeviceMethodCommon extends IntegrationTest
 
         try
         {
-            this.testInstance.deviceTestManager.stop();
+            this.testInstance.deviceTestManager.tearDown();
         }
         catch (IOException e)
         {
@@ -261,7 +261,7 @@ public class DeviceMethodCommon extends IntegrationTest
 
         try
         {
-            this.testInstance.deviceTestManager.start(true, false);
+            this.testInstance.deviceTestManager.setup(true, false);
             IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
         }
         catch (IOException | InterruptedException e)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -64,7 +64,7 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static final Integer PAGE_SIZE = 2;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     // Constants used in for Testing
     protected static final String PROPERTY_KEY = "Key";
@@ -218,9 +218,10 @@ public class DeviceTwinCommon extends IntegrationTest
             devicesUnderTest[i].sCModuleForRegistryManager = com.microsoft.azure.sdk.iot.service.Module.createFromId(id, "module", null);
             devicesUnderTest[i].sCDeviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, devicesUnderTest[i].sCDeviceForRegistryManager);
             devicesUnderTest[i].sCModuleForRegistryManager = Tools.addModuleWithRetry(registryManager, devicesUnderTest[i].sCModuleForRegistryManager);
-            Thread.sleep(2000);
             setUpTwin(devicesUnderTest[i]);
         }
+
+        Thread.sleep(2000);
     }
 
     protected void removeMultipleDevices(int numberOfDevices) throws IOException, IotHubException, InterruptedException

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -91,7 +91,7 @@ public class ProvisioningCommon extends IntegrationTest
     public static final String TPM_SIMULATOR_IP_ADDRESS_ENV_NAME = "IOT_DPS_TPM_SIMULATOR_IP_ADDRESS"; // ip address of TPM simulator
     public static String tpmSimulatorIpAddress = "";
 
-    public static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 30 * 1000;
+    public static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION = 60 * 1000;
 
     public static final String HMAC_SHA256 = "HmacSHA256";
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -263,13 +263,13 @@ public class ProvisioningCommon extends IntegrationTest
             }
         }
 
-        assertEquals(PROVISIONING_DEVICE_STATUS_ASSIGNED, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus());
+        assertEquals(buildExceptionMessageDpsIndividualOrGroup("Unexpected status", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), PROVISIONING_DEVICE_STATUS_ASSIGNED, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus());
         testInstance.provisionedDeviceId = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId();
         testInstance.provisionedIotHubUri = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri();
-        assertNotNull(testInstance.provisionedDeviceId);
-        assertFalse(testInstance.provisionedDeviceId.isEmpty());
-        assertNotNull(testInstance.provisionedIotHubUri);
-        assertFalse(testInstance.provisionedIotHubUri.isEmpty());
+        assertNotNull(buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId);
+        assertFalse(buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId.isEmpty());
+        assertNotNull(buildExceptionMessageDpsIndividualOrGroup("Expected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri);
+        assertFalse(buildExceptionMessageDpsIndividualOrGroup("Expected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri.isEmpty());
     }
 
     public ProvisioningStatus registerDevice(ProvisioningDeviceClientTransportProtocol protocol, SecurityProvider securityProvider, String globalEndpoint, boolean withRetry, String jsonPayload, String... expectedIotHubsToProvisionTo) throws Exception
@@ -318,14 +318,14 @@ public class ProvisioningCommon extends IntegrationTest
                 String deviceId = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId();
                 String provisionedHubUri = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri();
 
-                assertTrue(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() == ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_ASSIGNED);
-                assertFalse(deviceId.isEmpty());
-                assertFalse(provisionedHubUri.isEmpty());
+                assertTrue(buildExceptionMessageDpsIndividualOrGroup("Unexpected status", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() == ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_ASSIGNED);
+                assertFalse(buildExceptionMessageDpsIndividualOrGroup("Unexpected deviceId", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), deviceId.isEmpty());
+                assertFalse(buildExceptionMessageDpsIndividualOrGroup("Unexpected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisionedHubUri.isEmpty());
 
                 if (jsonPayload != null && !jsonPayload.isEmpty())
                 {
                     String returnJson = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningPayload();
-                    assertTrue("Payload received from service is not the same values. Sent Json: " + jsonPayload + " returned json " + returnJson, returnJson.equals(jsonPayload));
+                    assertTrue(buildExceptionMessageDpsIndividualOrGroup("Payload received from service is not the same values. Sent Json: " + jsonPayload + " returned json " + returnJson, getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), returnJson.equals(jsonPayload));
                 }
                 assertProvisionedIntoCorrectHub(expectedIotHubsToProvisionTo, provisionedHubUri);
                 assertProvisionedDeviceWorks(provisionedHubUri, deviceId);
@@ -386,15 +386,15 @@ public class ProvisioningCommon extends IntegrationTest
     {
         DeviceTwin deviceTwin = DeviceTwin.createFromConnectionString(provisionedHubConnectionString);
         Query query = deviceTwin.queryTwin("SELECT * FROM devices WHERE deviceId = '" + testInstance.provisionedDeviceId +"'");
-        assertTrue(deviceTwin.hasNextDeviceTwin(query));
+        assertTrue(buildExceptionMessageDpsIndividualOrGroup("Provisioned device " + testInstance.provisionedDeviceId + "not found in expected hub", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), deviceTwin.hasNextDeviceTwin(query));
         DeviceTwinDevice provisionedDevice = deviceTwin.getNextDeviceTwin(query);
         if (expectedDeviceCapabilities.isIotEdge())
         {
-            assertTrue(provisionedDevice.getCapabilities().isIotEdge());
+            assertTrue(buildExceptionMessageDpsIndividualOrGroup("Provisioned device isn't edge device: " + testInstance.provisionedDeviceId, getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisionedDevice.getCapabilities().isIotEdge());
         }
         else
         {
-            assertTrue(provisionedDevice.getCapabilities() == null || !provisionedDevice.getCapabilities().isIotEdge());
+            assertTrue(buildExceptionMessageDpsIndividualOrGroup("Provisioned device shouldn't be edge device " + testInstance.provisionedDeviceId, getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisionedDevice.getCapabilities() == null || !provisionedDevice.getCapabilities().isIotEdge());
         }
     }
 
@@ -497,15 +497,15 @@ public class ProvisioningCommon extends IntegrationTest
             {
                 Attestation attestation = new SymmetricKeyAttestation(null, null);
                 createTestIndividualEnrollment(attestation, allocationPolicy, reprovisionPolicy, customAllocationDefinition, iothubs, twinState, deviceCapabilities);
-                assertTrue(testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
+                assertTrue(buildExceptionMessageDpsIndividualOrGroup("Expected symmetric key attestation", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
                 SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) testInstance.individualEnrollment.getAttestation();
                 securityProvider = new SecurityProviderSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(), testInstance.registrationId);
             }
 
-            assertEquals(testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());
-            assertNotNull(testInstance.individualEnrollment.getInitialTwin());
-            assertEquals(TEST_VALUE_TAG, testInstance.individualEnrollment.getInitialTwin().getTags().get(TEST_KEY_TAG));
-            assertEquals(TEST_VALUE_DP, testInstance.individualEnrollment.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
+            assertEquals(buildExceptionMessageDpsIndividualOrGroup("Unexpected device id assigned", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());
+            assertNotNull(buildExceptionMessageDpsIndividualOrGroup("Expected twin to not be null", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getInitialTwin());
+            assertEquals(buildExceptionMessageDpsIndividualOrGroup("Unexpected tags found", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), TEST_VALUE_TAG, testInstance.individualEnrollment.getInitialTwin().getTags().get(TEST_KEY_TAG));
+            assertEquals(buildExceptionMessageDpsIndividualOrGroup("Unexpected desired properties", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), TEST_VALUE_DP, testInstance.individualEnrollment.getInitialTwin().getDesiredProperty().get(TEST_KEY_DP));
         }
 
         return securityProvider;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -102,7 +102,7 @@ public class ProvisioningCommon extends IntegrationTest
     public ProvisioningServiceClient provisioningServiceClient = null;
     public RegistryManager registryManager = null;
 
-    public static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    public static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     //sending reported properties for twin operations takes some time to get the appropriate callback
     public static final int MAX_TWIN_PROPAGATION_WAIT_SECONDS = 60;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -54,7 +54,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
 
     protected static String expectedCorrelationId = "1234";
     protected static String expectedMessageId = "5678";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     protected static final long ERROR_INJECTION_RECOVERY_TIMEOUT = 1 * 60 * 1000; // 1 minute
 
     public ReceiveMessagesTestInstance testInstance;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -53,7 +53,7 @@ public class SendMessagesCommon extends IntegrationTest
     protected static final Integer RETRY_MILLISECONDS = 100;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     protected static String hostName;
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -52,7 +52,7 @@ public class TransportClientTests extends IntegrationTest
 
     private static final long RETRY_MILLISECONDS = 100; //.1 seconds
     private static final long SEND_TIMEOUT_MILLISECONDS = 5 * 60 * 1000; // 5 minutes
-    private static final long INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 2000;
+    private static final long INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     private static final long RECEIVE_MESSAGE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 10 * 1000; // 10 seconds
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION = 500; // .5 seconds

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/JobClientTests.java
@@ -126,7 +126,7 @@ public class JobClientTests
         {
             testDevice = Tools.addDeviceWithRetry(registryManager, Device.createFromId(DEVICE_ID_NAME.concat("-" + i + "-" + uuid), DeviceStatus.Enabled, null));
             DeviceTestManager testManager = new DeviceTestManager(new DeviceClient(registryManager.getDeviceConnectionString(testDevice), IotHubClientProtocol.AMQPS));
-            testManager.start(true, true);
+            testManager.setup(true, true);
             devices.add(testManager);
         }
     }
@@ -174,7 +174,7 @@ public class JobClientTests
     {
         for (DeviceTestManager device:devices)
         {
-            device.stop();
+            device.tearDown();
         }
 
         if (registryManager != null)


### PR DESCRIPTION
Methods e2e tests have pretty costly logic in the before methods which is adding roughly 100 minutes of total android test time. Most of it was doing nothing useful (deviceThread instance tied to the device emulator just held onto a thread for some odd reason)

Also removed a lot of Thread.sleep(...) calls that were unnecessary (exhaustive testing of this branch should prove they didn't do anything helpful).

Lastly, removed the inter-test delays. Now that each test spawns up its own iot device, we have a 2 second delay after each device is created anyways, so the intertest delay is redundant now.

With all of these changes, the total android build time for Canary Standard went down from 1:20 to 1:07