### PR TITLE
Fix digital twin device/service poms to build javadoc and sources jars

### DIFF
--- a/digital-twin/device/pom.xml
+++ b/digital-twin/device/pom.xml
@@ -34,6 +34,27 @@
                         com.microsoft.azure.sdk.iot.digitaltwin.device.model.dto,com.microsoft.azure.sdk.iot.digitaltwin.device.serializer
                     </excludePackageNames>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/digital-twin/service/pom.xml
+++ b/digital-twin/service/pom.xml
@@ -21,6 +21,37 @@
                     <target>${java-sdk-service-version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <configuration>
+                    <includeDependencySources>true</includeDependencySources>
+                    <show>protected</show>
+                    <sourcepath>${project.build.directory}/delombok</sourcepath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Pom files needed to be configured to output all four necessary artifacts for the release process. Before, they only produced the pom and the base jar