### PR TITLE
Dps relaxation on registration id

### DIFF
--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/DeviceRegistrationState.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/DeviceRegistrationState.java
@@ -115,17 +115,12 @@ public class DeviceRegistrationState
         Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().disableHtmlEscaping().create();
         DeviceRegistrationState result = gson.fromJson(json, DeviceRegistrationState.class);
 
-        /* SRS_DEVICE_REGISTRATION_STATE_21_004: [The constructor shall throw IllegalArgumentException if the provided registrationId is null, empty, or invalid.] */
-        ParserUtility.validateId(result.registrationId);
-
         /* SRS_DEVICE_REGISTRATION_STATE_21_005: [The constructor shall store the provided registrationId.] */
         this.registrationId = result.registrationId;
 
         /* SRS_DEVICE_REGISTRATION_STATE_21_006: [The constructor shall throw IllegalArgumentException if the provided deviceId is empty, or invalid.] */
         if(result.deviceId != null)
         {
-            ParserUtility.validateId(result.deviceId);
-
             /* SRS_DEVICE_REGISTRATION_STATE_21_007: [The constructor shall store the provided deviceId.] */
             this.deviceId = result.deviceId;
         }
@@ -147,8 +142,6 @@ public class DeviceRegistrationState
         /* SRS_DEVICE_REGISTRATION_STATE_21_010: [If the assignedHub is not null, the constructor shall judge and store it.] */
         if(result.assignedHub != null)
         {
-            /* SRS_DEVICE_REGISTRATION_STATE_21_011: [The constructor shall throw IllegalArgumentException if an provided assignedHub is empty or invalid.] */
-            ParserUtility.validateHostName(result.assignedHub);
             this.assignedHub = result.assignedHub;
         }
 

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroup.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroup.java
@@ -365,9 +365,6 @@ public class EnrollmentGroup extends Serializable
      */
     protected final void setEnrollmentGroupId(String enrollmentGroupId)
     {
-        /* SRS_ENROLLMENT_GROUP_21_015: [The setEnrollmentGroupId shall throw IllegalArgumentException if the provided enrollmentGroupId is null, empty, or invalid.] */
-        ParserUtility.validateId(enrollmentGroupId);
-
         /* SRS_ENROLLMENT_GROUP_21_016: [The setEnrollmentGroupId shall store the provided enrollmentGroupId.] */
         this.enrollmentGroupId = enrollmentGroupId;
     }
@@ -488,9 +485,6 @@ public class EnrollmentGroup extends Serializable
     @Deprecated
     public void setIotHubHostName(String iotHubHostName)
     {
-        /* SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-        ParserUtility.validateHostName(iotHubHostName);
-
         /* SRS_ENROLLMENT_GROUP_21_022: [The setIotHubHostName shall store the provided iotHubHostName.] */
         this.iotHubHostName = iotHubHostName;
     }
@@ -511,9 +505,6 @@ public class EnrollmentGroup extends Serializable
      */
     public final void setIotHubHostNameFinal(String iotHubHostName)
     {
-        /* SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-        ParserUtility.validateHostName(iotHubHostName);
-
         /* SRS_ENROLLMENT_GROUP_21_022: [The setIotHubHostName shall store the provided iotHubHostName.] */
         this.iotHubHostName = iotHubHostName;
     }
@@ -717,9 +708,6 @@ public class EnrollmentGroup extends Serializable
     @Deprecated
     public void setEtag(String etag)
     {
-        /* SRS_ENROLLMENT_GROUP_21_036: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-        ParserUtility.validateStringUTF8(etag);
-
         /* SRS_ENROLLMENT_GROUP_21_037: [The setEtag shall store the provided etag.] */
         this.etag = etag;
     }
@@ -732,9 +720,6 @@ public class EnrollmentGroup extends Serializable
      */
     public final void setEtagFinal(String etag)
     {
-        /* SRS_ENROLLMENT_GROUP_21_036: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-        ParserUtility.validateStringUTF8(etag);
-
         /* SRS_ENROLLMENT_GROUP_21_037: [The setEtag shall store the provided etag.] */
         this.etag = etag;
     }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollment.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollment.java
@@ -377,9 +377,6 @@ public class IndividualEnrollment extends Serializable
      */
     protected final void setRegistrationId(String registrationId)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_017: [The setRegistrationId shall throw IllegalArgumentException if the provided registrationId is null, empty, or invalid.] */
-        ParserUtility.validateId(registrationId);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_018: [The setRegistrationId shall store the provided registrationId.] */
         this.registrationId = registrationId;
     }
