### PR TITLE
feat(iot-serv): Allow ConfigurationMetrics to be set on Configuration objects

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/Configuration.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/Configuration.java
@@ -111,6 +111,15 @@ public class Configuration
     }
 
     /**
+     * Set the configuration metrics of this object
+     * @param metrics the metrics to set
+     */
+    public void setMetrics(ConfigurationMetrics metrics)
+    {
+        this.metrics = metrics;
+    }
+
+    /**
      * Specifies the configuration content
      */
     protected ConfigurationContent content;

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ConfigurationTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ConfigurationTest.java
@@ -1,17 +1,14 @@
 package tests.unit.com.microsoft.azure.sdk.iot.service;
 
 import com.microsoft.azure.sdk.iot.deps.serializer.*;
-import com.microsoft.azure.sdk.iot.service.BaseDevice;
 import com.microsoft.azure.sdk.iot.service.Configuration;
-import com.microsoft.azure.sdk.iot.service.ConfigurationContent;
 import com.microsoft.azure.sdk.iot.service.ConfigurationMetrics;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import mockit.Deencapsulation;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -191,5 +188,15 @@ public class ConfigurationTest
         assertEquals(new Long(100), configurationCA.getMetrics().getResults().get("resultKey"));
         assertEquals("squeryVal", configurationCA.getSystemMetrics().getQueries().get("squeryKey"));
         assertEquals(new Long(101), configurationCA.getSystemMetrics().getResults().get("sresultKey"));
+    }
+
+    @Test
+    public void canSetConfigurationMetrics(@Mocked final ConfigurationMetrics mockedConfigurationMetrics)
+    {
+        Configuration configuration = new Configuration("asdf");
+
+        configuration.setMetrics(mockedConfigurationMetrics);
+
+        Assert.assertEquals(mockedConfigurationMetrics, configuration.getMetrics());
     }
 }


### PR DESCRIPTION
Issue #600 pointed out that the SDK does not allow users to set the configuration metrics on a configuration object. Other SDK's do allow this, so this PR is bringing the SDK up to par.