### PR TITLE
Add .flattened-pom.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ java/**/target/
 java/**/*.iml
 java/**/*dependency-reduced-pom.xml
 java/**/*.crt
+.flattened-pom.xml
 
 # VS Code stuff
 **/typings/**


### PR DESCRIPTION
The current pom files generate a .flattened-pom.xml, which should not be checked into the repository. This PR adds it to .gitignore.