### PR TITLE
fix(iot-dev): Fix issue where client can't be re-opened if disconnected and retry policy is exhausted

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
@@ -135,6 +135,8 @@ public class TransportClient
             this.deviceIO = null;
         }
 
+        this.transportClientState = TransportClientState.CLOSED;
+
         log.info("Transport client closed successfully");
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportConnectionListener.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportConnectionListener.java
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.device;
+
+public interface TransportConnectionListener
+{
+    public void onTransportConnectionClosed();
+
+    public void onTransportConnectionOpened();
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -294,7 +294,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
     @Override
     public void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService)
     {
-
+        this.listener.onConnectionEstablished(this.getConnectionId());
     }
 
     @Override

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
@@ -197,6 +197,7 @@ public class TransportClientTest
         IotHubClientProtocol iotHubClientProtocol = IotHubClientProtocol.AMQPS;
         final TransportClient transportClient = new TransportClient(iotHubClientProtocol);
         Deencapsulation.setField(transportClient, "deviceIO", mockDeviceIO);
+        Deencapsulation.setField(transportClient, "transportClientState", TransportClient.TransportClientState.OPENED);
 
         // act
         transportClient.closeNow();
@@ -207,6 +208,9 @@ public class TransportClientTest
 
         DeviceIO deviceIO = Deencapsulation.getField(transportClient, "deviceIO");
         assertNull(deviceIO);
+
+        TransportClient.TransportClientState state = Deencapsulation.getField(transportClient, "transportClientState");
+        assertEquals(TransportClient.TransportClientState.CLOSED, state);
 
         new Verifications()
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -2146,9 +2146,20 @@ public class HttpsIotHubConnectionTest
 
     //Just for code coverage over dummy methods
     @Test
-    public void openAndCloseDoNothing() throws IOException, TransportException
+    public void openNotifiesOnConnectionEstablishedAndCloseDoesNothing() throws IOException, TransportException
     {
         HttpsIotHubConnection connection = new HttpsIotHubConnection(mockConfig);
+
+        new Expectations()
+        {
+            {
+                mockedListener.onConnectionEstablished(anyString);
+                times = 1;
+            }
+        };
+
+        connection.setListener(mockedListener);
+
         connection.open(null, mockedScheduledExecutorService);
         connection.close();
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/TransportClientTests.java
@@ -230,6 +230,28 @@ public class TransportClientTests extends IntegrationTest
     }
 
     @Test
+    public void sendMessagesAfterClosingAndReopeningTransportClient() throws URISyntaxException, IOException, InterruptedException
+    {
+        testInstance.transportClient.open();
+
+        for (int i = 0; i < testInstance.clientArrayList.size(); i++)
+        {
+            sendMessagesMultiplex(testInstance.clientArrayList.get(i), IotHubClientProtocol.AMQPS, NUM_MESSAGES_PER_CONNECTION, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS);
+        }
+
+        testInstance.transportClient.closeNow();
+
+        testInstance.transportClient.open();
+
+        for (int i = 0; i < testInstance.clientArrayList.size(); i++)
+        {
+            sendMessagesMultiplex(testInstance.clientArrayList.get(i), IotHubClientProtocol.AMQPS, NUM_MESSAGES_PER_CONNECTION, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS);
+        }
+
+        testInstance.transportClient.closeNow();
+    }
+
+    @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void receiveMessagesIncludingProperties() throws Exception
     {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/SendMessagesErrInjTests.java
@@ -283,6 +283,64 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         testInstance.client.setRetryPolicy(new ExponentialBackoffWithJitter());
     }
 
+    @Test
+    public void clientCanReopenAfterDisconnectionEvent() throws Exception
+    {
+        if (testInstance.protocol == HTTPS || testInstance.useHttpProxy)
+        {
+            return;
+        }
+
+        this.testInstance.setup();
+
+        this.testInstance.client.setRetryPolicy(new NoRetry());
+
+        this.testInstance.client.open();
+
+        Message tcpConnectionDropErrorInjectionMessageUnrecoverable = ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(1, 5);
+        sendMessagesExpectingUnrecoverableConnectionLossAndTimeout(testInstance.client, testInstance.protocol, tcpConnectionDropErrorInjectionMessageUnrecoverable, testInstance.authenticationType);
+
+        testInstance.client.open();
+
+        IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+    }
+
+    @Test
+    public void clientCanReopenAfterDisconnectionEventUsingApplicationLevelRetryInConnectionStatusCallback() throws Exception
+    {
+        if (testInstance.protocol == HTTPS || testInstance.useHttpProxy)
+        {
+            return;
+        }
+
+        this.testInstance.setup();
+
+        Message tcpConnectionDropErrorInjectionMessageUnrecoverable = ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(1, 5);
+        IotHubServicesCommon.sendMessagesExpectingRecoverableConnectionLossAndRecoversUsingConnectionStatusCallback(testInstance.client, testInstance.protocol, tcpConnectionDropErrorInjectionMessageUnrecoverable, testInstance.authenticationType);
+
+        IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+    }
+
+    @Test
+    public void clientCanReopenAndSendMessagesAfterClosing() throws Exception
+    {
+        if (testInstance.useHttpProxy)
+        {
+            return;
+        }
+
+        int maxTimesToCloseAndReopen = 5;
+
+        this.testInstance.setup();
+
+        for (int i = 0; i < maxTimesToCloseAndReopen; i++)
+        {
+            this.testInstance.client.open();
+            IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+            this.testInstance.client.closeNow();
+        }
+    }
+
     private void errorInjectionTestFlowNoDisconnect(Message errorInjectionMessage, IotHubStatusCode expectedStatus, boolean noRetry) throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
     {
         // Arrange


### PR DESCRIPTION
(I closed the old PR for this issue since it was getting cluttered, and its code was different enough to warrant a new PR)

IothubTransport layer did not notify DeviceIO layer when connection was lost for good, so it always believed to be open until closeNow is called. As a result, it would reject further attempts to open it even when the connection status callback reported as disconnected

This PR modifies the DeviceIO and IotHubTransport layer such that when the connection status in the transport layer changes to CONNECTED or DISCONNECTED, it executes a callback to the DeviceIO layer which then modifies its own state to stay consistent.

It also fixes a very small bug in the TransportClient class where it never set its own state to disconnected after calling close. An E2E test has been added for using a closed and reopened transportclient

This PR removes state tracking from the DeviceIO layer, instead deferring to the IotHubTransport layer for isOpen() type checks.

This PR also adds some e2e tests around recycling a device client including:

Verify that a client object can be re-opened after closing it manually
Verify that a client object can be re-opened from a main thread after a disconnection event exhausts the retry policy
Verify that a client object can be re-opened from a thread spawned in the connection status callback thread after a disconnection event exhausts the retry policy