### PR TITLE
fix(vsts): Fix issue where android test could not be run in azure devops

### DIFF
--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -180,7 +180,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy Test Results to Artifact Staging Directory'
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)\iot-e2e-tests\android\app\build\outputs\apk'
+      SourceFolder: '$(Build.SourcesDirectory)/iot-e2e-tests/android/app/build/outputs/apk'
       Contents: |
        *.*
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
@@ -190,12 +190,12 @@ jobs:
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: 'androidBuildFiles'
-      targetPath: 'iot-e2e-tests\android\app\build\outputs\apk'
+      targetPath: 'iot-e2e-tests/android/app/build/outputs/apk'
     
 - job: AndroidTest
   timeoutInMinutes: 180
   pool:
-    name: Hosted VS2017
+    vmImage: 'macOS-latest'
   strategy:
     maxParallel: 12
     matrix:
@@ -288,14 +288,14 @@ jobs:
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: 'androidBuildFiles'
-      targetPath: $(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk
+      targetPath: $(Build.ArtifactStagingDirectory)/iot-e2e-tests/android/app/build/outputs/apk
   
   - task: AppCenterTest@1
     displayName: 'E2E with Visual Studio App Center'
     inputs:
-      appFile: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\debug\app-debug.apk'
+      appFile: '$(Build.ArtifactStagingDirectory)/iot-e2e-tests/android/app/build/outputs/apk/debug/app-debug.apk'
       frameworkOption: espresso
-      espressoBuildDirectory: '$(Build.ArtifactStagingDirectory)\iot-e2e-tests\android\app\build\outputs\apk\androidTest\debug'
+      espressoBuildDirectory: '$(Build.ArtifactStagingDirectory)/iot-e2e-tests/android/app/build/outputs/apk/androidTest/debug'
       serverEndpoint: 'AppCenter connection aziotclb'
       appSlug: 'Azure-Iot-Sdk/androide2e'
       devices: 'Azure-Iot-Sdk/api28_2'


### PR DESCRIPTION
Currently, there is a bug where Hosted VS2017 agents fail to run the app center test task. Migrating to use a Mac agent instead mitigates this issue

https://github.com/microsoft/azure-pipelines-tasks/issues/11757

This task didn't really need to be on a Windows machine. It is just making HTTP requests to app center over and over until the tests complete. Mac is good enough to do that, too

Had to change the backslashes to forward slashes because Mac's use forward slashes for directory navigation