### PR TITLE
feat(iot-dev): Allow clients to provide SSLContext rather than certif…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.device.transport.amqps.IoTHubConnectionType;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.Closeable;
 import java.io.IOError;
 import java.io.IOException;
@@ -212,6 +213,24 @@ public final class DeviceClient extends InternalClient implements Closeable
 
         // Codes_SRS_DEVICECLIENT_12_013: [The constructor shall set the connection type to SINGLE_CLIENT.]
         // Codes_SRS_DEVICECLIENT_12_014: [The constructor shall set the transportClient to null.]
+        commonConstructorSetup();
+    }
+
+    /**
+     * Creates a device client that uses the provided SSLContext for SSL negotiation
+     * @param connString the connection string for the device. May be an x509 connection string (format: "HostName=...;DeviceId=...;x509=true")
+     *                   and it may be a SAS connection string (format: "HostName=...;DeviceId=...;SharedAccessKey=..."). If
+     *                   this connection string is an x509 connection string, the client will use the provided SSLContext for authentication.
+     * @param protocol the protocol to use when communicating with IotHub
+     * @param sslContext the ssl context that will be used during authentication. If the provided connection string does not contain
+     *                   SAS based credentials, then the sslContext will be used for x509 authentication. If the provided connection string
+     *                   does contain SAS based credentials, the sslContext will still be used during SSL negotiation.
+     * @throws URISyntaxException if the hostname in the connection string is not a valid URI
+     */
+    public DeviceClient(String connString, IotHubClientProtocol protocol, SSLContext sslContext) throws URISyntaxException
+    {
+        super(new IotHubConnectionString(connString), protocol, sslContext, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
+        commonConstructorVerifications();
         commonConstructorSetup();
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -64,6 +65,15 @@ public class InternalClient
 
         // Codes_SRS_INTERNALCLIENT_34_080: [This function shall save a new DeviceIO instance using the created config and the provided send/receive periods.]
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
+    }
+
+    InternalClient(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, SSLContext sslContext, long sendPeriodMillis, long receivePeriod)
+    {
+        commonConstructorVerification(iotHubConnectionString, protocol);
+
+        this.config = new DeviceClientConfig(iotHubConnectionString, sslContext);
+        this.config.setProtocol(protocol);
+        this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriod);
     }
 
     InternalClient(String uri, String deviceId, SecurityProvider securityProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis) throws URISyntaxException, IOException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -22,6 +22,7 @@ import com.microsoft.azure.sdk.iot.device.hsm.HttpHsmSignatureProvider;
 import com.microsoft.azure.sdk.iot.device.hsm.IotHubSasTokenHsmAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
@@ -112,6 +113,25 @@ public class ModuleClient extends InternalClient
 
         //Codes_SRS_MODULECLIENT_34_008: [If the provided protocol is not MQTT, AMQPS, MQTT_WS, or AMQPS_WS, this function shall throw an UnsupportedOperationException.]
         //Codes_SRS_MODULECLIENT_34_009: [If the provided connection string does not contain a module id, this function shall throw an IllegalArgumentException.]
