### PR TITLE
Remove open with retry in test logic and remove dead code

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceEmulator.java
@@ -54,7 +54,7 @@ public class DeviceEmulator
         this.client = client;
     }
 
-    void setup() throws InterruptedException
+    void setup() throws IOException
     {
         try
         {
@@ -72,7 +72,7 @@ public class DeviceEmulator
 
         if (this.client != null)
         {
-            IotHubServicesCommon.openClientWithRetry(this.client);
+            this.client.open();
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -52,7 +52,6 @@ public class DeviceMethodCommon extends IntegrationTest
     protected static final String PAYLOAD_STRING = "This is a valid payload";
 
     protected static final int NUMBER_INVOKES_PARALLEL = 10;
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     // How much to wait until a message makes it to the server, in milliseconds
     protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60000;
 
@@ -284,18 +283,8 @@ public class DeviceMethodCommon extends IntegrationTest
     }
 
     @After
-    public void afterTest() throws IOException, IotHubException
+    public void afterTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (Exception e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         this.testInstance.dispose();
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -66,7 +66,6 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static final Integer PAGE_SIZE = 2;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     // Constants used in for Testing
     protected static final String PROPERTY_KEY = "Key";
@@ -471,27 +470,16 @@ public class DeviceTwinCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownNewDeviceAndModule() throws IOException, IotHubException
+    public void tearDownNewDeviceAndModule()
     {
-        tearDownTwin(deviceUnderTest);
-
         try
         {
+            tearDownTwin(deviceUnderTest);
             registryManager.removeDevice(deviceUnderTest.sCDeviceForRegistryManager.getDeviceId());
         }
         catch (Exception e)
         {
-
-        }
-
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail(buildExceptionMessage("Unexpected exception encountered", internalClient));
+            //Don't care if tear down failed. Nightly job will clean up these identities
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -276,7 +276,7 @@ public class DeviceTwinCommon extends IntegrationTest
                             false);
                 }
             }
-            IotHubServicesCommon.openClientWithRetry(internalClient);
+            internalClient.open();
             if (internalClient instanceof DeviceClient)
             {
                 ((DeviceClient) internalClient).startDeviceTwin(new DeviceTwinStatusCallBack(), deviceState, deviceState.dCDeviceForTwin, deviceState);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ProvisioningCommon.java
@@ -102,8 +102,6 @@ public class ProvisioningCommon extends IntegrationTest
     public ProvisioningServiceClient provisioningServiceClient = null;
     public RegistryManager registryManager = null;
 
-    public static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
-
     //sending reported properties for twin operations takes some time to get the appropriate callback
     public static final int MAX_TWIN_PROPAGATION_WAIT_SECONDS = 60;
 
@@ -185,16 +183,6 @@ public class ProvisioningCommon extends IntegrationTest
     @After
     public void tearDown()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         registryManager.close();
         provisioningServiceClient = null;
         registryManager = null;

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -54,7 +54,6 @@ public class ReceiveMessagesCommon extends IntegrationTest
 
     protected static String expectedCorrelationId = "1234";
     protected static String expectedMessageId = "5678";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     protected static final long ERROR_INJECTION_RECOVERY_TIMEOUT = 1 * 60 * 1000; // 1 minute
 
     public ReceiveMessagesTestInstance testInstance;
@@ -251,18 +250,8 @@ public class ReceiveMessagesCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            TestCase.fail("Unexpected exception encountered");
-        }
-
         testInstance.dispose();
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -373,7 +373,7 @@ public class SendMessagesCommon extends IntegrationTest
         public void openConnection() throws IOException, URISyntaxException, InterruptedException
         {
             client = new DeviceClient(connString, protocol);
-            IotHubServicesCommon.openClientWithRetry(client);
+            client.open();
         }
 
         public void sendMessages()

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/SendMessagesCommon.java
@@ -55,7 +55,6 @@ public class SendMessagesCommon extends IntegrationTest
     protected static final Integer RETRY_MILLISECONDS = 100;
 
     protected static String iotHubConnectionString = "";
-    protected static final int INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
 
     protected static String hostName;
 
@@ -130,7 +129,6 @@ public class SendMessagesCommon extends IntegrationTest
             fail("Failed to stop the test proxy");
         }
     }
