### PR TITLE
fix(iot-dev): Upgrade JNR unixsocet dependency to fix issue #434

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-unixsocket</artifactId>
-            <version>0.19</version>
+            <version>0.23</version>
         </dependency>
         <dependency>
             <groupId>org.apache.qpid</groupId>


### PR DESCRIPTION
JNR Unixsocket version 0.19 did not have arm64 support, which prevented some customers from using custom modules in their edgehub deployments. 0.23 has support for arm64, so I have upgraded our dependency.