+        commonConstructorVerifications(protocol, this.getConfig());
+    }
+
+
+    /**
+     * Create a module client instance that uses the provided SSLContext for SSL negotiation.
+     *
+     * @param connectionString The connection string for the edge module to connect to. May be an x509 connection string
+     *                         or a SAS connection string. If it is an x509 connection string, the provided SSLContext will be
+     *                         used for x509 authentication
+     * @param protocol The protocol to communicate with
+     * @param sslContext the ssl context that will be used during authentication. If the provided connection string does not contain
+     *                   SAS based credentials, then the sslContext will be used for x509 authentication. If the provided connection string
+     *                   does contain SAS based credentials, the sslContext will still be used during SSL negotiation.
+     * @throws URISyntaxException if the hostname in the connection string is not a valid URI
+     */
+    public ModuleClient(String connectionString, IotHubClientProtocol protocol, SSLContext sslContext) throws ModuleClientException, URISyntaxException
+    {
+        super(new IotHubConnectionString(connectionString), protocol, sslContext, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
         commonConstructorVerifications(protocol, this.getConfig());
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
@@ -30,6 +30,35 @@ public abstract class IotHubAuthenticationProvider
     protected String iotHubTrustedCert;
     protected String pathToIotHubTrustedCert;
 
+    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
+    {
+        if (hostname == null || hostname.isEmpty())
+        {
+            // Codes_SRS_AUTHENTICATIONPROVIDER_34_006: [If the provided hostname is null, this function shall throw an IllegalArgumentException.]
+            throw new IllegalArgumentException("hostname cannot be null");
+        }
+
+        if (deviceId == null || deviceId.isEmpty())
+        {
+            // Codes_SRS_AUTHENTICATIONPROVIDER_34_007: [If the provided device id is null, this function shall throw an IllegalArgumentException.]
+            throw new IllegalArgumentException("deviceId cannot be null");
+        }
+
+        // Codes_SRS_AUTHENTICATIONPROVIDER_34_001: [The constructor shall save the provided hostname, gatewayhostname, deviceid and moduleid.]
+        this.hostname = hostname;
+        this.gatewayHostname = gatewayHostname;
+        this.deviceId = deviceId;
+        this.moduleId = moduleId;
+    }
+
+    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+    {
+        this(hostname, gatewayHostname, deviceId, moduleId);
+
+        this.sslContextNeedsUpdate = false;
+        this.iotHubSSLContext = new IotHubSSLContext(sslContext);
+    }
+
     public SSLContext getSSLContext() throws IOException
     {
         try
@@ -81,27 +110,6 @@ public abstract class IotHubAuthenticationProvider
 
         // Codes_SRS_AUTHENTICATIONPROVIDER_34_064: [This function shall save the provided pathToIotHubTrustedCert.]
         this.iotHubTrustedCert = certificate;
-    }
-
-    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
-    {
-        if (hostname == null || hostname.isEmpty())
-        {
-            // Codes_SRS_AUTHENTICATIONPROVIDER_34_006: [If the provided hostname is null, this function shall throw an IllegalArgumentException.]
-            throw new IllegalArgumentException("hostname cannot be null");
-        }
-
-        if (deviceId == null || deviceId.isEmpty())
-        {
-            // Codes_SRS_AUTHENTICATIONPROVIDER_34_007: [If the provided device id is null, this function shall throw an IllegalArgumentException.]
-            throw new IllegalArgumentException("deviceId cannot be null");
-        }
-
-        // Codes_SRS_AUTHENTICATIONPROVIDER_34_001: [The constructor shall save the provided hostname, gatewayhostname, deviceid and moduleid.]
-        this.hostname = hostname;
-        this.gatewayHostname = gatewayHostname;
-        this.deviceId = deviceId;
-        this.moduleId = moduleId;
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.sdk.iot.device.auth;
 
-import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 
 import javax.net.ssl.SSLContext;
@@ -40,6 +39,11 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
     public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
     {
         super(hostname, gatewayHostname, deviceId, moduleId);
+    }
+
+    public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+    {
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
     }
 
     public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, long tokenValidSecs, int timeBufferPercentage)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -66,6 +66,27 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
     }
 
     /**
+     * Constructor that takes a connection string containing a sas token or a device key and uses the default token valid seconds and timeBufferPercentage
+     * @param hostname the IotHub host name
+     * @param gatewayHostname The gateway hostname to use, or null if connecting to an IotHub
+     * @param deviceId the IotHub device id
+     * @param moduleId the module id. May be null if not using a module
+     * @param deviceKey the device key for the device. Must be null if the provided sharedAccessToken is not
+     * @param sharedAccessToken the sas token string for accessing the device. Must be null if the provided deviceKey is not.
+     * @param sslContext the sslContext to use for SSL negotiation
+     * @throws SecurityException if the provided sas token has expired
+     */
+    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken, SSLContext sslContext) throws SecurityException
+    {
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
+
+        this.deviceKey = deviceKey;
+
+        //Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_003: [This constructor shall save the provided hostname, device id, module id, deviceKey, and sharedAccessToken.]
+        this.sasToken = new IotHubSasToken(hostname, deviceId, deviceKey, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
+    }
+
+    /**
      * Returns true if the saved sas token has expired and cannot be auto-renewed through the device key
      * @return if the sas token needs manual renewal
      */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareAuthenticationProvider.java
@@ -40,6 +40,12 @@ public class IotHubX509SoftwareAuthenticationProvider extends IotHubAuthenticati
         this.sslContextNeedsUpdate = false;
     }
 
