### PR TITLE
fix(iot-dev): Fix issue where client can't be re-opened if disconnected and retry policy is exhausted

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -10,7 +10,7 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubTransport;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit;
  * The task scheduler for sending and receiving messages for the Device Client
  */
 @Slf4j
-public final class DeviceIO
+public final class DeviceIO  implements TransportConnectionListener
 {
     /** The state of the IoT Hub client's connection with the IoT Hub. */
     protected enum IotHubClientState
@@ -79,16 +79,16 @@ public final class DeviceIO
     private long sendPeriodInMilliseconds;
     private long receivePeriodInMilliseconds;
 
-    private IotHubTransport transport;
-    private DeviceClientConfig config;
+    private final IotHubTransport transport;
     private IotHubSendTask sendTask = null;
     private IotHubReceiveTask receiveTask = null;
-    private IotHubClientProtocol protocol = null;
+    private final IotHubClientProtocol protocol;
 
     private ScheduledExecutorService taskScheduler;
     private IotHubClientState state;
+    private final Object stateLock = new Object();
 
-    private List<DeviceClientConfig> deviceClientConfigs = new LinkedList<>();
+    private List<DeviceClientConfig> deviceClientConfigs = new ArrayList<>();
 
     /**
      * Constructor that takes a connection string as an argument.
@@ -110,23 +110,17 @@ public final class DeviceIO
 
         /* Codes_SRS_DEVICE_IO_21_001: [The constructor shall store the provided protocol and config information.] */
         deviceClientConfigs.add(config);
-        this.config = config;
-        this.protocol = this.config.getProtocol();
-
-        /* Codes_SRS_DEVICE_IO_21_037: [The constructor shall initialize the `sendPeriodInMilliseconds` with default value of 10 milliseconds.] */
-        this.sendPeriodInMilliseconds = sendPeriodInMilliseconds;
-        /* Codes_SRS_DEVICE_IO_21_038: [The constructor shall initialize the `receivePeriodInMilliseconds` with default value of each protocol.] */
-        this.receivePeriodInMilliseconds = receivePeriodInMilliseconds;
+        this.protocol = config.getProtocol();
 
         /* Codes_SRS_DEVICE_IO_21_006: [The constructor shall set the `state` as `DISCONNECTED`.] */
         this.state = IotHubClientState.CLOSED;
 
         if (protocol == IotHubClientProtocol.AMQPS_WS || protocol == IotHubClientProtocol.MQTT_WS)
         {
-            this.config.setUseWebsocket(true);
+            config.setUseWebsocket(true);
         }
 
-        this.transport = new IotHubTransport(config);
+        this.transport = new IotHubTransport(config, this);
 
         /* Codes_SRS_DEVICE_IO_21_037: [The constructor shall initialize the `sendPeriodInMilliseconds` with default value of 10 milliseconds.] */
         this.sendPeriodInMilliseconds = sendPeriodInMilliseconds;
@@ -145,26 +139,37 @@ public final class DeviceIO
      */
     void open() throws IOException
     {
-        /* Codes_SRS_DEVICE_IO_21_007: [If the client is already open, the open shall do nothing.] */
-        if (this.state == IotHubClientState.OPEN)
-        {
-            return;
-        }
+        open(true);
+    }
 
-        /* Codes_SRS_DEVICE_IO_21_012: [The open shall open the transport to communicate with an IoT Hub.] */
-        /* Codes_SRS_DEVICE_IO_21_015: [If an error occurs in opening the transport, the open shall throw an IOException.] */
-        try
+    void open(boolean openTransport) throws IOException
+    {
+        synchronized (stateLock)
         {
-            this.transport.open(deviceClientConfigs);
-        }
-        catch (DeviceClientException e)
-        {
-            throw new IOException("Could not open the connection", e);
-        }
+            /* Codes_SRS_DEVICE_IO_21_007: [If the client is already open, the open shall do nothing.] */
+            if (this.state == IotHubClientState.OPEN)
+            {
+                return;
+            }
 
-        /* Codes_SRS_DEVICE_IO_21_014: [The open shall schedule receive tasks to run every receivePeriodInMilliseconds milliseconds.] */
-        /* Codes_SRS_DEVICE_IO_21_016: [The open shall set the `state` as `CONNECTED`.] */
-        commonOpenSetup();
+            if (openTransport)
+            {
+                /* Codes_SRS_DEVICE_IO_21_012: [The open shall open the transport to communicate with an IoT Hub.] */
+                /* Codes_SRS_DEVICE_IO_21_015: [If an error occurs in opening the transport, the open shall throw an IOException.] */
+                try
+                {
+                    this.transport.open(deviceClientConfigs);
+                }
+                catch (DeviceClientException e)
+                {
+                    throw new IOException("Could not open the connection", e);
+                }
+            }
+
+            /* Codes_SRS_DEVICE_IO_21_014: [The open shall schedule receive tasks to run every receivePeriodInMilliseconds milliseconds.] */
+            /* Codes_SRS_DEVICE_IO_21_016: [The open shall set the `state` as `CONNECTED`.] */
+            commonOpenSetup();
+        }
     }
 
     /**
@@ -215,26 +220,37 @@ public final class DeviceIO
      */
     public void close() throws IOException
     {
-        /* Codes_SRS_DEVICE_IO_21_017: [The close shall finish all ongoing tasks.] */
-        /* Codes_SRS_DEVICE_IO_21_018: [The close shall cancel all recurring tasks.] */
-        if (taskScheduler != null)
-        {
-            this.taskScheduler.shutdown();
-        }
+        close(true);
+    }
 
