### PR TITLE
refactor(pom): Fix pom files to inherit jar versions from master pom

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -4,6 +4,11 @@
   -->
 
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-sdk-java</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Dependencies for Iot Hub Java SDK</name>
     <description>Dependencies for Iot Hub Java SDK</description>
@@ -28,7 +33,7 @@
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-deps</artifactId>
-    <version>0.8.5</version>
+    <version>${iot-deps-version}</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -1,10 +1,15 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-device-client-parent</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client</artifactId>
     <name>IoT Hub Java Device Client</name>
-    <version>1.18.0</version>
+    <version>${iot-device-client-version}</version>
     <description>The Microsoft Azure IoT Device SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -50,7 +55,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.5</version>
+            <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -65,7 +70,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/device/iot-device-samples/device-method-sample/pom.xml
+++ b/device/iot-device-samples/device-method-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>device-method-sample</artifactId>
@@ -10,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/device-twin-sample/pom.xml
+++ b/device/iot-device-samples/device-twin-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>device-twin-sample</artifactId>
@@ -10,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/file-upload-sample/pom.xml
+++ b/device/iot-device-samples/file-upload-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>file-upload-sample</artifactId>
@@ -10,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/handle-messages/pom.xml
+++ b/device/iot-device-samples/handle-messages/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>handle-messages</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/module-invoke-method-sample/pom.xml
+++ b/device/iot-device-samples/module-invoke-method-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>module-invoke-method-sample</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/module-method-sample/pom.xml
+++ b/device/iot-device-samples/module-method-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>module-method-sample</artifactId>
@@ -10,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/module-twin-sample/pom.xml
+++ b/device/iot-device-samples/module-twin-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>module-twin-sample</artifactId>
@@ -10,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-device-client-parent</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-device-samples</artifactId>
@@ -33,7 +38,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/device/iot-device-samples/send-event-with-proxy/pom.xml
+++ b/device/iot-device-samples/send-event-with-proxy/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-event-with-proxy</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/send-event-x509/pom.xml
+++ b/device/iot-device-samples/send-event-x509/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-event-x509</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/send-event/pom.xml
+++ b/device/iot-device-samples/send-event/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-event</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/send-receive-module-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-module-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-receive-module-sample</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/iot-device-samples/send-receive-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-receive-sample</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/device/iot-device-samples/send-receive-x509-sample/pom.xml
+++ b/device/iot-device-samples/send-receive-x509-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-receive-x509-sample</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/device/iot-device-samples/send-serialized-event/pom.xml
+++ b/device/iot-device-samples/send-serialized-event/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>send-serialized-event</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/device/iot-device-samples/transportclient-sample/pom.xml
+++ b/device/iot-device-samples/transportclient-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>transportclient-sample</artifactId>
@@ -9,11 +15,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-device-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/device/pom.xml
+++ b/device/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-sdk-java</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-device-client-parent</artifactId>

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -1,6 +1,11 @@
 <!-- Copyright (c) Microsoft. All rights reserved. -->
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-e2e-tests</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-common</artifactId>
@@ -21,7 +26,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -42,30 +47,30 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-service-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.1</version>
+            <version>${provisioning-device-client-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>tpm-provider-emulator</artifactId>
-            <version>1.1.1</version>
+            <version>${tpm-provider-emulator-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>x509-provider</artifactId>
-            <version>1.1.3</version>
+            <version>${x509-provider-version}</version>
             <scope>compile</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.littleshoot/littleproxy -->

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -1,4 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-e2e-tests</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure.sdk.iot</groupId>
@@ -44,13 +49,13 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-service-client-version}</version>
         </dependency>
     </dependencies>
 

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -3,6 +3,11 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-e2e-tests</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-e2e-jvm-tests</artifactId>
@@ -23,36 +28,36 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>tpm-provider-emulator</artifactId>
-            <version>1.1.1</version>
+            <version>${tpm-provider-emulator-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>x509-provider</artifactId>
-            <version>1.1.3</version>
+            <version>${x509-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.1</version>
+            <version>${provisioning-device-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-service-client-version}</version>
             <scope>test</scope>
         </dependency>
         <!-- test dependencies -->

--- a/iot-e2e-tests/pom.xml
+++ b/iot-e2e-tests/pom.xml
@@ -3,6 +3,11 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-sdk-java</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
 	<artifactId>iot-e2e-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,19 @@
         <module>iot-e2e-tests</module>
         <module>provisioning</module>
     </modules>
+    <properties>
+        <iot-device-client-version>1.18.0</iot-device-client-version>
+        <iot-service-client-version>1.18.0</iot-service-client-version>
+        <iot-deps-version>0.8.5</iot-deps-version>
+        <provisioning-device-client-version>1.7.1</provisioning-device-client-version>
+        <provisioning-service-client-version>1.5.2</provisioning-service-client-version>
+        <security-provider-version>1.3.0</security-provider-version>
+        <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
+        <tpm-hsm-version>1.1.2</tpm-hsm-version>
+        <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
+        <dice-provider-version>1.1.1</dice-provider-version>
+        <x509-provider-version>1.1.3</x509-provider-version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -34,3 +47,4 @@
         </plugins>
     </build>
 </project>
+

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -4,6 +4,11 @@
   -->
 
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-sdk-java</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning</artifactId>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -3,11 +3,16 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
+        <artifactId>provisioning</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning-device-client</artifactId>
     <name>Provisioning Device Client</name>
-    <version>1.7.1</version>
+    <version>${provisioning-device-client-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Device Client for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -36,12 +41,12 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.5</version>
+            <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/provisioning-samples/pom.xml
+++ b/provisioning/provisioning-samples/pom.xml
@@ -3,6 +3,11 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
+        <artifactId>provisioning</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-samples</artifactId>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-X509-sample</artifactId>
@@ -18,17 +23,17 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>x509-provider</artifactId>
-            <version>1.1.3</version>
+            <version>${x509-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.1</version>
+            <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -5,6 +5,11 @@
   ~
   --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-symmetrickey-sample</artifactId>
@@ -23,17 +28,17 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.1</version>
+            <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -5,6 +5,11 @@
   ~
   --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-tpm-sample</artifactId>
@@ -23,17 +28,17 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>tpm-provider-emulator</artifactId>
-            <version>1.1.1</version>
+            <version>${tpm-provider-emulator-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-device-client</artifactId>
-            <version>1.7.1</version>
+            <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-device-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
@@ -1,6 +1,11 @@
 <!-- Copyright (c) Microsoft. All rights reserved. -->
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.sample</groupId>
     <artifactId>service-bulkoperation-sample</artifactId>
@@ -19,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
@@ -1,6 +1,11 @@
 <!-- Copyright (c) Microsoft. All rights reserved. -->
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-group-sample</artifactId>
@@ -19,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
@@ -1,6 +1,11 @@
 <!-- Copyright (c) Microsoft. All rights reserved. -->
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-sample</artifactId>
@@ -19,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
@@ -1,6 +1,11 @@
 <!-- Copyright (c) Microsoft. All rights reserved. -->
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
+        <artifactId>provisioning-samples</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-update-enrollment-sample</artifactId>
@@ -19,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
             <artifactId>provisioning-service-client</artifactId>
-            <version>1.5.2</version>
+            <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -3,11 +3,16 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
+        <artifactId>provisioning</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
     <artifactId>provisioning-service-client</artifactId>
     <name>Provisioning Service Client</name>
-    <version>1.5.2</version>
+    <version>${provisioning-service-client-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Service Client SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -36,7 +41,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.5</version>
+            <version>${iot-deps-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/provisioning/provisioning-tools/pom.xml
+++ b/provisioning/provisioning-tools/pom.xml
@@ -3,6 +3,11 @@
   ~  Licensed under the MIT license. See LICENSE file in the project root for full license information.
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
+        <artifactId>provisioning</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.tools</groupId>
     <artifactId>provisioning-tools</artifactId>
@@ -11,6 +16,7 @@
     <packaging>pom</packaging>
     <description>The Microsoft Azure IoT Provisioning Tools for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
+
     <developers>
         <developer>
             <id>microsoft</id>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>dice-provider-emulator</artifactId>
     <name>Provisioning Security DICE Emulator Provider</name>
-    <version>1.1.1</version>
+    <version>${dice-provider-emulator-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security DICE provider emulator for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -43,7 +48,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>dice-provider</artifactId>
     <name>Provisioning Security DICE Provider</name>
-    <version>1.1.1</version>
+    <version>${dice-provider-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security DICE provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -43,7 +48,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/provisioning/security/pom.xml
+++ b/provisioning/security/pom.xml
@@ -4,6 +4,11 @@
   -->
 
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
+        <artifactId>provisioning</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>security</artifactId>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>security-provider</artifactId>
     <name>Provisioning Security Provider</name>
-    <version>1.3.0</version>
+    <version>${security-provider-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security Provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>tpm-provider-emulator</artifactId>
     <name>Provisioning Security TPM Emulator Provider</name>
-    <version>1.1.1</version>
+    <version>${tpm-provider-emulator-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security TPM provider emulator for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -43,7 +48,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>tpm-provider</artifactId>
     <name>Provisioning Security TPM Provider</name>
-    <version>1.1.2</version>
+    <version>${tpm-hsm-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security TPM provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -43,7 +48,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -5,11 +5,16 @@
   ~
   -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
+        <artifactId>security</artifactId>
+        <version>1.3.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>x509-provider</artifactId>
     <name>Provisioning Security X509 Provider</name>
-    <version>1.1.3</version>
+    <version>${x509-provider-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security X509 provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
@@ -38,7 +43,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>security-provider</artifactId>
-            <version>1.3.0</version>
+            <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -1,9 +1,15 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-service-client-parent</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client</artifactId>
     <name>Iot Hub Java Service SDK</name>
-    <version>1.18.0</version>
+    <version>${iot-service-client-version}</version>
     <description>The Microsoft Azure IoT Service SDK for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>
     <developers>
@@ -36,7 +42,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-deps</artifactId>
-            <version>0.8.5</version>
+            <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/service/iot-service-samples/device-manager-sample/pom.xml
+++ b/service/iot-service-samples/device-manager-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-service-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-manager-sample</artifactId>
@@ -10,11 +16,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-service-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/service/iot-service-samples/device-method-sample/pom.xml
+++ b/service/iot-service-samples/device-method-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-service-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-method-sample</artifactId>
@@ -10,11 +16,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-service-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/service/iot-service-samples/device-twin-sample/pom.xml
+++ b/service/iot-service-samples/device-twin-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-service-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>device-twin-sample</artifactId>
@@ -10,11 +16,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-service-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/service/iot-service-samples/job-client-sample/pom.xml
+++ b/service/iot-service-samples/job-client-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-service-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>job-client-sample</artifactId>
@@ -10,11 +16,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-service-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/service/iot-service-samples/pom.xml
+++ b/service/iot-service-samples/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-service-client-parent</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
     <artifactId>iot-service-samples</artifactId>
@@ -23,7 +28,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>iot-service-client</artifactId>
-            <version>1.18.0</version>
+            <version>${iot-service-client-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/iot-service-samples/service-client-sample/pom.xml
+++ b/service/iot-service-samples/service-client-sample/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-service-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.samples.service</groupId>
     <artifactId>service-client-sample</artifactId>
@@ -10,11 +16,6 @@
             <name>Microsoft</name>
         </developer>
     </developers>
-    <parent>
-        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
-        <artifactId>iot-service-samples</artifactId>
-        <version>1.18.0</version>
-    </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,4 +1,10 @@
-<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. --><project>
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot</groupId>
+        <artifactId>iot-sdk-java</artifactId>
+        <version>0.26.0</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
     <artifactId>iot-service-client-parent</artifactId>

--- a/versions.json
+++ b/versions.json
@@ -1,15 +1,13 @@
 {
-    "device": "1.17.0",
-    "service": "1.16.2",
-    "deps": "0.8.1",
-    "securityProvider": "1.2.0",
+    "device": "1.18.0",
+    "service": "1.18.0",
+    "deps": "0.8.5",
+    "securityProvider": "1.3.0",
     "tpmEmulator": "1.1.1",
-    "tpmHsm": "1.1.1",
+    "tpmHsm": "1.1.2",
     "diceEmulator": "1.1.1",
     "dice": "1.1.1",
-    "x509": "1.1.2",
-    "provisioning": "1.7.0",
-    "provisioningDevice": "1.6.0",
-    "provisioningService": "1.5.0",
-    "java": "0.24.0"
+    "x509": "1.1.3",
+    "provisioningDevice": "1.7.1",
+    "provisioningService": "1.5.2"
 }


### PR DESCRIPTION
Fix lack of pom inheritance as well so that the property can be inherited from the master pom

Also updated the versions.json file to remove all versions associated with poms that aren't published as packages. There is no reason for us to be bumping the versions of such poms