+    public IotHubX509SoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext) throws IllegalArgumentException
+    {
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
+        this.iotHubX509 = null;
+    }
+
     /**
      * Getter for IotHubSSLContext
      * @throws IOException if an error occurs when generating the SSLContext

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientConfigTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientConfigTest.java
@@ -652,6 +652,78 @@ public class DeviceClientConfigTest
         new DeviceClientConfig(mockIotHubConnectionString, "", false, "", false);
     }
 
+    @Test
+    public void constructorWithSSLContextBuildsX509SoftwareAuthenticationProvider(@Mocked final SSLContext mockSSLContext)
+    {
+        final String hostname = "hostname";
+        final String gatewayhostname = "gatewayhostname";
+        final String deviceId = "deviceId";
+        final String moduleId = "moduleId";
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.isUsingX509();
+                result = true;
+
+                mockIotHubConnectionString.getHostName();
+                result = hostname;
+
+                mockIotHubConnectionString.getGatewayHostName();
+                result = gatewayhostname;
+
+                mockIotHubConnectionString.getDeviceId();
+                result = deviceId;
+
+                mockIotHubConnectionString.getModuleId();
+                result = moduleId;
+
+                new IotHubX509SoftwareAuthenticationProvider(hostname, gatewayhostname, deviceId, moduleId, mockSSLContext);
+            }
+        };
+
+        new DeviceClientConfig(mockIotHubConnectionString, mockSSLContext);
+    }
+
+    @Test
+    public void constructorWithSSLContextBuildsSasSoftwareAuthenticationProvider(@Mocked final SSLContext mockSSLContext)
+    {
+        final String hostname = "hostname";
+        final String gatewayhostname = "gatewayhostname";
+        final String deviceId = "deviceId";
+        final String moduleId = "moduleId";
+        final String sharedAccessKey = "sharedAccessKey";
+        final String sharedAccessToken = "sharedAccessToken";
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.isUsingX509();
+                result = false;
+
+                mockIotHubConnectionString.getHostName();
+                result = hostname;
+
+                mockIotHubConnectionString.getGatewayHostName();
+                result = gatewayhostname;
+
+                mockIotHubConnectionString.getDeviceId();
+                result = deviceId;
+
+                mockIotHubConnectionString.getModuleId();
+                result = moduleId;
+
+                mockIotHubConnectionString.getSharedAccessKey();
+                result = sharedAccessKey;
+
+                mockIotHubConnectionString.getSharedAccessToken();
+                result = sharedAccessToken;
+
+                new IotHubSasTokenSoftwareAuthenticationProvider(hostname, gatewayhostname, deviceId, moduleId, sharedAccessKey, sharedAccessToken, mockSSLContext);
+            }
+        };
+
+        new DeviceClientConfig(mockIotHubConnectionString, mockSSLContext);
+    }
+
     // Tests_SRS_DEVICECLIENTCONFIG_12_002: [If the authentication type is X509 the constructor shall throw an IllegalArgumentException.]
     @Test (expected = IllegalArgumentException.class)
     public void constructorWithX509AuthThrows(@Mocked final IotHubConnectionString mockIotHubConnectionString) throws IOException

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import mockit.*;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
@@ -183,6 +184,40 @@ public class DeviceClientTest
 
                 TransportClient transportClient = Deencapsulation.getField(client, "transportClient");
                 assertNull(transportClient);
+            }
+        };
+    }
+
+    @Test
+    public void constructorWithSSLContextSuccess(@Mocked final SSLContext mockedSSLContext) throws URISyntaxException
+    {
+        // arrange
+        final String connString =
+                "HostName=iothub.device.com;deviceId=testdevice;x509=true";
+        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS_WS;
+
+        new Expectations()
+        {
+            {
+                new IotHubConnectionString(connString);
+                result = mockIotHubConnectionString;
+            }
+        };
+
+        // act
+        final DeviceClient client = new DeviceClient(connString, protocol, mockedSSLContext);
+
+        // assert
+        new Verifications()
+        {
+            {
+                IoTHubConnectionType ioTHubConnectionType = Deencapsulation.getField(client, "ioTHubConnectionType");
+                assertEquals(SINGLE_CLIENT, ioTHubConnectionType);
+
+                TransportClient transportClient = Deencapsulation.getField(client, "transportClient");
+                assertNull(transportClient);
+
+                new DeviceClientConfig(mockIotHubConnectionString, mockedSSLContext);
             }
         };
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
@@ -7,7 +7,6 @@ package tests.unit.com.microsoft.azure.sdk.iot.device;
 
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
-import com.microsoft.azure.sdk.iot.device.auth.SignatureProvider;
 import com.microsoft.azure.sdk.iot.device.edge.HttpsHsmTrustBundleProvider;
 import com.microsoft.azure.sdk.iot.device.edge.MethodRequest;
 import com.microsoft.azure.sdk.iot.device.edge.MethodResult;
@@ -20,6 +19,7 @@ import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 import mockit.*;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -161,6 +161,31 @@ public class ModuleClientTest
         //assert
         assertNotNull(client.getConfig());
         assertNotNull(Deencapsulation.getField(client, "deviceIO"));
+    }
+
+    @Test
+    public void constructorWithSSLContextSuccess(@Mocked final SSLContext mockedSSLContext) throws URISyntaxException, ModuleClientException {
+        // arrange
+        final String connString =
+                "HostName=iothub.device.com;deviceId=testdevice;ModuleId=testmodule;x509=true";
+        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS_WS;
+
+        new Expectations()
+        {
+            {
+                new IotHubConnectionString(connString);
+                result = mockedIotHubConnectionString;
+
+                new DeviceClientConfig(mockedIotHubConnectionString, mockedSSLContext);
+                result = mockedDeviceClientConfig;
+
+                mockedDeviceClientConfig.getModuleId();
+                result = "some module id";
+            }
+        };
+
+        // act
+        final ModuleClient client = new ModuleClient(connString, protocol, mockedSSLContext);
     }
 
     //Tests_SRS_MODULECLIENT_34_001: [If the provided outputName is null or empty, this function shall throw an IllegalArgumentException.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
@@ -7,11 +7,9 @@ package tests.unit.com.microsoft.azure.sdk.iot.device.auth;
 
 import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
+import com.microsoft.azure.sdk.iot.device.auth.IotHubX509SoftwareAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
-import mockit.Deencapsulation;
-import mockit.Mocked;
-import mockit.NonStrictExpectations;
-import mockit.Verifications;
+import mockit.*;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
@@ -20,6 +18,8 @@ import java.security.cert.CertificateException;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class IotHubAuthenticationProviderTest
 {
@@ -40,6 +40,11 @@ public class IotHubAuthenticationProviderTest
         {
             super(hostname, gatewayHostname, deviceId, moduleId);
         }
+
+        public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+        {
+            super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
+        }
     }
 
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_001: [The constructor shall save the provided hostname, gatewayhostname, deviceid and moduleid.]
@@ -50,6 +55,30 @@ public class IotHubAuthenticationProviderTest
         IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
         
         //assert
+        assertEquals(expectedHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "hostname"));
+        assertEquals(expectedGatewayHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "gatewayHostname"));
+        assertEquals(expectedDeviceId, Deencapsulation.getField(iotHubAuthenticationProvider, "deviceId"));
+        assertEquals(expectedModuleId, Deencapsulation.getField(iotHubAuthenticationProvider, "moduleId"));
+    }
+
+
+    @Test
+    public void constructorSuccessWithSSLContext()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                new IotHubSSLContext(mockedSSLContext);
+                result = mockedIotHubSSLContext;
+            }
+        };
+
+        //act
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockedSSLContext);
+
+        //assert
+        assertFalse((boolean) Deencapsulation.getField(iotHubAuthenticationProvider, "sslContextNeedsUpdate"));
         assertEquals(expectedHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "hostname"));
         assertEquals(expectedGatewayHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "gatewayHostname"));
         assertEquals(expectedDeviceId, Deencapsulation.getField(iotHubAuthenticationProvider, "deviceId"));

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
@@ -77,6 +77,41 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         assertEquals(expectedSasToken, actualSasToken.toString());
     }
 
+    @Test
+    public void constructorSavesArgumentsWithSSLContext()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, anyString, anyString, anyString, anyString, anyString, anyLong);
+                result = mockSasToken;
+
+                mockSasToken.toString();
+                result = expectedSasToken;
+
+                new IotHubSSLContext(mockSSLContext);
+                result = mockIotHubSSLContext;
+            }
+        };
+
+        //act
+        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken, mockSSLContext);
+
+        //assert
+        String actualDeviceId = sasAuth.getDeviceId();
+        String actualModuleId = sasAuth.getModuleId();
+        String actualHostName = sasAuth.getHostname();
+        String actualDeviceKey = Deencapsulation.getField(sasAuth, "deviceKey");
+        IotHubSasToken actualSasToken = Deencapsulation.getField(sasAuth, "sasToken");
+
+        assertEquals(expectedDeviceId, actualDeviceId);
+        assertEquals(expectedModuleId, actualModuleId);
+        assertEquals(expectedHostname, actualHostName);
+        assertEquals(expectedDeviceKey, actualDeviceKey);
+        assertEquals(expectedSasToken, actualSasToken.toString());
+    }
+
     //Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_003: [This constructor shall save the provided hostname, device id, module id, deviceKey, and sharedAccessToken.]
     @Test
     public void overloadedConstructorSavesArguments()

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareIotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareIotHubAuthenticationProviderTest.java
@@ -11,10 +11,7 @@ import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubX509SoftwareAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.provisioning.security.exceptions.SecurityProviderException;
-import mockit.Deencapsulation;
-import mockit.Mocked;
-import mockit.NonStrictExpectations;
-import mockit.Verifications;
+import mockit.*;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
@@ -25,8 +22,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for IotHubX509SoftwareAuthenticationProvider.java
@@ -76,6 +72,25 @@ public class IotHubX509SoftwareIotHubAuthenticationProviderTest
                 times = 1;
             }
         };
+    }
+
+    @Test
+    public void constructorSuccessWithSSLContext()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                new IotHubSSLContext(mockSSLContext);
+                result = mockIotHubSSLContext;
+            }
+        };
+
+        //act
+        IotHubX509SoftwareAuthenticationProvider provider = new IotHubX509SoftwareAuthenticationProvider(hostname, gatewayHostname, deviceId, moduleId, mockSSLContext);
+
+        //assert
+        assertNull(Deencapsulation.getField(provider, "iotHubX509"));
     }
 
     //Tests_SRS_IOTHUBX509AUTHENTICATION_34_002: [This constructor will create and save an IotHubX509 object using the provided public key certificate and private key.]

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/DeviceTestManager.java
@@ -8,8 +8,10 @@ package com.microsoft.azure.sdk.iot.common.helpers;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
@@ -75,7 +77,7 @@ public class DeviceTestManager
         deviceEmulator.tearDown();
     }
 
-    public void restartDevice(String connectionString, IotHubClientProtocol protocol, String publicCert, String privateKey) throws InterruptedException, IOException, URISyntaxException, ModuleClientException
+    public void restartDevice(String connectionString, IotHubClientProtocol protocol, String publicCert, String privateKey) throws InterruptedException, IOException, URISyntaxException, ModuleClientException, GeneralSecurityException
     {
         deviceEmulator.tearDown();
 
@@ -87,7 +89,8 @@ public class DeviceTestManager
             }
             else
             {
-                this.client = new DeviceClient(connectionString, protocol, publicCert, false, privateKey, false);
+                SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicCert, privateKey);
+                this.client = new DeviceClient(connectionString, protocol, sslContext);
             }
         }
         else if (this.client instanceof ModuleClient)

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/SSLContextBuilder.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/SSLContextBuilder.java
@@ -1,0 +1,240 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.common.helpers;
+
+import com.microsoft.azure.sdk.iot.deps.auth.IotHubCertificateManager;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+
+public class SSLContextBuilder
+{
+    private static final String SSL_CONTEXT_INSTANCE = "TLSv1.2";
+
+    private static final String CERTIFICATE_ALIAS = "cert-alias";
+    private static final String PRIVATE_KEY_ALIAS = "key-alias";
+
+    /**
+     * Create an SSLContext instance with the provided public and private keys that also trusts the base iot hub certificates
+     */
+    public static SSLContext buildSSLContext(String publicKeyCertificateString, String privateKeyString) throws GeneralSecurityException, IOException
+    {
+        Key privateKey = parsePrivateKeyString(privateKeyString);
+        Certificate[] publicKeyCertificates = parsePublicKeyCertificateString(publicKeyCertificateString);
+
+        char[] temporaryPassword = generateTemporaryPassword();
+
+        KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keystore.load(null);
+        keystore.setCertificateEntry(CERTIFICATE_ALIAS, publicKeyCertificates[0]);
+        keystore.setKeyEntry(PRIVATE_KEY_ALIAS, privateKey, temporaryPassword, publicKeyCertificates);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keystore, temporaryPassword);
+
+        TrustManagerFactory trustManagerFactory = generateTrustManagerFactory(keystore);
+
+        SSLContext sslContext = SSLContext.getInstance(SSL_CONTEXT_INSTANCE);
+
+        sslContext.init(kmf.getKeyManagers(), trustManagerFactory.getTrustManagers(), new SecureRandom());
+
+        return sslContext;
+    }
+
+    /**
+     * Build the default SSLContext. Trusts the iot hub base certificates, but can only be used for sas auth
+     */
+    public static SSLContext buildSSLContext() throws NoSuchAlgorithmException, KeyManagementException, CertificateException, KeyStoreException, IOException
+    {
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_002: [The constructor shall create default SSL context for TLSv1.2.]
+        SSLContext sslContext = SSLContext.getInstance(SSL_CONTEXT_INSTANCE);
+
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_003: [The constructor shall create default TrustManagerFactory with the default algorithm.]
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_004: [The constructor shall create default KeyStore instance with the default type and initialize it.]
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_005: [The constructor shall set the above created certificateManager into a keystore.]
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_006: [The constructor shall initialize TrustManagerFactory with the above initialized keystore.]
+        //Codes_SRS_IOTHUBSSLCONTEXT_25_007: [The constructor shall initialize SSL context with the above initialized TrustManagerFactory and a new secure random.]
+        TrustManagerFactory trustManagerFactory = generateTrustManagerFactory(null);
+
+        sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+
+        return sslContext;
+    }
+
+    public static RSAPrivateKey parsePrivateKeyString(String privateKeyPEM) throws IOException, GeneralSecurityException
+    {
+        if (privateKeyPEM == null || privateKeyPEM.isEmpty())
+        {
+            throw new GeneralSecurityException("Public key certificate cannot be null or empty");
+        }
+
+        privateKeyPEM = privateKeyPEM.replace("-----BEGIN PRIVATE KEY-----\n", "");
+        privateKeyPEM = privateKeyPEM.replace("-----END PRIVATE KEY-----", "");
+        byte[] encoded = Base64.decodeBase64(privateKeyPEM.getBytes("UTF-8"));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+        RSAPrivateKey privKey = (RSAPrivateKey) kf.generatePrivate(keySpec);
+        return privKey;
+    }
+
+    public static X509Certificate[] parsePublicKeyCertificateString(String pemString) throws GeneralSecurityException
+    {
+        if (pemString == null || pemString.isEmpty())
+        {
+            throw new GeneralSecurityException("Public key certificate cannot be null or empty");
+        }
+
+        InputStream pemInputStream = new ByteArrayInputStream(pemString.getBytes());
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        Collection<X509Certificate> collection = new ArrayList<>();
+        X509Certificate x509Cert;
+
+        try
+        {
+            while (pemInputStream.available() > 0)
+            {
+                x509Cert = (X509Certificate) cf.generateCertificate(pemInputStream);
+                collection.add(x509Cert);
+            }
+        }
+        catch (IOException e)
+        {
+            throw new GeneralSecurityException("Unable to generate x509 certificate from public key certificate string", e);
+        }
+
+        return collection.toArray(new X509Certificate[collection.size()]);
+    }
+
+    private static char[] generateTemporaryPassword()
+    {
+        byte[] randomBytes = new byte[256];
+        char[] randomChars = new char[256];
+        new SecureRandom().nextBytes(randomBytes);
+
+        for (int i = 0; i < 256; i++)
+        {
+            randomChars[i] = (char) randomBytes[i];
+        }
+
+        return randomChars;
+    }
+
+    private static TrustManagerFactory generateTrustManagerFactory(KeyStore trustKeyStore)
+            throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException
+    {
+        if (trustKeyStore == null)
+        {
+            trustKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustKeyStore.load(null);
+        }
+
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+        try (InputStream inputStream = new ByteArrayInputStream(DEFAULT_CERT.getBytes()))
+        {
+            Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(inputStream);
+
+            for (Certificate c : certificates)
+            {
+                trustKeyStore.setCertificateEntry(TRUSTED_IOT_HUB_CERT_PREFIX + UUID.randomUUID(), c);
+            }
+        }
+
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(trustKeyStore);
+
+        return trustManagerFactory;
+    }
+
+    private static final String TRUSTED_IOT_HUB_CERT_PREFIX = "trustedIotHubCert-";
+    private static final String DEFAULT_CERT =
+            /*D-TRUST Root Class 3 CA 2 2009*/
+            "-----BEGIN CERTIFICATE-----\r\n" +
+                    "MIIEMzCCAxugAwIBAgIDCYPzMA0GCSqGSIb3DQEBCwUAME0xCzAJBgNVBAYTAkRF\r\n" +
+                    "MRUwEwYDVQQKDAxELVRydXN0IEdtYkgxJzAlBgNVBAMMHkQtVFJVU1QgUm9vdCBD\r\n" +
+                    "bGFzcyAzIENBIDIgMjAwOTAeFw0wOTExMDUwODM1NThaFw0yOTExMDUwODM1NTha\r\n" +
+                    "ME0xCzAJBgNVBAYTAkRFMRUwEwYDVQQKDAxELVRydXN0IEdtYkgxJzAlBgNVBAMM\r\n" +
+                    "HkQtVFJVU1QgUm9vdCBDbGFzcyAzIENBIDIgMjAwOTCCASIwDQYJKoZIhvcNAQEB\r\n" +
+                    "BQADggEPADCCAQoCggEBANOySs96R+91myP6Oi/WUEWJNTrGa9v+2wBoqOADER03\r\n" +
+                    "UAifTUpolDWzU9GUY6cgVq/eUXjsKj3zSEhQPgrfRlWLJ23DEE0NkVJD2IfgXU42\r\n" +
+                    "tSHKXzlABF9bfsyjxiupQB7ZNoTWSPOSHjRGICTBpFGOShrvUD9pXRl/RcPHAY9R\r\n" +
+                    "ySPocq60vFYJfxLLHLGvKZAKyVXMD9O0Gu1HNVpK7ZxzBCHQqr0ME7UAyiZsxGsM\r\n" +
+                    "lFqVlNpQmvH/pStmMaTJOKDfHR+4CS7zp+hnUquVH+BGPtikw8paxTGA6Eian5Rp\r\n" +
+                    "/hnd2HN8gcqW3o7tszIFZYQ05ub9VxC1X3a/L7AQDcUCAwEAAaOCARowggEWMA8G\r\n" +
+                    "A1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFP3aFMSfMN4hvR5COfyrYyNJ4PGEMA4G\r\n" +
+                    "A1UdDwEB/wQEAwIBBjCB0wYDVR0fBIHLMIHIMIGAoH6gfIZ6bGRhcDovL2RpcmVj\r\n" +
+                    "dG9yeS5kLXRydXN0Lm5ldC9DTj1ELVRSVVNUJTIwUm9vdCUyMENsYXNzJTIwMyUy\r\n" +
+                    "MENBJTIwMiUyMDIwMDksTz1ELVRydXN0JTIwR21iSCxDPURFP2NlcnRpZmljYXRl\r\n" +
+                    "cmV2b2NhdGlvbmxpc3QwQ6BBoD+GPWh0dHA6Ly93d3cuZC10cnVzdC5uZXQvY3Js\r\n" +
+                    "L2QtdHJ1c3Rfcm9vdF9jbGFzc18zX2NhXzJfMjAwOS5jcmwwDQYJKoZIhvcNAQEL\r\n" +
+                    "BQADggEBAH+X2zDI36ScfSF6gHDOFBJpiBSVYEQBrLLpME+bUMJm2H6NMLVwMeni\r\n" +
+                    "acfzcNsgFYbQDfC+rAF1hM5+n02/t2A7nPPKHeJeaNijnZflQGDSNiH+0LS4F9p0\r\n" +
+                    "o3/U37CYAqxva2ssJSRyoWXuJVrl5jLn8t+rSfrzkGkj2wTZ51xY/GXUl77M/C4K\r\n" +
+                    "zCUqNQT4YJEVdT1B/yMfGchs64JTBKbkTCJNjYy6zltz7GRUUG3RnFX7acM2w4y8\r\n" +
+                    "PIWmawomDeCTmGCufsYkl4phX5GOZpIJhzbNi5stPvZR1FDUWSi9g/LMKHtThm3Y\r\n" +
+                    "Johw1+qRzT65ysCQblrGXnRl11z+o+I=\r\n" +
+                    "-----END CERTIFICATE-----\r\n" +
+                    /*DigiCert Global Root CA*/
+                    "-----BEGIN CERTIFICATE-----\r\n" +
+                    "MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\r\n" +
+                    "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\r\n" +
+                    "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\r\n" +
+                    "QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\r\n" +
+                    "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\r\n" +
+                    "b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\r\n" +
+                    "9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\r\n" +
+                    "CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\r\n" +
+                    "nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\r\n" +
+                    "43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\r\n" +
+                    "T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\r\n" +
+                    "gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\r\n" +
+                    "BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\r\n" +
+                    "TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\r\n" +
+                    "DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\r\n" +
+                    "hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\r\n" +
+                    "06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\r\n" +
+                    "PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\r\n" +
+                    "YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\r\n" +
+                    "CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\r\n" +
+                    "-----END CERTIFICATE-----\r\n" +
+                    /* Baltimore */
+                    "-----BEGIN CERTIFICATE-----\r\n" +
+                    "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\r\n" +
+                    "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\r\n" +
+                    "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\r\n" +
+                    "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\r\n" +
+                    "ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy\r\n" +
+                    "VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr\r\n" +
+                    "mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr\r\n" +
+                    "IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK\r\n" +
+                    "mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu\r\n" +
+                    "XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy\r\n" +
+                    "dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye\r\n" +
+                    "jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1\r\n" +
+                    "BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3\r\n" +
+                    "DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92\r\n" +
+                    "9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx\r\n" +
+                    "jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0\r\n" +
+                    "Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz\r\n" +
+                    "ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS\r\n" +
+                    "R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp\r\n" +
+                    "-----END CERTIFICATE-----\r\n";
+}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import junit.framework.TestCase;
 import org.junit.*;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