-        /* Codes_SRS_DEVICE_IO_21_019: [The close shall close the transport.] */
-        try
+    void close(boolean closeTransport) throws IOException
+    {
+        synchronized (stateLock)
         {
-            this.transport.close(IotHubConnectionStatusChangeReason.CLIENT_CLOSE, null);
-        }
-        catch (DeviceClientException e)
-        {
+            /* Codes_SRS_DEVICE_IO_21_017: [The close shall finish all ongoing tasks.] */
+            /* Codes_SRS_DEVICE_IO_21_018: [The close shall cancel all recurring tasks.] */
+            if (taskScheduler != null)
+            {
+                this.taskScheduler.shutdown();
+            }
+
+            if (closeTransport)
+            {
+                /* Codes_SRS_DEVICE_IO_21_019: [The close shall close the transport.] */
+                try
+                {
+                    this.transport.close(IotHubConnectionStatusChangeReason.CLIENT_CLOSE, null);
+                }
+                catch (DeviceClientException e)
+                {
+                    this.state = IotHubClientState.CLOSED;
+                    throw new IOException(e);
+                }
+            }
+
+            /* Codes_SRS_DEVICE_IO_21_021: [The close shall set the `state` as `CLOSE`.] */
             this.state = IotHubClientState.CLOSED;
-            throw new IOException(e);
         }
-
-        /* Codes_SRS_DEVICE_IO_21_021: [The close shall set the `state` as `CLOSE`.] */
-        this.state = IotHubClientState.CLOSED;
     }
 
     /**
@@ -428,5 +444,33 @@ public final class DeviceIO
     {
         //Codes_SRS_DEVICE_IO_34_020: [This function shall register the callback with the transport.]
         this.transport.registerConnectionStatusChangeCallback(statusChangeCallback, callbackContext);
+    }
+
+    @Override
+    public void onTransportConnectionLost()
+    {
+        try
+        {
+            //only close the device io layer, not the transport layer. The transport layer is already closed when this method is called
+            this.close(false);
+        }
+        catch (IOException e)
+        {
+            log.warn("Encountered an exception while closing device IO layer due to transport disconnection event", e);
+        }
+    }
+
+    @Override
+    public void onTransportConnectionRecovered()
+    {
+        try
+        {
+            //only open the device io layer, not the transport layer. The transport layer is already open when this method is called
+            this.open(false);
+        }
+        catch (IOException e)
+        {
+            log.warn("Encountered an exception while opening device IO layer after transport layer recovered from disconnection event", e);
+        }
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
@@ -135,6 +135,8 @@ public class TransportClient
             this.deviceIO = null;
         }
 
+        this.transportClientState = TransportClientState.CLOSED;
+
         log.info("Transport client closed successfully");
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportConnectionListener.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportConnectionListener.java
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.device;
+
+public interface TransportConnectionListener
+{
+    public void onTransportConnectionLost();
+
+    public void onTransportConnectionRecovered();
+}

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
@@ -197,6 +197,7 @@ public class TransportClientTest
         IotHubClientProtocol iotHubClientProtocol = IotHubClientProtocol.AMQPS;
         final TransportClient transportClient = new TransportClient(iotHubClientProtocol);
         Deencapsulation.setField(transportClient, "deviceIO", mockDeviceIO);
+        Deencapsulation.setField(transportClient, "transportClientState", TransportClient.TransportClientState.OPENED);
 
         // act
         transportClient.closeNow();
@@ -207,6 +208,9 @@ public class TransportClientTest
 
         DeviceIO deviceIO = Deencapsulation.getField(transportClient, "deviceIO");
         assertNull(deviceIO);
+
+        TransportClient.TransportClientState state = Deencapsulation.getField(transportClient, "transportClientState");
+        assertEquals(TransportClient.TransportClientState.CLOSED, state);
 
         new Verifications()
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -93,6 +93,9 @@ public class IotHubTransportTest
 
     @Mocked
     Executors mockExecutors;
+    
+    @Mocked
+    TransportConnectionListener mockedTransportConnectionListener;
 
     //Tests_SRS_IOTHUBTRANSPORT_34_001: [The constructor shall save the default config.]
     //Tests_SRS_IOTHUBTRANSPORT_34_003: [The constructor shall set the connection status as DISCONNECTED and the current retry attempt to 0.]
@@ -100,7 +103,7 @@ public class IotHubTransportTest
     public void constructorSucceeds()
     {
         //act
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //assert
         assertEquals(mockedConfig, Deencapsulation.getField(transport, "defaultConfig"));
@@ -113,7 +116,7 @@ public class IotHubTransportTest
     public void constructorThrowsForNullConfig()
     {
         //act
-        IotHubTransport transport = new IotHubTransport(null);
+        IotHubTransport transport = new IotHubTransport(null, mockedTransportConnectionListener);
     }
 
     //Tests_SRS_IOTHUBTRANSPORT_34_004: [This function shall retrieve a packet from the inProgressPackets queue with the message id from the provided message if there is one.]
@@ -122,7 +125,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndCallsHandleMessageExceptionForTransportException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -156,7 +159,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndAddsToCallbackForNoException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -191,7 +194,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndCallsHandleMessageExceptionForNonTransportException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final String messageId = "1234";
         final IOException nonTransportException = new IOException();
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
@@ -229,7 +232,7 @@ public class IotHubTransportTest
     public void onMessageReceivedWithMessageAndNoExceptionAddsToQueue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         transport.onMessageReceived(mockedTransportMessage, null);
@@ -256,7 +259,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
@@ -288,7 +291,7 @@ public class IotHubTransportTest
                 fail("should not have called this method");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -325,7 +328,7 @@ public class IotHubTransportTest
                 methodsCalled.append("addReceivedMessagesOverHttpToReceivedQueue");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final IOException nonTransportException = new IOException();
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
@@ -362,7 +365,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final IOException nonTransportException = new IOException();
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
@@ -404,7 +407,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -413,6 +416,9 @@ public class IotHubTransportTest
             {
                 mockedIotHubTransportConnection.getConnectionId();
                 result = expectedConnectionId;
+
+                mockedTransportConnectionListener.onTransportConnectionRecovered();
+                times = 1;
             }
         };
 
@@ -428,7 +434,7 @@ public class IotHubTransportTest
     public void openThrowsForNullConfigList() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         transport.open(null);
@@ -439,7 +445,7 @@ public class IotHubTransportTest
     public void openThrowsForEmptyConfigList() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         transport.open(new ArrayList<DeviceClientConfig>());
@@ -450,7 +456,7 @@ public class IotHubTransportTest
     public void openThrowsIfConnectionStatusIsDisconnectedRetrying() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -472,7 +478,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -487,7 +493,7 @@ public class IotHubTransportTest
     {
         //arrange
         final StringBuilder verifier = new StringBuilder();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -525,7 +531,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -540,7 +546,8 @@ public class IotHubTransportTest
     public void closeThrowsForNullReason() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
+        Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
 
         //act
         transport.close(null, mockedTransportException);
@@ -580,7 +587,7 @@ public class IotHubTransportTest
         inProgressPackets.put("2", mockedPacket);
 
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
@@ -621,7 +628,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonWithNonTransportException()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, new IOException());
@@ -635,7 +642,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonWithRetryableTransportException()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         new NonStrictExpectations()
         {
@@ -664,7 +671,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         new Expectations()
         {
@@ -686,7 +693,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForAmqpUnauthorizedException(@Mocked final AmqpUnauthorizedAccessException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -711,7 +718,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForMqttUnauthorizedException(@Mocked final MqttUnauthorizedException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -737,7 +744,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForGenericUnauthorizedException(@Mocked final UnauthorizedException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -765,7 +772,7 @@ public class IotHubTransportTest
     public void openConnectionWithHttp()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -807,7 +814,7 @@ public class IotHubTransportTest
     public void openConnectionWithMqtt() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -844,7 +851,7 @@ public class IotHubTransportTest
     public void openConnectionWithMqttWS() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -881,7 +888,7 @@ public class IotHubTransportTest
     public void openConnectionWithAmqps() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -919,7 +926,7 @@ public class IotHubTransportTest
     public void openConnectionWithAmqpsWS() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -960,7 +967,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -982,7 +989,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         waitingPacketsQueue.add(mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1004,7 +1011,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         inProgressPackets.put("asdf", mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1026,7 +1033,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         callbackPacketsQueue.add(mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1043,7 +1050,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutTrue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -1064,7 +1071,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutReturnsFalseIfProvidedTimeIsZero()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -1085,7 +1092,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutFalse()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -1106,7 +1113,7 @@ public class IotHubTransportTest
     public void addMessageThrowsIfDisconnected()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
 
         //act
@@ -1118,7 +1125,7 @@ public class IotHubTransportTest
     public void addMessageAddsMessage()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
@@ -1143,7 +1150,7 @@ public class IotHubTransportTest
     public void sendMessagesDoesNothingIfNotConnected()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         waitingPacketsQueue.add(mockedPacket);
@@ -1170,7 +1177,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final int MAX_MESSAGES_TO_SEND_PER_THREAD = Deencapsulation.getField(transport, "MAX_MESSAGES_TO_SEND_PER_THREAD");
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -1194,7 +1201,7 @@ public class IotHubTransportTest
     public void invokeCallbacksInvokesAllCallbacks(final @Mocked IotHubStatusCode mockedStatus)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         callbackPacketsQueue.add(mockedPacket);
         callbackPacketsQueue.add(mockedPacket);
@@ -1241,7 +1248,7 @@ public class IotHubTransportTest
                 fail("should not have called this method");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1279,7 +1286,7 @@ public class IotHubTransportTest
                 methodsCalled.append("addReceivedMessagesOverHttpToReceivedQueue");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1314,7 +1321,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1334,7 +1341,7 @@ public class IotHubTransportTest
     public void registerConnectionStateCallbackThrowsForNullCallback()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         transport.registerConnectionStateCallback(null, new Object());
@@ -1345,7 +1352,7 @@ public class IotHubTransportTest
     public void registerConnectionStateCallbackSavesProvidedCallbackAndContext()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Object context = new Object();
 
         //act
@@ -1361,7 +1368,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackThrowsForNullCallback()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         transport.registerConnectionStatusChangeCallback(null, new Object());
@@ -1372,7 +1379,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackDoesNotThrowForNullCallbackIfContextIsAlsoNull()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         transport.registerConnectionStatusChangeCallback(mockedIotHubConnectionStatusChangeCallback, new Object());
         assertNotNull(Deencapsulation.getField(transport, "connectionStatusChangeCallback"));
         assertNotNull(Deencapsulation.getField(transport, "connectionStatusChangeCallbackContext"));
@@ -1391,7 +1398,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackSavesProvidedCallbackAndContext()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Object context = new Object();
 
         //act
@@ -1410,7 +1417,7 @@ public class IotHubTransportTest
     public void acknowledgeReceivedMessageSendsAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1446,7 +1453,7 @@ public class IotHubTransportTest
     public void acknowledgeReceivedMessageReQueuesFailedMessages() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1489,7 +1496,7 @@ public class IotHubTransportTest
     public void addReceivedMessagesOverHttpToReceivedQueueChecksForHttpMessages() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
 
         //act
@@ -1539,7 +1546,7 @@ public class IotHubTransportTest
                 methodsCalled.append("reconnect");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "handleDisconnection", mockedTransportException);
@@ -1563,7 +1570,7 @@ public class IotHubTransportTest
                 //do nothing
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations()
@@ -1587,7 +1594,7 @@ public class IotHubTransportTest
     public void singleReconnectAttemptReturnsEncounteredException() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations(IotHubTransport.class)
@@ -1629,7 +1636,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         final long expectedDelay = 0;
         final long duration = 0;
@@ -1683,7 +1690,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1738,7 +1745,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1793,7 +1800,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1861,7 +1868,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new Expectations()
         {
@@ -1877,6 +1884,9 @@ public class IotHubTransportTest
 
                 mockedRetryDecision.shouldRetry();
                 result = false;
+
+                mockedTransportConnectionListener.onTransportConnectionLost();
+                times = 1;
             }
         };
 
@@ -1912,8 +1922,16 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
+
+        new Expectations()
+        {
+            {
+                mockedTransportConnectionListener.onTransportConnectionLost();
+                times = 1;
+            }
+        };
 
         //act
         Deencapsulation.invoke(transport, "reconnect", mockedTransportException);
@@ -1953,8 +1971,16 @@ public class IotHubTransportTest
                 return IotHubConnectionStatusChangeReason.BAD_CREDENTIAL;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
+
+        new Expectations()
+        {
+            {
+                mockedTransportConnectionListener.onTransportConnectionLost();
+                times = 1;
+            }
+        };
 
         //act
         Deencapsulation.invoke(transport, "reconnect", mockedTransportException);
@@ -2003,7 +2029,7 @@ public class IotHubTransportTest
                 throw new TransportException("close failed");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new NonStrictExpectations()
         {
@@ -2037,7 +2063,7 @@ public class IotHubTransportTest
     public void isMessageValidWithMessageExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2075,7 +2101,7 @@ public class IotHubTransportTest
     public void isMessageValidWithMessageNotExpiredAndValidSasToken()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2132,7 +2158,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2174,7 +2200,7 @@ public class IotHubTransportTest
                 methodsCalled.append("invokeConnectionStatusChangeCallback");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
         Deencapsulation.setField(transport, "reconnectionAttemptStartTimeMillis", 5);
@@ -2198,7 +2224,7 @@ public class IotHubTransportTest
     public void updateStatusConnectionStatusNotChanged()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
         new Expectations(IotHubTransport.class)
@@ -2238,7 +2264,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
 
@@ -2258,7 +2284,7 @@ public class IotHubTransportTest
     public void invokeConnectionStatusChangeCallbackWithCallback()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatusChangeCallback", mockedIotHubConnectionStatusChangeCallback);
 
         //act
@@ -2285,7 +2311,7 @@ public class IotHubTransportTest
     public void invokeConnectionStatusChangeCallbackWithNullCallback()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Deencapsulation.setField(transport, "connectionStatusChangeCallback", null);
 
         //act
@@ -2313,7 +2339,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeIsSasTokenAndExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2336,7 +2362,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeIsSasTokenAndNotExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2359,7 +2385,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeNotSasToken()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2382,7 +2408,7 @@ public class IotHubTransportTest
     public void addToCallbackQueuePacketHasCallback(@Mocked final IotHubEventCallback mockCallback)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2405,7 +2431,7 @@ public class IotHubTransportTest
     public void addToCallbackQueuePacketNoCallback(@Mocked final IotHubEventCallback mockCallback)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         new NonStrictExpectations()
         {
             {
@@ -2435,7 +2461,7 @@ public class IotHubTransportTest
             }
         };
         final MqttUnauthorizedException testException = new MqttUnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2465,7 +2491,7 @@ public class IotHubTransportTest
         };
 
         final UnauthorizedException testException = new UnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2495,7 +2521,7 @@ public class IotHubTransportTest
         };
 
         final AmqpUnauthorizedAccessException testException = new AmqpUnauthorizedAccessException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2524,7 +2550,7 @@ public class IotHubTransportTest
             }
         };
         final UnauthorizedException testException = new UnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2553,7 +2579,7 @@ public class IotHubTransportTest
             }
         };
         final TransportException testException = new TransportException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2575,7 +2601,7 @@ public class IotHubTransportTest
     public void sendPacketHappyPathWithAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -2618,7 +2644,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -2650,7 +2676,7 @@ public class IotHubTransportTest
     public void sendPacketHappyPathWithoutAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2700,7 +2726,7 @@ public class IotHubTransportTest
                 methodsCalled.append("handleMessageException");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2746,7 +2772,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2781,7 +2807,7 @@ public class IotHubTransportTest
     public void handleMessageExceptionChecksForAmqpThrottling()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
 
         //act
         Deencapsulation.invoke(transport, "handleMessageException", new Class[] {IotHubTransportPacket.class, TransportException.class}, mockedPacket, new AmqpConnectionThrottledException());
@@ -2800,7 +2826,7 @@ public class IotHubTransportTest
     public void sendMessagesChecksForExpiredMessagesInWaitingQueue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -2840,7 +2866,7 @@ public class IotHubTransportTest
     public void sendMessagesChecksForExpiredMessagesInInProgressPackets()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedTransportConnectionListener);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
IothubTransport layer did not notify DeviceIO layer when connection was lost for good, so it always believed to be open until closeNow is called. As a result, it would reject further attempts to open it even when the connection status callback reported as disconnected

This PR modifies the DeviceIO and IotHubTransport layer such that when the connection status in the transport layer changes to CONNECTED or DISCONNECTED, it executes a callback to the DeviceIO layer which then modifies its own state to stay consistent.

It also fixes a very small bug in the TransportClient class where it never set its own state to disconnected after calling close.

This PR also adds some basic state locks to the DeviceIO layer such that an open call and a close call cannot be executed simultaneously.

This PR also adds some e2e tests around recycling a device client including:

- Verify that a client object can be re-opened after closing it manually
- Verify that a client object can be re-opened from a main thread after a disconnection event exhausts the retry policy
- Verify that a client object can be re-opened from a thread spawned in the connection status callback thread after a disconnection event exhausts the retry policy