### PR TITLE
Fix issue where amqp stack opened links on non reactor threads

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
@@ -293,6 +293,8 @@ public class DeviceTwin
 
     public void getDeviceTwin()
     {
+        checkSubscription();
+
         /*
          **Codes_SRS_DEVICETWIN_25_005: [**The method shall create a device twin message with empty payload to be sent IotHub.**]**
          */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -768,12 +768,12 @@ public class InternalClient
         IotHubClientProtocol protocol = this.deviceIO.getProtocol();
         if (protocol != HTTPS && protocol != AMQPS_WS)
         {
-            throw new UnsupportedOperationException("Use of proxies is unsupported unless using HTTPS or AMQPS_WS");
+            throw new IllegalArgumentException("Use of proxies is unsupported unless using HTTPS or AMQPS_WS");
         }
 
         if (protocol == AMQPS_WS && proxySettings.getUsername() != null)
         {
-            throw new UnsupportedOperationException("Use of username/password authentication is not supported for AMQPS_WS proxies");
+            throw new IllegalArgumentException("Use of username/password authentication is not supported for AMQPS_WS proxies");
         }
 
         this.config.setProxy(proxySettings);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -28,7 +28,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class IotHubTransport implements IotHubListener
 {
     private static final int MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
-    private IotHubConnectionStatus connectionStatus;
+    private volatile IotHubConnectionStatus connectionStatus;
     private IotHubTransportConnection iotHubTransportConnection;
 
     /* Messages waiting to be sent to the IoT Hub. */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportConnection.java
@@ -26,6 +26,7 @@ public interface IotHubTransportConnection
      * Opens the transport connection object
      * @param deviceClientConfigs The list of configs to use. If more than 1 configs are in this list, multiplexing
      *                            will be used
+     * @param scheduledExecutorService the executor service to use when spawning threads
      * @throws TransportException If any exceptions are encountered while opening the connection
      */
     void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService) throws TransportException;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthentication.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthentication.java
@@ -1,20 +1,22 @@
 package com.microsoft.azure.sdk.iot.device.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
+import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.ProtonUnsupportedOperationException;
-import org.apache.qpid.proton.engine.*;
+import org.apache.qpid.proton.engine.SslDomain;
+import org.apache.qpid.proton.engine.Transport;
 
 import javax.net.ssl.SSLContext;
 import java.util.UUID;
 
-public class AmqpsDeviceAuthentication extends AmqpsDeviceOperations
+public abstract class AmqpsDeviceAuthentication extends AmqpsDeviceOperations
 {
-    AmqpsDeviceAuthentication(DeviceClientConfig deviceClientConfig)
+    public AmqpsDeviceAuthentication(DeviceClientConfig config)
     {
         // Codes_SRS_AMQPSDEVICEAUTHENTICATION_34_009: [This constructor shall call super with the provided user agent string.]
-        super(deviceClientConfig, "", "", "", "", "", "");
+        super(config, "", "", "", "", "", "");
     }
 
     /**
@@ -30,15 +32,10 @@ public class AmqpsDeviceAuthentication extends AmqpsDeviceOperations
 
         try
         {
-            // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_001: [The function shall get the sslDomain object from the Proton reactor.]
             domain = Proton.sslDomain();
-            // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_002: [The function shall set the sslContext on the domain.]
             domain.setSslContext(sslContext);
-            // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_003: [The function shall set the peer authentication mode to VERIFY_PEER.]
             domain.setPeerAuthentication(SslDomain.VerifyMode.VERIFY_PEER);
-            // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_004: [The function shall initialize the sslDomain.]
             domain.init(SslDomain.Mode.CLIENT);
-            // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_005: [The function shall return with the sslDomain.]
         }
         catch (ProtonUnsupportedOperationException e)
         {
@@ -49,38 +46,40 @@ public class AmqpsDeviceAuthentication extends AmqpsDeviceOperations
     }
 
     /**
-     * Prototype (empty) function for set the SslDomain
+     * abstract function for set the SslDomain
      *
      * @param transport The transport to set the SSL context to
      * @throws TransportException if setting ssl domain fails
      */
-    protected void setSslDomain(Transport transport) throws TransportException
-    {
-        // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_067: [The prototype function does nothing.]
-    }
+    abstract protected void setSslDomain(Transport transport) throws TransportException;
 
     /**
-     * Prototype (empty) function for set the SslDomain
+     * abstract function for set the SslDomain
      *
      * @param deviceClientConfig The deviceClientConfig to use for authentication
      * @param correlationId the authentication message's correlationId.
      * @throws TransportException if authentication fails
      */
-    protected void authenticate(DeviceClientConfig deviceClientConfig, UUID correlationId) throws TransportException
-    {
-        // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_007: [The prototype function does nothing.]
-    }
+    abstract protected void authenticate(DeviceClientConfig deviceClientConfig, UUID correlationId) throws TransportException;
 
     /**
-     * Prototype (empty) function for evaluation function of received message.
+     * abstract function for evaluation function of received message.
      *
      * @param amqpsMessage the message to evaluate.
      * @param authenticationCorrelationId the expected correlation ID.
      * @return true if the message acknowledge the authentication, false otherwise.
      */
-    protected Boolean authenticationMessageReceived(AmqpsMessage amqpsMessage, UUID authenticationCorrelationId)
+    abstract protected boolean authenticationMessageReceived(AmqpsMessage amqpsMessage, UUID authenticationCorrelationId);
+
+    @Override
+    protected AmqpsConvertFromProtonReturnValue convertFromProton(AmqpsMessage amqpsMessage, DeviceClientConfig deviceClientConfig) throws TransportException
     {
-        // Codes_SRS_AMQPSDEVICEAUTHENTICATION_12_008: [The prototype function shall return false.]
-        return false;
+        throw new TransportException("Should not be called");
+    }
+
+    @Override
+    protected AmqpsConvertToProtonReturnValue convertToProton(Message message) throws TransportException
+    {
+        throw new TransportException("Should not be called");
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationX509.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationX509.java
@@ -2,12 +2,14 @@ package com.microsoft.azure.sdk.iot.device.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.device.CustomLogger;
 import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
-import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
+import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.MessageType;
+import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import org.apache.qpid.proton.engine.SslDomain;
 import org.apache.qpid.proton.engine.Transport;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class AmqpsDeviceAuthenticationX509 extends AmqpsDeviceAuthentication
 {
@@ -86,6 +88,18 @@ public class AmqpsDeviceAuthenticationX509 extends AmqpsDeviceAuthentication
         transport.ssl(domain);
     }
 
+    @Override
+    protected void authenticate(DeviceClientConfig deviceClientConfig, UUID correlationId) throws TransportException
+    {
+        throw new TransportException("Cannot authenticate on demand with x509 auth");
+    }
+
+    @Override
+    protected boolean authenticationMessageReceived(AmqpsMessage amqpsMessage, UUID authenticationCorrelationId)
+    {
+        return false;
+    }
+
     /**
      * Found the link by name.
      *
@@ -93,9 +107,19 @@ public class AmqpsDeviceAuthenticationX509 extends AmqpsDeviceAuthentication
      * @return true if link found, false otherwise.
      */
     @Override
-    protected Boolean isLinkFound(String linkName)
+    protected boolean onLinkRemoteOpen(String linkName)
     {
-        // Codes_SRS_AMQPSDEVICEAUTHENTICATIONX509_12_012: [The function shall override the default behaviour and return true.]
+        //No link should ever be opened specifically for x509 auth, so this always returns false
+        return false;
+    }
+
+    /**
+     * X509 authentication does not have any links, so this will always return true
+     * @return true
+     */
+    @Override
+    public boolean operationLinksOpened()
+    {
         return true;
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethods.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethods.java
@@ -3,8 +3,11 @@
 
 package com.microsoft.azure.sdk.iot.device.transport.amqps;
 
-import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageCallback;
+import com.microsoft.azure.sdk.iot.device.MessageType;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.TransportUtils;
@@ -70,7 +73,7 @@ public final class AmqpsDeviceMethods extends AmqpsDeviceOperations
      * @return true if the link is owned by the operation, false otherwise
      */
     @Override
-    protected Boolean isLinkFound(String linkName)
+    protected boolean onLinkRemoteOpen(String linkName)
     {
         // Codes_SRS_AMQPSDEVICEMETHODS_12_047: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
         if (linkName.equals(this.getSenderLinkTag()))
@@ -122,10 +125,9 @@ public final class AmqpsDeviceMethods extends AmqpsDeviceOperations
      *
      * @param linkName The receiver link's name to read from
      * @return the received message
-     * @throws TransportException if Proton throws
      */
     @Override
-    protected AmqpsMessage getMessageFromReceiverLink(String linkName) throws TransportException
+    protected AmqpsMessage getMessageFromReceiverLink(String linkName)
     {
         // Codes_SRS_AMQPSDEVICEMETHODS_12_012: [The function shall call the super function.]
         AmqpsMessage amqpsMessage = super.getMessageFromReceiverLink(linkName);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetry.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetry.java
@@ -63,7 +63,7 @@ public final class AmqpsDeviceTelemetry extends AmqpsDeviceOperations
      * @return true if the link is owned by the operation, false otherwise
      */
     @Override
-    protected Boolean isLinkFound(String linkName)
+    protected boolean onLinkRemoteOpen(String linkName)
     {
         // Codes_SRS_AMQPSDEVICETELEMETRY_12_026: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
         if (linkName.equals(this.getSenderLinkTag()))
@@ -116,10 +116,9 @@ public final class AmqpsDeviceTelemetry extends AmqpsDeviceOperations
      * @param linkName The receiver link's name to read from
      * @return the received message
      * @throws IllegalArgumentException if linkName argument is empty
-     * @throws TransportException if Proton throws
      */
     @Override
-    protected AmqpsMessage getMessageFromReceiverLink(String linkName) throws TransportException
+    protected AmqpsMessage getMessageFromReceiverLink(String linkName)
     {
         // Codes_SRS_AMQPSDEVICETELEMETRY_12_020: [The function shall call the super function.]
         AmqpsMessage amqpsMessage = super.getMessageFromReceiverLink(linkName);
@@ -198,7 +197,6 @@ public final class AmqpsDeviceTelemetry extends AmqpsDeviceOperations
      * Converts an AMQPS message to a corresponding IoT Hub message.
      *
      * @param protonMsg the AMQPS message.
-     * @throws TransportException if the conversion fails
      * @return the corresponding IoT Hub message.
      */
     @Override
@@ -231,7 +229,6 @@ public final class AmqpsDeviceTelemetry extends AmqpsDeviceOperations
     /**
      * Creates a proton message from the IoTHub message.
      * @param message the IoTHub input message.
-     * @throws TransportException if the conversion fails
      * @return the proton message.
      */
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwin.java
@@ -3,13 +3,17 @@
 
 package com.microsoft.azure.sdk.iot.device.transport.amqps;
 
-import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageCallback;
+import com.microsoft.azure.sdk.iot.device.MessageType;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.TransportUtils;
 import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.messaging.*;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Properties;
 import org.apache.qpid.proton.message.impl.MessageImpl;
 
 import java.util.HashMap;
@@ -81,7 +85,7 @@ public final class AmqpsDeviceTwin extends AmqpsDeviceOperations
      * @return true if the link is owned by the operation, false otherwise
      */
     @Override
-    protected Boolean isLinkFound(String linkName)
+    protected boolean onLinkRemoteOpen(String linkName)
     {
         // Codes_SRS_AMQPSDEVICETWIN_12_046: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
         if (linkName.equals(this.getSenderLinkTag()))
@@ -133,11 +137,9 @@ public final class AmqpsDeviceTwin extends AmqpsDeviceOperations
      *
      * @param linkName The receiver link's name to read from
      * @return the received message
-     * @throws IllegalArgumentException if linkName argument is empty
-     * @throws TransportException if Proton throws
      */
     @Override
-    protected AmqpsMessage getMessageFromReceiverLink(String linkName) throws IllegalArgumentException, TransportException
+    protected AmqpsMessage getMessageFromReceiverLink(String linkName)
     {
         // Codes_SRS_AMQPSDEVICETWIN_12_012: [The function shall call the super function.]
         AmqpsMessage amqpsMessage = super.getMessageFromReceiverLink(linkName);
@@ -157,7 +159,6 @@ public final class AmqpsDeviceTwin extends AmqpsDeviceOperations
      *
      * @param amqpsMessage The Proton message to convert
      * @param deviceClientConfig The device client configuration
-     * @throws TransportException if the conversion fails
      * @return the converted message
      */
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -47,6 +47,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     /** The {@link Delivery} tag. */
     private static final String WEB_SOCKET_PATH = "/$iothub/websocket";
     private static final String WEB_SOCKET_SUB_PROTOCOL = "AMQPWSB10";
+    private static final String WEBSOCKET_QUERY = "iothub-no-client-cert=true";
+    private static final int WEBSOCKET_PORT = 443;
     private static final int AMQP_PORT = 5671;
     private static final int AMQP_WEB_SOCKET_PORT = 443;
 
@@ -568,8 +570,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             {
                 // Codes_SRS_AMQPSIOTHUBCONNECTION_25_049: [If websocket enabled the event handler shall configure the transport layer for websocket.]
                 WebSocketImpl webSocket = new WebSocketImpl();
-                String query = "iothub-no-client-cert=true";
-                webSocket.configure(this.hostName, WEB_SOCKET_PATH, query, 443, WEB_SOCKET_SUB_PROTOCOL, null, null);
+                webSocket.configure(this.hostName, WEB_SOCKET_PATH, WEBSOCKET_QUERY, WEBSOCKET_PORT, WEB_SOCKET_SUB_PROTOCOL, null, null);
                 ((TransportInternal)transport).addTransportLayer(webSocket);
             }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -31,7 +31,8 @@ import java.util.UUID;
 import java.util.concurrent.*;
 
 import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.*;
-import static com.microsoft.azure.sdk.iot.device.MessageType.*;
+import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
+import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
 
 /**
  * An AMQPS IotHub connection between a device and an IoTHub. This class contains functionality for sending/receiving
@@ -39,7 +40,9 @@ import static com.microsoft.azure.sdk.iot.device.MessageType.*;
  */
 public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTransportConnection
 {
-    private static final int MAX_WAIT_TO_OPEN_CLOSE_CONNECTION = 90*1000; // 90 second timeout
+    private static final int MAX_WAIT_TO_CLOSE_CONNECTION = 60*1000; // 60 second timeout
+    private static final int MAX_WAIT_TO_OPEN_CBS_LINKS = 20*1000; // 20 second timeout
+    private static final int MAX_WAIT_TO_OPEN_WORKER_LINKS = 60*1000; // 60 second timeout
     private static final int MAX_WAIT_TO_TERMINATE_EXECUTOR = 30;
     private static final int SEND_MESSAGES_PERIOD_MILLIS = 50; //every 50 seconds, the method onTimerTask will fire to send queued messages
     private IotHubConnectionStatus state;
@@ -51,6 +54,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private static final int WEBSOCKET_PORT = 443;
     private static final int AMQP_PORT = 5671;
     private static final int AMQP_WEB_SOCKET_PORT = 443;
+
+    private static final int REACTOR_COUNT = 1;
+    private static final int CBS_LINK_COUNT = 2; //even for multiplex scenarios
 
     private Connection connection;
 
@@ -69,12 +75,16 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private boolean reconnectionScheduled = false;
 
     private ExecutorService executorService;
-    private ScheduledExecutorService scheduledExecutorService;
 
     private AmqpSasTokenRenewalHandler sasTokenRenewalHandler;
 
-    private CountDownLatch openLatch;
-    private CountDownLatch closeLatch;
+    private CountDownLatch authenticationLinkOpenLatch;
+    private CountDownLatch workerLinksOpenLatch;
+    private CountDownLatch cbsLinkAuthorizedLatch;
+    private CountDownLatch closeReactorLatch;
+    
+    //Used to track if the full connection is authenticated. This means cbs auth messages have received 200 from service for each device's sas auth
+    boolean isAuthenticated;
 
     public String connectionId;
 
@@ -91,9 +101,6 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     //sending messages is done on reactor thread, but we don't want to hog that thread indefinitely, so there is a limit
     // on how many messages to send per reactor callback
     private final static int MAX_MESSAGES_TO_SEND_PER_CALLBACK = 1000;
-
-    private boolean methodSubscribed;
-    private boolean twinSubscribed;
 
     /**
      * Constructor to set up connection parameters using the {@link DeviceClientConfig}.
@@ -147,6 +154,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_006: [The constructor shall set its state to DISCONNECTED.]
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
+        this.amqpsSessionManager = new AmqpsSessionManager(this.deviceClientConfig);
+
         logger.LogInfo("AmqpsIotHubConnection object is created successfully using port %s in %s method ", useWebSockets ? AMQP_WEB_SOCKET_PORT : AMQP_PORT, logger.getMethodName());
     }
 
@@ -184,13 +193,10 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         reconnectionScheduled = false;
         connectionId = UUID.randomUUID().toString();
 
-        this.scheduledExecutorService = scheduledExecutorService;
+        this.isAuthenticated = false;
 
-        this.closeLatch = new CountDownLatch(1);
-        this.openLatch = new CountDownLatch(1);
         this.savedException = null;
 
-        this.amqpsSessionManager = new AmqpsSessionManager(this.deviceClientConfig);
         this.sasTokenRenewalHandler = new AmqpSasTokenRenewalHandler(this.amqpsSessionManager, this.deviceClientConfig);
 
         logger.LogDebug("Entered in method %s", logger.getMethodName());
@@ -207,6 +213,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 }
             }
 
+            initializeStateLatches(deviceClientConfigs.size());
+
             // Codes_SRS_AMQPSIOTHUBCONNECTION_15_010: [The function shall wait for the reactor to be ready and for
             // enough link credit to become available.]
             try
@@ -215,41 +223,28 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 this.openAsync();
 
                 // Codes_SRS_AMQPSIOTHUBCONNECTION_12_059: [The function shall call await on open latch.]
-                this.openLatch.await(MAX_WAIT_TO_OPEN_CLOSE_CONNECTION, TimeUnit.MILLISECONDS);
-
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_12_057: [The function shall call the connection to authenticate.]
-                this.authenticate();
-
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_12_058: [The function shall call the connection to open device client links.]
-                this.openLinks();
+                boolean authenticationLinksOpenTimedOut = !this.authenticationLinkOpenLatch.await(MAX_WAIT_TO_OPEN_CBS_LINKS, TimeUnit.MILLISECONDS);
 
                 if (this.savedException != null)
                 {
-                    // Codes_SRS_AMQPSIOTHUBCONNECTION_34_062: [If, after attempting to open the connection, this
-                    // object has a saved exception, this function shall throw that saved exception.]
                     throw this.savedException;
                 }
 
-                if (!this.amqpsSessionManager.isAuthenticationOpened())
+                if (authenticationLinksOpenTimedOut)
                 {
-                    // Codes_SRS_AMQPSIOTHUBCONNECTION_12_074: [If authentication has not succeeded after calling
-                    // authenticate() and openLinks(), or if all links are not open yet,
-                    // this function shall throw a retryable transport exception.]
-                    this.close();
-                    TransportException transportException = new TransportException("Timed out waiting for authentication links to open from service");
-                    transportException.setRetryable(true);
-                    throw transportException;
+                    closeConnectionWithException("Timed out waiting for authentication links to open", true);
                 }
 
-                if (!this.amqpsSessionManager.areAllLinksOpen())
+                boolean workerLinksOpenTimedOut = !this.workerLinksOpenLatch.await(MAX_WAIT_TO_OPEN_WORKER_LINKS, TimeUnit.MILLISECONDS);
+
+                if (this.savedException != null)
                 {
-                    // Codes_SRS_AMQPSIOTHUBCONNECTION_12_074: [If authentication has not succeeded after calling
-                    // authenticate() and openLinks(), or if all links are not open yet,
-                    // this function shall throw a retryable transport exception.]
-                    this.close();
-                    TransportException transportException = new TransportException("Timed out waiting for worker links to open from service");
-                    transportException.setRetryable(true);
-                    throw transportException;
+                    throw this.savedException;
+                }
+
+                if (workerLinksOpenTimedOut)
+                {
+                    closeConnectionWithException("Timed out waiting for worker links to open", true);
                 }
             }
             catch (InterruptedException e)
@@ -265,6 +260,40 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         this.state = IotHubConnectionStatus.CONNECTED;
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
+    }
+
+    /**
+     * @param deviceCount The number of devices involved in this connection. For Multiplexed scenarios, this should be greater than 1.
+     *                    For non-multiplexed scenarios, this should be exactly 1.
+     */
+    private void initializeStateLatches(int deviceCount)
+    {
+        this.closeReactorLatch = new CountDownLatch(REACTOR_COUNT);
+
+        if (deviceClientConfig.getAuthenticationProvider() instanceof IotHubSasTokenAuthenticationProvider)
+        {
+            this.authenticationLinkOpenLatch = new CountDownLatch(CBS_LINK_COUNT);
+        }
+        else
+        {
+            //x509 connections don't have authentication links to open
+            this.authenticationLinkOpenLatch = new CountDownLatch(0);
+        }
+
+        //Each session has a device, and each device can have 2, 4, or 6 worker links depending on if that device is subscribed to twin and methods or not
+        int expectedWorkerLinkCount = this.amqpsSessionManager.getExpectedWorkerLinkCount();
+        this.workerLinksOpenLatch = new CountDownLatch(expectedWorkerLinkCount);
+
+        //expect one cbs 200 per device
+        this.cbsLinkAuthorizedLatch = new CountDownLatch(deviceCount);
+    }
+
+    private void closeConnectionWithException(String errorMessage, boolean isRetryable) throws TransportException
+    {
+        this.close();
+        TransportException transportException = new TransportException(errorMessage);
+        transportException.setRetryable(isRetryable);
+        throw transportException;
     }
 
     /**
@@ -302,40 +331,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_12_020: [The function shall do nothing if the authentication is already open.]
-        if (this.amqpsSessionManager.isAuthenticationOpened())
-        {
-            // Codes_SRS_AMQPSIOTHUBCONNECTION_12_021: [The function shall call AmqpsSessionManager.authenticate.]
-            this.amqpsSessionManager.authenticate();
-        }
-
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
-    }
-
-    /**
-     * Opens all the operation links by calling the AmqpsSessionManager.
-     *
-     * @throws TransportException if Proton throws.
-     */
-    public void openLinks() throws TransportException
-    {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-
-        // Codes_SRS_AMQPSIOTHUBCONNECTION_12_022: [The function shall do nothing if the authentication is already open.]
-        if (this.amqpsSessionManager.isAuthenticationOpened())
-        {
-            // Codes_SRS_AMQPSIOTHUBCONNECTION_12_023: [The function shall call AmqpsSessionManager.openDeviceOperationLinks.]
-            this.amqpsSessionManager.openDeviceOperationLinks(DEVICE_TELEMETRY);
-
-            if (methodSubscribed)
-            {
-                this.amqpsSessionManager.openDeviceOperationLinks(DEVICE_METHODS);
-            }
-
-            if (twinSubscribed)
-            {
-                this.amqpsSessionManager.openDeviceOperationLinks(DEVICE_TWIN);
-            }
-        }
+        // Codes_SRS_AMQPSIOTHUBCONNECTION_12_021: [The function shall call AmqpsSessionManager.authenticate.]
+        this.amqpsSessionManager.authenticate();
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
@@ -357,7 +354,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         try
         {
-            closeLatch.await(MAX_WAIT_TO_OPEN_CLOSE_CONNECTION, TimeUnit.MILLISECONDS);
+            closeReactorLatch.await(MAX_WAIT_TO_CLOSE_CONNECTION, TimeUnit.MILLISECONDS);
         }
         catch (InterruptedException e)
         {
@@ -512,8 +509,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_12_011: [The function shall call countdown on close latch and open latch.]
-        closeLatch.countDown();
-        openLatch.countDown();
+        releaseLatch(authenticationLinkOpenLatch);
+        releaseLatch(workerLinksOpenLatch);
+        releaseLatch(closeReactorLatch);
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_12_012: [The function shall set the reactor member variable to null.]
         this.reactor = null;
@@ -539,10 +537,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         try
         {
             // Codes_SRS_AMQPSIOTHUBCONNECTION_12_009: [The event handler shall call the amqpsSessionManager.onConnectionInit function with the connection.]
-            if (this.amqpsSessionManager.onConnectionInit(this.connection))
-            {
-                openLatch.countDown();
-            }
+            this.amqpsSessionManager.onConnectionInit(this.connection);
         }
         catch (TransportException e)
         {
@@ -551,6 +546,12 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
+    }
+
+    @Override
+    public void onSessionRemoteOpen(Event e)
+    {
+        this.amqpsSessionManager.onSessionRemoteOpen(e.getSession());
     }
 
     /**
@@ -568,10 +569,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         {
             if (this.useWebSockets)
             {
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_25_049: [If websocket enabled the event handler shall configure the transport layer for websocket.]
-                WebSocketImpl webSocket = new WebSocketImpl();
-                webSocket.configure(this.hostName, WEB_SOCKET_PATH, WEBSOCKET_QUERY, WEBSOCKET_PORT, WEB_SOCKET_SUB_PROTOCOL, null, null);
-                ((TransportInternal)transport).addTransportLayer(webSocket);
+                addWebsocketLayer(transport);
             }
 
             try
@@ -588,16 +586,27 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             //Adding proxy layer needs to be done after sending SSL message
             if (this.deviceClientConfig.getProxySettings() != null)
             {
-                final ProxyImpl proxy = new ProxyImpl();
-                final String hostName = event.getConnection().getHostname();
-                final ProxyHandler proxyHandler = new ProxyHandlerImpl();
-                proxy.configure(hostName, null, proxyHandler, transport);
-
-                ((TransportInternal) transport).addTransportLayer(proxy);
+                addProxyLayer(transport, event.getConnection().getHostname());
             }
         }
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
+    }
+
+    private void addWebsocketLayer(Transport transport)
+    {
+        // Codes_SRS_AMQPSIOTHUBCONNECTION_25_049: [If websocket enabled the event handler shall configure the transport layer for websocket.]
+        WebSocketImpl webSocket = new WebSocketImpl();
+        webSocket.configure(this.hostName, WEB_SOCKET_PATH, WEBSOCKET_QUERY, WEBSOCKET_PORT, WEB_SOCKET_SUB_PROTOCOL, null, null);
+        ((TransportInternal)transport).addTransportLayer(webSocket);
+    }
+
+    private void addProxyLayer(Transport transport, String hostName)
+    {
+        final ProxyImpl proxy = new ProxyImpl();
+        final ProxyHandler proxyHandler = new ProxyHandlerImpl();
+        proxy.configure(hostName, null, proxyHandler, transport);
+        ((TransportInternal) transport).addTransportLayer(proxy);
     }
 
     /**
@@ -739,19 +748,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_12_016: [The function shall get the link from the event and call device operation objects with it.]
         Link link = event.getLink();
-        try
-        {
-            this.amqpsSessionManager.onLinkInit(link);
-        }
-        catch (TransportException e)
-        {
-            // Codes_SRS_AMQPSIOTHUBCONNECTION_34_067: [If an exception is thrown while executing the callback onLinkInit on the saved amqpsSessionManager, that exception shall be saved.]
-            this.savedException = e;
-            logger.LogError(this.savedException);
-        }
+        this.amqpsSessionManager.onLinkInit(link);
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
-
     }
 
     /**
@@ -764,81 +763,28 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_040: [The event handler shall save the remaining link credit.]
-        this.amqpsSessionManager.onLinkFlow(event);
+        this.amqpsSessionManager.onLinkFlow(event.getLink());
 
-        processMessagesToSend();
+        //With new link credit available, new messages can be sent
+        processOutgoingMessages();
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
-    private void processMessagesToSend()
+    private void processOutgoingMessages()
     {
         int messagesAttemptedToBeProcessed = 0;
         int lastDeliveryTag = 0;
         com.microsoft.azure.sdk.iot.device.Message message = messagesToSend.poll();
         while (message != null && messagesAttemptedToBeProcessed < MAX_MESSAGES_TO_SEND_PER_CALLBACK && lastDeliveryTag >= 0)
         {
-            messagesAttemptedToBeProcessed++;
-            AmqpsConvertToProtonReturnValue amqpsConvertToProtonReturnValue = null;
-            try
+            if (!subscriptionChangeHandler(message))
             {
-                amqpsConvertToProtonReturnValue = this.convertToProton(message);
-            }
-            catch (TransportException e)
-            {
-                if (e.isRetryable())
-                {
-                    this.logger.LogError("Encountered exception while converting message to proton message, retrying", e);
-                    messagesToSend.add(message);
-                }
-                else
-                {
-                    this.logger.LogError("Encountered non-retryable exception while converting message to proton message, not retryable so discarding message", e);
-                }
-
-                return;
+                messagesAttemptedToBeProcessed++;
+                lastDeliveryTag = processMessage(message);
             }
 
-            if (amqpsConvertToProtonReturnValue == null)
-            {
-                // Codes_SRS_AMQPSTRANSPORT_34_076: [The function throws IllegalStateException if none of the device operation object could handle the conversion.]
-                this.logger.LogError("No handler found for message conversion! Abandoning message");
-                return;
-            }
-            else
-            {
-                try
-                {
-                    lastDeliveryTag = this.sendMessage(amqpsConvertToProtonReturnValue, message.getConnectionDeviceId());
-                }
-                catch (TransportException e)
-                {
-                    if (e.isRetryable())
-                    {
-                        this.logger.LogError("Encountered exception while sending amqp message, retrying", e);
-                        messagesToSend.add(message);
-                    }
-                    else
-                    {
-                        this.logger.LogError("Encountered non-retryable exception while sending amqp message, abandoning message", e);
-                    }
-
-                    return;
-                }
-
-                if (lastDeliveryTag != -1)
-                {
-                    // Codes_SRS_AMQPSTRANSPORT_34_078: [If the sent message hash is valid, it shall be added to the in progress map and this function shall return OK.]
-                    this.inProgressMessages.put(lastDeliveryTag, message);
-                }
-                else
-                {
-                    //message failed to send, likely due to lack of link credit available. Re-queue and try again later
-                    messagesToSend.add(message);
-                }
-
-                message = messagesToSend.poll();
-            }
+            message = messagesToSend.poll();
         }
 
         if (message != null)
@@ -846,6 +792,71 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             //message was polled out of list, but loop exited from processing too many messages before it could process this message, so re-queue it for later
             messagesToSend.add(message);
         }
+    }
+
+    private int processMessage(com.microsoft.azure.sdk.iot.device.Message message)
+    {
+        int lastDeliveryTag = -1;
+        AmqpsConvertToProtonReturnValue amqpsConvertToProtonReturnValue = null;
+        try
+        {
+            amqpsConvertToProtonReturnValue = this.convertToProton(message);
+        }
+        catch (TransportException e)
+        {
+            if (e.isRetryable())
+            {
+                this.logger.LogError("Encountered exception while converting message to proton message, retrying", e);
+                messagesToSend.add(message);
+            }
+            else
+            {
+                this.logger.LogError("Encountered non-retryable exception while converting message to proton message, not retryable so discarding message", e);
+            }
+
+            return lastDeliveryTag;
+        }
+
+        if (amqpsConvertToProtonReturnValue == null)
+        {
+            // Codes_SRS_AMQPSTRANSPORT_34_076: [The function throws IllegalStateException if none of the device operation object could handle the conversion.]
+            this.logger.LogError("No handler found for message conversion! Abandoning message");
+            return lastDeliveryTag;
+        }
+        else
+        {
+            try
+            {
+                lastDeliveryTag = this.sendMessage(amqpsConvertToProtonReturnValue, message.getConnectionDeviceId());
+            }
+            catch (TransportException e)
+            {
+                if (e.isRetryable())
+                {
+                    this.logger.LogError("Encountered exception while sending amqp message, retrying", e);
+                    messagesToSend.add(message);
+                }
+                else
+                {
+                    this.logger.LogError("Encountered non-retryable exception while sending amqp message, abandoning message", e);
+                }
+
+                return lastDeliveryTag;
+            }
+
+            if (lastDeliveryTag != -1)
+            {
+                // Codes_SRS_AMQPSTRANSPORT_34_078: [If the sent message hash is valid, it shall be added to the in progress map and this function shall return OK.]
+                this.inProgressMessages.put(lastDeliveryTag, message);
+            }
+            else
+            {
+                //message failed to send, likely due to lack of link credit available. Re-queue and try again later
+                messagesToSend.add(message);
+            }
+        }
+
+        return lastDeliveryTag;
     }
 
     /**
@@ -859,10 +870,29 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         logger.LogDebug("Entered in method %s", logger.getMethodName());
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_12_052: [The function shall call AmqpsSessionManager.onLinkRemoteOpen with the given link.]
-        if (this.amqpsSessionManager.onLinkRemoteOpen(event))
+        this.amqpsSessionManager.onLinkRemoteOpen(event.getLink());
+
+        if (this.amqpsSessionManager.isAuthenticationOpened() && !isAuthenticated)
         {
-            // Codes_SRS_AMQPSIOTHUBCONNECTION_21_051 [The open latch shall be notified when that the connection has been established.]
-            openLatch.countDown();
+            try
+            {
+                this.authenticate();
+            }
+            catch (TransportException e)
+            {
+                this.savedException = e;
+            }
+        }
+
+        if (event.getLink().getName().startsWith(AmqpsDeviceAuthenticationCBS.RECEIVER_LINK_TAG_PREFIX) || event.getLink().getName().startsWith(AmqpsDeviceAuthenticationCBS.SENDER_LINK_TAG_PREFIX))
+        {
+            //TODO maybe pass the latches down into the session, into the links so that this comparison can be done down there instead?
+            authenticationLinkOpenLatch.countDown();
+        }
+        else
+        {
+            //TODO maybe pass the latches down into the session, into the links so that this comparison can be done down there instead?
+            workerLinksOpenLatch.countDown();
         }
 
         logger.LogDebug("Exited from method %s", logger.getMethodName());
@@ -1004,7 +1034,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     @Override
     public void onTimerTask(Event event)
     {
-        processMessagesToSend();
+        processOutgoingMessages();
 
         event.getReactor().schedule(SEND_MESSAGES_PERIOD_MILLIS, this);
     }
@@ -1048,7 +1078,19 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
                                 //Codes_SRS_AMQPSIOTHUBCONNECTION_34_089: [If an amqp message can be received from the receiver link, and that amqp message contains a status code that is not 200 or 204, this function shall notify this object's listeners that that message was received and provide the status code's mapped exception.]
                                 this.savedException = IotHubStatusCode.getConnectionStatusException(iotHubStatusCode, statusDescription);
+
                                 logger.LogError(this.savedException);
+
+                                releaseLatch(cbsLinkAuthorizedLatch);
+                            }
+                            else
+                            {
+                                cbsLinkAuthorizedLatch.countDown();
+                                if (this.cbsLinkAuthorizedLatch.getCount() <= 0)
+                                {
+                                    this.isAuthenticated = true;
+                                    this.amqpsSessionManager.openWorkerLinks();
+                                }
                             }
                         }
                         catch (NumberFormatException nfe)
@@ -1115,16 +1157,10 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
     private Queue<com.microsoft.azure.sdk.iot.device.Message> messagesToSend = new ConcurrentLinkedQueue<>();
 
-    int queueCount = 0;
-
     @Override
     public IotHubStatusCode sendMessage(com.microsoft.azure.sdk.iot.device.Message message) throws TransportException
     {
-        if (!subscriptionChangeHandler(message))
-        {
-            messagesToSend.add(message);
-        }
-
+        messagesToSend.add(message);
         return IotHubStatusCode.OK;
     }
 
@@ -1263,7 +1299,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         return transportException;
     }
 
-    private boolean subscriptionChangeHandler(com.microsoft.azure.sdk.iot.device.Message message) throws TransportException
+    private boolean subscriptionChangeHandler(com.microsoft.azure.sdk.iot.device.Message message)
     {
         boolean handled = false;
         if (message.getMessageType() != null)
@@ -1273,8 +1309,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 case DEVICE_METHODS:
                     if (((IotHubTransportMessage) message).getDeviceOperationType() == DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST)
                     {
-                        this.amqpsSessionManager.openDeviceOperationLinks(DEVICE_METHODS);
-                        methodSubscribed = true;
+                        this.amqpsSessionManager.subscribeDeviceToMessageType(DEVICE_METHODS, message.getConnectionDeviceId());
+                        this.listener.onMessageSent(message, null);
                         handled = true;
                     }
 
@@ -1286,14 +1322,11 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                         //this.amqpSessionManager to sever the connection
                         //twinSubscribed = false;
                     }
-                    else
+                    else if (((IotHubTransportMessage) message).getDeviceOperationType() == DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST)
                     {
-                        this.amqpsSessionManager.openDeviceOperationLinks(DEVICE_TWIN);
-                        twinSubscribed = true;
-                        if (((IotHubTransportMessage) message).getDeviceOperationType() == DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST)
-                        {
-                            handled = true;
-                        }
+                        this.amqpsSessionManager.subscribeDeviceToMessageType(DEVICE_TWIN, message.getConnectionDeviceId());
+                        this.listener.onMessageSent(message, null);
+                        handled = true;
                     }
                     break;
                 default:
@@ -1302,5 +1335,14 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
 
         return handled;
+    }
+
+    private void releaseLatch(CountDownLatch latch)
+    {
+        //Countdown the latch until it hits 0
+        for (int i = 0; i < latch.getCount(); i++)
+        {
+            latch.countDown();
+        }
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
@@ -143,11 +143,12 @@ public class DeviceTwinTest
                 times = 1;
                 mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_REQUEST);
                 times = 1;
-                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST);
                 times = 1;
+                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                times = 2;
             }
         };
-
     }
 
     /*
@@ -177,8 +178,10 @@ public class DeviceTwinTest
                 times = 1;
                 mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_REQUEST);
                 times = 1;
-                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST);
                 times = 1;
+                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                times = 2;
             }
         };
 
@@ -211,8 +214,10 @@ public class DeviceTwinTest
                 times = 1;
                 mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_REQUEST);
                 times = 1;
-                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                mockedDeviceTwinMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST);
                 times = 1;
+                mockedDeviceIO.sendEventAsync(mockedDeviceTwinMessage, (IotHubEventCallback)any , null, null);
+                times = 2;
             }
         };
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -2638,19 +2638,19 @@ public class InternalClientTest
         client.setProxySettings(mockProxySettings);
     }
 
-    @Test (expected = UnsupportedOperationException.class)
+    @Test (expected = IllegalArgumentException.class)
     public void setProxyThrowsIfClientIsUsingMQTT()
     {
         setProxyThrowsIfClientUsingUnsupportedProtocol(IotHubClientProtocol.MQTT);
     }
 
-    @Test (expected = UnsupportedOperationException.class)
+    @Test (expected = IllegalArgumentException.class)
     public void setProxyThrowsIfClientIsUsingAMQPS()
     {
         setProxyThrowsIfClientUsingUnsupportedProtocol(IotHubClientProtocol.AMQPS);
     }
 
-    @Test (expected = UnsupportedOperationException.class)
+    @Test (expected = IllegalArgumentException.class)
     public void setProxyThrowsIfClientIsUsingMQTTWS()
     {
         setProxyThrowsIfClientUsingUnsupportedProtocol(IotHubClientProtocol.MQTT_WS);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBSTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationCBSTest.java
@@ -465,7 +465,7 @@ public class AmqpsDeviceAuthenticationCBSTest
 
     // Tests_SRS_AMQPSDEVICEAUTHENTICATIONCBS_12_020: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundSendTrue()
+    public void onLinkRemoteOpenSendTrue()
     {
         // arrange
         final AmqpsDeviceAuthenticationCBS amqpsDeviceAuthenticationCBS = new AmqpsDeviceAuthenticationCBS(mockDeviceClientConfig);
@@ -477,7 +477,7 @@ public class AmqpsDeviceAuthenticationCBSTest
         Deencapsulation.setField(amqpsDeviceAuthenticationCBS, "senderLinkTag", linkName);
 
         // act
-        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "isLinkFound", linkName);
+        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "onLinkRemoteOpen", linkName);
 
         // assert
         assertTrue(isFound);
@@ -490,7 +490,7 @@ public class AmqpsDeviceAuthenticationCBSTest
 
     // Tests_SRS_AMQPSDEVICEAUTHENTICATIONCBS_12_021: [The function shall return true and set the recvLinkState to OPENED if the receiverLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundRecvTrue()
+    public void onLinkRemoteOpenRecvTrue()
     {
         // arrange
         final AmqpsDeviceAuthenticationCBS amqpsDeviceAuthenticationCBS = new AmqpsDeviceAuthenticationCBS(mockDeviceClientConfig);
@@ -502,7 +502,7 @@ public class AmqpsDeviceAuthenticationCBSTest
         Deencapsulation.setField(amqpsDeviceAuthenticationCBS, "receiverLinkTag", linkName);
 
         // act
-        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "isLinkFound", linkName);
+        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "onLinkRemoteOpen", linkName);
 
         // assert
         assertTrue(isFound);
@@ -515,7 +515,7 @@ public class AmqpsDeviceAuthenticationCBSTest
 
     // Tests_SRS_AMQPSDEVICEAUTHENTICATIONCBS_12_022: [The function shall return false if neither the senderLinkTag nor the receiverLinkTag is matcing with the given linkName.]
     @Test
-    public void isLinkFoundFalse()
+    public void onLinkRemoteOpenFalse()
     {
         // arrange
         final AmqpsDeviceAuthenticationCBS amqpsDeviceAuthenticationCBS = new AmqpsDeviceAuthenticationCBS(mockDeviceClientConfig);
@@ -525,7 +525,7 @@ public class AmqpsDeviceAuthenticationCBSTest
         final String linkName = "linkName";
 
         // act
-        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "isLinkFound", linkName);
+        Boolean isFound = Deencapsulation.invoke(amqpsDeviceAuthenticationCBS, "onLinkRemoteOpen", linkName);
 
         // assert
         assertFalse(isFound);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationTest.java
@@ -1,6 +1,7 @@
 package tests.unit.com.microsoft.azure.sdk.iot.device.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
+import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpsDeviceAuthentication;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpsMessage;
 import mockit.Deencapsulation;
@@ -38,16 +39,39 @@ public class AmqpsDeviceAuthenticationTest
     SslDomain mockDomain;
 
     @Mocked
-    Transport mockTransport;
-
-    @Mocked
     DeviceClientConfig mockDeviceClientConfig;
 
-    @Mocked
-    UUID mockUUID;
+    private class AmqpsDeviceAuthenticationMock extends AmqpsDeviceAuthentication
+    {
+        public AmqpsDeviceAuthenticationMock(DeviceClientConfig config)
+        {
+            super(config);
+        }
 
-    @Mocked
-    AmqpsMessage mockAmqpsMessage;
+        @Override
+        protected void setSslDomain(Transport transport) throws TransportException
+        {
+            //do nothing
+        }
+
+        @Override
+        protected void authenticate(DeviceClientConfig deviceClientConfig, UUID correlationId) throws TransportException
+        {
+            //do nothing
+        }
+
+        @Override
+        protected boolean authenticationMessageReceived(AmqpsMessage amqpsMessage, UUID authenticationCorrelationId)
+        {
+            return false;
+        }
+
+        @Override
+        protected boolean onLinkRemoteOpen(String linkName)
+        {
+            return false;
+        }
+    }
 
     // Tests_SRS_AMQPSDEVICEAUTHENTICATION_12_001: [The function shall get the sslDomain oject from the Proton reactor.]
     // Tests_SRS_AMQPSDEVICEAUTHENTICATION_12_002: [The function shall set the sslContext on the domain.]
@@ -58,7 +82,7 @@ public class AmqpsDeviceAuthenticationTest
     public void makeDomainSuccess()
     {
         // arrange
-        final AmqpsDeviceAuthentication amqpsDeviceAuthentication = Deencapsulation.newInstance(AmqpsDeviceAuthentication.class, mockDeviceClientConfig);
+        final AmqpsDeviceAuthenticationMock amqpsDeviceAuthentication = new AmqpsDeviceAuthenticationMock(mockDeviceClientConfig);
 
         new NonStrictExpectations()
         {
@@ -86,63 +110,5 @@ public class AmqpsDeviceAuthenticationTest
                 times = 1;
             }
         };
-    }
-
-    // Tests_SRS_AMQPSDEVICEAUTHENTICATION_12_006: [The prototype function does nothing.]
-    @Test
-    public void setSslDomain()
-    {
-        // arrange
-        final AmqpsDeviceAuthentication amqpsDeviceAuthentication = Deencapsulation.newInstance(AmqpsDeviceAuthentication.class, mockDeviceClientConfig);
-
-        // act
-        Deencapsulation.invoke(amqpsDeviceAuthentication, "setSslDomain", mockTransport);
-    }
-
-    // Tests_SRS_AMQPSDEVICEAUTHENTICATION_12_007: [The prototype function does nothing.]
-    @Test
-    public void authenticate()
-    {
-        // arrange
-        final AmqpsDeviceAuthentication amqpsDeviceAuthentication = Deencapsulation.newInstance(AmqpsDeviceAuthentication.class, mockDeviceClientConfig);
-
-        // act
-        Deencapsulation.invoke(amqpsDeviceAuthentication, "authenticate", mockDeviceClientConfig, mockUUID);
-    }
-
-    // Tests_SRS_AMQPSDEVICEAUTHENTICATION_12_008: [The prototype function shall return false.]
-    @Test
-    public void authenticationMessageReceived()
-    {
-        // arrange
-        final AmqpsDeviceAuthentication amqpsDeviceAuthentication = Deencapsulation.newInstance(AmqpsDeviceAuthentication.class, mockDeviceClientConfig);
-
-        // act
-        Boolean actualReturn = Deencapsulation.invoke(amqpsDeviceAuthentication, "authenticationMessageReceived", mockAmqpsMessage, mockUUID);
-
-        // assert
-        assertEquals(false, actualReturn);
-    }
-
-    // Tests_SRS_AMQPSDEVICEAUTHENTICATION_34_009: [This constructor shall call super with the provided user agent string.]
-    @Test
-    public void constructorCallsSuperWithUserAgentString()
-    {
-        //arrange
-        final String expectedUserAgentString = "asdf";
-        new NonStrictExpectations()
-        {
-            {
-                mockDeviceClientConfig.getProductInfo().getUserAgentString();
-                result = expectedUserAgentString;
-            }
-        };
-
-        //act
-        AmqpsDeviceAuthentication actual = Deencapsulation.newInstance(AmqpsDeviceAuthentication.class, mockDeviceClientConfig);
-
-        //assert
-        Map<Symbol, Object> amqpProperties = Deencapsulation.getField(actual, "amqpProperties");
-        assertTrue(amqpProperties.containsValue(expectedUserAgentString));
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationX509Test.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceAuthenticationX509Test.java
@@ -234,15 +234,15 @@ public class AmqpsDeviceAuthenticationX509Test
 
     // Tests_SRS_AMQPSDEVICEAUTHENTICATIONX509_12_012: [The function shall override the default behaviour and return true.]
     @Test
-    public void isLinkFoundReturnsTrue()
+    public void onLinkRemoteOpenReturnsFalse()
     {
         //arrange
         final AmqpsDeviceAuthenticationX509 auth = new AmqpsDeviceAuthenticationX509(mockDeviceClientConfig);
 
         //act
-        boolean result = Deencapsulation.invoke(auth, "isLinkFound", new Class[] {String.class}, "");
+        boolean result = Deencapsulation.invoke(auth, "onLinkRemoteOpen", new Class[] {String.class}, "");
 
         //assert
-        assertTrue(result);
+        assertFalse(result);
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethodsTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethodsTest.java
@@ -90,7 +90,7 @@ public class AmqpsDeviceMethodsTest
 
     // Tests_SRS_AMQPSDEVICEMETHODS_12_047: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundReturnsTrueIfSenderLinkTagMatches()
+    public void onLinkRemoteOpenReturnsTrueIfSenderLinkTagMatches()
     {
         // arrange
         String linkName = "linkName";
@@ -99,7 +99,7 @@ public class AmqpsDeviceMethodsTest
         AmqpsDeviceMethods amqpsDeviceMethods = Deencapsulation.newInstance(AmqpsDeviceMethods.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceMethods, "senderLinkTag", linkName);
         AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceMethods, "amqpsSendLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "onLinkRemoteOpen", linkName);
         AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceMethods, "amqpsSendLinkState");
 
         // assert
@@ -110,7 +110,7 @@ public class AmqpsDeviceMethodsTest
 
     // Tests_SRS_AMQPSDEVICEMETHODS_12_048: [The function shall return true and set the recvLinkState to OPENED if the receiverLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundReturnsTrueIfReceiverLinkTagMatches()
+    public void onLinkRemoteOpenReturnsTrueIfReceiverLinkTagMatches()
     {
         // arrange
         String linkName = "linkName";
@@ -119,7 +119,7 @@ public class AmqpsDeviceMethodsTest
         AmqpsDeviceMethods amqpsDeviceMethods = Deencapsulation.newInstance(AmqpsDeviceMethods.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceMethods, "receiverLinkTag", linkName);
         AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceMethods, "amqpsRecvLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "onLinkRemoteOpen", linkName);
         AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceMethods, "amqpsRecvLinkState");
 
         // assert
@@ -130,7 +130,7 @@ public class AmqpsDeviceMethodsTest
 
     // Tests_SRS_AMQPSDEVICEMETHODS_12_049: [The function shall return false if neither the senderLinkTag nor the receiverLinkTag is matcing with the given linkName.]
     @Test
-    public void isLinkFoundReturnsFalseIfThereIsNoMatch()
+    public void onLinkRemoteOpenReturnsFalseIfThereIsNoMatch()
     {
         // arrange
         String linkName = "linkName";
@@ -139,7 +139,7 @@ public class AmqpsDeviceMethodsTest
         AmqpsDeviceMethods amqpsDeviceMethods = Deencapsulation.newInstance(AmqpsDeviceMethods.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceMethods, "senderLinkTag", "xxx");
         Deencapsulation.setField(amqpsDeviceMethods, "receiverLinkTag", "yyy");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceMethods, "onLinkRemoteOpen", linkName);
 
         // assert
         assertFalse(retVal);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperationsTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperationsTest.java
@@ -5,6 +5,7 @@
 package tests.unit.com.microsoft.azure.sdk.iot.device.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.*;
@@ -72,6 +73,32 @@ public class AmqpsDeviceOperationsTest
     @Mocked
     ProductInfo mockedProductInfo;
 
+    private class AmqpsDeviceOperationsMock extends AmqpsDeviceOperations
+    {
+        public AmqpsDeviceOperationsMock(DeviceClientConfig config)
+        {
+            super(config, "", "", "", "", "", "");
+        }
+
+        @Override
+        protected boolean onLinkRemoteOpen(String linkName)
+        {
+            return false;
+        }
+
+        @Override
+        protected AmqpsConvertFromProtonReturnValue convertFromProton(AmqpsMessage amqpsMessage, DeviceClientConfig deviceClientConfig) throws TransportException
+        {
+            return null;
+        }
+
+        @Override
+        protected AmqpsConvertToProtonReturnValue convertToProton(Message message) throws TransportException
+        {
+            return null;
+        }
+    }
+
     /*
     **Tests_SRS_AMQPSDEVICEOPERATIONS_12_001: [**The constructor shall initialize amqpProperties with device client identifier and version.**]**
     **Tests_SRS_AMQPSDEVICEOPERATIONS_12_002: [**The constructor shall initialize sender and receiver tags with UUID string.**]**
@@ -100,7 +127,7 @@ public class AmqpsDeviceOperationsTest
         };
 
         //act
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //assert
         assertNotNull(amqpsDeviceOperations);
@@ -139,7 +166,7 @@ public class AmqpsDeviceOperationsTest
         DeviceClientConfig nullConfig = null;
 
         //act
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, nullConfig);
+        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperationsMock.class, nullConfig);
     }
 
     /*
@@ -152,7 +179,7 @@ public class AmqpsDeviceOperationsTest
         String API_VERSION = TransportUtils.IOTHUB_API_VERSION;
 
         //act
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         String VERSION_IDENTIFIER_KEY = Deencapsulation.getField(amqpsDeviceOperations, "VERSION_IDENTIFIER_KEY");
         String API_VERSION_KEY = Deencapsulation.getField(amqpsDeviceOperations, "API_VERSION_KEY");
 
@@ -168,7 +195,7 @@ public class AmqpsDeviceOperationsTest
     public void openLinksThrowsIllegalArgumentException() throws IllegalArgumentException
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", null);
@@ -183,7 +210,7 @@ public class AmqpsDeviceOperationsTest
     public void openLinksCreatesReceiverAndSenderLinksWithTag()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         AmqpsDeviceOperationLinkState amqpsSendLinkState1 = Deencapsulation.getField(amqpsDeviceOperations, "amqpsSendLinkState");
@@ -220,7 +247,7 @@ public class AmqpsDeviceOperationsTest
     public void openLinksCreatesReceiverAndSenderLinksWithTag_CBS()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         AmqpsDeviceOperationLinkState amqpsSendLinkState1 = Deencapsulation.getField(amqpsDeviceOperations, "amqpsSendLinkState");
@@ -260,7 +287,7 @@ public class AmqpsDeviceOperationsTest
     public void openLinksSetsAmqpsProperties()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
@@ -287,7 +314,7 @@ public class AmqpsDeviceOperationsTest
     public void openLinksOpensLinks()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
@@ -314,7 +341,7 @@ public class AmqpsDeviceOperationsTest
     public void closeLinksClosesLinks()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLink", mockReceiver);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLink", mockSender);
@@ -347,7 +374,7 @@ public class AmqpsDeviceOperationsTest
     public void initLinkThrowsIllegalArgumentException()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         Deencapsulation.invoke(amqpsDeviceOperations, "initLink", null);
@@ -362,7 +389,7 @@ public class AmqpsDeviceOperationsTest
     public void initLinkSetsSenderLink()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final String senderLinkTag = "senderLinkTag";
         Deencapsulation.setField(amqpsDeviceOperations, "senderLinkTag",senderLinkTag);
         final String senderLinkAddress = "senderLinkAddress";
@@ -404,7 +431,7 @@ public class AmqpsDeviceOperationsTest
     public void initLinkSetsReceiverLink()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final String receiverLinkTag = "receiverLinkTag";
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLinkTag", receiverLinkTag);
         final String receiverLinkAddress = "receiverLinkAddress";
@@ -440,7 +467,7 @@ public class AmqpsDeviceOperationsTest
     public void initLinkDoesNothing()
     {
         //arrange
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final String senderLinkTag = "senderLinkTag";
         Deencapsulation.setField(amqpsDeviceOperations, "senderLinkTag",senderLinkTag);
         final String receiverLinkTag = "receiverLinkTag";
@@ -490,7 +517,7 @@ public class AmqpsDeviceOperationsTest
     public void sendMessageAndGetDeliveryHashThrowsIllegalStateExceptionIfSenderLinkNull()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         byte[] msgData = new byte[1];
         int offset = 0;
         int length = 1;
@@ -506,7 +533,7 @@ public class AmqpsDeviceOperationsTest
     public void sendMessageAndGetDeliveryHashThrowsIllegalArgumentExceptionIfDeliveryTagNull()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final byte[] msgData = new byte[1];
         final int offset = 0;
         final int length = 1;
@@ -528,7 +555,7 @@ public class AmqpsDeviceOperationsTest
     public void sendMessageAndGetDeliveryHashSendSuccessful()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final byte[] msgData = new byte[1];
         final int offset = 0;
         final int length = 1;
@@ -572,7 +599,7 @@ public class AmqpsDeviceOperationsTest
     public void sendMessageAndGetDeliveryHashFailsIfNoLinkCreditAvailable()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final byte[] msgData = new byte[1];
         final int offset = 0;
         final int length = 1;
@@ -618,7 +645,7 @@ public class AmqpsDeviceOperationsTest
     public void sendMessageAndGetDeliveryHashSendFails()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         final byte[] msgData = new byte[1];
         final int offset = 0;
         final int length = 1;
@@ -660,7 +687,7 @@ public class AmqpsDeviceOperationsTest
     public void getMessageFromReceiverLinkThrowIfLinkNameEmpty()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         AmqpsMessage amqpsMessage = Deencapsulation.invoke(amqpsDeviceOperations, "getMessageFromReceiverLink", "");
@@ -675,7 +702,7 @@ public class AmqpsDeviceOperationsTest
         //arrange
         String linkName1 = "receiver1";
         String linkName2 = "receiver2";
-        final AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        final AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLink", mockReceiver);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLink", mockSender);
@@ -709,7 +736,7 @@ public class AmqpsDeviceOperationsTest
     {
         //arrange
         String linkName = "receiver";
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLink", mockReceiver);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLink", mockSender);
@@ -752,7 +779,7 @@ public class AmqpsDeviceOperationsTest
     {
         //arrange
         String linkName = "receiver";
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLink", mockReceiver);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLink", mockSender);
@@ -798,7 +825,7 @@ public class AmqpsDeviceOperationsTest
     {
         //arrange
         String linkName = "receiver";
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLink", mockReceiver);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLink", mockSender);
@@ -839,7 +866,7 @@ public class AmqpsDeviceOperationsTest
     public void operationLinksOpenedTrue()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "amqpsSendLinkState", AmqpsDeviceOperationLinkState.OPENED);
         Deencapsulation.setField(amqpsDeviceOperations, "amqpsRecvLinkState", AmqpsDeviceOperationLinkState.OPENED);
 
@@ -855,7 +882,7 @@ public class AmqpsDeviceOperationsTest
     public void operationLinksOpenedFalse()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "amqpsSendLinkState", AmqpsDeviceOperationLinkState.OPENED);
         Deencapsulation.setField(amqpsDeviceOperations, "amqpsRecvLinkState", AmqpsDeviceOperationLinkState.CLOSED);
 
@@ -866,52 +893,6 @@ public class AmqpsDeviceOperationsTest
         assertFalse(isOpened);
     }
 
-    // Tests_SRS_AMQPSDEVICEOPERATIONS_12_046: [The prototype function shall return null.]
-    @Test
-    public void isLinkFound()
-    {
-        //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
-
-        //act
-        Boolean isFound = Deencapsulation.invoke(amqpsDeviceOperations, "isLinkFound", "linkName");
-
-        //assert
-        assertNull(isFound);
-    }
-
-    /*
-    **Test_SRS_AMQPSDEVICEOPERATIONS_12_039: [**The prototype function shall return null.**]**
-    */
-    @Test
-    public void convertFromProton()
-    {
-        //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
-
-        //act
-        AmqpsConvertFromProtonReturnValue amqpsConvertFromProtonReturnValue = Deencapsulation.invoke(amqpsDeviceOperations, "convertFromProton", mockAmqpsMessage, mockDeviceClientConfig);
-
-        //assert
-        assertTrue(amqpsConvertFromProtonReturnValue == null);
-    }
-
-    /*
-    **Test_SRS_AMQPSDEVICEOPERATIONS_12_040: [**The prototype function shall return null.**]**
-    */
-    @Test
-    public void convertToProton()
-    {
-        //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
-
-        //act
-        AmqpsConvertFromProtonReturnValue amqpsConvertFromProtonReturnValue = Deencapsulation.invoke(amqpsDeviceOperations, "convertToProton", mockMessage);
-
-        //assert
-        assertTrue(amqpsConvertFromProtonReturnValue == null);
-    }
-
     /*
     **Tests_SRS_AMQPSDEVICEOPERATIONS_12_027: [**The getter shall return with the value of the amqpProperties.**]**
      */
@@ -919,7 +900,7 @@ public class AmqpsDeviceOperationsTest
     public void getAmqpPropertiesReturnsAmqpsProperties()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "amqpProperties", mockHashMap);
 
         //act
@@ -937,7 +918,7 @@ public class AmqpsDeviceOperationsTest
     {
         //arrange
         String linkTag = "linkTag";
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLinkTag", linkTag);
 
         //act
@@ -954,7 +935,7 @@ public class AmqpsDeviceOperationsTest
     public void getReceiverLinkTagReturnsReceiverLinkTag()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLinkTag", "xxx");
 
         //act
@@ -971,7 +952,7 @@ public class AmqpsDeviceOperationsTest
     public void getSenderLinkAddressReturnsSenderLinkAddress()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "senderLinkAddress", "xxx");
 
         //act
@@ -988,7 +969,7 @@ public class AmqpsDeviceOperationsTest
     public void getReceiverLinkAddressReturnsReceiverLinkAddress()
     {
         //arrange
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "", "", "", "", "", "");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceOperations, "receiverLinkAddress", "xxx");
 
         //act
@@ -1027,7 +1008,7 @@ public class AmqpsDeviceOperationsTest
         userProperties.put(iotHubMessageProperties[0].getName(), iotHubMessageProperties[0].getValue());
         userProperties.put(iotHubMessageProperties[1].getName(), iotHubMessageProperties[1].getValue());
 
-        AmqpsDeviceOperations amqpsDeviceOperation = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "some string", "some string", "some string", "some string", "some string", "some string");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         new NonStrictExpectations()
         {
             {
@@ -1070,7 +1051,7 @@ public class AmqpsDeviceOperationsTest
         };
 
         //act
-        MessageImpl protonMessage = Deencapsulation.invoke(amqpsDeviceOperation, "iotHubMessageToProtonMessage", mockMessage);
+        MessageImpl protonMessage = Deencapsulation.invoke(amqpsDeviceOperations, "iotHubMessageToProtonMessage", mockMessage);
 
         //assert
         assertTrue(protonMessage != null);
@@ -1088,7 +1069,7 @@ public class AmqpsDeviceOperationsTest
         byte[] bytes = new byte[1];
         final Object messageContext = "context";
 
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "some string", "some string", "some string", "some string", "some string", "some string");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
 
         new NonStrictExpectations()
@@ -1150,7 +1131,7 @@ public class AmqpsDeviceOperationsTest
         applicationPropertiesMap.put(MessageProperty.CONNECTION_MODULE_ID, connectionModuleId);
         applicationPropertiesMap.put(MessageProperty.CONNECTION_DEVICE_ID, connectionDeviceId);
 
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "some string", "some string", "some string", "some string", "some string", "some string");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
         Deencapsulation.invoke(amqpsDeviceOperations, "openLinks", mockSession);
         final String AMQPS_APP_PROPERTY_PREFIX = Deencapsulation.getField(amqpsDeviceOperations, "AMQPS_APP_PROPERTY_PREFIX");
 
@@ -1213,7 +1194,7 @@ public class AmqpsDeviceOperationsTest
     {
         //arrange
         int expectedLinkCredit = 2345;
-        AmqpsDeviceOperations amqpsDeviceOperations = Deencapsulation.newInstance(AmqpsDeviceOperations.class, mockDeviceClientConfig, "some string", "some string", "some string", "some string", "some string", "some string");
+        AmqpsDeviceOperationsMock amqpsDeviceOperations = new AmqpsDeviceOperationsMock(mockDeviceClientConfig);
 
         //act
         amqpsDeviceOperations.onLinkFlow(expectedLinkCredit);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetryTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetryTest.java
@@ -210,7 +210,7 @@ public class AmqpsDeviceTelemetryTest
 
     // Tests_SRS_AMQPSDEVICETELEMETRY_12_026: [The function shall return true and set the sendLinkState to OPENED if the senderLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundReturnsTrueIfSenderLinkTagMatches()
+    public void onLinkRemoteOpenReturnsTrueIfSenderLinkTagMatches()
     {
         // arrange
         String linkName = "linkName";
@@ -219,7 +219,7 @@ public class AmqpsDeviceTelemetryTest
         AmqpsDeviceTelemetry amqpsDeviceTelemetry = Deencapsulation.newInstance(AmqpsDeviceTelemetry.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceTelemetry, "senderLinkTag", linkName);
         AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceTelemetry, "amqpsSendLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "onLinkRemoteOpen", linkName);
         AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceTelemetry, "amqpsSendLinkState");
 
         // assert
@@ -230,7 +230,7 @@ public class AmqpsDeviceTelemetryTest
 
     // Tests_SRS_AMQPSDEVICETELEMETRY_12_027: [The function shall return true and set the recvLinkState to OPENED if the receiverLinkTag is equal to the given linkName.]
     @Test
-    public void isLinkFoundReturnsTrueIfReceiverLinkTagMatches()
+    public void onLinkRemoteOpenReturnsTrueIfReceiverLinkTagMatches()
     {
         // arrange
         String linkName = "linkName";
@@ -239,7 +239,7 @@ public class AmqpsDeviceTelemetryTest
         AmqpsDeviceTelemetry amqpsDeviceTelemetry = Deencapsulation.newInstance(AmqpsDeviceTelemetry.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceTelemetry, "receiverLinkTag", linkName);
         AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceTelemetry, "amqpsRecvLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "onLinkRemoteOpen", linkName);
         AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceTelemetry, "amqpsRecvLinkState");
 
         // assert
@@ -250,7 +250,7 @@ public class AmqpsDeviceTelemetryTest
 
     // Tests_SRS_AMQPSDEVICETELEMETRY_12_028: [The function shall return false if neither the senderLinkTag nor the receiverLinkTag is matcing with the given linkName.]
     @Test
-    public void isLinkFoundReturnsFalseIfThereIsNoMatch()
+    public void onLinkRemoteOpenReturnsFalseIfThereIsNoMatch()
     {
         // arrange
         String linkName = "linkName";
@@ -259,7 +259,7 @@ public class AmqpsDeviceTelemetryTest
         AmqpsDeviceTelemetry amqpsDeviceTelemetry = Deencapsulation.newInstance(AmqpsDeviceTelemetry.class, mockDeviceClientConfig);
         Deencapsulation.setField(amqpsDeviceTelemetry, "senderLinkTag", "xxx");
         Deencapsulation.setField(amqpsDeviceTelemetry, "receiverLinkTag", "yyy");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "isLinkFound", linkName);
+        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTelemetry, "onLinkRemoteOpen", linkName);
 
         // assert
         Assert.assertFalse(retVal);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwinTest.java
@@ -255,60 +255,6 @@ public class AmqpsDeviceTwinTest
         assertTrue(MESSAGE_ANNOTATION_FIELD_VALUE_NOTIFICATIONS_TWIN_PROPERTIES_DESIRED.equals("/notifications/twin/properties/desired"));
     }
 
-    @Test
-    public void isLinkFoundReturnsTrueIfSenderLinkTagMatches()
-    {
-        // arrange
-        String linkName = "linkName";
-
-        //act
-        AmqpsDeviceTwin amqpsDeviceTwin = Deencapsulation.newInstance(AmqpsDeviceTwin.class, mockDeviceClientConfig);
-        Deencapsulation.setField(amqpsDeviceTwin, "senderLinkTag", linkName);
-        AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceTwin, "amqpsSendLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTwin, "isLinkFound", linkName);
-        AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceTwin, "amqpsSendLinkState");
-
-        // assert
-        assertTrue(retVal);
-        assertEquals(linkSate1, AmqpsDeviceOperationLinkState.CLOSED);
-        assertEquals(linkSate2, AmqpsDeviceOperationLinkState.OPENED);
-    }
-
-    @Test
-    public void isLinkFoundReturnsTrueIfReceiverLinkTagMatches()
-    {
-        // arrange
-        String linkName = "linkName";
-
-        //act
-        AmqpsDeviceTwin amqpsDeviceTwin = Deencapsulation.newInstance(AmqpsDeviceTwin.class, mockDeviceClientConfig);
-        Deencapsulation.setField(amqpsDeviceTwin, "receiverLinkTag", linkName);
-        AmqpsDeviceOperationLinkState linkSate1 = Deencapsulation.getField(amqpsDeviceTwin, "amqpsRecvLinkState");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTwin, "isLinkFound", linkName);
-        AmqpsDeviceOperationLinkState linkSate2 = Deencapsulation.getField(amqpsDeviceTwin, "amqpsRecvLinkState");
-
-        // assert
-        assertTrue(retVal);
-        assertEquals(linkSate1, AmqpsDeviceOperationLinkState.CLOSED);
-        assertEquals(linkSate2, AmqpsDeviceOperationLinkState.OPENED);
-    }
-
-    @Test
-    public void isLinkFoundReturnsFalseIfThereIsNoMatch()
-    {
-        // arrange
-        String linkName = "linkName";
-
-        //act
-        AmqpsDeviceTwin amqpsDeviceTwin = Deencapsulation.newInstance(AmqpsDeviceTwin.class, mockDeviceClientConfig);
-        Deencapsulation.setField(amqpsDeviceTwin, "senderLinkTag", "xxx");
-        Deencapsulation.setField(amqpsDeviceTwin, "receiverLinkTag", "yyy");
-        Boolean retVal = Deencapsulation.invoke(amqpsDeviceTwin, "isLinkFound", linkName);
-
-        // assert
-        assertFalse(retVal);
-    }
-
     // Tests_SRS_AMQPSDEVICETWIN_12_010: [The function shall call the super function if the MessageType is DEVICE_TWIN, and return with it's return value.]
     @Test
     public void sendMessageAndGetDeliveryTagCallsSuper() throws IOException

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/provisioning/ProvisioningTests.java
@@ -433,7 +433,7 @@ public class ProvisioningTests extends ProvisioningCommon
         reportedProperties.add(new Property(expectedReportedPropertyName, expectedReportedPropertyValue));
         deviceClient.sendReportedProperties(reportedProperties);
         twinLock.await(MAX_TWIN_PROPAGATION_WAIT_SECONDS, TimeUnit.SECONDS);
-        deviceClient.close();
+        deviceClient.closeNow();
     }
 
     private void updateEnrollmentToForceReprovisioning(EnrollmentType enrollmentType, List<String> iothubsToFinishAt) throws ProvisioningServiceClientException


### PR DESCRIPTION
Reactor operations are not thread safe, and need to be done on a reactor exposed thread. This PR fixes the device client so that it no longer does any reactor operations on a non-reactor thread.

Benefits include fixing an issue where calling open on an AMQP device client often failed. Now open is significantly more consistent.

Miscellaneous fixes in this PR include fixing reconnection logic in AMQP to work regardless of if client is multiplexing, subscribed to twin, subscribed to methods, etc.

Also removing openClientWithRetry logic now, since AMQP stack now should be relied on to open a connection without retry