### PR TITLE
Fix pom structures for preview release

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -9,8 +9,8 @@ public class TransportUtils
 {
     public static String IOTHUB_API_VERSION = "2019-07-01-preview";
 
-    private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.18.0";
+    private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client-preview";
+    private static final String CLIENT_VERSION = "1.0.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.18.0'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client-preview:1.0.1'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -21,17 +21,17 @@
         <module>provisioning</module>
     </modules>
     <properties>
-        <iot-device-client-version>1.0.0</iot-device-client-version>
-        <iot-service-client-version>1.0.0</iot-service-client-version>
-        <iot-deps-version>1.0.0</iot-deps-version>
-        <provisioning-device-client-version>1.0.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.0.0</provisioning-service-client-version>
-        <security-provider-version>1.0.0</security-provider-version>
-        <tpm-provider-emulator-version>1.0.0</tpm-provider-emulator-version>
-        <tpm-provider-version>1.0.0</tpm-provider-version>
-        <dice-provider-emulator-version>1.0.0</dice-provider-emulator-version>
-        <dice-provider-version>1.0.0</dice-provider-version>
-        <x509-provider-version>1.0.0</x509-provider-version>
+        <iot-device-client-version>1.0.1</iot-device-client-version>
+        <iot-service-client-version>1.0.1</iot-service-client-version>
+        <iot-deps-version>1.0.1</iot-deps-version>
+        <provisioning-device-client-version>1.0.1</provisioning-device-client-version>
+        <provisioning-service-client-version>1.0.1</provisioning-service-client-version>
+        <security-provider-version>1.0.1</security-provider-version>
+        <tpm-provider-emulator-version>1.0.1</tpm-provider-emulator-version>
+        <tpm-provider-version>1.0.1</tpm-provider-version>
+        <dice-provider-emulator-version>1.0.1</dice-provider-emulator-version>
+        <dice-provider-version>1.0.1</dice-provider-version>
+        <x509-provider-version>1.0.1</x509-provider-version>
     </properties>
     <build>
         <plugins>
@@ -63,4 +63,3 @@
         </plugins>
     </build>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,22 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -10,8 +10,8 @@ package com.microsoft.azure.sdk.iot.provisioning.device.internal;
 public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
-    public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.7.1";
+    public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client-preview/";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.0.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -6,7 +6,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-X509-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning X509 Sample for Device Client</name>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -11,7 +11,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-symmetrickey-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning Symmetric Key Sample for Device Client</name>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -11,7 +11,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-tpm-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning TPM Sample for Device Client</name>

--- a/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.sample</groupId>
     <artifactId>service-bulkoperation-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning bulk individual enrollments using service Sample</name>

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-group-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning enrollmentGroup using service Sample</name>

--- a/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning individual enrollment using service Sample</name>

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-update-enrollment-sample</artifactId>
     <version>1.8.1</version>
     <name>Update individual enrollment using service Sample</name>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -9,8 +9,8 @@ package com.microsoft.azure.sdk.iot.provisioning.service.contract;
 public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
-    private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.5.2";
+    private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client-preview/";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.0.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -7,8 +7,8 @@ public class TransportUtils
 {
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
-    public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.18.0";
+    public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client-preview/";
+    public static String serviceVersion = "1.0.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -73,7 +73,7 @@ phases:
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate
-      tsaEnvironment: Production
+      tsaEnvironment: PROD
       codeBaseName: 'Azure-Iot-SDK-Java-Master'
       notificationAlias: 'timtay@microsoft.com, prmathur@microsoft.com, jasminel@microsoft.com'
       codeBaseAdmins: 'REDMOND\timtay;REDMOND\prmathur;REDMOND\jasminel'


### PR DESCRIPTION
By flattening the pom files, dependencies declared in parent poms are brought down to children poms. Similarly, property values declared in parent poms are propagated down into the children poms.

As a result, the generated pom files for each published jar (device client, service client, deps, etc.) contain no parent declaration, but inherit all the properties and dependencies that the parent brought

Also, David noticed a provisioning sample that declared the wrong group id, so I'm removing the groupId from each provisioning sample so this isn't a issue moving forward