### PR TITLE
fix(iot-dev): Fix amqp layer not checking for local errors during err…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslator.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslator.java
@@ -91,6 +91,8 @@ public class AmqpsExceptionTranslator
             case AmqpConnectionThrottledException.errorCode:
                 // Codes_SRS_AMQPSEXCEPTIONTRANSLATOR_28_001: [The function shall map amqp exception code "com.microsoft:device-container-throttled" to TransportException "AmqpConnectionThrottledException".]
                 return new AmqpConnectionThrottledException(description);
+            case ProtonIOException.errorCode:
+                return  new ProtonIOException(description);
             default:
                 // Codes_SRS_AMQPSEXCEPTIONTRANSLATOR_34_026: [The function shall map all other amqp exception codes to the generic TransportException "ProtocolException".]
                 return new ProtocolException(description);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/exceptions/ProtonIOException.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/exceptions/ProtonIOException.java
@@ -1,0 +1,32 @@
+package com.microsoft.azure.sdk.iot.device.transport.amqps.exceptions;
+
+import com.microsoft.azure.sdk.iot.device.exceptions.ProtocolException;
+
+public class ProtonIOException extends ProtocolException
+{
+    public static final String errorCode = "proton:io";
+
+    public ProtonIOException()
+    {
+        super();
+        this.isRetryable = true;
+    }
+
+    public ProtonIOException(String message)
+    {
+        super(message);
+        this.isRetryable = true;
+    }
+
+    public ProtonIOException(String message, Throwable cause)
+    {
+        super(message, cause);
+        this.isRetryable = true;
+    }
+
+    public ProtonIOException(Throwable cause)
+    {
+        super(cause);
+        this.isRetryable = true;
+    }
+}

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslatorTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslatorTest.java
@@ -73,5 +73,6 @@ public class AmqpsExceptionTranslatorTest
         assertTrue(Deencapsulation.invoke(AmqpsExceptionTranslator.class, "convertToAmqpException", AmqpLinkRedirectException.errorCode, "") instanceof AmqpLinkRedirectException);
         assertTrue(Deencapsulation.invoke(AmqpsExceptionTranslator.class, "convertToAmqpException", AmqpConnectionThrottledException.errorCode, "") instanceof AmqpConnectionThrottledException);
         assertTrue(Deencapsulation.invoke(AmqpsExceptionTranslator.class, "convertToAmqpException", "Not a protocol standard error code", "") instanceof ProtocolException);