@@ -420,11 +417,6 @@ public class IndividualEnrollment extends Serializable
      */
     public final void setDeviceIdFinal(String deviceId)
     {
-        if (deviceId == null || deviceId.isEmpty())
-        {
-            throw new IllegalArgumentException("Invalid deviceId parameter specified");
-        }
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_021: [The setDeviceId shall store the provided deviceId.] */
         this.deviceId = deviceId;
     }
@@ -449,9 +441,6 @@ public class IndividualEnrollment extends Serializable
      */
     protected final void setRegistrationState(DeviceRegistrationState registrationState)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_023: [The setRegistrationState shall throw IllegalArgumentException if the provided registrationState is null.] */
-        ParserUtility.validateObject(registrationState);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_024: [The setRegistrationState shall store the provided registrationState.] */
         this.registrationState = registrationState;
     }
@@ -481,9 +470,6 @@ public class IndividualEnrollment extends Serializable
      */
     protected final void setAttestation(AttestationMechanism attestationMechanism)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_026: [The setAttestation shall throw IllegalArgumentException if the attestation is null or invalid.] */
-        ParserUtility.validateObject(attestationMechanism);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_027: [The setAttestation shall store the provided attestation.] */
         try
         {
@@ -551,9 +537,6 @@ public class IndividualEnrollment extends Serializable
     @Deprecated
     public void setIotHubHostName(String iotHubHostName)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-        ParserUtility.validateHostName(iotHubHostName);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_030: [The setIotHubHostName shall store the provided iotHubHostName.] */
         this.iotHubHostName = iotHubHostName;
     }
@@ -574,9 +557,6 @@ public class IndividualEnrollment extends Serializable
      */
     public final void setIotHubHostNameFinal(String iotHubHostName)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-        ParserUtility.validateHostName(iotHubHostName);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_030: [The setIotHubHostName shall store the provided iotHubHostName.] */
         this.iotHubHostName = iotHubHostName;
     }
@@ -604,9 +584,6 @@ public class IndividualEnrollment extends Serializable
      */
     public void setInitialTwin(TwinState initialTwin)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_032: [The setInitialTwin shall throw IllegalArgumentException if the initialTwin is null.] */
-        ParserUtility.validateObject(initialTwin);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_033: [The setInitialTwin shall store the provided initialTwin.] */
         this.initialTwin = initialTwin;
     }
@@ -637,9 +614,6 @@ public class IndividualEnrollment extends Serializable
     @Deprecated
     public void setProvisioningStatus(ProvisioningStatus provisioningStatus)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_035: [The setProvisioningStatus shall throw IllegalArgumentException if the provisioningStatus is null.] */
-        ParserUtility.validateObject(provisioningStatus);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_036: [The setProvisioningStatus shall store the provided provisioningStatus.] */
         this.provisioningStatus = provisioningStatus;
     }
@@ -656,9 +630,6 @@ public class IndividualEnrollment extends Serializable
      */
     public final void setProvisioningStatusFinal(ProvisioningStatus provisioningStatus)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_035: [The setProvisioningStatus shall throw IllegalArgumentException if the provisioningStatus is null.] */
-        ParserUtility.validateObject(provisioningStatus);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_036: [The setProvisioningStatus shall store the provided provisioningStatus.] */
         this.provisioningStatus = provisioningStatus;
     }
@@ -749,9 +720,6 @@ public class IndividualEnrollment extends Serializable
     @Deprecated
     public void setEtag(String etag)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_047: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-        ParserUtility.validateStringUTF8(etag);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_048: [The setEtag shall store the provided etag.] */
         this.etag = etag;
     }
@@ -764,9 +732,6 @@ public class IndividualEnrollment extends Serializable
      */
     public final void setEtagFinal(String etag)
     {
-        /* SRS_INDIVIDUAL_ENROLLMENT_21_047: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-        ParserUtility.validateStringUTF8(etag);
-
         /* SRS_INDIVIDUAL_ENROLLMENT_21_048: [The setEtag shall store the provided etag.] */
         this.etag = etag;
     }

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/DeviceRegistrationStateTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/DeviceRegistrationStateTest.java
@@ -113,77 +113,6 @@ public class DeviceRegistrationStateTest
         assertNotNull(deviceRegistrationState);
     }
 
