### PR TITLE
fix(iot-device): Fix issue where provisioned devices don't receive C2D over MQTT

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
@@ -141,7 +141,7 @@ public class IotHubConnectionString
                                   String sharedAccessKey, String sharedAccessToken)
             throws IllegalArgumentException, URISyntaxException
     {
-        this(hostName, deviceId, sharedAccessKey, sharedAccessToken, "");
+        this(hostName, deviceId, sharedAccessKey, sharedAccessToken, null);
     }
 
     public IotHubConnectionString(String hostName, String deviceId,

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -157,7 +157,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
                 {
                     host = this.config.getIotHubHostname();
                 }
-                 if (this.config.isUseWebsocket())
+                if (this.config.isUseWebsocket())
                 {
                     //Codes_SRS_MQTTIOTHUBCONNECTION_25_018: [The function shall establish an MQTT WS connection with a server uri as wss://<hostName>/$iothub/websocket?iothub-no-client-cert=true if websocket was enabled.]
                     final String wsServerUri = WS_SSL_PREFIX + host + WEBSOCKET_RAW_PATH + WEBSOCKET_QUERY ;
@@ -173,7 +173,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
                 }
 
                 //Codes_SRS_MQTTIOTHUBCONNECTION_34_030: [This function shall instantiate this object's MqttMessaging object with this object as the listener.]
-                this.deviceMessaging = new MqttMessaging(mqttConnection, this.config.getDeviceId(), this.listener, this, this.connectionId, this.config.getModuleId(), this.config.getGatewayHostname() != null, unacknowledgedSentMessages);
+                this.deviceMessaging = new MqttMessaging(mqttConnection, this.config.getDeviceId(), this.listener, this, this.connectionId, this.config.getModuleId(), this.config.getGatewayHostname() != null && !this.config.getGatewayHostname().isEmpty(), unacknowledgedSentMessages);
                 this.mqttConnection.setMqttCallback(this.deviceMessaging);
                 this.deviceMethod = new MqttDeviceMethod(mqttConnection, this.connectionId, unacknowledgedSentMessages);
                 this.deviceTwin = new MqttDeviceTwin(mqttConnection, this.connectionId, unacknowledgedSentMessages);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -293,7 +293,6 @@ public class ProvisioningCommon extends IntegrationTest
         long startTime = System.currentTimeMillis();
         long timeoutInMillis = 180*1000; //3 minutes
         boolean deviceRegisteredSuccessfully = false;
-        Thread.sleep(10*1000);
         do
         {
             try

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -335,7 +335,7 @@ public class ProvisioningCommon extends IntegrationTest
             {
                 if (withRetry)
                 {
-                    if (((System.currentTimeMillis() - startTime) < timeoutInMillis))
+                    if (((System.currentTimeMillis() - startTime) > timeoutInMillis))
                     {
                         fail(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Timed out waiting for device to register successfully, last exception: " + Tools.getStackTraceFromThrowable(e), getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId));
                     }


### PR DESCRIPTION
Device clients created using security providers led to some confusion between null and empty string within MQTT layer that caused the SDK to not subscribe to C2D. Fixing the SDK to set the gatewayhost name to null, rather than empty string. Also adding check within MQTT layer to prevent this bug if gateway hostname ends up as empty string again later.

Removing unnecessary delay in provisioning e2e tests, and fixing a timeout logic bug too