### PR TITLE
refactor(pom): Factor out published artifactids into master pom

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -32,7 +32,7 @@
         <url>https://github.com/Azure/azure-iot-sdk-java.git</url>
     </scm>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
-    <artifactId>iot-deps</artifactId>
+    <artifactId>${iot-deps-artifact-id}</artifactId>
     <version>${iot-deps-version}</version>
     <packaging>jar</packaging>
 

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
-    <artifactId>iot-device-client</artifactId>
+    <artifactId>${iot-device-client-artifact-id}</artifactId>
     <name>IoT Hub Java Device Client</name>
     <version>${iot-device-client-version}</version>
     <description>The Microsoft Azure IoT Device SDK for Java</description>
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-deps</artifactId>
+            <artifactId>${iot-deps-artifact-id}</artifactId>
             <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <!-- test dependencies -->

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
         <!-- test dependencies -->
@@ -46,30 +46,30 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-service-client</artifactId>
+            <artifactId>${iot-service-client-artifact-id}</artifactId>
             <version>${iot-service-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-device-client</artifactId>
+            <artifactId>${provisioning-device-client-artifact-id}</artifactId>
             <version>${provisioning-device-client-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>tpm-provider-emulator</artifactId>
+            <artifactId>${tpm-provider-emulator-artifact-id}</artifactId>
             <version>${tpm-provider-emulator-version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>x509-provider</artifactId>
+            <artifactId>${x509-provider-artifact-id}</artifactId>
             <version>${x509-provider-version}</version>
             <scope>compile</scope>
         </dependency>

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -48,13 +48,13 @@
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-service-client</artifactId>
+            <artifactId>${iot-service-client-artifact-id}</artifactId>
             <version>${iot-service-client-version}</version>
         </dependency>
     </dependencies>

--- a/iot-e2e-tests/jvm/pom.xml
+++ b/iot-e2e-tests/jvm/pom.xml
@@ -27,36 +27,36 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>tpm-provider-emulator</artifactId>
+            <artifactId>${tpm-provider-emulator-artifact-id}</artifactId>
             <version>${tpm-provider-emulator-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>x509-provider</artifactId>
+            <artifactId>${x509-provider-artifact-id}</artifactId>
             <version>${x509-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-device-client</artifactId>
+            <artifactId>${provisioning-device-client-artifact-id}</artifactId>
             <version>${provisioning-device-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-service-client</artifactId>
+            <artifactId>${iot-service-client-artifact-id}</artifactId>
             <version>${iot-service-client-version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,18 @@
         <module>provisioning</module>
     </modules>
     <properties>
+        <iot-device-client-artifact-id>iot-device-client</iot-device-client-artifact-id>
+        <iot-service-client-artifact-id>iot-service-client</iot-service-client-artifact-id>
+        <iot-deps-artifact-id>iot-deps</iot-deps-artifact-id>
+        <provisioning-device-client-artifact-id>provisioning-device-client</provisioning-device-client-artifact-id>
+        <provisioning-service-client-artifact-id>provisioning-service-client</provisioning-service-client-artifact-id>
+        <security-provider-artifact-id>security-provider</security-provider-artifact-id>
+        <tpm-provider-emulator-artifact-id>tpm-provider-emulator</tpm-provider-emulator-artifact-id>
+        <tpm-provider-artifact-id>tpm-provider</tpm-provider-artifact-id>
+        <dice-provider-emulator-artifact-id>dice-provider-emulator</dice-provider-emulator-artifact-id>
+        <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
+        <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
+
         <iot-device-client-version>1.19.0</iot-device-client-version>
         <iot-service-client-version>1.19.0</iot-service-client-version>
         <iot-deps-version>0.8.5</iot-deps-version>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-    <artifactId>provisioning-device-client</artifactId>
+    <artifactId>${provisioning-device-client-artifact-id}</artifactId>
     <name>Provisioning Device Client</name>
     <version>${provisioning-device-client-version}</version>
     <packaging>jar</packaging>
@@ -40,12 +40,12 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-deps</artifactId>
+            <artifactId>${iot-deps-artifact-id}</artifactId>
             <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-X509-sample/pom.xml
@@ -21,17 +21,17 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>x509-provider</artifactId>
+            <artifactId>${x509-provider-artifact-id}</artifactId>
             <version>${x509-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-device-client</artifactId>
+            <artifactId>${provisioning-device-client-artifact-id}</artifactId>
             <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-sample/pom.xml
@@ -26,17 +26,17 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-device-client</artifactId>
+            <artifactId>${provisioning-device-client-artifact-id}</artifactId>
             <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-tpm-sample/pom.xml
@@ -26,17 +26,17 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>tpm-provider-emulator</artifactId>
+            <artifactId>${tpm-provider-emulator-artifact-id}</artifactId>
             <version>${tpm-provider-emulator-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-device-client</artifactId>
+            <artifactId>${provisioning-device-client-artifact-id}</artifactId>
             <version>${provisioning-device-client-version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-device-client</artifactId>
+            <artifactId>${iot-device-client-artifact-id}</artifactId>
             <version>${iot-device-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-enrollment-sample/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-            <artifactId>provisioning-service-client</artifactId>
+            <artifactId>${provisioning-service-client-artifact-id}</artifactId>
             <version>${provisioning-service-client-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning</groupId>
-    <artifactId>provisioning-service-client</artifactId>
+    <artifactId>${provisioning-service-client-artifact-id}</artifactId>
     <name>Provisioning Service Client</name>
     <version>${provisioning-service-client-version}</version>
     <packaging>jar</packaging>
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-deps</artifactId>
+            <artifactId>${iot-deps-artifact-id}</artifactId>
             <version>${iot-deps-version}</version>
         </dependency>
         <!-- test dependencies -->

--- a/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
+++ b/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
@@ -23,7 +23,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>dice-provider-emulator</artifactId>
+            <artifactId>${dice-provider-emulator-artifact-id}</artifactId>
             <version>${dice-provider-emulator-version}</version>
         </dependency>
     </dependencies>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>dice-provider-emulator</artifactId>
+    <artifactId>${dice-provider-emulator-artifact-id}</artifactId>
     <name>Provisioning Security DICE Emulator Provider</name>
     <version>${dice-provider-emulator-version}</version>
     <packaging>jar</packaging>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>dice-provider</artifactId>
+    <artifactId>${dice-provider-artifact-id}</artifactId>
     <name>Provisioning Security DICE Provider</name>
     <version>${dice-provider-version}</version>
     <packaging>jar</packaging>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>security-provider</artifactId>
+    <artifactId>${security-provider-artifact-id}</artifactId>
     <name>Provisioning Security Provider</name>
     <version>${security-provider-version}</version>
     <packaging>jar</packaging>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>tpm-provider-emulator</artifactId>
+    <artifactId>${tpm-provider-emulator-artifact-id}</artifactId>
     <name>Provisioning Security TPM Emulator Provider</name>
     <version>${tpm-provider-emulator-version}</version>
     <packaging>jar</packaging>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>tpm-provider</artifactId>
+    <artifactId>${tpm-provider-artifact-id}</artifactId>
     <name>Provisioning Security TPM Provider</name>
     <version>${tpm-provider-version}</version>
     <packaging>jar</packaging>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-    <artifactId>x509-provider</artifactId>
+    <artifactId>${x509-provider-artifact-id}</artifactId>
     <name>Provisioning Security X509 Provider</name>
     <version>${x509-provider-version}</version>
     <packaging>jar</packaging>
@@ -42,7 +42,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
-            <artifactId>security-provider</artifactId>
+            <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
         <dependency>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure.sdk.iot</groupId>
-    <artifactId>iot-service-client</artifactId>
+    <artifactId>${iot-service-client-artifact-id}</artifactId>
     <name>Iot Hub Java Service SDK</name>
     <version>${iot-service-client-version}</version>
     <description>The Microsoft Azure IoT Service SDK for Java</description>
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-deps</artifactId>
+            <artifactId>${iot-deps-artifact-id}</artifactId>
             <version>${iot-deps-version}</version>
         </dependency>
         <dependency>

--- a/service/iot-service-samples/pom.xml
+++ b/service/iot-service-samples/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-service-client</artifactId>
+            <artifactId>${iot-service-client-artifact-id}</artifactId>
             <version>${iot-service-client-version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Edge e2e tests need this change so that it can avoid declaring dependencies on preview vs. non-preview device and service client