-    /* SRS_DEVICE_REGISTRATION_STATE_21_004: [The constructor shall throw IllegalArgumentException if the provided registrationId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnNullRegistrationId()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"assignedHub\":\"" + VALID_ASSIGNED_HUB + "\",\n" +
-                "    \"deviceId\":\"" + VALID_DEVICE_ID + "\",\n" +
-                "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                "}";
-
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_004: [The constructor shall throw IllegalArgumentException if the provided registrationId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnEmptyRegistrationId()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                "    \"registrationId\":\"\",\n" +
-                "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"assignedHub\":\"" + VALID_ASSIGNED_HUB + "\",\n" +
-                "    \"deviceId\":\"" + VALID_DEVICE_ID + "\",\n" +
-                "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                "}";
-
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_004: [The constructor shall throw IllegalArgumentException if the provided registrationId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidRegistrationId()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                "    \"registrationId\":\"&InvalidId\",\n" +
-                "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"assignedHub\":\"" + VALID_ASSIGNED_HUB + "\",\n" +
-                "    \"deviceId\":\"" + VALID_DEVICE_ID + "\",\n" +
-                "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                "}";
-
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
-    }
-
     /* SRS_DEVICE_REGISTRATION_STATE_21_005: [The constructor shall store the provided registrationId.] */
     @Test
     public void constructorStoreRegistrationId()
@@ -194,54 +123,6 @@ public class DeviceRegistrationStateTest
 
         // assert
         assertEquals(VALID_REGISTRATION_ID, Deencapsulation.getField(deviceRegistrationState, "registrationId"));
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_006: [The constructor shall throw IllegalArgumentException if the provided deviceId is empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnEmptyDeviceId()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                "    \"registrationId\":\"" + VALID_REGISTRATION_ID + "\",\n" +
-                "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"assignedHub\":\"" + VALID_ASSIGNED_HUB + "\",\n" +
-                "    \"deviceId\":\"\",\n" +
-                "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                "}";
-
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_006: [The constructor shall throw IllegalArgumentException if the provided deviceId is empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidDeviceId()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                "    \"registrationId\":\"" + VALID_REGISTRATION_ID + "\",\n" +
-                "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"assignedHub\":\"" + VALID_ASSIGNED_HUB + "\",\n" +
-                "    \"deviceId\":\"&InvalidId\",\n" +
-                "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                "}";
-
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
     }
 
     /* SRS_DEVICE_REGISTRATION_STATE_21_007: [The constructor shall store the provided deviceId.] */
@@ -451,52 +332,6 @@ public class DeviceRegistrationStateTest
 
         // assert
         assertNull(Deencapsulation.getField(deviceRegistrationState, "assignedHub"));
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_011: [The constructor shall throw IllegalArgumentException if an provided assignedHub is empty or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnEmptyAssignedHub()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                        "    \"registrationId\":\"" + VALID_REGISTRATION_ID + "\",\n" +
-                        "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                        "    \"assignedHub\":\"\",\n" +
-                        "    \"deviceId\":\"" + VALID_DEVICE_ID + "\",\n" +
-                        "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                        "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                        "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                        "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                        "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                        "}";
-        // act
-        new DeviceRegistrationState(json);
-
-        // assert
-    }
-
-    /* SRS_DEVICE_REGISTRATION_STATE_21_011: [The constructor shall throw IllegalArgumentException if an provided assignedHub is empty or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidAssignedHub()
-    {
-        // arrange
-        final String json =
-                "{\n" +
-                        "    \"registrationId\":\"" + VALID_REGISTRATION_ID + "\",\n" +
-                        "    \"createdDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                        "    \"assignedHub\":\"IncompleteHubName\",\n" +
-                        "    \"deviceId\":\"" + VALID_DEVICE_ID + "\",\n" +
-                        "    \"status\":\"" + VALID_STATUS + "\",\n" +
-                        "    \"lastUpdatedDateTimeUtc\": \"" + VALID_DATE_AS_STRING + "\",\n" +
-                        "    \"errorCode\":" + VALID_ERROR_CODE + ",\n" +
-                        "    \"errorMessage\":\"" + VALID_ERROR_MESSAGE + "\",\n" +
-                        "    \"etag\": \"" + VALID_ETAG + "\"\n" +
-                        "}";
-        // act
-        DeviceRegistrationState deviceRegistrationState = new DeviceRegistrationState(json);
-
-        // assert
     }
 
     /* SRS_DEVICE_REGISTRATION_STATE_21_014: [The constructor shall throw IllegalArgumentException if the provided status is invalid.] */

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
@@ -907,58 +907,6 @@ public class EnrollmentGroupTest
         assertEquals(VALID_PARSED_ETAG, enrollmentGroup.getEtag());
     }
 
