### PR TITLE
refactor(e2e): Adjust timing in token renewal tests

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
@@ -75,9 +75,9 @@ public class TokenRenewalTests extends IotHubIntegrationTest
     @Test
     public void tokenRenewalWorks() throws Exception
     {
-        final long SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL = 60;
-        final long EXPIRED_SAS_TOKEN_GRACE_PERIOD_SECONDS = 600;
-        final long EXTRA_BUFFER_TO_ENSURE_TOKEN_EXPIRED_SECONDS = 30;
+        final long SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL = 30;
+        final long EXPIRED_SAS_TOKEN_GRACE_PERIOD_SECONDS = 600; //service extends 10 minute grace period after a token has expired
+        final long EXTRA_BUFFER_TO_ENSURE_TOKEN_EXPIRED_SECONDS = 120; //wait time beyond the expected grace period, just in case
 
         List<InternalClient> clients = createClientsToTest();
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
@@ -81,7 +81,7 @@ public class TokenRenewalTests extends IotHubIntegrationTest
 
         List<InternalClient> clients = createClientsToTest();
 
-        //service grants a 5 minute grace period beyond when sas token expires, this test attempts to send a message after that grace period
+        //service grants a 10 minute grace period beyond when sas token expires, this test attempts to send a message after that grace period
         // to ensure that the first sas token has expired, and that the sas token was renewed successfully.
         final long WAIT_BUFFER_FOR_TOKEN_TO_EXPIRE = EXPIRED_SAS_TOKEN_GRACE_PERIOD_SECONDS + EXTRA_BUFFER_TO_ENSURE_TOKEN_EXPIRED_SECONDS;
 
@@ -90,8 +90,7 @@ public class TokenRenewalTests extends IotHubIntegrationTest
             //set it so a newly generated sas token only lasts for a small amount of time
             client.setOption("SetSASTokenExpiryTime", SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL);
         }
-
-
+        
         Success[] amqpDisconnectDidNotHappenSuccesses = new Success[clients.size()];
         Success[] mqttDisconnectDidHappenSuccesses = new Success[clients.size()];
         Success[] shutdownWasGracefulSuccesses = new Success[clients.size()];

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/TokenRenewalTests.java
@@ -90,7 +90,7 @@ public class TokenRenewalTests extends IotHubIntegrationTest
             //set it so a newly generated sas token only lasts for a small amount of time
             client.setOption("SetSASTokenExpiryTime", SECONDS_FOR_SAS_TOKEN_TO_LIVE_BEFORE_RENEWAL);
         }
-        
+
         Success[] amqpDisconnectDidNotHappenSuccesses = new Success[clients.size()];
         Success[] mqttDisconnectDidHappenSuccesses = new Success[clients.size()];
         Success[] shutdownWasGracefulSuccesses = new Success[clients.size()];


### PR DESCRIPTION
test sometimes fails with case that mqtt connection never lost connection to hub. This implied that the test didn't wait long enough before checking that the grace period had ended. Adding more buffer time to ensure that the grace period ends before we check that mqtt connection was lost