### PR TITLE
Bump package versions for release on 2019-09-30

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.8.4</version>
+    <version>0.8.5</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client</artifactId>
     <name>IoT Hub Java Device Client</name>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <description>The Microsoft Azure IoT Device SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.17.5";
+    private static final String CLIENT_VERSION = "1.18.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.17.5'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.18.0'
 }
 
 repositories {

--- a/device/iot-device-samples/device-method-sample/pom.xml
+++ b/device/iot-device-samples/device-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/device-twin-sample/pom.xml
+++ b/device/iot-device-samples/device-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/file-upload-sample/pom.xml
+++ b/device/iot-device-samples/file-upload-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/handle-messages/pom.xml
+++ b/device/iot-device-samples/handle-messages/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-invoke-method-sample/pom.xml
+++ b/device/iot-device-samples/module-invoke-method-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-method-sample/pom.xml
+++ b/device/iot-device-samples/module-method-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/module-twin-sample/pom.xml
+++ b/device/iot-device-samples/module-twin-sample/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-device-samples</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <name>IoT Hub Java Device SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/device/iot-device-samples/send-event-with-proxy/pom.xml
+++ b/device/iot-device-samples/send-event-with-proxy/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-event-x509/pom.xml
+++ b/device/iot-device-samples/send-event-x509/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-event/pom.xml
+++ b/device/iot-device-samples/send-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-module-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-module-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/iot-device-samples/send-receive-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-receive-x509-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-x509-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/send-serialized-event/pom.xml
+++ b/device/iot-device-samples/send-serialized-event/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-device-samples</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/device/pom.xml
+++ b/device/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client-parent</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <name>IoT Hub Java Device Client Parent </name>
     <packaging>pom</packaging>
     <developers>

--- a/iot-e2e-tests/android/app/build.gradle
+++ b/iot-e2e-tests/android/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:multidex:1.0.3'
 
-    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.3'){
+    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.26.0'){
         exclude module: 'junit'
         exclude module: 'azure-storage'
     }

--- a/iot-e2e-tests/android/things/build.gradle
+++ b/iot-e2e-tests/android/things/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:multidex:1.0.3'
 
-    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.25.3'){
+    implementation ('com.microsoft.azure.sdk.iot:iot-e2e-common:0.26.0'){
         exclude module: 'junit'
         exclude module: 'azure-storage'
     }

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-common</artifactId>
     <name>IoT Hub Java SDK common</name>
-    <version>0.25.3</version>
+    <version>0.26.0</version>
     <description>Test suite fot the Microsoft Azure IoT Device SDK for Java</description>
     <developers>
         <developer>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
 

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-jvm-tests</artifactId>
     <name>IoT Hub Java SDK jvm tests</name>
-    <version>0.25.3</version>
+    <version>0.26.0</version>
     <description>Test suite for the Microsoft Azure IoT Device SDK for Java</description>
     <developers>
         <developer>
@@ -46,13 +46,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
             <scope>test</scope>
         </dependency>
         <!-- test dependencies -->
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-e2e-common</artifactId>
-            <version>0.25.3</version>
+            <version>0.26.0</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/iot-e2e-tests/pom.xml
+++ b/iot-e2e-tests/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
 	<artifactId>iot-e2e-tests</artifactId>
 	<name>IoT Hub Java SDK tests</name>
-	<version>0.25.3</version>
+	<version>0.26.0</version>
 	<description>Test suite fot the Microsoft Azure IoT Device SDK for Java</description>
     <packaging>pom</packaging>
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-sdk-java</artifactId>
-    <version>0.25.3</version>
+    <version>0.26.0</version>
     <name>Azure IoT Sdk Java</name>
     <packaging>pom</packaging>
     <developers>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.17.5</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>tpm-provider</artifactId>
     <name>Provisioning Security TPM Provider</name>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security TPM provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client</artifactId>
     <name>Iot Hub Java Service SDK</name>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <description>The Microsoft Azure IoT Service SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.17.1";
+    public static String serviceVersion = "1.18.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-manager-sample</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>Device Manager Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.1</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-method-sample</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>Device Method Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.1</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-twin-sample</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>Device Twin Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.1</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>job-client-sample</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>Job Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.1</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/iot-service-samples/pom.xml
+++ b/service/iot-service-samples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-service-samples</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>IoT Hub Service SDK Samples</name>
     <packaging>pom</packaging>
     <developers>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>service-client-sample</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>Service Client Sample</name>
     <developers>
         <developer>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
         <artifactId>iot-service-samples</artifactId>
-        <version>1.17.1</version>
+        <version>1.18.0</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client-parent</artifactId>
-    <version>1.17.1</version>
+    <version>1.18.0</version>
     <name>IoT Hub Java Service SDK Parent</name>
     <packaging>pom</packaging>
     <developers>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.18.0)
•	Add proxy support for clients, including optional Basic authentication support (#25)
•	Add support for ASC security messages
•	Add enhanced logging for better tracking of messages through the SDK at different log levels (#58)

**Bug Fixes**
•	Fixed bug where AMQP open logic sometimes reported being open prematurely and didn't function correctly afterwards
•	Fixed bug where AMQP logic opened links on non-reactor threads (proton-j race condition)
•	Fixed bug where AMQP layer got stuck trying to send messages


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.18.0)
•	Add mapping for 409 status code to IotHubConflictException (#272)

**Bug Fixes**
•	 Fixed bug where queried deviceTwinDevice objects did not propagate up connection state or configurations (#520)



## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.8.5)
•	Add proxy support for clients, including optional Basic authentication support
•	Upgrade mqtt Paho dependency to latest version, eliminate leaked threads upon closing client (#453)

**Bug Fixes**
•	Fixed bug where calling closeNow on client using MQTT leaked threads (#453, #541)
•	Fixed bug where calling closeNow and open again on a client using MQTT over LTE connection leaves a socket partially closed (#552)



## Java Provisioning Security TPM Provider (com.microsoft.azure.sdk.iot.provisioning.security:tpm-provider:1.1.2)
•	 Update TSS.Java to latest version


## Merge Pull Request
#586, #587, #583, #577, #576, #569, #566, #563, #563, #560, #559, #558, #548

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.18.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.18.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.8.5/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/tpm-provider/1.1.2/jar

old
{
    "device": "1.17.5",
    "service": "1.17.1",
    "deps": "0.8.4",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.1",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.3",
    "provisioning": "1.8.1",
    "provisioningDevice": "1.7.1",
    "provisioningService": "1.5.2",
    "java": "0.25.3"
}


new
{
    "device": "1.18.0",
    "service": "1.18.0",
    "deps": "0.8.5",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.3",
    "provisioning": "1.8.1",
    "provisioningDevice": "1.7.1",
    "provisioningService": "1.5.2",
    "java": "0.26.0"
}