-    /* Tests_SRS_ENROLLMENT_GROUP_21_015: [The setEnrollmentGroupId shall throw IllegalArgumentException if the provided enrollmentGroupId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEnrollmentGroupIdThrowsOnNull()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEnrollmentGroupId", new Class[] {String.class}, (String)null);
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_015: [The setEnrollmentGroupId shall throw IllegalArgumentException if the provided enrollmentGroupId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEnrollmentGroupIdThrowsOnEmpty()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEnrollmentGroupId", new Class[] {String.class}, "");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_015: [The setEnrollmentGroupId shall throw IllegalArgumentException if the provided enrollmentGroupId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEnrollmentGroupIdThrowsOnNotUtf8()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEnrollmentGroupId", new Class[] {String.class}, "\u1234-invalid");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_015: [The setEnrollmentGroupId shall throw IllegalArgumentException if the provided enrollmentGroupId is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEnrollmentGroupIdThrowsOnInvalidChar()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEnrollmentGroupId", new Class[] {String.class}, "invalid&");
-
-        // assert
-    }
-
     /* Tests_SRS_ENROLLMENT_GROUP_21_016: [The setEnrollmentGroupId shall store the provided enrollmentGroupId.] */
     @Test
     public void setEnrollmentGroupIdSucceed()
@@ -1199,71 +1147,6 @@ public class EnrollmentGroupTest
         };
     }
 
-    /* Tests_SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnNull()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        enrollmentGroup.setIotHubHostNameFinal(null);
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnEmpty()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        enrollmentGroup.setIotHubHostNameFinal("");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnNotUTF8()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        enrollmentGroup.setIotHubHostNameFinal("NewHostName.\u1234a.b");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnInvalidChar()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        enrollmentGroup.setIotHubHostNameFinal("NewHostName.&a.b");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_021: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnIncompleteName()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        enrollmentGroup.setIotHubHostNameFinal("NewHostName");
-
-        // assert
-    }
-
     /* Tests_SRS_ENROLLMENT_GROUP_21_022: [The setIotHubHostName shall store the provided iotHubHostName.] */
     @Test
     public void setIotHubHostNameSucceed()
@@ -1440,45 +1323,6 @@ public class EnrollmentGroupTest
 
         // act
         Deencapsulation.invoke(enrollmentGroup,"setLastUpdatedDateTimeUtc", new Class[] {String.class}, (String)"0000-00-00 00:00:00");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_036: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnNull()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEtag", new Class[] {String.class}, (String)null);
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_036: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnEmpty()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardSymmetricKeyEnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEtag", new Class[] {String.class}, (String)"");
-
-        // assert
-    }
-
-    /* Tests_SRS_ENROLLMENT_GROUP_21_036: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnNotUTF8()
-    {
-        // arrange
-        EnrollmentGroup enrollmentGroup = makeStandardSymmetricKeyEnrollmentGroup();
-
-        // act
-        Deencapsulation.invoke(enrollmentGroup, "setEtag", new Class[] {String.class}, (String)"\u1234InvalidEtag");
 
         // assert
     }

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
@@ -771,58 +771,6 @@ public class IndividualEnrollmentTest
         assertEquals(VALID_PARSED_ETAG, individualEnrollment.getEtag());
     }
 
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_017: [The setRegistrationId shall throw IllegalArgumentException if the provided registrationId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setRegistrationIdThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setRegistrationId", new Class[] {String.class}, (String)null);
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_017: [The setRegistrationId shall throw IllegalArgumentException if the provided registrationId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setRegistrationIdThrowsOnEmpty()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setRegistrationId", new Class[] {String.class}, "");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_017: [The setRegistrationId shall throw IllegalArgumentException if the provided registrationId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setRegistrationIdThrowsOnNotUtf8()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setRegistrationId", new Class[] {String.class}, "\u1234-invalid");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_017: [The setRegistrationId shall throw IllegalArgumentException if the provided registrationId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setRegistrationIdThrowsOnInvalidChar()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setRegistrationId", new Class[] {String.class}, "invalid&");
-
-        // assert
-    }
-
     /* SRS_INDIVIDUAL_ENROLLMENT_21_018: [The setRegistrationId shall store the provided registrationId.] */
     @Test
     public void setRegistrationIdSucceed()
