### PR TITLE
Bump package versions for release on 2019-12-3

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.18.0";
+    private static final String CLIENT_VERSION = "1.19.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.18.0'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.19.0'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <module>provisioning</module>
     </modules>
     <properties>
-        <iot-device-client-version>1.18.0</iot-device-client-version>
-        <iot-service-client-version>1.18.0</iot-service-client-version>
+        <iot-device-client-version>1.19.0</iot-device-client-version>
+        <iot-service-client-version>1.19.0</iot-service-client-version>
         <iot-deps-version>0.8.5</iot-deps-version>
         <provisioning-device-client-version>1.7.1</provisioning-device-client-version>
         <provisioning-service-client-version>1.5.2</provisioning-service-client-version>
@@ -64,4 +64,3 @@
         </plugins>
     </build>
 </project>
-

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.18.0";
+    public static String serviceVersion = "1.19.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.19.0)
•	 Add constructor for Device and Module client that takes SSLContext (#578)
•	 Add additional log statements within the AMQP layer

**Bug Fixes**
•	 Remove device side validation of twin key value pairs
•	 Fix bug where AmqpLinkDetachForcedException was not categorized as retryable


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.19.0)
•	 Add API to set configuration metrics on Configuration instance

**Bug Fixes**
•	 Remove device side validation of twin key value pairs


## Merge Pull Request
#604, #610, #616, #617, #618, #619, #621, #622, #623, #626, #627, #626, #629, #630

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.19.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.19.0/jar
