### PR TITLE
refactor(e2e): Fix SDK so it compiles under java 11

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -124,6 +124,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <version>3.0.1</version>
                 <executions>
                     <execution>

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/auth/IotHubSSLContext.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/auth/IotHubSSLContext.java
@@ -125,6 +125,7 @@ public class IotHubSSLContext
      * @throws IOException If the certificate provided was null or invalid
      * @throws CertificateException As per https://docs.oracle.com/javase/7/docs/api/java/security/cert/CertificateException.html
      * @throws NoSuchAlgorithmException if the default SSL Context cannot be created
+     * @throws UnrecoverableKeyException if accessing the protected keystore fails
      */
     public IotHubSSLContext(String publicKeyCertificateString, String privateKeyString, String cert, boolean isPath)
             throws KeyStoreException, KeyManagementException, IOException, CertificateException, NoSuchAlgorithmException, UnrecoverableKeyException

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ExportImportDeviceParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ExportImportDeviceParser.java
@@ -269,7 +269,7 @@ public class ExportImportDeviceParser
 
     /**
      * Setter for authentication
-     *
+     * @param authentication the authentication to set
      * @throws IllegalArgumentException if authentication is null
      */
     public void setAuthentication(AuthenticationParser authentication) throws IllegalArgumentException

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -130,6 +130,7 @@ public class AmqpsConnection extends BaseHandler
 
     /**
      * Returns the status of the connection
+     * @throws Exception if any exception occurred during sasl negotiation
      * @return status of the connection
      */
     public boolean isConnected() throws Exception

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -125,6 +125,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -287,7 +287,7 @@ public class InternalClient
      * be provided alongside the status and reason.
      *
      * @param callback The callback to be fired when the connection status of the device changes. Can be null to
-     *                 unset this listener as long as the provided callbackContext is also null.
+     *                 unset this listener as long as the maven-javadoc-pluginprovided callbackContext is also null.
      * @param callbackContext a context to be passed to the callback. Can be {@code null}.
      * @throws IllegalArgumentException if provided callback is null
      */

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -179,11 +179,11 @@ public class ReceiveMessagesCommon extends IntegrationTest
 
             /* Create device on the service */
             Device device = Device.createFromId(deviceId, null, null);
-            Module module = Module.createFromId(deviceId, moduleId, null);
+            com.microsoft.azure.sdk.iot.service.Module module = com.microsoft.azure.sdk.iot.service.Module.createFromId(deviceId, moduleId, null);
 
             Device deviceX509 = Device.createDevice(deviceX509Id, AuthenticationType.SELF_SIGNED);
             deviceX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
-            Module moduleX509 = Module.createModule(deviceX509Id, moduleX509Id, AuthenticationType.SELF_SIGNED);
+            com.microsoft.azure.sdk.iot.service.Module moduleX509 = com.microsoft.azure.sdk.iot.service.Module.createModule(deviceX509Id, moduleX509Id, AuthenticationType.SELF_SIGNED);
             moduleX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
             device = Tools.addDeviceWithRetry(registryManager, device);
             deviceX509 = Tools.addDeviceWithRetry(registryManager, deviceX509);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -193,11 +193,11 @@ public class SendMessagesCommon extends IntegrationTest
 
             /* Create device on the service */
             Device device = Device.createFromId(deviceId, null, null);
-            Module module = Module.createFromId(deviceId, moduleId, null);
+            com.microsoft.azure.sdk.iot.service.Module module = com.microsoft.azure.sdk.iot.service.Module.createFromId(deviceId, moduleId, null);
 
             Device deviceX509 = Device.createDevice(deviceX509Id, AuthenticationType.SELF_SIGNED);
             deviceX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
-            Module moduleX509 = Module.createModule(deviceX509Id, moduleX509Id, AuthenticationType.SELF_SIGNED);
+            com.microsoft.azure.sdk.iot.service.Module moduleX509 = com.microsoft.azure.sdk.iot.service.Module.createModule(deviceX509Id, moduleX509Id, AuthenticationType.SELF_SIGNED);
             moduleX509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
             device = Tools.addDeviceWithRetry(registryManager, device);
             deviceX509 = Tools.addDeviceWithRetry(registryManager, deviceX509);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/serviceclient/RegistryManagerTests.java
