### PR TITLE
Bump package versions for release on 2019-06-03

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.4</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client</artifactId>
     <name>IoT Hub Java Device Client</name>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
     <description>The Microsoft Azure IoT Device SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.4</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.17.2";
+    private static final String CLIENT_VERSION = "1.17.3";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.17.2'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.17.3'
 }
 
 repositories {

--- a/device/iot-device-samples/device-method-sample/pom.xml
+++ b/device/iot-device-samples/device-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/device-twin-sample/pom.xml
+++ b/device/iot-device-samples/device-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/file-upload-sample/pom.xml
+++ b/device/iot-device-samples/file-upload-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/handle-messages/pom.xml
+++ b/device/iot-device-samples/handle-messages/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-invoke-method-sample/pom.xml
+++ b/device/iot-device-samples/module-invoke-method-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-method-sample/pom.xml
+++ b/device/iot-device-samples/module-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-twin-sample/pom.xml
+++ b/device/iot-device-samples/module-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-device-samples</artifactId>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
     <name>IoT Hub Java Device SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/device/iot-device-samples/send-event-x509/pom.xml
+++ b/device/iot-device-samples/send-event-x509/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-event/pom.xml
+++ b/device/iot-device-samples/send-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-module-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-module-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-receive-x509-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-x509-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-serialized-event/pom.xml
+++ b/device/iot-device-samples/send-serialized-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/pom.xml
+++ b/device/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client-parent</artifactId>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
     <name>IoT Hub Java Device Client Parent </name>
     <packaging>pom</packaging>
     <developers>

--- a/iot-e2e-tests/android/app/build.gradle
+++ b/iot-e2e-tests/android/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:multidex:1.0.3'
 
-    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.0'){
+    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.1'){
         exclude module: 'junit'
         exclude module: 'azure-storage'
     }

--- a/iot-e2e-tests/android/things/build.gradle
+++ b/iot-e2e-tests/android/things/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:multidex:1.0.3'
 
-    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.0'){
+    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.1'){
         exclude module: 'junit'
         exclude module: 'azure-storage'
     }

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-common</artifactId>
     <name>IoT Hub Java SDK common</name>
-    <version>0.25.0</version>
+    <version>0.25.1</version>
     <description>Test suite fot the Microsoft Azure IoT Device SDK for Java</description>
     <developers>
         <developer>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -42,18 +42,18 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
 

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-jvm-tests</artifactId>
     <name>IoT Hub Java SDK jvm tests</name>
-    <version>0.25.0</version>
+    <version>0.25.1</version>
     <description>Test suite for the Microsoft Azure IoT Device SDK for Java</description>
     <developers>
         <developer>
@@ -34,25 +34,25 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
             <scope>test</scope>
         </dependency>
         <!-- test dependencies -->
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-e2e-common</artifactId>
-            <version>0.25.0</version>
+            <version>0.25.1</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/iot-e2e-tests/pom.xml
+++ b/iot-e2e-tests/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
 	<artifactId>iot-e2e-tests</artifactId>
 	<name>IoT Hub Java SDK tests</name>
-	<version>0.25.0</version>
+	<version>0.25.1</version>
 	<description>Test suite fot the Microsoft Azure IoT Device SDK for Java</description>
     <packaging>pom</packaging>
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-sdk-java</artifactId>
-    <version>0.25.0</version>
+    <version>0.25.1</version>
     <name>Azure IoT Sdk Java</name>
     <packaging>pom</packaging>
     <developers>

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning</artifactId>
     <name>Provisioning Client</name>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
     <description>The Microsoft Azure IoT Provisioning Client SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning-device-client</artifactId>
     <name>Provisioning Device Client</name>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Device Client for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.4</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.7.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.7.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-samples/pom.xml
+++ b/provisioning/provisioning-samples/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-samples</artifactId>
     <name>Provisioning Samples</name>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
     <description>The Microsoft Azure IoT Provisioning Samples for Device and Service SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-X509-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning X509 Sample for Device Client</name>
     <developers>
         <developer>
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-symmetrickey-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning Symmetric Key Sample for Device Client</name>
     <developers>
         <developer>
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-tpm-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning TPM Sample for Device Client</name>
     <developers>
         <developer>
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.sample</groupId>
     <artifactId>service-bulkoperation-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning bulk individual enrollments using service Sample</name>
     <developers>
         <developer>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-group-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning enrollmentGroup using service Sample</name>
     <developers>
         <developer>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Provisioning individual enrollment using service Sample</name>
     <developers>
         <developer>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-update-enrollment-sample</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <name>Update individual enrollment using service Sample</name>
     <developers>
         <developer>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning-service-client</artifactId>
     <name>Provisioning Service Client</name>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Service Client SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.4</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.5.1";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.5.2";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-tools/pom.xml
+++ b/provisioning/provisioning-tools/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.tools</groupId>
     <artifactId>provisioning-tools</artifactId>
     <name>Provisioning Tools</name>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
     <description>The Microsoft Azure IoT Provisioning Tools for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
+++ b/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.tools</groupId>
     <artifactId>provisioning-x509-cert-generator</artifactId>
     <name>Provisioning X509 cert generator</name>
-    <version>1.7.0</version>
+    <version>1.8.1</version>
     <description>The Microsoft Azure IoT Provisioning Cert Generator for Java</description>
     <developers>
         <developer>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client</artifactId>
     <name>Iot Hub Java Service SDK</name>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <description>The Microsoft Azure IoT Service SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.17.0";
+    public static String serviceVersion = "1.17.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-manager-sample</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>Device Manager Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-method-sample</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>Device Method Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-twin-sample</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>Device Twin Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>job-client-sample</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>Job Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/pom.xml
+++ b/service/iot-service-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-service-samples</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>IoT Hub Service SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>service-client-sample</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>Service Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client-parent</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <name>IoT Hub Java Service SDK Parent</name>
     <packaging>pom</packaging>
     <developers>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.17.3)
•	 Client objects now check for message expiry regardless of connection state (issue #523)

**Bug Fixes**
•	 Fix bug where client object created with security provider could not receive MQTT C2D messages (issue #528)
•	 Fix bug where amqp stack did not check for local endpoint errors during a lost connection



## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.17.1)
**Bug Fixes**
•	 Fix bug where ConnectionState was not parsed from service correctly, and was not propagated up to DeviceTwinDevice object (issue #520)



## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.8.4)
•	 Add support for retry-after headers sent by service

**Bug Fixes**
•	 Fix bug where ConnectionState was not parsed from service correctly, and was not propagated up to DeviceTwinDevice object (issue #520) 


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.7.1)
•	 Add support for retry-after headers sent by service

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.5.2)
•	Remove more device side validation of individual enrollment and enrollment group fields
