### PR TITLE
Cleanup e2e test code

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -52,7 +52,6 @@ public class DeviceMethodCommon extends IntegrationTest
     protected static final String PAYLOAD_STRING = "This is a valid payload";
 
     protected static final int NUMBER_INVOKES_PARALLEL = 10;
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     // How much to wait until a message makes it to the server, in milliseconds
     protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60000;
 
@@ -284,18 +283,8 @@ public class DeviceMethodCommon extends IntegrationTest
     }
 
     @After
-    public void afterTest() throws IOException, IotHubException
+    public void afterTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (Exception e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         this.testInstance.dispose();
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -66,7 +66,6 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static final Integer PAGE_SIZE = 2;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     // Constants used in for Testing
     protected static final String PROPERTY_KEY = "Key";
@@ -471,27 +470,16 @@ public class DeviceTwinCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownNewDeviceAndModule() throws IOException, IotHubException
+    public void tearDownNewDeviceAndModule()
     {
-        tearDownTwin(deviceUnderTest);
-
         try
         {
+            tearDownTwin(deviceUnderTest);
             registryManager.removeDevice(deviceUnderTest.sCDeviceForRegistryManager.getDeviceId());
         }
         catch (Exception e)
         {
-
-        }
-
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail(buildExceptionMessage("Unexpected exception encountered", internalClient));
+            //Don't care if tear down failed. Nightly job will clean up these identities
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -102,8 +102,6 @@ public class ProvisioningCommon extends IntegrationTest
     public ProvisioningServiceClient provisioningServiceClient = null;
     public RegistryManager registryManager = null;
 
-    public static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
-
     //sending reported properties for twin operations takes some time to get the appropriate callback
     public static final int MAX_TWIN_PROPAGATION_WAIT_SECONDS = 60;
 
@@ -185,16 +183,6 @@ public class ProvisioningCommon extends IntegrationTest
     @After
     public void tearDown()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         registryManager.close();
         provisioningServiceClient = null;
         registryManager = null;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -54,7 +54,6 @@ public class ReceiveMessagesCommon extends IntegrationTest
 
     protected static String expectedCorrelationId = "1234";
     protected static String expectedMessageId = "5678";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     protected static final long ERROR_INJECTION_RECOVERY_TIMEOUT = 1 * 60 * 1000; // 1 minute
 
     public ReceiveMessagesTestInstance testInstance;
@@ -251,18 +250,8 @@ public class ReceiveMessagesCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            TestCase.fail("Unexpected exception encountered");
-        }
-
         testInstance.dispose();
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -55,7 +55,6 @@ public class SendMessagesCommon extends IntegrationTest
     protected static final Integer RETRY_MILLISECONDS = 100;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     protected static String hostName;
 
@@ -130,7 +129,6 @@ public class SendMessagesCommon extends IntegrationTest
             fail("Failed to stop the test proxy");
         }
     }
-
 
     protected static Collection inputsCommon() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
     {
@@ -509,18 +507,8 @@ public class SendMessagesCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         this.testInstance.dispose();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -52,7 +52,6 @@ public class TransportClientTests extends IntegrationTest
 
     private static final long RETRY_MILLISECONDS = 100; //.1 seconds
     private static final long SEND_TIMEOUT_MILLISECONDS = 5 * 60 * 1000; // 5 minutes
-    private static final long INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     private static final long RECEIVE_MESSAGE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 10 * 1000; // 10 seconds
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION = 500; // .5 seconds
@@ -213,18 +212,8 @@ public class TransportClientTests extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         testInstance.dispose();
     }
 


### PR DESCRIPTION
Cleaning up the e2e tests to remove useless code, and to prevent tests from failing from tear down exceptions