### PR TITLE
fix(iot-service, deps, e2e): Fix issue where ConnectionState was never propagated up through DeviceTwinDevice object

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinConnectionState.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinConnectionState.java
@@ -10,9 +10,9 @@ import com.google.gson.annotations.SerializedName;
  */
 public enum TwinConnectionState
 {
-    @SerializedName("disconnected")
+    @SerializedName(value = "Disconnected", alternate = "disconnected")
     DISCONNECTED,
 
-    @SerializedName("connected")
+    @SerializedName(value = "Connected", alternate = "connected")
     CONNECTED
 }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinState.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinState.java
@@ -384,6 +384,20 @@ public class TwinState extends RegisterManager
     }
 
     /**
+     * Get the connection state
+     * @return the connection state
+     */
+    public String getConnectionState()
+    {
+        if (this.connectionState == null)
+        {
+            return null;
+        }
+
+        return this.connectionState.toString();
+    }
+
+    /**
      * Empty constructor
      *
      * <p>

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/RegisterManagerTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/RegisterManagerTest.java
@@ -27,7 +27,7 @@ public class RegisterManagerTest
             "\"status\":\"enabled\"," +
             "\"statusReason\":\"validStatusReason\"," +
             "\"statusUpdatedTime\":\"2016-06-01T21:22:41+00:00\"," +
-            "\"connectionState\":\"disconnected\"," +
+            "\"connectionState\":\"Disconnected\"," +
             "\"connectionStateUpdatedTime\":\"2016-06-01T21:22:41+00:00\"," +
             "\"lastActivityTime\":\"xxx\"," +
             "\"capabilities\": {\n" +

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinStateTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinStateTest.java
@@ -6,6 +6,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.deps.twin;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinConnectionState;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinProperties;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import mockit.Deencapsulation;
@@ -261,11 +262,14 @@ public class TwinStateTest
     {
         // arrange
         TwinState twinState = new TwinState(TAGS, PROPERTIES, PROPERTIES);
+        TwinConnectionState expectedConnectionState = TwinConnectionState.CONNECTED;
+        Deencapsulation.setField(twinState, "connectionState", expectedConnectionState);
 
         // act - assert
         assertEquals(TAGS, twinState.getTags());
         assertEquals(PROPERTIES, twinState.getDesiredProperty());
         assertEquals(PROPERTIES, twinState.getReportedProperty());
+        assertEquals(expectedConnectionState.toString(), twinState.getConnectionState());
     }
 
     /* SRS_TWIN_STATE_21_006: [The getDesiredProperty shall return a TwinCollection with the stored desired property.] */
@@ -388,7 +392,7 @@ public class TwinStateTest
     {
         // arrange
         final String json =
-                "{\"tags\":{\"tag1\":\"val1\",\"tag2\":\"val2\",\"tag3\":\"val3\"},\"properties\":{\"desired\":{\"prop2\":\"val2\",\"prop1\":\"val1\",\"prop3\":\"val3\"},\"reported\":{\"prop2\":\"val2\",\"prop1\":\"val1\",\"prop3\":\"val3\"}},\"configurations\":{\"p1\":{\"status\":\"targeted\"},\"p2\":{\"status\":\"applied\"}},\"deviceId\":\"validDeviceId\",\"moduleId\":null,\"generationId\":\"validGenerationId\",\"etag\":\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",\"version\":3,\"status\":\"enabled\",\"statusReason\":\"validStatusReason\",\"statusUpdatedTime\":\"2016-06-01T21:22:41+00:00\",\"connectionState\":\"disconnected\",\"connectionStateUpdatedTime\":\"2016-06-01T21:22:41+00:00\",\"lastActivityTime\":\"xxx\",\"capabilities\":null}";
+                "{\"tags\":{\"tag1\":\"val1\",\"tag2\":\"val2\",\"tag3\":\"val3\"},\"properties\":{\"desired\":{\"prop2\":\"val2\",\"prop1\":\"val1\",\"prop3\":\"val3\"},\"reported\":{\"prop2\":\"val2\",\"prop1\":\"val1\",\"prop3\":\"val3\"}},\"configurations\":{\"p1\":{\"status\":\"targeted\"},\"p2\":{\"status\":\"applied\"}},\"deviceId\":\"validDeviceId\",\"moduleId\":null,\"generationId\":\"validGenerationId\",\"etag\":\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",\"version\":3,\"status\":\"enabled\",\"statusReason\":\"validStatusReason\",\"statusUpdatedTime\":\"2016-06-01T21:22:41+00:00\",\"connectionState\":\"Disconnected\",\"connectionStateUpdatedTime\":\"2016-06-01T21:22:41+00:00\",\"lastActivityTime\":\"xxx\",\"capabilities\":null}";
 
         // act
         TwinState twinState = TwinState.createFromTwinJson(json);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.sdk.iot.common.setup;
 
 import com.microsoft.azure.sdk.iot.common.helpers.*;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinConnectionState;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Device;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
@@ -671,6 +672,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
 
         // assert
+        assertEquals(TwinConnectionState.CONNECTED.toString(), deviceUnderTest.sCDeviceForTwin.getConnectionState());
         waitAndVerifyTwinStatusBecomesSuccess();
         waitAndVerifyDesiredPropertyCallback(PROPERTY_VALUE_UPDATE, true);
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -121,6 +121,7 @@ public class DeviceTwin
         device.setReportedProperties(twinState.getReportedProperty());
         device.setCapabilities(twinState.getCapabilities());
         device.setConfigurations(twinState.getConfigurations());
+        device.setConnectionState(twinState.getConnectionState());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinDevice.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinDevice.java
@@ -33,6 +33,7 @@ public class DeviceTwinDevice
     private TwinCollection desiredProperties = null;
     private Map<String, ConfigurationInfo> configurations = null;
     private DeviceCapabilities capabilities = null;
+    private String connectionState;
 
     /**
      * Constructor to create instance for a device
@@ -203,7 +204,6 @@ public class DeviceTwinDevice
          */
         this.tag = this.setToMap(tags);
     }