@@ -179,7 +180,8 @@ public class DeviceMethodCommon extends IntegrationTest
                 else if (authenticationType == SELF_SIGNED)
                 {
                     //x509 device client
-                    DeviceClient deviceClientX509 = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, publicKeyCert, false, privateKey, false);
+                    SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicKeyCert, privateKey);
+                    DeviceClient deviceClientX509 = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, sslContext);
                     this.deviceTestManager = new DeviceTestManager(deviceClientX509);
                     this.identity = deviceX509;
                 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceTwinCommon.java
@@ -25,6 +25,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
@@ -207,7 +208,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    protected void addMultipleDevices(int numberOfDevices) throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    protected void addMultipleDevices(int numberOfDevices) throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         devicesUnderTest = new DeviceState[numberOfDevices];
 
@@ -235,7 +236,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    protected void setUpTwin(DeviceState deviceState) throws IOException, URISyntaxException, IotHubException, InterruptedException, ModuleClientException
+    protected void setUpTwin(DeviceState deviceState) throws IOException, URISyntaxException, IotHubException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         // set up twin on DeviceClient
         if (internalClient == null)
@@ -256,23 +257,18 @@ public class DeviceTwinCommon extends IntegrationTest
             }
             else if (this.testInstance.authenticationType == SELF_SIGNED)
             {
+                SSLContext sslContext = SSLContextBuilder.buildSSLContext(testInstance.publicKeyCert, testInstance.privateKey);
                 if (this.testInstance.clientType == ClientType.DEVICE_CLIENT)
                 {
                     internalClient = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceUnderTest.sCDeviceForRegistryManager),
                             this.testInstance.protocol,
-                            testInstance.publicKeyCert,
-                            false,
-                            testInstance.privateKey,
-                            false);
+                            sslContext);
                 }
                 else
                 {
                     internalClient = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceState.sCDeviceForRegistryManager, deviceState.sCModuleForRegistryManager),
                             this.testInstance.protocol,
