### PR TITLE
Bump package versions for release on 2020-01-23

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.19.0";
+    private static final String CLIENT_VERSION = "1.19.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.19.0'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.19.1'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.19.0</iot-device-client-version>
+        <iot-device-client-version>1.19.1</iot-device-client-version>
         <iot-service-client-version>1.19.0</iot-service-client-version>
-        <iot-deps-version>0.8.5</iot-deps-version>
+        <iot-deps-version>0.8.6</iot-deps-version>
         <provisioning-device-client-version>1.7.1</provisioning-device-client-version>
         <provisioning-service-client-version>1.5.2</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.19.1)
**Bug Fixes**
•	 Extend error logging base handler for device client
•	 Fix module client so it doesn't need to set urlStreamFactoryHandler


## Java IotHub Deps (com.microsoft.azure.sdk.iot:iot-deps:0.8.6)
**Bug Fixes**
 •	 Add error logging base handler for amqp connections
•	 Upgrade bouncy castle dependency to latest version (1.64)


## Merge Pull Request
#662, #679, #643 
