### PR TITLE
refactor(e2e): Fix e2e test swallowing an exception, remove needless …

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers/IotHubServicesCommon.java
@@ -55,10 +55,6 @@ public class IotHubServicesCommon
         try
         {
             client.open();
-            if (statusUpdates != null)
-            {
-                confirmOpenStabilized(statusUpdates, 120000, client);
-            }
 
             for (int i = 0; i < messagesToSend.size(); ++i)
             {
@@ -107,10 +103,6 @@ public class IotHubServicesCommon
         try
         {
             client.open();
-            if (statusUpdates != null)
-            {
-                confirmOpenStabilized(statusUpdates, 120000, client);
-            }
 
             // Send the initial message
             MessageAndResult messageToSend = new MessageAndResult(new Message("test message"), IotHubStatusCode.OK_EMPTY);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -271,12 +271,11 @@ public class DeviceMethodCommon extends IntegrationTest
         try
         {
             this.testInstance.deviceTestManager.setup(true, false);
-            IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
         }
         catch (IOException | InterruptedException e)
         {
             e.printStackTrace();
-            fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + e.getMessage(), this.testInstance.deviceTestManager.client));
+            fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + Tools.getStackTraceFromThrowable(e), this.testInstance.deviceTestManager.client));
         }
         catch (UnsupportedOperationException e)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/DeviceMethodCommon.java
@@ -271,6 +271,7 @@ public class DeviceMethodCommon extends IntegrationTest
         try
         {
             this.testInstance.deviceTestManager.setup(true, false);
+            IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
         }
         catch (IOException | InterruptedException e)
         {

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/errorinjection/ReceiveMessagesErrInjTests.java
@@ -214,7 +214,6 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         try
         {
             testInstance.client.open();
-            IotHubServicesCommon.confirmOpenStabilized(connectionStatusUpdates, 120000, testInstance.client);
 
             //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
             // we ensure that error injection message isn't resent to service too many times. The message will still likely

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothubservices/twin/ReportedPropertiesTests.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.common.tests.iothubservices.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ConditionalIgnoreRule;
 import com.microsoft.azure.sdk.iot.common.helpers.StandardTierOnlyRule;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.setup.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -161,7 +162,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
                     }
                     catch (IOException | InterruptedException e)
                     {
-                        fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + e.getMessage(), internalClient));
+                        fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + Tools.getStackTraceFromThrowable(e), internalClient));
                     }
                 }
             });


### PR DESCRIPTION
…confirmOpenStabilized calls

confirmOpenStabilized used to be used when open calls were less reliable, but now they are reliable so we can get rid of them