-                            testInstance.publicKeyCert,
-                            false,
-                            testInstance.privateKey,
-                            false);
+                            sslContext);
                 }
             }
             internalClient.open();
@@ -436,7 +432,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         deviceUnderTest = new DeviceState();
         this.testInstance.uuid = UUID.randomUUID().toString();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/ReceiveMessagesCommon.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
@@ -187,6 +188,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
             device = Tools.addDeviceWithRetry(registryManager, device);
             deviceX509 = Tools.addDeviceWithRetry(registryManager, deviceX509);
 
+            SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicKeyCert, privateKey);
             if (clientType == ClientType.DEVICE_CLIENT)
             {
                 if (authenticationType == SAS)
@@ -198,7 +200,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
                 else if (authenticationType == SELF_SIGNED)
                 {
                     //x509 device client
-                    this.client = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, publicKeyCert, false, privateKey, false);
+                    this.client = new DeviceClient(registryManager.getDeviceConnectionString(deviceX509), protocol, sslContext);
                     this.identity = deviceX509;
                 }
                 else
@@ -219,7 +221,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
                 {
                     //x509 module client
                     moduleX509 = Tools.addModuleWithRetry(registryManager, moduleX509);
-                    this.client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), protocol, publicKeyCert, false, privateKey, false);
+                    this.client = new ModuleClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509, moduleX509), protocol, sslContext);
                     this.identity = moduleX509;
                 }
                 else

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/FileUploadTests.java
@@ -15,6 +15,7 @@ import org.junit.*;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
+import javax.net.ssl.SSLContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -336,7 +338,7 @@ public class FileUploadTests extends IntegrationTest
         proxyServer.stop();
     }
 
