### PR TITLE
fix(iot-dev): Fix module client so it doesn't need to set urlStreamFactoryHandler

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpHsmSignatureProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpHsmSignatureProvider.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.device.auth.SignatureProvider;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.hsm.parser.SignRequest;
 import com.microsoft.azure.sdk.iot.device.hsm.parser.SignResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.crypto.Mac;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 /**
  * Provides a means to sign data for authentication purposes
  */
+@Slf4j
 public class HttpHsmSignatureProvider implements SignatureProvider
 {
     private static final String ENCODING_CHARSET = "UTF-8";
@@ -50,6 +52,8 @@ public class HttpHsmSignatureProvider implements SignatureProvider
             // Codes_SRS_HTTPHSMSIGNATUREPROVIDER_34_005: [If the apiVersion is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("apiVersion cannot be null or empty");
         }
+
+        log.trace("Creating HttpHsmSignatureProvider with providerUri {}", providerUri);
 
         // Codes_SRS_HTTPHSMSIGNATUREPROVIDER_34_002: [This constructor shall create a new HttpsHsmClient with the provided providerUri.]
         this.httpClient = new HttpsHsmClient(providerUri);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializer.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializer.java
@@ -44,12 +44,6 @@ public class HttpsRequestResponseSerializer
             throw new IllegalArgumentException("The httpsRequest cannot be null");
         }
 
-        if (httpsRequest.getRequestUrl() == null)
-        {
-            // Codes_SRS_HTTPREQUESTRESPONSESERIALIZER_34_002: [If the provided request's url is null, this function shall throw an IllegalArgumentException.]
-            throw new IllegalArgumentException("Request uri of the request cannot be null");
-        }
-
         if (path == null || path.isEmpty())
         {
             throw new IllegalArgumentException("path cannot be null or empty");

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
@@ -61,7 +61,7 @@ public class HttpsRequest
         headers = new HashMap<>();
 
         List<String> hostHeaderValues = new ArrayList<>();
-        if (url.getHost() != null && !url.getHost().isEmpty())
+        if (url != null && url.getHost() != null && !url.getHost().isEmpty())
         {
             String host = url.getHost();
             if (url.getPort() != -1)
@@ -93,6 +93,11 @@ public class HttpsRequest
      */
     public HttpsResponse send() throws TransportException
     {
+        if (this.url == null)
+        {
+            throw new IllegalArgumentException("url cannot be null");
+        }
+
         HttpsConnection connection = new HttpsConnection(url, method, this.proxySettings);
 
         for (String headerKey : headers.keySet())

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClientTest.java
@@ -105,37 +105,6 @@ public class HttpsHsmClientTest
         assertEquals(expectedBaseUrl, Deencapsulation.getField(client, "baseUrl"));
     }
 
-    // Tests_SRS_HSMHTTPCLIENT_34_012: [If the provided baseUrl uses the unix scheme, this constructor shall set
-    // a stub url stream handler factory to handle that unix scheme.]
-    @Test
-    public void constructorWithUnixScheme(@Mocked final URI mockedURI) throws TransportException, UnsupportedEncodingException, MalformedURLException, URISyntaxException
-    {
-        //act
-        new NonStrictExpectations()
-        {
-            {
-                new URI(expectedBaseUrl);
-                result = mockedURI;
-
-                mockedURI.getScheme();
-                result = expectedSchemeUnix;
-
-                URL.setURLStreamHandlerFactory((URLStreamHandlerFactory) any);
-            }
-        };
-        HttpsHsmClient client = new HttpsHsmClient(expectedBaseUrl);
-
-        //assert
-        assertEquals(expectedBaseUrl, Deencapsulation.getField(client, "baseUrl"));
-        new Verifications()
-        {
-            {
-                URL.setURLStreamHandlerFactory((URLStreamHandlerFactory) any);
-                times = 1;
-            }
-        };
-    }
-
     // Tests_SRS_HSMHTTPCLIENT_34_002: [This function shall build an http request with the url in the format
     // <base url>/modules/<url encoded name>/genid/<url encoded gen id>/sign?api-version=<url encoded api version>.]
     // Tests_SRS_HSMHTTPCLIENT_34_003: [This function shall build an http request with headers ContentType and Accept with value application/json.]

--- a/iot-e2e-tests/edge-e2e/src/main/java/glue/ModuleGlue.java
+++ b/iot-e2e-tests/edge-e2e/src/main/java/glue/ModuleGlue.java
@@ -25,13 +25,14 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Assert;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.net.*;
 import java.util.*;
 
 
 public class ModuleGlue
 {
     private static final long OPEN_RETRY_TIMEOUT = 3 * 60 * 1000;
+    private static final String UNIX_SCHEME = "unix";
 
     private IotHubClientProtocol transportFromString(String protocolStr)
     {
@@ -66,6 +67,42 @@ public class ModuleGlue
     public void connectFromEnvironment(String transportType, Handler<AsyncResult<ConnectResponse>> handler)
     {
         System.out.printf("ConnectFromEnvironment called with transport %s%n", transportType);
+
+        //This is the default URL stream handler factory
+        URLStreamHandlerFactory fac = new URLStreamHandlerFactory()
+        {
+            @Override
+            public URLStreamHandler createURLStreamHandler(String protocol)
+            {
+                if (protocol.equals("http"))
+                {
+                    return new sun.net.www.protocol.http.Handler();
+                }
+                else if(protocol.equals("https"))
+                {
+                    return new sun.net.www.protocol.https.Handler();
+                }
+
+                return null;
+            }
+        };
+
+        try
+        {
+            /*
+            This line of code used to be run in older versions of the SDK, and it caused bugs when this library builds
+            a module client from environment through the edgelet in conjunction with any other library that called this API.
+            This API can only be called once per JVM process, so we had to remove the call to this API from our SDK to maintain
+            compatibility with other libraries that call this API. We call this API in this test now so that we guarantee
+            that our module client code works even when this API is used beforehand to avoid regression
+             */
+            URL.setURLStreamHandlerFactory(fac);
+
+        }
+        catch (Error e)
+        {
+            //this function only throws if the factory has already been set, so we can ignore this error
+        }
 
         IotHubClientProtocol protocol = this.transportFromString(transportType);
         if (protocol == null)


### PR DESCRIPTION
setting the factory handler sometimes failed if this library was used alongside other libraries that set the same handler because that handler can only be set once per jvm session.

Most notably, customers trying to use this library alongside springboot would see failures when creating modules from environment as in #274 

Thankfully, we never really needed to set the urlStreamFactoryHandler for our createFromEnvironment flow. It was just one of a few options, so I have altered the code in question avoid it.