### PR TITLE
fix(pom): Fix issue where tpm-provider pom used version property tpm-hsm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <provisioning-service-client-version>1.5.2</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
-        <tpm-hsm-version>1.1.2</tpm-hsm-version>
+        <tpm-provider-version>1.1.2</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
         <x509-provider-version>1.1.3</x509-provider-version>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
     <artifactId>tpm-provider</artifactId>
     <name>Provisioning Security TPM Provider</name>
-    <version>${tpm-hsm-version}</version>
+    <version>${tpm-provider-version}</version>
     <packaging>jar</packaging>
     <description>The Microsoft Azure IoT Provisioning Security TPM provider for Java</description>
     <url>http://azure.github.io/azure-iot-sdk-java/</url>


### PR DESCRIPTION
release pipeline works best if the property name is the same as the artifactId but with "-version" suffix

Also tpm hsm is redundant