-    private DeviceClient setUpDeviceClient(IotHubClientProtocol protocol) throws URISyntaxException, InterruptedException, IOException, IotHubException
+    private DeviceClient setUpDeviceClient(IotHubClientProtocol protocol) throws URISyntaxException, InterruptedException, IOException, IotHubException, GeneralSecurityException
     {
         DeviceClient deviceClient;
         if (testInstance.authenticationType == AuthenticationType.SAS)
@@ -355,7 +357,8 @@ public class FileUploadTests extends IntegrationTest
             scDevicex509.setThumbprintFinal(x509Thumbprint, x509Thumbprint);
             scDevicex509 = Tools.addDeviceWithRetry(registryManager, scDevicex509);
 
-            deviceClient = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, scDevicex509), protocol, publicKeyCertificate, false, privateKeyCertificate, false);
+            SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicKeyCertificate, privateKeyCertificate);
+            deviceClient = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, scDevicex509), protocol, sslContext);
         }
         else
         {
@@ -400,7 +403,7 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
-    public void uploadToBlobAsyncSingleFileZeroLength() throws URISyntaxException, IOException, InterruptedException, IotHubException
+    public void uploadToBlobAsyncSingleFileZeroLength() throws URISyntaxException, IOException, InterruptedException, IotHubException, GeneralSecurityException
     {
         // arrange
         DeviceClient deviceClient = setUpDeviceClient(testInstance.protocol);
@@ -420,7 +423,7 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
-    public void uploadToBlobAsyncSingleFile() throws URISyntaxException, IOException, InterruptedException, IotHubException
+    public void uploadToBlobAsyncSingleFile() throws URISyntaxException, IOException, InterruptedException, IotHubException, GeneralSecurityException
     {
         // arrange
         DeviceClient deviceClient = setUpDeviceClient(testInstance.protocol);
@@ -442,7 +445,7 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
-    public void uploadToBlobAsyncMultipleFilesParallel() throws URISyntaxException, IOException, InterruptedException, ExecutionException, TimeoutException, IotHubException
+    public void uploadToBlobAsyncMultipleFilesParallel() throws URISyntaxException, IOException, InterruptedException, ExecutionException, TimeoutException, IotHubException, GeneralSecurityException
     {
         if (testInstance.withProxy)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/HubTierConnectionTests.java
@@ -16,6 +16,7 @@ import org.junit.*;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -148,6 +149,7 @@ public class HubTierConnectionTests extends IntegrationTest
         Tools.addDeviceWithRetry(registryManager, deviceX509);
 
         hostName = IotHubConnectionStringBuilder.createConnectionString(iotHubConnectionString).getHostName();
+        SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicKeyCert, privateKey);
 
         List inputs = new ArrayList();
         inputs.addAll(Arrays.asList(
@@ -158,7 +160,7 @@ public class HubTierConnectionTests extends IntegrationTest
                     {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, publicKeyCert, privateKey, x509Thumbprint, false},
 
                     //x509 device client
-                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, publicKeyCert, false, privateKey, false), AMQPS, deviceX509, SELF_SIGNED, publicKeyCert, privateKey, x509Thumbprint, false},
+                    {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, sslContext), AMQPS, deviceX509, SELF_SIGNED, publicKeyCert, privateKey, x509Thumbprint, false},
 
                     //sas token device client, with proxy
                     {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, publicKeyCert, privateKey, x509Thumbprint, true}

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/telemetry/SendMessagesTests.java
@@ -162,4 +162,24 @@ public class SendMessagesTests extends SendMessagesCommon
 
         IotHubServicesCommon.sendExpiredMessageExpectingMessageExpiredCallback(testInstance.client, testInstance.protocol, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, testInstance.authenticationType);
     }
+
+    @Test
+    public void sendMessagesWithCustomSSLContextAndSasAuth() throws Exception
+    {
+        if (testInstance.authenticationType != SAS)
+        {
+            //only testing sas based auth with custom ssl context here
+            return;
+        }
+
+        if (testInstance.protocol == MQTT_WS && (testInstance.authenticationType == SELF_SIGNED || testInstance.authenticationType == CERTIFICATE_AUTHORITY))
+        {
+            //mqtt_ws does not support x509 auth currently
+            return;
+        }
+
+        this.testInstance.setup(SSLContextBuilder.buildSSLContext());
+
+        IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+    }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/DesiredPropertiesTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +44,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     }
 
     @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         super.setUpNewDeviceAndModule();
     }