@@ -191,14 +191,14 @@ public class RegistryManagerTests extends IntegrationTest
         deleteModuleIfItExistsAlready(registryManager, testInstance.deviceId, testInstance.moduleId);
 
         //-Create-//
-        Module moduleAdded = Module.createFromId(testInstance.deviceId, testInstance.moduleId, null);
+        com.microsoft.azure.sdk.iot.service.Module moduleAdded = com.microsoft.azure.sdk.iot.service.Module.createFromId(testInstance.deviceId, testInstance.moduleId, null);
         Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
-        Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
+        com.microsoft.azure.sdk.iot.service.Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
 
         //-Update-//
-        Module moduleUpdated = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
+        com.microsoft.azure.sdk.iot.service.Module moduleUpdated = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
         moduleUpdated.getSymmetricKey().setPrimaryKeyFinal(expectedSymmetricKey.getPrimaryKey());
         moduleUpdated = registryManager.updateModule(moduleUpdated);
 
@@ -227,11 +227,11 @@ public class RegistryManagerTests extends IntegrationTest
         deleteModuleIfItExistsAlready(registryManager, testInstance.deviceId, testInstance.moduleId);
 
         //-Create-//
-        Module moduleAdded = Module.createModule(testInstance.deviceId, testInstance.moduleId, AuthenticationType.CERTIFICATE_AUTHORITY);
+        com.microsoft.azure.sdk.iot.service.Module moduleAdded = com.microsoft.azure.sdk.iot.service.Module.createModule(testInstance.deviceId, testInstance.moduleId, AuthenticationType.CERTIFICATE_AUTHORITY);
         Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
-        Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
+        com.microsoft.azure.sdk.iot.service.Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
 
         //-Delete-//
         registryManager.removeModule(testInstance.deviceId, testInstance.moduleId);
@@ -260,15 +260,15 @@ public class RegistryManagerTests extends IntegrationTest
         deleteModuleIfItExistsAlready(registryManager, testInstance.deviceId, testInstance.moduleId);
 
         //-Create-//
-        Module moduleAdded = Module.createModule(testInstance.deviceId, testInstance.moduleId, AuthenticationType.SELF_SIGNED);
+        com.microsoft.azure.sdk.iot.service.Module moduleAdded = com.microsoft.azure.sdk.iot.service.Module.createModule(testInstance.deviceId, testInstance.moduleId, AuthenticationType.SELF_SIGNED);
         moduleAdded.setThumbprintFinal(primaryThumbprint, secondaryThumbprint);
         Tools.addModuleWithRetry(registryManager, moduleAdded);
 
         //-Read-//
-        Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
+        com.microsoft.azure.sdk.iot.service.Module moduleRetrieved = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
 
         //-Update-//
-        Module moduleUpdated = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
+        com.microsoft.azure.sdk.iot.service.Module moduleUpdated = registryManager.getModule(testInstance.deviceId, testInstance.moduleId);
         moduleUpdated.setThumbprintFinal(primaryThumbprint2, secondaryThumbprint2);
         moduleUpdated = registryManager.updateModule(moduleUpdated);
 

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -84,6 +84,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -86,6 +86,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -91,6 +91,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -91,6 +91,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -81,6 +81,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -96,6 +96,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -96,6 +96,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -97,6 +97,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -102,6 +102,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <version>3.0.1</version>
                 <executions>
                     <execution>

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -26,6 +26,18 @@ jobs:
     env:
       COMMIT_FROM: $(COMMIT_FROM)
     condition: always()
