### PR TITLE
Fix SDL build, flatten maven poms, fix provisioning samples groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,22 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.1.0</version>
                 <configuration>
+					<flattenMode>oss</flattenMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -6,7 +6,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-X509-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning X509 Sample for Device Client</name>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -11,7 +11,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-symmetrickey-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning Symmetric Key Sample for Device Client</name>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -11,7 +11,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>provisioning-tpm-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning TPM Sample for Device Client</name>

--- a/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.sample</groupId>
     <artifactId>service-bulkoperation-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning bulk individual enrollments using service Sample</name>

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-group-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning enrollmentGroup using service Sample</name>

--- a/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-enrollment-sample</artifactId>
     <version>1.8.1</version>
     <name>Provisioning individual enrollment using service Sample</name>

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
@@ -7,7 +7,6 @@
         <version>1.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.microsoft.azure.sdk.iot.provisioning.samples</groupId>
     <artifactId>service-update-enrollment-sample</artifactId>
     <version>1.8.1</version>
     <name>Update individual enrollment using service Sample</name>

--- a/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
+++ b/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
@@ -1,5 +1,10 @@
 <!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.provisioning.tools</groupId>
+        <artifactId>provisioning-tools</artifactId>
+        <version>1.8.1</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.tools</groupId>
     <artifactId>provisioning-x509-cert-generator</artifactId>
@@ -19,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>dice-provider-emulator</artifactId>
-            <version>1.1.1</version>
+            <version>${dice-provider-emulator-version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -73,7 +73,7 @@ phases:
     inputs:
       tsaVersion: TsaV2
       codebase: NewOrUpdate
-      tsaEnvironment: Production
+      tsaEnvironment: PROD
       codeBaseName: 'Azure-Iot-SDK-Java-Master'
       notificationAlias: 'timtay@microsoft.com, prmathur@microsoft.com, jasminel@microsoft.com'
       codeBaseAdmins: 'REDMOND\timtay;REDMOND\prmathur;REDMOND\jasminel'


### PR DESCRIPTION
TSA upload task fixed by changing "Production" to "PROD". This was a breaking change made underneath us, not by something we checked in

Provisioning samples can just inherit the groupId, no need to declare it in each sample. The bulk operation sample even had the wrong groupId because of this

Add maven flatten plugin to base pom so that release pipeline only puts out flat poms with no parents, and with all inherited properties, plugins, and dependencies.