@@ -221,7 +222,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testUpdateDesiredProperties() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testUpdateDesiredProperties() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/GetTwinTests.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 
 /**
  * Test class containing all non error injection tests to be run on JVM and android pertaining to getDeviceTwin/getTwin. Class needs to be extended
@@ -32,7 +33,7 @@ public class GetTwinTests extends DeviceTwinCommon
     }
 
     @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         super.setUpNewDeviceAndModule();
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/QueryTwinTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -45,14 +46,14 @@ public class QueryTwinTests extends DeviceTwinCommon
     }
 
     @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         super.setUpNewDeviceAndModule();
     }
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testRawQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testRawQueryTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
         Gson gson = new GsonBuilder().enableComplexMapKeySerialization().serializeNulls().create();
@@ -89,7 +90,7 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testRawQueryMultipleInParallelTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testRawQueryMultipleInParallelTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
         final Gson gson = new GsonBuilder().enableComplexMapKeySerialization().serializeNulls().create();
@@ -196,7 +197,7 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testQueryTwin() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testQueryTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 
@@ -234,7 +235,7 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testQueryTwinWithContinuationToken() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testQueryTwinWithContinuationToken() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(PAGE_SIZE + 1);
 
@@ -321,7 +322,7 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testMultipleQueryTwinInParallel() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testMultipleQueryTwinInParallel() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
     }
 
     @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         super.setUpNewDeviceAndModule();
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/TwinTagsTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
@@ -43,14 +44,14 @@ public class TwinTagsTests extends DeviceTwinCommon
     }
 
     @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         super.setUpNewDeviceAndModule();
     }
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testGetTwinUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testGetTwinUpdates() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 
@@ -115,7 +116,7 @@ public class TwinTagsTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testAddTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testAddTagUpdates() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 
@@ -147,7 +148,7 @@ public class TwinTagsTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void testUpdateTagUpdates() throws IOException, InterruptedException, IotHubException, NoSuchAlgorithmException, URISyntaxException, ModuleClientException
+    public void testUpdateTagUpdates() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);
 


### PR DESCRIPTION
…icate string/certificate paths

some customer's have security concerns with saving their credentials as strings, and other customers may want to use their own library for parsing certificates into SSLContexts, so we should expose this option to the user

issue #578 