### PR TITLE
fix(iot-serv, iot-dev): Remove SDK side validation of reported and desired properties

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/Property.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/Property.java
@@ -23,13 +23,6 @@ public class Property
              */
             throw new IllegalArgumentException("Key cannot be null or empty");
         }
-        if (key.contains(" ") || key.contains("$") || key.contains("."))
-        {
-            /*
-            **Codes_SRS_Property_25_006: [**If the key contains illegal unicode control characters i.e ' ', '.', '$', the constructor shall throw an IllegalArgumentException.**]**
-             */
-            throw new IllegalArgumentException("Key cannot contain illegal unicode control characters '.', '$', ' '");
-        }
         /*
         **Codes_SRS_Property_25_001: [**The constructor shall save the key and value representing this property.**]**
          */

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/PropertyTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceTwin/PropertyTest.java
@@ -68,33 +68,6 @@ public class PropertyTest
 
     }
 
-    /*
-    **Tests_SRS_Property_25_006: [**If the key contains illegal unicode control characters i.e ' ', '.', '$', the constructor shall throw an IllegalArgumentException.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidKey()
-    {
-        //act
-        Property testProp = new Property("Key with space", 1);
-
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidKey_2()
-    {
-        //act
-        Property testProp = new Property("KeyWith$", 1);
-
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnInvalidKey_3()
-    {
-        //act
-        Property testProp = new Property("KKeyWith.", 1);
-
-    }
-
     @Test (expected = IllegalArgumentException.class)
     public void constructorThrowsOnInvalidKey_4()
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Pair.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Pair.java
@@ -21,13 +21,6 @@ public class Pair
              */
             throw new IllegalArgumentException("Key cannot be null or empty");
         }
-        if (key.contains(" ") || key.contains("$") || key.contains(".") || key.length() > MAX_ALLOWABLE_KEY_LENGTH)
-        {
-            /*
-            **Codes_SRS_Pair_25_003: [**If the key contains illegal unicode control characters i.e ' ', '.', '$' or if length is greater than 124 chars, the constructor shall throw an IllegalArgumentException.**]**
-             */
-            throw new IllegalArgumentException("Key cannot contain illegal unicode control characters '.', '$', ' '");
-        }
         /*
         **Codes_SRS_Pair_25_001: [**The constructor shall save the key and value representing this Pair.**]**
          */

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/PairTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/PairTest.java
@@ -48,37 +48,6 @@ public class PairTest
     }
 
     /*
-    **Tests_SRS_Pair_25_003: [**If the key contains illegal unicode control characters i.e ' ', '.', '$', the constructor shall throw an IllegalArgumentException.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsIfKeyIllegalCharacters_1()
-    {
-        //act
-        Pair testPair = new Pair("Key With Space", "TestObject");
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsIfKeyIllegalCharacters_2()
-    {
-        //act
-        Pair testPair = new Pair("Key With $", "TestObject");
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsIfKeyIllegalCharacters_3()
-    {
-        //act
-        Pair testPair = new Pair("Key With .", "TestObject");
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsIfKeyIllegalCharacters_4()
-    {
-        //act
-        Pair testPair = new Pair("Key With Length greater than 128 - 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
-                , "TestObject");
-    }
-    /*
     **Tests_SRS_Pair_25_005: [**The function shall return the value for this Pair.**]**
      */
     @Test


### PR DESCRIPTION
$ character is used in digital twin communication, so the device client should not do this validation anymore. Service client is updated to reflect that too.