-
 
     protected static Collection inputsCommon() throws IOException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException, InterruptedException
     {
@@ -509,18 +507,8 @@ public class SendMessagesCommon extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         this.testInstance.dispose();
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -379,7 +379,7 @@ public class FileUploadTests extends IntegrationTest
 
         Thread.sleep(5000);
 
-        IotHubServicesCommon.openClientWithRetry(deviceClient);
+        deviceClient.open();
         return deviceClient;
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
@@ -211,7 +211,7 @@ public class HubTierConnectionTests extends IntegrationTest
             }
         }, null);
 
-        IotHubServicesCommon.openClientWithRetry(testInstance.client);
+        testInstance.client.open();
 
         //act
         testInstance.client.subscribeToDeviceMethod(new DeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TokenRenewalTests.java
@@ -203,11 +203,11 @@ public class TokenRenewalTests extends IntegrationTest
         }
     }
 
-    private void openEachClient(List<InternalClient> clients) throws InterruptedException
+    private void openEachClient(List<InternalClient> clients) throws IOException
     {
         for (int clientIndex = 0; clientIndex < clients.size(); clientIndex++)
         {
-            IotHubServicesCommon.openClientWithRetry(clients.get(clientIndex));
+            clients.get(clientIndex).open();
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -51,7 +51,6 @@ public class TransportClientTests extends IntegrationTest
 
     private static final long RETRY_MILLISECONDS = 100; //.1 seconds
     private static final long SEND_TIMEOUT_MILLISECONDS = 5 * 60 * 1000; // 5 minutes
-    private static final long INTERTEST_GUARDIAN_DELAY_MILLISECONDS = 0;
     private static final long RECEIVE_MESSAGE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB = 10 * 1000; // 10 seconds
     private static final long MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION = 500; // .5 seconds
@@ -212,18 +211,8 @@ public class TransportClientTests extends IntegrationTest
     }
 
     @After
-    public void tearDownTest() throws IOException, IotHubException
+    public void tearDownTest()
     {
-        try
-        {
-            Thread.sleep(INTERTEST_GUARDIAN_DELAY_MILLISECONDS);
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-
         testInstance.dispose();
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.microsoft.azure.sdk.iot.common.helpers.CorrelationDetailsLoggingAssert.buildExceptionMessage;
-import static com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon.openTransportClientWithRetry;
 import static com.microsoft.azure.sdk.iot.common.helpers.IotHubServicesCommon.sendMessagesMultiplex;
 import static com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests.STATUS.FAILURE;
 import static com.microsoft.azure.sdk.iot.common.tests.iothubservices.TransportClientTests.STATUS.SUCCESS;
@@ -147,7 +146,7 @@ public class TransportClientTests extends IntegrationTest
 
             succeed = new AtomicBoolean();
 
-            System.out.print("TransportClientTests UUID: " + uuid);
+            System.out.println("TransportClientTests UUID: " + uuid);
 
             messageProperties = new HashMap<>(3);
             messageProperties.put("name1", "value1");
@@ -231,7 +230,7 @@ public class TransportClientTests extends IntegrationTest
     @Test
     public void sendMessages() throws URISyntaxException, IOException, InterruptedException
     {
-        openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         for (int i = 0; i < testInstance.clientArrayList.size(); i++)
         {
@@ -245,7 +244,7 @@ public class TransportClientTests extends IntegrationTest
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void receiveMessagesIncludingProperties() throws Exception
     {
-        IotHubServicesCommon.openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         for (int i = 0; i < testInstance.clientArrayList.size(); i++)
         {
@@ -267,7 +266,7 @@ public class TransportClientTests extends IntegrationTest
     {
         CountDownLatch cdl = new CountDownLatch(testInstance.clientArrayList.size());
 
-        IotHubServicesCommon.openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         for (int i = 0; i < testInstance.clientArrayList.size(); i++)
         {
@@ -292,7 +291,7 @@ public class TransportClientTests extends IntegrationTest
         // arrange
         setUpFileUploadState();
 
-        IotHubServicesCommon.openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -357,7 +356,7 @@ public class TransportClientTests extends IntegrationTest
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void invokeMethodSucceed() throws Exception
     {
-        IotHubServicesCommon.openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         for (int i = 0; i < testInstance.clientArrayList.size(); i++)
         {
@@ -381,7 +380,7 @@ public class TransportClientTests extends IntegrationTest
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void invokeMethodInvokeParallelSucceed() throws Exception
     {
-        IotHubServicesCommon.openTransportClientWithRetry(testInstance.transportClient, testInstance.clientArrayList);
+        testInstance.transportClient.open();
 
         for (int i = 0; i < testInstance.clientArrayList.size(); i++)
         {
@@ -955,7 +954,7 @@ public class TransportClientTests extends IntegrationTest
                 testInstance.clientArrayList.add(deviceState.deviceClient);
             }
 
-            IotHubServicesCommon.openTransportClientWithRetry(transportClient, testInstance.clientArrayList);
+            transportClient.open();
 
             for (int i = 0; i < MAX_DEVICES; i++)
             {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -213,7 +213,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
 
         try
         {
-            IotHubServicesCommon.openClientWithRetry(testInstance.client);
+            testInstance.client.open();
             IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000, testInstance.client);
 
             //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -335,7 +335,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         {
             client.setRetryPolicy(new NoRetry());
         }
-        IotHubServicesCommon.openClientWithRetry(client);
+        client.open();
 
         // Act
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage,null);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/ReceiveMessagesTests.java
@@ -53,7 +53,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
             testInstance.client.setOption(SET_MINIMUM_POLLING_INTERVAL, ONE_SECOND_POLLING_INTERVAL);
         }
 
-        IotHubServicesCommon.openClientWithRetry(testInstance.client);
+        testInstance.client.open();
 
         com.microsoft.azure.sdk.iot.device.MessageCallback callback = new MessageCallback();
 
@@ -105,7 +105,7 @@ public class ReceiveMessagesTests extends ReceiveMessagesCommon
         List<CompletableFuture<Void>> futureList = new ArrayList<>();
 
         // set identity to receive back to back different commands using AMQPS protocol
-        IotHubServicesCommon.openClientWithRetry(testInstance.client);
+        testInstance.client.open();
 
         // set call back for device client for receiving message
         com.microsoft.azure.sdk.iot.device.MessageCallback callBackOnRx = new MessageCallbackForBackToBackC2DMessages(messageIdListStoredOnReceive);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -127,7 +127,7 @@ public class SendMessagesTests extends SendMessagesCommon
 
         String soonToBeExpiredSASToken = generateSasTokenForIotDevice(hostName, testInstance.identity.getDeviceId(), testInstance.identity.getPrimaryKey(), SECONDS_FOR_SAS_TOKEN_TO_LIVE);
         DeviceClient client = new DeviceClient(soonToBeExpiredSASToken, testInstance.protocol);
-        IotHubServicesCommon.openClientWithRetry(client);
+        client.open();
 
         //Force the SAS token to expire before sending messages
         Thread.sleep(MILLISECONDS_TO_WAIT_FOR_TOKEN_TO_EXPIRE);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DeviceTwinWithVersionTests.java
@@ -203,7 +203,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
     private void createDevice(IotHubClientProtocol protocol) throws IOException, URISyntaxException, InterruptedException
     {
         testInstance.testDevice.deviceClient = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, testInstance.deviceForRegistryManager), protocol);
-        IotHubServicesCommon.openClientWithRetry(testInstance.testDevice.deviceClient);
+        testInstance.testDevice.deviceClient.open();
         testInstance.testDevice.deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), testInstance.testDevice, new DeviceTwinPropertyCallback(), testInstance.testDevice);
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/provisioning/ProvisioningTests.java
@@ -426,7 +426,7 @@ public class ProvisioningTests extends ProvisioningCommon
         //hardcoded AMQP here only because we aren't testing this connection. We just need to open a connection to send a twin update so that
         // we can test if the twin updates carry over after reprovisioning
         DeviceClient deviceClient = DeviceClient.createFromSecurityProvider(iothubUri, deviceId, testInstance.securityProvider, IotHubClientProtocol.AMQPS);
-        IotHubServicesCommon.openClientWithRetry(deviceClient);
+        deviceClient.open();
         CountDownLatch twinLock = new CountDownLatch(2);
         deviceClient.startDeviceTwin(new StubTwinCallback(twinLock), null, new StubTwinCallback(twinLock), null);
         Set<Property> reportedProperties = new HashSet<>();


### PR DESCRIPTION
With Amqp fixes to the open logic, e2e tests no longer need any sort of retry logic for the open calls.

Intertest delays were set to 0 anyways, so all references to them have now been removed

Ensured that e2e test tear down code cannot cause the test it is tearing down to fail