-
 
     /**
      * Getter to get Tags Set
@@ -493,6 +493,23 @@ public class DeviceTwinDevice
          **Codes_SRS_DEVICETWINDEVICE_28_004: [** The getCapabilities shall return the stored capabilities.**]**
          */
         return this.capabilities;
+    }
+
+    /**
+     * @return get the connection state as last reported by the service
+     */
+    public String getConnectionState()
+    {
+        return this.connectionState;
+    }
+
+    /**
+     * Set the connection state of the device
+     * @param connectionState the state to set
+     */
+    protected void setConnectionState(String connectionState)
+    {
+        this.connectionState = connectionState;
     }
 
     /**

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinDeviceTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinDeviceTest.java
@@ -5,10 +5,7 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
-import com.microsoft.azure.sdk.iot.deps.twin.ConfigurationInfo;
-import com.microsoft.azure.sdk.iot.deps.twin.ConfigurationStatus;
-import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
-import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
+import com.microsoft.azure.sdk.iot.deps.twin.*;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import mockit.Deencapsulation;
@@ -187,7 +184,21 @@ public class DeviceTwinDeviceTest
 
         //assert
         assertTrue(devId.equals("testDevice"));
+    }
 
+    @Test
+    public void getConnectionStateGets()
+    {
+        //arrange
+        String expectedConnectionState = TwinConnectionState.DISCONNECTED.toString();
+        DeviceTwinDevice testDevice = new DeviceTwinDevice("testDevice");
+        Deencapsulation.setField(testDevice, "connectionState", expectedConnectionState);
+
+        //act
+        String actualConnectionState = testDevice.getConnectionState();
+
+        //assert
+        assertEquals(expectedConnectionState, actualConnectionState);
     }
 
     /*

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -5,10 +5,7 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
-import com.microsoft.azure.sdk.iot.deps.twin.ConfigurationInfo;
-import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
-import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
-import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
+import com.microsoft.azure.sdk.iot.deps.twin.*;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
@@ -182,6 +179,7 @@ public class DeviceTwinTest
         final String connectionString = "testString";
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
+        String expectedConnectionState = TwinConnectionState.CONNECTED.toString();
         new NonStrictExpectations()
         {
             {
@@ -193,6 +191,8 @@ public class DeviceTwinTest
                 result = mockCapabilities;
                 mockedTwinState.getConfigurations();
                 result = mockConfigurations;
+                mockedTwinState.getConnectionState();
+                result = expectedConnectionState;
             }
         };
 
@@ -231,6 +231,8 @@ public class DeviceTwinTest
                 Deencapsulation.invoke(mockedDevice, "setCapabilities", mockCapabilities);
                 times = 1;
                 Deencapsulation.invoke(mockedDevice, "setConfigurations", mockConfigurations);
+                times = 1;
+                Deencapsulation.invoke(mockedDevice, "setConnectionState", expectedConnectionState);
                 times = 1;
             }
         };


### PR DESCRIPTION
service was sending uppercase "Disconnected" and "Connected" when the SDK was expected lowercase "disconnected" and "connected"

The SDK was missing logic to propagate up this Json field to the DeviceTwinDevice object, too.