+  
+  - task: JavaToolInstaller@0
+    inputs:
+    versionSpec: '12'
+    jdkArchitectureOption: 'x64'
+    jdkSourceOption: AzureStorage
+    azureResourceManagerEndpoint: javatestwin
+    azureStorageAccountName: myAzureStorageAccountName
+    azureContainerName: jdk12install
+    azureCommonVirtualFile: 'jdk-12.0.2_windows-x64_bin.zip'
+    jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk12'
+    cleanDestinationDirectory: false
     
   - powershell: ./vsts/build_repo.ps1
     displayName: 'Build and Test'
@@ -99,7 +111,19 @@ jobs:
        127.0.0.1:2321:2321
        127.0.0.1:2322:2322
       restartPolicy: unlessStopped      
-      
+
+  - task: JavaToolInstaller@0
+    inputs:
+    versionSpec: '12'
+    jdkArchitectureOption: 'x64'
+    jdkSourceOption: AzureStorage
+    azureResourceManagerEndpoint: javatestwin
+    azureStorageAccountName: myAzureStorageAccountName
+    azureContainerName: jdk12install
+    azureCommonVirtualFile: 'jdk-12.0.2_linux-x64_bin.tar.gz'
+    jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk12'
+    cleanDestinationDirectory: false
+    
   - powershell: ./vsts/build_repo.ps1
     displayName: 'Build and Test'
     env:
@@ -143,163 +167,3 @@ jobs:
     condition: always()  
     
  ### Android, Multi configuration build (12 different test groups to cover) ###