@@ -837,32 +785,6 @@ public class IndividualEnrollmentTest
 
         // assert
         assertEquals(newRegistrationId, Deencapsulation.getField(individualEnrollment, "registrationId"));
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_020: [The setDeviceId shall throw IllegalArgumentException if the provided deviceId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setDeviceIdThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setDeviceId", new Class[] {String.class}, (String)null);
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_020: [The setDeviceId shall throw IllegalArgumentException if the provided deviceId is {@code null}, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setDeviceIdThrowsOnEmpty()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setDeviceId", new Class[] {String.class}, "");
-
-        // assert
     }
 
     /* SRS_INDIVIDUAL_ENROLLMENT_21_021: [The setDeviceId shall store the provided deviceId.] */
@@ -881,19 +803,6 @@ public class IndividualEnrollmentTest
         assertEquals(newDeviceId, Deencapsulation.getField(individualEnrollment, "deviceId"));
     }
 
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_023: [The setRegistrationState shall throw IllegalArgumentException if the provided registrationState is null.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setRegistrationStateThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setRegistrationState", new Class[] {DeviceRegistrationState.class}, (DeviceRegistrationState)null);
-
-        // assert
-    }
-
     /* SRS_INDIVIDUAL_ENROLLMENT_21_024: [The setRegistrationState shall store the provided registrationState.] */
     @Test
     public void setRegistrationStateSucceed(@Mocked final DeviceRegistrationState mockedDeviceRegistrationState)
@@ -907,19 +816,6 @@ public class IndividualEnrollmentTest
 
         // assert
         assertEquals(mockedDeviceRegistrationState, Deencapsulation.getField(individualEnrollment, "registrationState"));
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_026: [The setAttestation shall throw IllegalArgumentException if the attestation is null.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setAttestationMechanismThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setAttestation", new Class[]{AttestationMechanism.class}, (AttestationMechanism)null);
-
-        // assert
     }
 
     /* SRS_INDIVIDUAL_ENROLLMENT_21_027: [The setAttestation shall store the provided attestation.] */
@@ -982,71 +878,6 @@ public class IndividualEnrollmentTest
         };
     }
 
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setIotHubHostNameFinal(null);
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnEmpty()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setIotHubHostNameFinal("");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnNotUTF8()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setIotHubHostNameFinal("NewHostName.\u1234a.b");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnInvalidChar()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setIotHubHostNameFinal("NewHostName.&a.b");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_029: [The setIotHubHostName shall throw IllegalArgumentException if the iotHubHostName is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setIotHubHostNameThrowsOnIncompleteName()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setIotHubHostNameFinal("NewHostName");
-
-        // assert
-    }
-
     /* SRS_INDIVIDUAL_ENROLLMENT_21_030: [The setIotHubHostName shall store the provided iotHubHostName.] */
     @Test
     public void setIotHubHostNameSucceed()
@@ -1063,19 +894,6 @@ public class IndividualEnrollmentTest
         assertEquals(newHostName, Deencapsulation.getField(individualEnrollment, "iotHubHostName"));
     }
 
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_032: [The setInitialTwin shall throw IllegalArgumentException if the initialTwin is null.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setInitialTwinThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setInitialTwin(null);
-
-        // assert
-    }
-
     /* SRS_INDIVIDUAL_ENROLLMENT_21_033: [The setInitialTwin shall store the provided initialTwin.] */
     @Test
     public void setInitialTwinSucceed(@Mocked final TwinState mockedTwinState)
@@ -1089,19 +907,6 @@ public class IndividualEnrollmentTest
 
         // assert
         assertEquals(mockedTwinState, Deencapsulation.getField(individualEnrollment, "initialTwin"));
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_035: [The setProvisioningStatus shall throw IllegalArgumentException if the provisioningStatus is null.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setProvisioningStatusThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        individualEnrollment.setProvisioningStatusFinal(null);
-
-        // assert
     }
 
     /* SRS_INDIVIDUAL_ENROLLMENT_21_036: [The setProvisioningStatus shall store the provided provisioningStatus.] */
@@ -1223,45 +1028,6 @@ public class IndividualEnrollmentTest
 
         // act
         Deencapsulation.invoke(individualEnrollment,"setLastUpdatedDateTimeUtc", new Class[] {String.class}, (String)"0000-00-00 00:00:00");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_047: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnNull()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setEtag", new Class[] {String.class}, (String)null);
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_047: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnEmpty()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setEtag", new Class[] {String.class}, (String)"");
-
-        // assert
-    }
-
-    /* SRS_INDIVIDUAL_ENROLLMENT_21_047: [The setEtag shall throw IllegalArgumentException if the etag is null, empty, or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void setEtagThrowsOnNotUTF8()
-    {
-        // arrange
-        IndividualEnrollment individualEnrollment = makeStandardEnrollment();
-
-        // act
-        Deencapsulation.invoke(individualEnrollment, "setEtag", new Class[] {String.class}, (String)"\u1234InvalidEtag");
 
         // assert
     }


### PR DESCRIPTION
-Relax all device side validation of registration id, device id, etag, etc. for provisioning
-Took out a useless Thread.sleep(...) in provisioning e2e test flow