### PR TITLE
fix(iot-dev): Fix issue where device client created with security pro…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
@@ -141,7 +141,7 @@ public class IotHubConnectionString
                                   String sharedAccessKey, String sharedAccessToken)
             throws IllegalArgumentException, URISyntaxException
     {
-        this(hostName, deviceId, sharedAccessKey, sharedAccessToken, "");
+        this(hostName, deviceId, sharedAccessKey, sharedAccessToken, null);
     }
 
     public IotHubConnectionString(String hostName, String deviceId,

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -335,7 +335,7 @@ public class ProvisioningCommon extends IntegrationTest
             {
                 if (withRetry)
                 {
-                    if (((System.currentTimeMillis() - startTime) < timeoutInMillis))
+                    if (((System.currentTimeMillis() - startTime) > timeoutInMillis))
                     {
                         fail(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Timed out waiting for device to register successfully, last exception: " + Tools.getStackTraceFromThrowable(e), getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId));
                     }


### PR DESCRIPTION
…vider could not receive c2d messages over mqtt

within mqtt layer, there is a check to subscribe to c2d only if the device is connecting to iot hub (rather than an edge device). That check is if the gateway hostname is null. Since it was being set to empty string within iothubconnectionstring's constructor, the check at the mqtt level believed it to be connecting to an edge device, and would not subscribe to c2d messages

Also fixed a small logical mistake when checking for timeouts in provisioning e2e device registration