+        assertTrue(Deencapsulation.invoke(AmqpsExceptionTranslator.class, "convertToAmqpException", ProtonIOException.errorCode, "") instanceof ProtonIOException);
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -2323,8 +2323,21 @@ public class AmqpsIotHubConnectionTest {
         new Expectations()
         {
             {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = null;
                 mockEvent.getTransport();
                 result = mockTransport;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = null;
+                mockTransport.getCondition();
+                result = null;
+
                 mockTransport.getRemoteCondition();
                 result = mockedErrorCondition;
                 mockedErrorCondition.getCondition();
@@ -2679,7 +2692,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getLink();
                 result = null;
 
-                mockSender.getRemoteCondition();
+                mockSender.getCondition();
                 result = mockedErrorCondition;
 
                 mockedErrorCondition.getCondition();
@@ -2732,7 +2745,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getLink();
                 result = null;
 
-                mockReceiver.getRemoteCondition();
+                mockReceiver.getCondition();
                 result = mockedErrorCondition;
 
                 mockedErrorCondition.getCondition();
@@ -2785,7 +2798,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getLink();
                 result = null;
 
-                mockTransport.getRemoteCondition();
+                mockTransport.getCondition();
                 result = mockedErrorCondition;
 
                 mockedErrorCondition.getCondition();
@@ -2838,7 +2851,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getLink();
                 result = null;
 
-                mockSession.getRemoteCondition();
+                mockSession.getCondition();
                 result = mockedErrorCondition;
 
                 mockedErrorCondition.getCondition();
@@ -2891,7 +2904,7 @@ public class AmqpsIotHubConnectionTest {
                 mockEvent.getLink();
                 result = null;
 
-                mockConnection.getRemoteCondition();
+                mockConnection.getCondition();
                 result = mockedErrorCondition;
 
                 mockedErrorCondition.getCondition();
@@ -2922,6 +2935,323 @@ public class AmqpsIotHubConnectionTest {
     // Tests_SRS_AMQPSIOTHUBCONNECTION_34_085: [If an exception can be found in the link, this function shall return a the mapped amqp exception derived from that exception.]
     @Test
     public void getErrorFromEventOutOfLink(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = null;
+                mockEvent.getTransport();
+                result = null;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = mockLink;
+
+                mockLink.getCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    @Test
+    public void getErrorFromEventOutOfSenderRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = mockSender;
+                mockEvent.getReceiver();
+                result = null;
+                mockEvent.getTransport();
+                result = null;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = null;
+
+                mockSender.getRemoteCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    // Tests_SRS_AMQPSIOTHUBCONNECTION_34_082: [If an exception can be found in the receiver, this function shall return a the mapped amqp exception derived from that exception.]
+    @Test
+    public void getErrorFromEventOutOfReceiverRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = mockReceiver;
+                mockEvent.getTransport();
+                result = null;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = null;
+
+                mockReceiver.getRemoteCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    // Tests_SRS_AMQPSIOTHUBCONNECTION_34_086: [If an exception can be found in the transport, this function shall return a the mapped amqp exception derived from that exception.]
+    @Test
+    public void getErrorFromEventOutOfTransportRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = null;
+                mockEvent.getTransport();
+                result = mockTransport;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = null;
+
+                mockTransport.getRemoteCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    // Tests_SRS_AMQPSIOTHUBCONNECTION_34_083: [If an exception can be found in the session, this function shall return a the mapped amqp exception derived from that exception.]
+    @Test
+    public void getErrorFromEventOutOfSessionRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = null;
+                mockEvent.getTransport();
+                result = null;
+                mockEvent.getSession();
+                result = mockSession;
+                mockEvent.getConnection();
+                result = null;
+                mockEvent.getLink();
+                result = null;
+
+                mockSession.getRemoteCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    // Tests_SRS_AMQPSIOTHUBCONNECTION_34_084: [If an exception can be found in the connection, this function shall return a the mapped amqp exception derived from that exception.]
+    @Test
+    public void getErrorFromEventOutOfConnectionRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
+    {
+        //arrange
+        baseExpectations();
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final String expectedError = AmqpConnectionFramingErrorException.errorCode;
+        final String expectedErrorDescription = "sender error description";
+        new NonStrictExpectations()
+        {
+            {
+                mockEvent.getSender();
+                result = null;
+                mockEvent.getReceiver();
+                result = null;
+                mockEvent.getTransport();
+                result = null;
+                mockEvent.getSession();
+                result = null;
+                mockEvent.getConnection();
+                result = mockConnection;
+                mockEvent.getLink();
+                result = null;
+
+                mockConnection.getRemoteCondition();
+                result = mockedErrorCondition;
+
+                mockedErrorCondition.getCondition();
+                result = mockedSymbol;
+
+                mockedSymbol.toString();
+                result = expectedError;
+
+                mockedErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                new AmqpConnectionFramingErrorException(expectedErrorDescription);
+                result = mockedAmqpConnectionFramingErrorException;
+
+                mockedAmqpConnectionFramingErrorException.getMessage();
+                result = expectedErrorDescription;
+            }
+        };
+
+        //act
+        TransportException actualException = Deencapsulation.invoke(connection, "getTransportExceptionFromEvent", mockEvent);
+
+        //assert
+        assertTrue(actualException instanceof AmqpConnectionFramingErrorException);
+        assertEquals(expectedErrorDescription, actualException.getMessage());
+    }
+
+    // Tests_SRS_AMQPSIOTHUBCONNECTION_34_085: [If an exception can be found in the link, this function shall return a the mapped amqp exception derived from that exception.]
+    @Test
+    public void getErrorFromEventOutOfLinkRemote(final @Mocked ErrorCondition mockedErrorCondition, @Mocked final AmqpConnectionFramingErrorException mockedAmqpConnectionFramingErrorException) throws TransportException
     {
         //arrange
         baseExpectations();


### PR DESCRIPTION
…or mapping

The SDK was only checking for remote errors previously