### PR TITLE
feat(iot-service): Add mapping for 409 status code to IotHubConflictException

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubConflictException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubConflictException.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.service.exceptions;
+
+/**
+ * 409 Conflict
+ * Likely caused by trying to create a resource that already exists
+ */
+public class IotHubConflictException extends IotHubException
+{
+    public IotHubConflictException()
+    {
+        this(null);
+    }
+
+    public IotHubConflictException(String message)
+    {
+        super(message);
+    }
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManager.java
@@ -70,6 +70,11 @@ public class IotHubExceptionManager
         {
             throw new IotHubNotFoundException(errorMessage);
         }
+        // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_34_018: [The function shall throw IotHubConflictException if the Http response status equal 409]
+        else if (409 == responseStatus)
+        {
+            throw new IotHubConflictException(errorMessage);
+        }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_005: [The function shall throw IotHubPreconditionFailedException if the Http response status equal 412]
         else if (412 == responseStatus)
         {

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
@@ -86,6 +86,21 @@ public class IotHubExceptionManagerTest
         IotHubExceptionManager.httpResponseVerification(response);
     }
 
+    // Tests_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_34_018: [The function shall throw IotHubConflictException if the Http response status equal 409]
+    // Assert
+    @Test (expected = IotHubConflictException.class)
+    public void httpResponseVerification409() throws IotHubException
+    {
+        // Arrange
+        final int status = 409;
+        final byte[] body = { 1 };
+        final Map<String, List<String>> headerFields = new HashMap<>();
+        final byte[] errorReason = { 2, 3, 4, 5 };
+        HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
+        // Act
+        IotHubExceptionManager.httpResponseVerification(response);
+    }
+
     // Tests_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_005: [The function shall throw IotHubPreconditionFailedException if the Http response status equal 412]
     // Assert
     @Test (expected = IotHubPreconditionFailedException.class)


### PR DESCRIPTION
The service SDK had mappings for all other http status codes to IotHubXYZException, but was missing the mapping for 409 errors