### PR TITLE
Refactor Device client and Deps amqp layers to add better error logging

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -84,6 +84,17 @@
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>1.2.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.8</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.util.concurrent.*;
 
-public class AmqpsConnection extends BaseHandler
+public class AmqpsConnection extends ErrorLoggingBaseHandler
 {
     private static final int MAX_WAIT_TO_OPEN_CLOSE_CONNECTION = 1*60*1000; // 1 minute timeout
     private static final int MAX_WAIT_TO_TERMINATE_EXECUTOR = 30;
@@ -535,28 +535,14 @@ public class AmqpsConnection extends BaseHandler
     }
 
     /**
-     * Event handler for the link remote close event. This triggers reconnection attempts until successful.
-     * Both sender and receiver links closing trigger this event, so we only handle one of them,
-     * since the other is redundant.
-     * @param event The Proton Event object.
-     */
-    @Override
-    public void onLinkRemoteClose(Event event)
-    {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
-    }
-
-    /**
      * Event handler for the transport error event. This triggers reconnection attempts until successful.
      * @param event The Proton Event object.
      */
     @Override
     public void onTransportError(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
+        super.onTransportError(event);
         this.isOpen = false;
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     @Override

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/ErrorLoggingBaseHandler.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/ErrorLoggingBaseHandler.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.deps.transport.amqp;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.qpid.proton.engine.BaseHandler;
+import org.apache.qpid.proton.engine.Event;
+
+@Slf4j
+public class ErrorLoggingBaseHandler extends BaseHandler
+{
+    protected ProtonJExceptionParser protonJExceptionParser;
+
+    @Override
+    public void onLinkRemoteClose(Event event)
+    {
+        protonJExceptionParser = new ProtonJExceptionParser(event);
+        if (protonJExceptionParser.getError() == null)
+        {
+            log.debug("Amqp link {} was closed remotely", event.getLink().getName());
+        }
+        else
+        {
+            if (event.getLink() != null && event.getLink().getName() != null)
+            {
+                log.warn("Amqp link {} was closed remotely with exception {} with description {}", event.getLink().getName(), protonJExceptionParser.getError(), protonJExceptionParser.getErrorDescription());
+            }
+            else
+            {
+                log.warn("Unknown amqp link was closed remotely with exception {} with description {}", protonJExceptionParser.getError(), protonJExceptionParser.getErrorDescription());
+            }
+        }
+    }
+
+    @Override
+    public void onSessionRemoteClose(Event event)
+    {
+        protonJExceptionParser = new ProtonJExceptionParser(event);
+        if (protonJExceptionParser.getError() == null)
+        {
+            log.warn("Amqp session was closed remotely with an unknown exception");
+        }
+        else
+        {
+            log.warn("Amqp session was closed remotely with exception {} with description {}", protonJExceptionParser.getError(), protonJExceptionParser.getErrorDescription());
+        }
+    }
+
+    @Override
+    public void onConnectionRemoteClose(Event event)
+    {
+        protonJExceptionParser = new ProtonJExceptionParser(event);
+        if (protonJExceptionParser.getError() == null)
+        {
+            log.warn("Amqp connection was closed remotely with an unknown exception");
+        }
+        else
+        {
+            log.warn("Amqp connection was closed remotely with exception {} with description {}", protonJExceptionParser.getError(), protonJExceptionParser.getErrorDescription());
+        }
+    }
+
+    @Override
+    public void onTransportError(Event event)
+    {
+        protonJExceptionParser = new ProtonJExceptionParser(event);
+        if (protonJExceptionParser.getError() == null)
+        {
+            log.warn("Amqp transport closed with an unknown exception");
+        }
+        else
+        {
+            log.warn("Amqp transport closed due to exception {} with description {}", protonJExceptionParser.getError(), protonJExceptionParser.getErrorDescription());
+        }
+    }
+}

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/ProtonJExceptionParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/ProtonJExceptionParser.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.deps.transport.amqp;
+
+import lombok.Getter;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.Endpoint;
+import org.apache.qpid.proton.engine.Event;
+
+@Getter
+public class ProtonJExceptionParser
+{
+    private String error;
+    private String errorDescription;
+
+    private static final String DEFAULT_ERROR_DESCRIPTION = "NoErrorDescription";
+
+    public ProtonJExceptionParser(Event event)
+    {
+        getTransportExceptionFromProtonEndpoints(event.getSender(), event.getReceiver(), event.getConnection(), event.getTransport(), event.getSession(), event.getLink());
+    }
+
+    private ErrorCondition getErrorConditionFromEndpoint(Endpoint endpoint)
+    {
+        return endpoint.getCondition() != null && endpoint.getCondition().getCondition() != null ? endpoint.getCondition() : endpoint.getRemoteCondition();
+    }
+
+    private void getTransportExceptionFromProtonEndpoints(Endpoint... endpoints)
+    {
+        for (Endpoint endpoint : endpoints)
+        {
+            if (endpoint == null)
+            {
+                continue;
+            }
+
+            ErrorCondition errorCondition = getErrorConditionFromEndpoint(endpoint);
+            if (errorCondition == null || errorCondition.getCondition() == null)
+            {
+                continue;
+            }
+
+            error = errorCondition.getCondition().toString();
+
+            if (errorCondition.getDescription() != null)
+            {
+                errorDescription = errorCondition.getDescription();
+            }
+            else
+            {
+                errorDescription = DEFAULT_ERROR_DESCRIPTION; //log statements can assume that if error != null, errorDescription != null, too.
+            }
+        }
+    }
+}

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/ErrorLoggingBaseHandlerTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/ErrorLoggingBaseHandlerTest.java
@@ -1,0 +1,39 @@
+/*
+*  Copyright (c) Microsoft. All rights reserved.
+*  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+package tests.unit.com.microsoft.azure.sdk.iot.deps.transport.amqp;
+
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.ErrorLoggingBaseHandler;
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.ProtonJExceptionParser;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.qpid.proton.engine.Event;
+import org.junit.Test;
+
+public class ErrorLoggingBaseHandlerTest
+{
+    @Mocked Event mockEvent;
+
+    @Mocked
+    ProtonJExceptionParser mockProtonJExceptionParser;
+
+    @Test
+    public void onTransportErrorParsesError()
+    {
+        new Expectations()
+        {
+            {
+                new ProtonJExceptionParser(mockEvent);
+                result = mockProtonJExceptionParser;
+
+                mockProtonJExceptionParser.getError();
+                result = "amqp:io";
+            }
+        };
+
+        ErrorLoggingBaseHandler errorLoggingBaseHandler = new ErrorLoggingBaseHandler();
+        errorLoggingBaseHandler.onTransportError(mockEvent);
+    }
+}

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/ProtonJExceptionParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/ProtonJExceptionParserTest.java
@@ -1,0 +1,219 @@
+/*
+*  Copyright (c) Microsoft. All rights reserved.
+*  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+package tests.unit.com.microsoft.azure.sdk.iot.deps.transport.amqp;
+
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.ProtonJExceptionParser;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.Event;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProtonJExceptionParserTest
+{
+    @Mocked
+    Event mockEvent;
+
+    @Mocked
+    ErrorCondition mockErrorCondition;
+
+    private final String expectedErrorDescription = "an error occurred";
+    private final String expectedErrorCondition = "amqp:foo";
+
+    @Test
+    public void errorFromTransport()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getTransport().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorFromSender()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getSender().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorFromReceiver()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getReceiver().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorFromConnection()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getConnection().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorFromSession()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getSession().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorFromLink()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getLink().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = expectedErrorCondition;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertEquals(expectedErrorCondition, exceptionParser.getError());
+        Assert.assertEquals(expectedErrorDescription, exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void noError()
+    {
+        new Expectations()
+        {
+            {
+                mockEvent.getLink();
+                result = null;
+
+                mockEvent.getSession();
+                result = null;
+
+                mockEvent.getSender();
+                result = null;
+
+                mockEvent.getReceiver();
+                result = null;
+
+                mockEvent.getConnection();
+                result = null;
+
+                mockEvent.getTransport();
+                result = null;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertNull(exceptionParser.getError());
+        Assert.assertNull(exceptionParser.getErrorDescription());
+    }
+
+    @Test
+    public void errorWithNoDescription()
+    {
+        //errors without descriptions should set the description to a non-null value for logging purposes
+        new Expectations()
+        {
+            {
+                mockEvent.getTransport().getCondition();
+                result = mockErrorCondition;
+
+                mockErrorCondition.getDescription();
+                result = expectedErrorDescription;
+
+                mockErrorCondition.getCondition().toString();
+                result = null;
+            }
+        };
+
+        ProtonJExceptionParser exceptionParser = new ProtonJExceptionParser(mockEvent);
+
+        Assert.assertNotNull(exceptionParser.getErrorDescription());
+    }
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
 import com.microsoft.azure.proton.transport.proxy.impl.ProxyHandlerImpl;
 import com.microsoft.azure.proton.transport.proxy.impl.ProxyImpl;
 import com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl;
+import com.microsoft.azure.sdk.iot.deps.transport.amqp.ErrorLoggingBaseHandler;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubSasTokenAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
@@ -42,7 +43,7 @@ import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
  * a message, and logic to re-establish the connection with the IoTHub in case it gets lost.
  */
 @Slf4j
-public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTransportConnection
+public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler implements IotHubTransportConnection
 {
     private static final int MAX_WAIT_TO_CLOSE_CONNECTION = 60 * 1000; // 60 second timeout
     private static final int MAX_WAIT_TO_OPEN_CBS_LINKS = 20 * 1000; // 20 second timeout
@@ -895,6 +896,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     @Override
     public void onLinkRemoteClose(Event event)
     {
+        super.onLinkRemoteClose(event);
         this.amqpsSessionManager.onLinkRemoteClose(event.getLink());
 
         log.trace("onLinkRemoteClose fired by proton, setting AMQP connection state as DISCONNECTED");
@@ -914,7 +916,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     @Override
     public void onTransportError(Event event)
     {
-        this.log.warn("OnTransportError fired by proton");
+        super.onTransportError(event);
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
         //Codes_SRS_AMQPSIOTHUBCONNECTION_34_060 [If the provided event object's transport holds an error condition object, this function shall report the associated TransportException to this object's listeners.]


### PR DESCRIPTION
Created an Error Logging Base Handler class that all amqp connections will eventually extend from. It's purpose is to log whenever a link/session/connection is closed remotely (generally considered an error case) or when a transport error occurs.

The deps amqp layer is used only by provisioning device client currently, but this PR makes the device client use it, too. IoT Service client will use it soon when the v2 changes come.