### PR TITLE
Add proxy support for clients using AMQPS_WS

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -40,6 +40,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>qpid-proton-j-extensions</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk15on</artifactId>
             <version>1.61</version>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -763,9 +763,14 @@ public class InternalClient
         }
 
         IotHubClientProtocol protocol = this.deviceIO.getProtocol();
-        if (protocol != HTTPS)
+        if (protocol != HTTPS && protocol != AMQPS_WS)
         {
-            throw new UnsupportedOperationException("Cannot use proxy unsupported unless you are using HTTPS");
+            throw new UnsupportedOperationException("Use of proxies is unsupported unless using HTTPS or AMQPS_WS");
+        }
+
+        if (protocol == AMQPS_WS && proxySettings.getUsername() != null)
+        {
+            throw new UnsupportedOperationException("Use of username/password authentication is not supported for AMQPS_WS proxies");
         }
 
         this.config.setProxy(proxySettings);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -557,7 +557,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             {
                 // Codes_SRS_AMQPSIOTHUBCONNECTION_25_049: [If websocket enabled the event handler shall configure the transport layer for websocket.]
                 WebSocketImpl webSocket = new WebSocketImpl();
-                webSocket.configure(this.hostName, WEB_SOCKET_PATH, 0, WEB_SOCKET_SUB_PROTOCOL, null, null);
+                String query = "iothub-no-client-cert=true";
+                webSocket.configure(this.hostName, WEB_SOCKET_PATH, query, 443, WEB_SOCKET_SUB_PROTOCOL, null, null);
                 ((TransportInternal)transport).addTransportLayer(webSocket);
             }
 
@@ -1183,29 +1184,6 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
 
         return this.deviceClientConfig.getIotHubHostname();
-    }
-
-    private String getErrorCondition(ErrorCondition condition)
-    {
-        if (condition != null)
-        {
-            if (condition.getCondition() != null)
-            {
-                return condition.getCondition().toString();
-            }
-        }
-
-        return null;
-    }
-
-    private String getErrorDescription(ErrorCondition condition)
-    {
-        if (condition != null)
-        {
-            return condition.getDescription();
-        }
-
-        return null;
     }
 
     private ErrorCondition getErrorConditionFromEndpoint(Endpoint endpoint)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
@@ -86,8 +86,6 @@ public class HttpsConnection
             // Codes_SRS_HTTPSCONNECTION_11_001: [The constructor shall open a connection to the given URL.]
             if (proxySettings != null)
             {
-                this.connection = (HttpURLConnection) url.openConnection(proxySettings.getProxy());
-
                 if (proxySettings.getUsername() != null && proxySettings.getPassword() != null)
                 {
                     Authenticator authenticator = new Authenticator()
@@ -99,6 +97,8 @@ public class HttpsConnection
                     };
                     Authenticator.setDefault(authenticator);
                 }