-- job: AndroidBuild
-  timeoutInMinutes: 180
-  pool:
-    name: Hosted VS2017
-  displayName: Android Build
-
-  steps:
-  - powershell: ./vsts/echo_inputs.ps1
-    displayName: 'Echo Inputs'
-    env:
-      COMMIT_FROM: $(COMMIT_FROM)
-    condition: always()
-    
-  - powershell: ./vsts/manual_checkout.ps1
-    displayName: 'GIT checkout'
-    env:
-      COMMIT_FROM: $(COMMIT_FROM)
-    condition: always()
-
-  - powershell: ./vsts/android_java.cmd
-    displayName: 'Android Build'
-    env:
-      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
-      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
-      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
-      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
-      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
-      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
-      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
-      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
-      IS_BASIC_TIER_HUB: $(IS-BASIC-TIER-HUB) 
-    condition: always()
-      
-  - task: CopyFiles@2
-    displayName: 'Copy Test Results to Artifact Staging Directory'
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\iot-e2e-tests\android\app\build\outputs\apk'
-      Contents: |
-       *.*
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    continueOnError: true
-    condition: always()
-    
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'androidBuildFiles'
-      targetPath: 'iot-e2e-tests\android\app\build\outputs\apk'
-    
-- job: AndroidTest
-  timeoutInMinutes: 180
-  pool:
-    name: Hosted VS2017
-  strategy:
-    maxParallel: 12
-    matrix:
-      TestGroup1:
-        ANDROID_TEST_GROUP_ID: TestGroup1
-      TestGroup2:
-        ANDROID_TEST_GROUP_ID: TestGroup2
-      TestGroup3:
-        ANDROID_TEST_GROUP_ID: TestGroup3
-      TestGroup4:
-        ANDROID_TEST_GROUP_ID: TestGroup4
-      TestGroup5:
-        ANDROID_TEST_GROUP_ID: TestGroup5
-      TestGroup6:
-        ANDROID_TEST_GROUP_ID: TestGroup6
-      TestGroup7:
-        ANDROID_TEST_GROUP_ID: TestGroup7
-      TestGroup8:
-        ANDROID_TEST_GROUP_ID: TestGroup8
-      TestGroup9:
-        ANDROID_TEST_GROUP_ID: TestGroup9
-      TestGroup10:
-        ANDROID_TEST_GROUP_ID: TestGroup10
-      TestGroup11:
-        ANDROID_TEST_GROUP_ID: TestGroup11
-      TestGroup12:
-        ANDROID_TEST_GROUP_ID: TestGroup12
-      TestGroup13:
-        ANDROID_TEST_GROUP_ID: TestGroup13
-      TestGroup14:
-        ANDROID_TEST_GROUP_ID: TestGroup14
-      TestGroup15:
-        ANDROID_TEST_GROUP_ID: TestGroup15
-      TestGroup16:
-        ANDROID_TEST_GROUP_ID: TestGroup16
-      TestGroup17:
-        ANDROID_TEST_GROUP_ID: TestGroup17
-      TestGroup18:
-        ANDROID_TEST_GROUP_ID: TestGroup18
-      TestGroup19:
-        ANDROID_TEST_GROUP_ID: TestGroup19
-      TestGroup20:
-        ANDROID_TEST_GROUP_ID: TestGroup20
-      TestGroup21:
-        ANDROID_TEST_GROUP_ID: TestGroup21
-      TestGroup22:
-        ANDROID_TEST_GROUP_ID: TestGroup22
-      TestGroup23:
-        ANDROID_TEST_GROUP_ID: TestGroup23
-      TestGroup24:
-        ANDROID_TEST_GROUP_ID: TestGroup24
-      TestGroup25:
-        ANDROID_TEST_GROUP_ID: TestGroup25
-      TestGroup26:
-        ANDROID_TEST_GROUP_ID: TestGroup26
-      TestGroup27:
-        ANDROID_TEST_GROUP_ID: TestGroup27
-      TestGroup28:
-        ANDROID_TEST_GROUP_ID: TestGroup28
-      TestGroup29:
-        ANDROID_TEST_GROUP_ID: TestGroup29
-      TestGroup30:
-        ANDROID_TEST_GROUP_ID: TestGroup30
-      TestGroup31:
-        ANDROID_TEST_GROUP_ID: TestGroup31
-      TestGroup32:
-        ANDROID_TEST_GROUP_ID: TestGroup32
-      TestGroup33:
-        ANDROID_TEST_GROUP_ID: TestGroup33
-      TestGroup34:
-        ANDROID_TEST_GROUP_ID: TestGroup34
-      TestGroup35:
-        ANDROID_TEST_GROUP_ID: TestGroup35
-      TestGroup36:
-        ANDROID_TEST_GROUP_ID: TestGroup36
-      TestGroup37:
-        ANDROID_TEST_GROUP_ID: TestGroup37
-      TestGroup38:
-        ANDROID_TEST_GROUP_ID: TestGroup38
-      TestGroup39:
-        ANDROID_TEST_GROUP_ID: TestGroup39
-      
-  displayName: Android Test
-  dependsOn: AndroidBuild
-  steps:
-  - powershell: ./vsts/install_appcenter_cli.ps1
-    displayName: 'Install app center cli'
-    condition: always()
-   
-  - task: DownloadPipelineArtifact@0
-    inputs:
-      artifactName: 'androidBuildFiles'
-      targetPath: $(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk
-  
-  - task: AppCenterTest@1
-    displayName: 'E2E with Visual Studio App Center'
-    inputs:
-      appFile: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
-      frameworkOption: espresso
-      espressoBuildDirectory: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
-      serverEndpoint: 'AppCenter connection aziotclb'
-      appSlug: 'Azure-Iot-Sdk/androide2e'
-      devices: 'Azure-Iot-Sdk/api28_2'
-      runOptions: '--test-parameter annotation=com.microsoft.azure.sdk.iot.android.helper.$(ANDROID_TEST_GROUP_ID)'
-      showDebugOutput: true

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -26,18 +26,6 @@ jobs:
     env:
       COMMIT_FROM: $(COMMIT_FROM)
     condition: always()
-  
-  - task: JavaToolInstaller@0
-    inputs:
-    versionSpec: '12'
-    jdkArchitectureOption: 'x64'
-    jdkSourceOption: AzureStorage
-    azureResourceManagerEndpoint: javatestwin
-    azureStorageAccountName: myAzureStorageAccountName
-    azureContainerName: jdk12install
-    azureCommonVirtualFile: 'jdk-12.0.2_windows-x64_bin.zip'
-    jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk12'
-    cleanDestinationDirectory: false
     
   - powershell: ./vsts/build_repo.ps1
     displayName: 'Build and Test'
@@ -111,19 +99,7 @@ jobs:
        127.0.0.1:2321:2321
        127.0.0.1:2322:2322
       restartPolicy: unlessStopped      
-
-  - task: JavaToolInstaller@0
-    inputs:
-    versionSpec: '12'
-    jdkArchitectureOption: 'x64'
-    jdkSourceOption: AzureStorage
-    azureResourceManagerEndpoint: javatestwin
-    azureStorageAccountName: myAzureStorageAccountName
-    azureContainerName: jdk12install
-    azureCommonVirtualFile: 'jdk-12.0.2_linux-x64_bin.tar.gz'
-    jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk12'
-    cleanDestinationDirectory: false
-    
+      
   - powershell: ./vsts/build_repo.ps1
     displayName: 'Build and Test'
     env:
@@ -167,3 +143,163 @@ jobs:
     condition: always()  
     
  ### Android, Multi configuration build (12 different test groups to cover) ###
+- job: AndroidBuild
+  timeoutInMinutes: 180
+  pool:
+    name: Hosted VS2017
+  displayName: Android Build
+
+  steps:
+  - powershell: ./vsts/echo_inputs.ps1
+    displayName: 'Echo Inputs'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+    
+  - powershell: ./vsts/manual_checkout.ps1
+    displayName: 'GIT checkout'
+    env:
+      COMMIT_FROM: $(COMMIT_FROM)
+    condition: always()
+
+  - powershell: ./vsts/android_java.cmd
+    displayName: 'Android Build'
+    env:
+      IOTHUB_CONNECTION_STRING: $(ANDROID-IOTHUB-CONNECTION-STRING)
+      STORAGE_ACCOUNT_CONNECTION_STRING: $(ANDROID-STORAGE-ACCOUNT-CONNECTION-STRING)
+      IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      APPCENTER_APP_SECRET: $(APPCENTER-APP-SECRET)
+      DEVICE_PROVISIONING_SERVICE_ID_SCOPE: $(ANDROID-IOT-DPS-ID-SCOPE)
+      IOT_DPS_CONNECTION_STRING: $(ANDROID-IOT-DPS-CONNECTION-STRING)
+      DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_GLOBAL_ENDPOINT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
+      INVALID_DEVICE_PROVISIONING_SERVICE_CONNECTION_STRING: $(IOTHUB-CONN-STRING-INVALIDCERT)
+      CUSTOM_ALLOCATION_POLICY_WEBHOOK: $(CUSTOM-ALLOCATION-POLICY-WEBHOOK)
+      FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
+      IS_BASIC_TIER_HUB: $(IS-BASIC-TIER-HUB) 
+    condition: always()
+      
+  - task: CopyFiles@2
+    displayName: 'Copy Test Results to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)\iot-e2e-tests\android\app\build\outputs\apk'
+      Contents: |
+       *.*
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    continueOnError: true
+    condition: always()
+    
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'androidBuildFiles'
+      targetPath: 'iot-e2e-tests\android\app\build\outputs\apk'
+    
+- job: AndroidTest
+  timeoutInMinutes: 180
+  pool:
+    name: Hosted VS2017
+  strategy:
+    maxParallel: 12
+    matrix:
+      TestGroup1:
+        ANDROID_TEST_GROUP_ID: TestGroup1
+      TestGroup2:
+        ANDROID_TEST_GROUP_ID: TestGroup2
+      TestGroup3:
+        ANDROID_TEST_GROUP_ID: TestGroup3
+      TestGroup4:
+        ANDROID_TEST_GROUP_ID: TestGroup4
+      TestGroup5:
+        ANDROID_TEST_GROUP_ID: TestGroup5
+      TestGroup6:
+        ANDROID_TEST_GROUP_ID: TestGroup6
+      TestGroup7:
+        ANDROID_TEST_GROUP_ID: TestGroup7
+      TestGroup8:
+        ANDROID_TEST_GROUP_ID: TestGroup8
+      TestGroup9:
+        ANDROID_TEST_GROUP_ID: TestGroup9
+      TestGroup10:
+        ANDROID_TEST_GROUP_ID: TestGroup10
+      TestGroup11:
+        ANDROID_TEST_GROUP_ID: TestGroup11
+      TestGroup12:
+        ANDROID_TEST_GROUP_ID: TestGroup12
+      TestGroup13:
+        ANDROID_TEST_GROUP_ID: TestGroup13
+      TestGroup14:
+        ANDROID_TEST_GROUP_ID: TestGroup14
+      TestGroup15:
+        ANDROID_TEST_GROUP_ID: TestGroup15
+      TestGroup16:
+        ANDROID_TEST_GROUP_ID: TestGroup16
+      TestGroup17:
+        ANDROID_TEST_GROUP_ID: TestGroup17
+      TestGroup18:
+        ANDROID_TEST_GROUP_ID: TestGroup18
+      TestGroup19:
+        ANDROID_TEST_GROUP_ID: TestGroup19
+      TestGroup20:
+        ANDROID_TEST_GROUP_ID: TestGroup20
+      TestGroup21:
+        ANDROID_TEST_GROUP_ID: TestGroup21
+      TestGroup22:
+        ANDROID_TEST_GROUP_ID: TestGroup22
+      TestGroup23:
+        ANDROID_TEST_GROUP_ID: TestGroup23
+      TestGroup24:
+        ANDROID_TEST_GROUP_ID: TestGroup24
+      TestGroup25:
+        ANDROID_TEST_GROUP_ID: TestGroup25
+      TestGroup26:
+        ANDROID_TEST_GROUP_ID: TestGroup26
+      TestGroup27:
+        ANDROID_TEST_GROUP_ID: TestGroup27
+      TestGroup28:
+        ANDROID_TEST_GROUP_ID: TestGroup28
+      TestGroup29:
+        ANDROID_TEST_GROUP_ID: TestGroup29
+      TestGroup30:
+        ANDROID_TEST_GROUP_ID: TestGroup30
+      TestGroup31:
+        ANDROID_TEST_GROUP_ID: TestGroup31
+      TestGroup32:
+        ANDROID_TEST_GROUP_ID: TestGroup32
+      TestGroup33:
+        ANDROID_TEST_GROUP_ID: TestGroup33
+      TestGroup34:
+        ANDROID_TEST_GROUP_ID: TestGroup34
+      TestGroup35:
+        ANDROID_TEST_GROUP_ID: TestGroup35
+      TestGroup36:
+        ANDROID_TEST_GROUP_ID: TestGroup36
+      TestGroup37:
+        ANDROID_TEST_GROUP_ID: TestGroup37
+      TestGroup38:
+        ANDROID_TEST_GROUP_ID: TestGroup38
+      TestGroup39:
+        ANDROID_TEST_GROUP_ID: TestGroup39
+      
+  displayName: Android Test
+  dependsOn: AndroidBuild
+  steps:
+  - powershell: ./vsts/install_appcenter_cli.ps1
+    displayName: 'Install app center cli'
+    condition: always()
+   
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: 'androidBuildFiles'
+      targetPath: $(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk
+  
+  - task: AppCenterTest@1
+    displayName: 'E2E with Visual Studio App Center'
+    inputs:
+      appFile: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      frameworkOption: espresso
+      espressoBuildDirectory: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      serverEndpoint: 'AppCenter connection aziotclb'
+      appSlug: 'Azure-Iot-Sdk/androide2e'
+      devices: 'Azure-Iot-Sdk/api28_2'
+      runOptions: '--test-parameter annotation=com.microsoft.azure.sdk.iot.android.helper.$(ANDROID_TEST_GROUP_ID)'
+      showDebugOutput: true


### PR DESCRIPTION
Still can't run tests due to junit compatibility issues, and javadoc generation seems buggy, too.

However, users can now compile the jar files they need from source calling

```cmd
mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true
```