### PR TITLE
refactor(vsts): Parallelize mvn install during android build

### DIFF
--- a/vsts/android_java.cmd
+++ b/vsts/android_java.cmd
@@ -13,7 +13,7 @@ call RD /S /Q "c:/users/%USERNAME%/.m2/repository/com/microsoft/azure/sdk/iot"
 
 @REM -- Android Test Build --
 cd %build-root%
-call mvn clean install -DskipTests=true
+call mvn clean install -DskipTests=true -T 2C
 if errorlevel 1 goto :eof
 cd %build-root%\iot-e2e-tests\android
 call gradle wrapper


### PR DESCRIPTION
mvn install could be sped up by a minute or two with this small change