+
+                this.connection = (HttpURLConnection) url.openConnection(proxySettings.getProxy());
             }
             else
             {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -2668,6 +2668,9 @@ public class InternalClientTest
                 Deencapsulation.newInstance(DeviceIO.class, mockConfig, SEND_PERIOD, RECEIVE_PERIOD);
                 result = mockDeviceIO;
 
+                mockDeviceIO.isOpen();
+                result = false;
+
                 mockDeviceIO.getProtocol();
                 result = protocol;
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -5,8 +5,8 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.device.transport.amqps;
 
-import com.microsoft.azure.sdk.iot.deps.ws.WebSocketHandler;
-import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
+import com.microsoft.azure.proton.transport.ws.WebSocketHandler;
+import com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubSasTokenAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubX509SoftwareAuthenticationProvider;
@@ -1378,7 +1378,7 @@ public class AmqpsIotHubConnectionTest {
                 result = mockTransportInternal;
                 new WebSocketImpl();
                 result = mockWebSocket;
-                mockWebSocket.configure(anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
+                mockWebSocket.configure(anyString, anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
                 mockTransportInternal.addTransportLayer(mockWebSocket);
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -5,6 +5,8 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.device.transport.amqps;
 
+import com.microsoft.azure.proton.transport.proxy.impl.ProxyHandlerImpl;
+import com.microsoft.azure.proton.transport.proxy.impl.ProxyImpl;
 import com.microsoft.azure.proton.transport.ws.WebSocketHandler;
 import com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl;
 import com.microsoft.azure.sdk.iot.device.*;
@@ -1111,6 +1113,51 @@ public class AmqpsIotHubConnectionTest {
     }
 
     @Test
+    public void onReactorInitWithProxySettings(@Mocked final ProxySettings mockProxySettings) throws TransportException
+    {
+        baseExpectations();
+
+        final int expectedSasTokenRenewalPeriod = 444;
+        final String expectedProxyHostname = "127.0.0.1";
+        final int expectedProxyPort = 1234;
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.isUseWebsocket();
+                result = true;
+                mockConfig.getProxySettings();
+                result = mockProxySettings;
+                mockProxySettings.getHostname();
+                result = expectedProxyHostname;
+                mockProxySettings.getPort();
+                result = expectedProxyPort;
+                mockEvent.getReactor();
+                result = mockReactor;
+                mockReactor.connectionToHost(anyString, anyInt, (Handler) any);
+                mockConfig.getAuthenticationProvider();
+                result = mockIotHubSasTokenAuthenticationProvider;
+                mockConfig.getSasTokenAuthentication();
+                result = mockIotHubSasTokenAuthenticationProvider;
+                mockIotHubSasTokenAuthenticationProvider.getMillisecondsBeforeProactiveRenewal();
+                result = expectedSasTokenRenewalPeriod;
+            }
+        };
+
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        Deencapsulation.setField(connection, "sasTokenRenewalHandler", mockAmqpSasTokenRenewalHandler);
+
+
+        connection.onReactorInit(mockEvent);
+
+        new Verifications()
+        {
+            {
+                mockReactor.connectionToHost(expectedProxyHostname, expectedProxyPort, connection);
+            }
+        };
+    }
+
+    @Test
     public void onReactorInitX509() throws TransportException
     {
         baseExpectations();
@@ -1338,6 +1385,8 @@ public class AmqpsIotHubConnectionTest {
                 result = mockConnection;
                 mockConnection.getTransport();
                 result = mockTransport;
+                mockConfig.getProxySettings();
+                result = null;
             }
         };
 
@@ -1380,6 +1429,8 @@ public class AmqpsIotHubConnectionTest {
                 result = mockWebSocket;
                 mockWebSocket.configure(anyString, anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
                 mockTransportInternal.addTransportLayer(mockWebSocket);
+                mockConfig.getProxySettings();
+                result = null;
             }
         };
 
@@ -1393,6 +1444,49 @@ public class AmqpsIotHubConnectionTest {
         {
             {
                 Deencapsulation.invoke(mockAmqpsSessionManager, "onConnectionBound", mockTransportInternal);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void onConnectionBoundWebSocketsWithProxy(@Mocked final ProxyHandlerImpl mockProxyHandlerImpl, @Mocked final ProxyImpl mockProxyImpl, @Mocked final ProxySettings mockProxySettings) throws TransportException, IOException
+    {
+        baseExpectations();
+        new Expectations()
+        {
+            {
+                mockConfig.isUseWebsocket();
+                result = true;
+                mockEvent.getConnection();
+                result = mockConnection;
+                mockConnection.getTransport();
+                result = mockTransportInternal;
+                new WebSocketImpl();
+                result = mockWebSocket;
+                mockWebSocket.configure(anyString, anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
+                mockTransportInternal.addTransportLayer(mockWebSocket);
+                mockConfig.getProxySettings();
+                result = mockProxySettings;
+                new ProxyHandlerImpl();
+                result = mockProxyHandlerImpl;
+                new ProxyImpl();
+                result = mockProxyImpl;
+                mockProxyImpl.configure(anyString, null, mockProxyHandlerImpl, (Transport) any);
+
+            }
+        };
+
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        Deencapsulation.setField(connection, "amqpsSessionManager", mockAmqpsSessionManager);
+        Deencapsulation.setField(connection, "useWebSockets", true);
+
+        connection.onConnectionBound(mockEvent);
+
+        new Verifications()
+        {
+            {
+                mockTransportInternal.addTransportLayer(mockProxyImpl);
                 times = 1;
             }
         };

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -27,6 +27,7 @@
         <module>send-receive-x509-sample</module>
         <module>transportclient-sample</module>
         <module>module-invoke-method-sample</module>
+        <module>send-event-with-proxy</module>
     </modules>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-event-with-proxy/pom.xml
+++ b/device/iot-device-samples/send-event-with-proxy/pom.xml
@@ -1,0 +1,37 @@
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
+    <artifactId>send-event-with-proxy</artifactId>
+    <name>Send Event Sample</name>
+    <developers>
+        <developer>
+            <id>microsoft</id>
+            <name>Microsoft</name>
+        </developer>
+    </developers>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.17.5</version>
+    </parent>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>samples.com.microsoft.azure.sdk.iot.SendEventWithProxy</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/device/iot-device-samples/send-event-with-proxy/src/main/java/samples/com/microsoft/azure/sdk/iot/SendEventWithProxy.java
+++ b/device/iot-device-samples/send-event-with-proxy/src/main/java/samples/com/microsoft/azure/sdk/iot/SendEventWithProxy.java
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/** Sends a number of event messages to an IoT Hub. */
+public class SendEventWithProxy
+{
+    private static List failedMessageListOnClose = new ArrayList(); // List of messages that failed on close
+
+    protected static class EventCallback implements IotHubEventCallback
+    {
+        public void execute(IotHubStatusCode status, Object context)
+        {
+            Message msg = (Message) context;
+
+            System.out.println("IoT Hub responded to message "+ msg.getMessageId()  + " with status " + status.name());
+
+            if (status==IotHubStatusCode.MESSAGE_CANCELLED_ONCLOSE)
+            {
+                failedMessageListOnClose.add(msg.getMessageId());
+            }
+        }
+    }
+
+    protected static class IotHubConnectionStatusChangeCallbackLogger implements IotHubConnectionStatusChangeCallback
+    {
+        @Override
+        public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
+        {
+            System.out.println();
+            System.out.println("CONNECTION STATUS UPDATE: " + status);
+            System.out.println("CONNECTION STATUS REASON: " + statusChangeReason);
+            System.out.println("CONNECTION STATUS THROWABLE: " + (throwable == null ? "null" : throwable.getMessage()));
+            System.out.println();
+
+            if (throwable != null)
+            {
+                throwable.printStackTrace();
+            }
+
+            if (status == IotHubConnectionStatus.DISCONNECTED)
+            {
+                //connection was lost, and is not being re-established. Look at provided exception for
+                // how to resolve this issue. Cannot send messages until this issue is resolved, and you manually
+                // re-open the device client
+            }
+            else if (status == IotHubConnectionStatus.DISCONNECTED_RETRYING)
+            {
+                //connection was lost, but is being re-established. Can still send messages, but they won't
+                // be sent until the connection is re-established
+            }
+            else if (status == IotHubConnectionStatus.CONNECTED)
+            {
+                //Connection was successfully re-established. Can send messages.
+            }
+        }
+    }
+
+    /**
+     * Sends a number of messages to an IoT or Edge Hub. Default protocol is to
+     * use MQTT transport.
+     *
+     * @param args
+     * args[0] = IoT Hub or Edge Hub connection string
+     * args[1] = number of messages to send
+     * args[2] = protocol (optional, one of 'https' or 'amqps_ws')
+     * args[3] = proxy host name ie: "127.0.0.1", "localhost", etc.
+     * args[4] = proxy port number ie "8888", "3128", etc
+     * args[5] = (optional) proxy username
+     * args[6] = (optional) proxy password
+     */
+    public static void main(String[] args)
+            throws IOException, URISyntaxException
+    {
+        System.out.println("Starting...");
+        System.out.println("Beginning setup.");
+
+        if (args.length != 5 && args.length != 7)
+        {
+            System.out.format(
+                    "Expected 5 or 7 arguments but received: %d.\n"
+                            + "The program should be called with the following args: \n"
+                            + "1. [Device connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key> or HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>;GatewayHostName=<gateway> \n"
+                            + "2. [number of requests to send]\n"
+                            + "3. (https | amqps_ws)\n"
+                            + "4. proxy hostname (ie: '127.0.0.1', 'localhost', etc.)\n"
+                            + "5. proxy port number\n"
+                            + "6. (optional) username for the proxy \n"
+                            + "7. (optional) password for the proxy \n",
+                    args.length);
+            return;
+        }
+
+        String connString = args[0];
+        int numRequests;
+        try
+        {
+            numRequests = Integer.parseInt(args[1]);
+        }
+        catch (NumberFormatException e)
+        {
+            System.out.format(
+                    "Could not parse the number of requests to send. "
+                            + "Expected an int but received:\n%s.\n", args[1]);
+            return;
+        }
+        IotHubClientProtocol protocol;
+        String protocolStr = args[2];
+        if (protocolStr.toLowerCase().equals("https"))
+        {
+            protocol = IotHubClientProtocol.HTTPS;
+        }
+        else if (protocolStr.toLowerCase().equals("amqps"))
+        {
+            throw new UnsupportedOperationException("AMQPS does not have proxy support");
+        }
+        else if (protocolStr.toLowerCase().equals("mqtt"))
+        {
+            throw new UnsupportedOperationException("MQTT does not have proxy support");
+        }
+        else if (protocolStr.toLowerCase().equals("amqps_ws"))
+        {
+            protocol = IotHubClientProtocol.AMQPS_WS;
+        }
+        else if (protocolStr.toLowerCase().equals("mqtt_ws"))
+        {
+            throw new UnsupportedOperationException("MQTT_WS does not have proxy support");
+        }
+        else
+        {
+            System.out.format(
+                    "Received a protocol string that could not be understood: %d.\n"
+                            + "The program should be called with the following args: \n"
+                            + "1. [Device connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key> or HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>;GatewayHostName=<gateway> \n"
+                            + "2. [number of requests to send]\n"
+                            + "3. (https | amqps_ws)\n"
+                            + "4. proxy hostname (ie: '127.0.0.1', 'localhost', etc.)\n"
+                            + "5. proxy port number\n"
+                            + "6. (optional) username for the proxy \n"
+                            + "7. (optional) password for the proxy \n",
+                    protocolStr);
+            return;
+        }
+
+        String proxyHostname = args[3];
+        int proxyPort;
+        try
+        {
+            proxyPort = Integer.parseInt(args[4]);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException("Expected argument 5 (port number) to be an integer");
+        }
+
+        String proxyUsername = "";
+        char[] proxyPassword = new char[0];
+        if (args.length == 7)
+        {
+            proxyUsername = args[5];
+            proxyPassword = args[6].toCharArray();
+        }
+
+        System.out.println("Successfully read input parameters.");
+        System.out.format("Using communication protocol %s.\n", protocol.name());
+
+        DeviceClient client = new DeviceClient(connString, protocol);
+
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHostname, proxyPort));
+        ProxySettings httpProxySettings = new ProxySettings(proxy, proxyUsername, proxyPassword);
+        System.out.println("Using proxy address: " + proxyHostname + ":" + proxyPort);
+        client.setProxySettings(httpProxySettings);
+
+        System.out.println("Successfully created an IoT Hub client.");
+
+        client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeCallbackLogger(), new Object());
+
+        client.open();
+
+        System.out.println("Opened connection to IoT Hub.");
+        System.out.println("Sending the following event messages:");
+
+        for (int i = 0; i < numRequests; ++i)
+        {
+            String msgStr = "This is a message sent over proxy";
+
+            try
+            {
+                Message msg = new Message(msgStr);
+                System.out.println(msgStr);
+
+                EventCallback callback = new EventCallback();
+                client.sendEventAsync(msg, callback, msg);
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace(); // Trace the exception
+            }
+        }
+
+        System.out.println("Wait for a response from the IoT Hub...");
+
+        // Wait for IoT Hub to respond.
+        try
+        {
+            Thread.sleep(10000);
+        }
+        catch (InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+
+        // close the connection
+        System.out.println("Closing");
+        client.closeNow();
+
+        if (!failedMessageListOnClose.isEmpty())
+        {
+            System.out.println("List of messages that were cancelled on close:" + failedMessageListOnClose.toString());
+        }
+
+        System.out.println("Shutting down...");
+    }
+}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -170,7 +170,7 @@ public class SendMessagesCommon extends IntegrationTest
 
                                     //sas token device client, with proxy
                                     //{MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
-                                    //{AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
+                                    {AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
 
                                     //x509 device client, with proxy
                                     {HTTPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true}
@@ -194,7 +194,7 @@ public class SendMessagesCommon extends IntegrationTest
 
                                         //sas token module client, with proxy
                                         //{MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
-                                        //{AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true}
+                                        {AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true}
                                 }
                 ));
             }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
@@ -14,6 +14,8 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import org.junit.*;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.*;
@@ -90,6 +92,16 @@ public class HubTierConnectionTests extends IntegrationTest
         catch (IOException e)
         {
             fail("Failed to stop the test proxy");
+        }
+    }
+
+    @Before
+    public void SetProxyIfApplicable()
+    {
+        if (testInstance.useHttpProxy)
+        {
+            Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
+            testInstance.client.setProxySettings(new ProxySettings(testProxy));
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -12,7 +12,6 @@ import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
-import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Device;
 import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -44,7 +43,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithTcpConnectionDrop() throws Exception
     {
-        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
+        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS) || testInstance.useHttpProxy)
         {
             //TCP connection is not maintained between device and service when using HTTPS, so this test case isn't applicable
             //MQTT_WS + x509 is not supported for sending messages
@@ -59,7 +58,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithConnectionDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -73,7 +72,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithSessionDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -87,7 +86,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithCbsRequestLinkDrop() throws Exception
     {
-        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
+        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -107,7 +106,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithCbsResponseLinkDrop() throws Exception
     {
-        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
+        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -127,7 +126,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithD2CLinkDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -141,7 +140,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithC2DLinkDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -163,7 +162,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithThrottling() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -182,7 +181,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithThrottlingNoRetry() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -201,7 +200,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithAuthenticationError() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -219,7 +218,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithQuotaExceeded() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -236,7 +235,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithGracefulShutdown() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -250,7 +249,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverMqttWithGracefulShutdown() throws Exception
     {
-        if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))
+        if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS) || testInstance.useHttpProxy)
         {
             //This error injection test only applies for MQTT and MQTT_WS
             return;
@@ -264,7 +263,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithTcpConnectionDropNotifiesUserIfRetryExpires() throws Exception
     {
-        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
+        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS) || testInstance.useHttpProxy)
         {
             //TCP connection is not maintained between device and service when using HTTPS, so this test case isn't applicable
             //MQTT_WS + x509 is not supported for sending messages


### PR DESCRIPTION
Building on earlier work for proxy support for HTTPS, this PR enables AMQPS_WS to communicate over proxies now, too.

A part of this pr is migrating away from maintaining the Websocket layer implementation over proton-j, and instead taking a dependency on the proton-j-extensions jar, which is very similar, but also includes proxy support.

Also adding a simple sample for using proxy when sending telemetry