### PR TITLE
fix(deps, prov-service): Remove SDK-side validation of max twin depth

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ExportImportDeviceParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ExportImportDeviceParser.java
@@ -269,7 +269,7 @@ public class ExportImportDeviceParser
 
     /**
      * Setter for authentication
-     *
+     * @param authentication the authentication to set
      * @throws IllegalArgumentException if authentication is null
      */
     public void setAuthentication(AuthenticationParser authentication) throws IllegalArgumentException

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
@@ -151,43 +151,6 @@ public class ParserUtility
     }
 
     /**
-     * Helper to validate if the provided string is a valid json key.
-     *
-     * @param key is the string to be validated.
-     * @param isMetadata defines if the key belongs to a metadata, which allows character `$`.
-     * @throws IllegalArgumentException if the string do not fit the criteria.
-     */
-    public static void validateKey(String key, boolean isMetadata) throws IllegalArgumentException
-    {
-        /* Codes_SRS_PARSER_UTILITY_21_014: [The validateKey shall throw IllegalArgumentException if the provided string is null or empty.] */
-        /* Codes_SRS_PARSER_UTILITY_21_015: [The validateKey shall throw IllegalArgumentException if the provided string contains at least one not UTF-8 character.] */
-        try
-        {
-            validateStringUTF8(key);
-        }
-        catch (IllegalArgumentException e)
-        {
-            throw new IllegalArgumentException("The provided key is not valid");
-        }
-
-        /* Codes_SRS_PARSER_UTILITY_21_016: [The validateKey shall throw IllegalArgumentException if the provided string contains more than 128 characters.] */
-        if(key.length() > 128)
-        {
-            throw new IllegalArgumentException("The provided key is bigger than 128 characters");
-        }
-
-        /* Codes_SRS_PARSER_UTILITY_21_017: [The validateKey shall throw IllegalArgumentException if the provided string contains an illegal character (`$`,`.`, space).] */
-        /* Codes_SRS_PARSER_UTILITY_21_018: [If `isMetadata` is `true`, the validateKey shall accept the character `$` as valid.] */
-        /* Codes_SRS_PARSER_UTILITY_21_019: [If `isMetadata` is `false`, the validateKey shall not accept the character `$` as valid.] */
-        if((key.contains(".") || key.contains(" ") || (key.contains("$") && ! isMetadata)))
-        {
-            throw new IllegalArgumentException("The provided key is not valid");
-        }
-
-        /* Codes_SRS_PARSER_UTILITY_21_013: [The validateKey shall do nothing if the string is a valid key.] */
-    }
-
-    /**
      * Helper to validate if the provided map in terms of maximum
      * levels and optionally if the keys ar not metadata.
      *
@@ -196,26 +159,21 @@ public class ParserUtility
      * @throws IllegalArgumentException If the Map contains more than maxLevel levels or do not allow metadata
      *                                  but contains metadata key.
      */
-    public static void validateMap(Map<String, Object> map, boolean allowMetadata) throws IllegalArgumentException
+    public static void validateMap(Map<String, Object> map) throws IllegalArgumentException
     {
         /* Codes_SRS_PARSER_UTILITY_21_048: [The validateMap shall do nothing if the map is null.] */
         if(map != null)
         {
             /* Codes_SRS_PARSER_UTILITY_21_047: [The validateMap shall do nothing if the map is a valid Map.] */
-            validateMapInternal(map, allowMetadata);
+            validateMapInternal(map);
         }
     }
 
-    private static void validateMapInternal(Map<String, Object> map, boolean allowMetadata) throws IllegalArgumentException
+    private static void validateMapInternal(Map<String, Object> map) throws IllegalArgumentException
     {
         for(Map.Entry<String, Object> entry : map.entrySet())
         {
-            String key = entry.getKey();
             Object value = entry.getValue();
-
-            /* Codes_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
-            /* Codes_SRS_PARSER_UTILITY_21_050: [If `isMetadata` is `true`, the validateMap shall accept the character `$` in the key.] */
-            ParserUtility.validateKey(key, allowMetadata);
 
             /* Codes_SRS_PARSER_UTILITY_21_051: [The validateMap shall throws IllegalArgumentException if any value contains illegal type (array or invalid class).] */
             if((value != null) && ((value.getClass().isArray()) || (value.getClass().isLocalClass())))
@@ -226,7 +184,7 @@ public class ParserUtility
             if((value != null) && (value instanceof Map))
             {
                 /* Codes_SRS_PARSER_UTILITY_21_052: [The validateMap shall throws IllegalArgumentException if the provided map contains more than maxLevel levels and those extra levels contain more than just metadata.] */
-                validateMapInternal((Map<String, Object>) value, allowMetadata);
+                validateMapInternal((Map<String, Object>) value);
             }
         }
     }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
@@ -192,30 +192,22 @@ public class ParserUtility
      * levels and optionally if the keys ar not metadata.
      *
      * @param map the {@code Map} to be validate. It can be {@code null}, and it will succeed in this case.
-     * @param maxLevel the max number of level allowed in the map.
      * @param allowMetadata the {@code boolean} that indicates if the key can contain metadata `$` or not.
      * @throws IllegalArgumentException If the Map contains more than maxLevel levels or do not allow metadata
      *                                  but contains metadata key.
      */
-    public static void validateMap(Map<String, Object> map, int maxLevel, boolean allowMetadata) throws IllegalArgumentException
+    public static void validateMap(Map<String, Object> map, boolean allowMetadata) throws IllegalArgumentException
     {
-        /* Codes_SRS_PARSER_UTILITY_21_046: [The validateMap shall throws IllegalArgumentException if the maxLevel is `0` or negative.] */
-        if(maxLevel <= 0)
-        {
-            throw new IllegalArgumentException("maxLevel cannot be zero or negative");
-        }
         /* Codes_SRS_PARSER_UTILITY_21_048: [The validateMap shall do nothing if the map is null.] */
         if(map != null)
         {
             /* Codes_SRS_PARSER_UTILITY_21_047: [The validateMap shall do nothing if the map is a valid Map.] */
-            validateMapInternal(map, 1, maxLevel, allowMetadata);
+            validateMapInternal(map, allowMetadata);
         }
     }
 
-    private static void validateMapInternal(Map<String, Object> map, int level, int maxLevel, boolean allowMetadata) throws IllegalArgumentException
+    private static void validateMapInternal(Map<String, Object> map, boolean allowMetadata) throws IllegalArgumentException
     {
-        level ++;
-
         for(Map.Entry<String, Object> entry : map.entrySet())
         {
             String key = entry.getKey();
@@ -234,17 +226,7 @@ public class ParserUtility
             if((value != null) && (value instanceof Map))
             {
                 /* Codes_SRS_PARSER_UTILITY_21_052: [The validateMap shall throws IllegalArgumentException if the provided map contains more than maxLevel levels and those extra levels contain more than just metadata.] */
-                if(level <= maxLevel)
-                {
-                    validateMapInternal((Map<String, Object>) value, level, maxLevel, allowMetadata);
-                }
-                else
-                {
-                    if (!mapOnlyContainsMetaData((Map<String, Object>)value))
-                    {
-                        throw new IllegalArgumentException("Map exceed maximum of " + maxLevel + " levels");
-                    }
-                }
+                validateMapInternal((Map<String, Object>) value, allowMetadata);
             }
         }
     }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
@@ -155,7 +155,6 @@ public class ParserUtility
      * levels and optionally if the keys ar not metadata.
      *
      * @param map the {@code Map} to be validate. It can be {@code null}, and it will succeed in this case.
-     * @param allowMetadata the {@code boolean} that indicates if the key can contain metadata `$` or not.
      * @throws IllegalArgumentException If the Map contains more than maxLevel levels or do not allow metadata
      *                                  but contains metadata key.
      */

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinParser.java
@@ -1061,25 +1061,18 @@ public class TwinParser
     {
         if(map != null)
         {
-            validateMap(map, 0, MAX_MAP_LEVEL, false);
+            validateMap(map, 0, MAX_MAP_LEVEL);
         }
     }
 
-    private void validateMap(Map<String, Object> map, int level, int maxLevel, boolean allowDollar) throws IllegalArgumentException
+    private void validateMap(Map<String, Object> map, int level, int maxLevel) throws IllegalArgumentException
     {
         level ++;
         
         for(Map.Entry<String, Object> entry : map.entrySet())
         {
-            String key = entry.getKey();
             Object value = entry.getValue();
 
-            /* Codes_SRS_TWINPARSER_21_152: [A valid `key` shall not be null.] */
-            /* Codes_SRS_TWINPARSER_21_153: [A valid `key` shall not be empty.] */
-            /* Codes_SRS_TWINPARSER_21_154: [A valid `key` shall be less than 128 characters long.] */
-            /* Codes_SRS_TWINPARSER_21_155: [A valid `key` shall not have an illegal character (`$`,`.`, space).] */
-            ParserUtility.validateKey(key, allowDollar);
-            
             /* Codes_SRS_TWINPARSER_21_156: [A valid `value` shall contains types of boolean, number, string, or object.] */
             if((value != null) && ((value.getClass().isArray()) || (value.getClass().isLocalClass())))
             {
@@ -1092,7 +1085,7 @@ public class TwinParser
                 /* Codes_TWIN_21_158: [A valid `value` shall contains less than 5 levels of sub-maps.] */
                 if(level <= maxLevel)
                 {
-                    validateMap((Map<String, Object>) value, level, maxLevel, allowDollar);
+                    validateMap((Map<String, Object>) value, level, maxLevel);
                 }
                 else
                 {

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
@@ -30,9 +30,6 @@ public class TwinProperty
     private static final String LAST_UPDATE_TAG = "$lastUpdated";
     private static final String LAST_UPDATE_VERSION_TAG = "$lastUpdatedVersion";
 
-    private static final int MAX_PROPERTY_LEVEL = 5;
-    private static final int MAX_METADATA_LEVEL = MAX_PROPERTY_LEVEL + 2;
-
     private Object lock = new Object();
 
     private class Property
@@ -168,14 +165,14 @@ public class TwinProperty
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), MAX_METADATA_LEVEL, true);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), true);
                 }
             }
             else if(!entry.getKey().equals(VERSION_TAG))
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), MAX_PROPERTY_LEVEL, false);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), false);
                 }
             }
         }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
@@ -165,14 +165,14 @@ public class TwinProperty
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), true);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue());
                 }
             }
             else if(!entry.getKey().equals(VERSION_TAG))
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), false);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue());
                 }
             }
         }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinTags.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinTags.java
@@ -163,14 +163,14 @@ public class TwinTags
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), true);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue());
                 }
             }
             else if(!entry.getKey().equals(VERSION_TAG))
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), false);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue());
                 }
             }
         }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinTags.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinTags.java
@@ -22,8 +22,6 @@ public class TwinTags
 {
     private static final String VERSION_TAG = "$version";
     private static final String METADATA_TAG = "$metadata";
-    private static final int MAX_PROPERTY_LEVEL = 5;
-    private static final int MAX_METADATA_LEVEL = MAX_PROPERTY_LEVEL + 2;
 
     private Map<String, Object> tags;
 
@@ -165,14 +163,14 @@ public class TwinTags
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), MAX_METADATA_LEVEL, true);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), true);
                 }
             }
             else if(!entry.getKey().equals(VERSION_TAG))
             {
                 if(entry.getValue() instanceof Map)
                 {
-                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), MAX_PROPERTY_LEVEL, false);
+                    ParserUtility.validateMap((Map<String, Object>)entry.getValue(), false);
                 }
             }
         }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
@@ -267,7 +267,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, true);
+            ParserUtility.validateMap(this);
         }
 
         return last;
@@ -310,7 +310,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, true);
+            ParserUtility.validateMap(this);
         }
 
         return last;

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/twin/TwinCollection.java
@@ -95,9 +95,6 @@ import java.util.Map;
  */
 public class TwinCollection extends HashMap<String, Object>
 {
-    // By definition, Twin maps cannot contain more than 5 levels.
-    private static final int MAX_TWIN_LEVEL = 6;
-
     // the Twin collection version
     private static final String VERSION_TAG = "$version";
     private Integer version;
@@ -270,7 +267,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, MAX_TWIN_LEVEL, true);
+            ParserUtility.validateMap(this, true);
         }
 
         return last;
@@ -313,7 +310,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, MAX_TWIN_LEVEL, true);
+            ParserUtility.validateMap(this, true);
         }
 
         return last;

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtilityTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtilityTest.java
@@ -256,156 +256,12 @@ public class ParserUtilityTest
         Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateHostName", new Class[]{String.class} , "hostName.azure-devices.net");
     }
 
-    /* Tests_SRS_PARSER_UTILITY_21_013: [The validateKey shall do nothing if the string is a valid key.] */
-    /* Tests_SRS_PARSER_UTILITY_21_019: [If `isMetadata` is `false`, the validateKey shall not accept the character `$` as valid.] */
-    @Test
-    public void validateKeyNoMetadataSucceed() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "test-key", false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_013: [The validateKey shall do nothing if the string is a valid key.] */
-    /* Tests_SRS_PARSER_UTILITY_21_018: [If `isMetadata` is `true`, the validateKey shall accept the character `$` as valid.] */
-    @Test
-    public void validateKeyMetadataSucceed() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "$test-key", true);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_014: [The validateKey shall throw IllegalArgumentException if the provided string is null or empty.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyNullKeyThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey",
-                new Class[]{String.class, Boolean.class}, (String)null, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_014: [The validateKey shall throw IllegalArgumentException if the provided string is null or empty.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyEmptyKeyThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "", false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_015: [The validateKey shall throw IllegalArgumentException if the provided string contains at least one not UTF-8 character.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyInvalidKeyThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "\u1234-test-key", false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_016: [The validateKey shall throw IllegalArgumentException if the provided string contains more than 128 characters.] */
-    @Test
-    public void validateKeyEdgeSizeSucceed() throws ClassNotFoundException
-    {
-        // arrange
-        String key = "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "12345678";
-
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", key, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_016: [The validateKey shall throw IllegalArgumentException if the provided string contains more than 128 characters.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyInvalidBigKeyThrows() throws ClassNotFoundException
-    {
-        // arrange
-        String key = "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "123456789";
-
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", key, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_017: [The validateKey shall throw IllegalArgumentException if the provided string contains an illegal character (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyInvalidDotThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "test.key", false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_017: [The validateKey shall throw IllegalArgumentException if the provided string contains an illegal character (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyInvalidSpaceThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "test key", false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_017: [The validateKey shall throw IllegalArgumentException if the provided string contains an illegal character (`$`,`.`, space).] */
-    /* Tests_SRS_PARSER_UTILITY_21_019: [If `isMetadata` is `false`, the validateKey shall not accept the character `$` as valid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateKeyNoDollarInvalidDollarThrows() throws ClassNotFoundException
-    {
-        // act
-        Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "$test-key", false);
-    }
-
     /* Tests_SRS_PARSER_UTILITY_21_048: [The validateMap shall do nothing if the map is null.] */
     @Test
     public void validateMapNullMapSucceed() throws ClassNotFoundException
     {
         // act
-        ParserUtility.validateMap(null, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnNullKey() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put(null, "value");
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnEmptyKey() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put("", "value");
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnInvalidKey() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put("$key", "value");
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, false);
+        ParserUtility.validateMap(null);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_050: [If `isMetadata` is `true`, the validateMap shall accept the character `$` in the key.] */
@@ -421,7 +277,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, true);
+        ParserUtility.validateMap(mapSample);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_051: [The validateMap shall throws IllegalArgumentException if any value contains illegal type (array or invalid class).] */
@@ -437,7 +293,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, true);
+        ParserUtility.validateMap(mapSample);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_051: [The validateMap shall throws IllegalArgumentException if any value contains illegal type (array or invalid class).] */
@@ -457,7 +313,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, true);
+        ParserUtility.validateMap(mapSample);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_020: [The getDateTimeUtc shall parse the provide string using `UTC` timezone.] */

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtilityTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtilityTest.java
@@ -352,66 +352,12 @@ public class ParserUtilityTest
         Deencapsulation.invoke(Class.forName("com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility"),"validateKey", "$test-key", false);
     }
 
-    /* Tests_SRS_PARSER_UTILITY_21_046: [The validateMap shall throws IllegalArgumentException if the maxLevel is `0` or negative.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnZeroMaxLevel() throws ClassNotFoundException
-    {
-        // act
-        ParserUtility.validateMap(new HashMap<String, Object>(), 0, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_046: [The validateMap shall throws IllegalArgumentException if the maxLevel is `0` or negative.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnNegativeMaxLevel() throws ClassNotFoundException
-    {
-        // act
-        ParserUtility.validateMap(new HashMap<String, Object>(), -1, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_047: [The validateMap shall do nothing if the map is a valid Map.] */
-    @Test
-    public void validateMapLowerThanMaxLevelSucceed() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put("key1", "value");
-                put("root", new HashMap<String, Object>()
-                {
-                    {
-                        put("inner1", new HashMap<String, Object>()
-                        {
-                            {
-                                put("innerI1", "innerValue");
-                            }
-                        });
-                        put("inner20", new HashMap<String, Object>()
-                        {
-                            {
-                                put("inner21", new HashMap<String, Object>()
-                                {
-                                    {
-                                        put("inner22", "innerValue");
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, 4, false);
-    }
-
     /* Tests_SRS_PARSER_UTILITY_21_048: [The validateMap shall do nothing if the map is null.] */
     @Test
     public void validateMapNullMapSucceed() throws ClassNotFoundException
     {
         // act
-        ParserUtility.validateMap(null, 4, false);
+        ParserUtility.validateMap(null, false);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
@@ -427,7 +373,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, false);
+        ParserUtility.validateMap(mapSample, false);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
@@ -443,27 +389,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnMoreThan128CharKey() throws ClassNotFoundException
-    {
-        // arrange
-        final String bigKey = "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "1234567890123456789012345678901234567890" +
-                "123456789";
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put(bigKey, "value");
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, 10, false);
+        ParserUtility.validateMap(mapSample, false);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_049: [The validateMap shall throws IllegalArgumentException if any key in the map is null, empty, contains more than 128 characters, or illegal characters (`$`,`.`, space).] */
@@ -479,7 +405,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, false);
+        ParserUtility.validateMap(mapSample, false);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_050: [If `isMetadata` is `true`, the validateMap shall accept the character `$` in the key.] */
@@ -495,7 +421,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, true);
+        ParserUtility.validateMap(mapSample, true);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_051: [The validateMap shall throws IllegalArgumentException if any value contains illegal type (array or invalid class).] */
@@ -511,7 +437,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, true);
+        ParserUtility.validateMap(mapSample, true);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_051: [The validateMap shall throws IllegalArgumentException if any value contains illegal type (array or invalid class).] */
@@ -531,83 +457,7 @@ public class ParserUtilityTest
         };
 
         // act
-        ParserUtility.validateMap(mapSample, 10, true);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_052: [The validateMap shall throws IllegalArgumentException if the provided map contains more than maxLevel levels and those extra levels contain more than just metadata.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void validateMapThrowsOnBiggerThanMaxLevel() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put("key1", "value");
-                put("root", new HashMap<String, Object>()
-                {
-                    {
-                        put("inner1", new HashMap<String, Object>()
-                        {
-                            {
-                                put("innerI1", "innerValue");
-                            }
-                        });
-                        put("inner20", new HashMap<String, Object>()
-                        {
-                            {
-                                put("inner21", new HashMap<String, Object>()
-                                {
-                                    {
-                                        put("inner22", "innerValue");
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, 3, false);
-    }
-
-    /* Tests_SRS_PARSER_UTILITY_21_052: [The validateMap shall throws IllegalArgumentException if the provided map contains more than maxLevel levels and those extra levels contain more than just metadata.] */
-    @Test
-    public void validateMapDoesNotThrowOnBiggerThanMaxLevelIfOnlyMetadata() throws ClassNotFoundException
-    {
-        // arrange
-        final Map<String, Object> mapSample = new HashMap<String, Object>()
-        {
-            {
-                put("key1", "value");
-                put("root", new HashMap<String, Object>()
-                {
-                    {
-                        put("inner1", new HashMap<String, Object>()
-                        {
-                            {
-                                put("innerI1", "innerValue");
-                            }
-                        });
-                        put("inner20", new HashMap<String, Object>()
-                        {
-                            {
-                                put("inner21", new HashMap<String, Object>()
-                                {
-                                    {
-                                        put(TwinMetadata.LAST_UPDATE_TAG, "metaDataValue");
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
-        // act
-        ParserUtility.validateMap(mapSample, 3, false);
+        ParserUtility.validateMap(mapSample, true);
     }
 
     /* Tests_SRS_PARSER_UTILITY_21_020: [The getDateTimeUtc shall parse the provide string using `UTC` timezone.] */

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
@@ -291,58 +291,6 @@ public class TwinCollectionTest
         // assert
     }
 
-    /* SRS_TWIN_COLLECTION_21_004: [The putAll shall throw IllegalArgumentException if the provided Map is null, empty or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void putAllThrowsOnIllegal6InnerMaps()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        putFinal("Value", 500.0);
-                        putFinal("NewValue", 300.0);
-                        putFinal("Inner1", new TwinCollection()
-                        {
-                            {
-                                putFinal("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        putFinal("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                putFinal("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                    	putFinal("Inner5", new TwinCollection()
-                                                        {
-                                                    		{
-                                                    			putFinal("Inner6", "FinalInnerValue");
-                                                    		}
-                                                        });
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.putAllFinal(rawMap);
-
-        // assert
-    }
-
     /* SRS_TWIN_COLLECTION_21_005: [The putAll shall copy all entries in the provided Map to the TwinCollection.] */
     @Test
     public void putAllSucceedOn5InnerMaps()
@@ -472,53 +420,6 @@ public class TwinCollectionTest
         assertTrue(inner instanceof TwinCollection);
     }
 
-    /* SRS_TWIN_COLLECTION_21_009: [The put shall throw IllegalArgumentException if the final collection contains more that 5 levels.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void putThrowsOn6InnerMaps()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        putFinal("Value", 500.0);
-                        putFinal("NewValue", 300.0);
-                        putFinal("Inner1", new TwinCollection()
-                        {
-                            {
-                                putFinal("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        putFinal("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                putFinal("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                        putFinal("Inner5", "FinalInnerValue");
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.putFinal("Key1", rawMap);
-
-        // assert
-    }
-
     /* Tests_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
     @Test
     public void putDoesNotThrowOn6InnerMapsIfHighestLevelIsMetaData(@Mocked final ParserUtility mockedParserUtility,
@@ -568,62 +469,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyInt, anyBoolean);
-                times = 0;
-            }
-        };
-    }
-
-    /* Tests_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
-    @Test
-    public void putDoesNotThrowOn6InnerMapsIfHighestLevelIsVersionTag(@Mocked final ParserUtility mockedParserUtility,
-                                                                    @Mocked final JsonElement mockedJsonElement)
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        putFinal("Value", 500.0);
-                        putFinal("NewValue", 300.0);
-                        putFinal("Inner1", new TwinCollection()
-                        {
-                            {
-                                putFinal("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        putFinal("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                putFinal("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                        putFinal("Inner5", "FinalInnerValue");
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-        final TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.putFinal(Deencapsulation.getField(TwinCollection.class, "VERSION_TAG").toString(), rawMap);
-
-        // assert
-        new Verifications()
-        {
-            {
-                mockedParserUtility.validateMap(twinCollection, anyInt, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection, anyBoolean);
                 times = 0;
             }
         };
@@ -898,57 +744,6 @@ public class TwinCollectionTest
                 "    }\n";
         Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().disableHtmlEscaping().create();
         TwinCollection rawMap = gson.fromJson(inconsistentJson, TwinCollection.class);
-
-        // act
-        Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);
-
-        // assert
-    }
-
-    /* SRS_TWIN_COLLECTION_21_015: [The constructor shall throw IllegalArgumentException if the Twin collection contains more than 5 levels.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnMoreThan5Levels()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        putFinal("Value", 500.0);
-                        putFinal("NewValue", 300.0);
-                        putFinal("Inner1", new TwinCollection()
-                        {
-                            {
-                                putFinal("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        putFinal("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                putFinal("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                    	putFinal("Inner5", new TwinCollection()
-                                                    	{
-                                                    		{
-                                                    			putFinal("Inner6", "FinalInnerValue");
-                                                    		}
-                                                    	});
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
 
         // act
         Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/twin/TwinCollectionTest.java
@@ -469,7 +469,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection);
                 times = 0;
             }
         };
@@ -497,19 +497,6 @@ public class TwinCollectionTest
 
         // act
         twinCollection.putFinal("", "NewNiceCar");
-
-        // assert
-    }
-
-    /* SRS_TWIN_COLLECTION_21_010: [The put shall throw IllegalArgumentException if the provided key is null, empty, or invalid, or if the value is invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void putThrowsOnKeyInvalid()
-    {
-        // arrange
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.putFinal("Invalid space", "NewNiceCar");
 
         // assert
     }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/DesiredPropertiesTests.java
@@ -190,36 +190,6 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void setDesiredPropertiesAtMaxDepthAllowed() throws IOException, IotHubException
-    {
-        deviceUnderTest.sCDeviceForTwin.clearTwin();
-        deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
-
-        sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
-
-        //Update twin Tags and Desired Properties
-        Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
-
-        HashMap<String, String> map5 = new HashMap<>();
-        map5.put("5", "this value is at an allowable depth");
-        HashMap<String, Map> map4 = new HashMap<>();
-        map4.put("4", map5);
-        HashMap<String, Map> map3 = new HashMap<>();
-        map3.put("3", map4);
-        HashMap<String, Map> map2 = new HashMap<>();
-        map2.put("2", map3);
-        HashMap<String, Map> map1 = new HashMap<>();
-        map1.put("1", map2);
-        desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair("0", map1));
-        deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
-
-        //This line will ensure that the SDK does not complain when receiving a valid, full twin depth from the service
-        sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
-    }
-
-    @Test
-    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void testUpdateDesiredProperties() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/TwinTagsTests.java
@@ -207,31 +207,4 @@ public class TwinTagsTests extends DeviceTwinCommon
 
         removeMultipleDevices(MAX_DEVICES);
     }
-
-    @Test
-    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void setTagsAtMaxDepthAllowed() throws IOException, IotHubException
-    {
-        sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
-
-        //Update twin Tags and Desired Properties
-        Set<Pair> tags = new HashSet<>();
-
-        HashMap<String, String> map5 = new HashMap<>();
-        map5.put("5", "this value is at an allowable depth");
-        HashMap<String, Map> map4 = new HashMap<>();
-        map4.put("4", map5);
-        HashMap<String, Map> map3 = new HashMap<>();
-        map3.put("3", map4);
-        HashMap<String, Map> map2 = new HashMap<>();
-        map2.put("2", map3);
-        HashMap<String, Map> map1 = new HashMap<>();
-        map1.put("1", map2);
-        tags.add(new Pair("0", map1));
-        deviceUnderTest.sCDeviceForTwin.setTags(tags);
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
-
-        //This line will ensure that the SDK does not complain when receiving a valid, full twin depth from the service
-        sCDeviceTwin.getTwin(deviceUnderTest.sCDeviceForTwin);
-    }
 }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollection.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollection.java
@@ -204,7 +204,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, true);
+            ParserUtility.validateMap(this);
         }
 
         return last;

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollection.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollection.java
@@ -96,9 +96,6 @@ import java.util.Map;
  */
 public class TwinCollection extends HashMap<String, Object>
 {
-    // By definition, Twin maps cannot contain more than 5 levels.
-    private static final int MAX_TWIN_LEVEL = 5;
-
     // the Twin collection version
     private static final String VERSION_TAG = "$version";
     private Integer version;
@@ -207,7 +204,7 @@ public class TwinCollection extends HashMap<String, Object>
         /* Codes_SRS_TWIN_COLLECTION_34_028: [The put shall not validate the map if the provided key is a metadata tag, or a version tag.] */
         if (!key.equals(VERSION_TAG) && !key.equals(METADATA_TAG))
         {
-            ParserUtility.validateMap(this, MAX_TWIN_LEVEL, true);
+            ParserUtility.validateMap(this, true);
         }
 
         return last;

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
@@ -350,19 +350,6 @@ public class TwinCollectionTest
 
     /* SRS_TWIN_COLLECTION_21_010: [The put shall throw IllegalArgumentException if the provided key is null, empty, or invalid, or if the value is invalid.] */
     @Test (expected = IllegalArgumentException.class)
-    public void putThrowsOnKeyInvalid()
-    {
-        // arrange
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.put("Invalid space", "NewNiceCar");
-
-        // assert
-    }
-
-    /* SRS_TWIN_COLLECTION_21_010: [The put shall throw IllegalArgumentException if the provided key is null, empty, or invalid, or if the value is invalid.] */
-    @Test (expected = IllegalArgumentException.class)
     public void putThrowsOnValueInvalidArray()
     {
         // arrange
@@ -680,7 +667,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection);
                 times = 0;
             }
         };
@@ -735,7 +722,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection);
                 times = 0;
             }
         };

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
@@ -862,7 +862,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyInt, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection, anyBoolean);
                 times = 0;
             }
         };
@@ -917,7 +917,7 @@ public class TwinCollectionTest
         new Verifications()
         {
             {
-                mockedParserUtility.validateMap(twinCollection, anyInt, anyBoolean);
+                mockedParserUtility.validateMap(twinCollection, anyBoolean);
                 times = 0;
             }
         };

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
@@ -193,53 +193,6 @@ public class TwinCollectionTest
         // assert
     }
 
-    /* SRS_TWIN_COLLECTION_21_004: [The putAll shall throw IllegalArgumentException if the provided Map is null, empty or invalid.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void putAllThrowsOnIllegal6InnerMaps()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
-                            {
-                                put("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        put("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                put("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                        put("Inner5", "FinalInnerValue");
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.putAll(rawMap);
-
-        // assert
-    }
-
     /* SRS_TWIN_COLLECTION_21_005: [The putAll shall copy all entries in the provided Map to the TwinCollection.] */
     @Test
     public void putAllSucceedOn5InnerMaps()
@@ -367,53 +320,6 @@ public class TwinCollectionTest
         // assert
         Object inner = twinCollection.get("MaxSpeed");
         assertTrue(inner instanceof TwinCollection);
-    }
-
-    /* SRS_TWIN_COLLECTION_21_009: [The put shall throw IllegalArgumentException if the final collection contains more that 5 levels.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void putThrowsOn6InnerMaps()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
-                            {
-                                put("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        put("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                put("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                        put("Inner5", "FinalInnerValue");
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-        TwinCollection twinCollection = new TwinCollection();
-
-        // act
-        twinCollection.put("Key1", rawMap);
-
-        // assert
     }
 
     /* SRS_TWIN_COLLECTION_21_010: [The put shall throw IllegalArgumentException if the provided key is null, empty, or invalid, or if the value is invalid.] */
@@ -644,94 +550,6 @@ public class TwinCollectionTest
         Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);
 
         // assert
-    }
-
-    /* SRS_TWIN_COLLECTION_21_015: [The constructor shall throw IllegalArgumentException if the Twin collection contains more than 5 levels.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnMoreThan5Levels()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
-                            {
-                                put("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        put("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                put("Inner4", new TwinCollection()
-                                                {
-                                                    {
-                                                        put("Inner5", "FinalInnerValue");
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
-        // act
-        Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);
-
-        // assert
-    }
-
-    /* SRS_TWIN_COLLECTION_21_015: [The constructor shall throw IllegalArgumentException if the Twin collection contains more than 5 levels.] */
-    @Test
-    public void constructorSucceedOn5Levels()
-    {
-        // arrange
-        final Map<String, Object> rawMap = new HashMap<String, Object>()
-        {
-            {
-                put(VALID_KEY_NAME, VALID_VALUE_NAME);
-                put("MaxSpeed", new TwinCollection()
-                {
-                    {
-                        put("Value", 500.0);
-                        put("NewValue", 300.0);
-                        put("Inner1", new TwinCollection()
-                        {
-                            {
-                                put("Inner2", new TwinCollection()
-                                {
-                                    {
-                                        put("Inner3", new TwinCollection()
-                                        {
-                                            {
-                                                put("Inner4", "FinalInnerValue");
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-        };
-
-        // act
-        TwinCollection twinCollection = Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);
-
-        // assert
-        assertNotNull(twinCollection);
     }
 
     /* SRS_TWIN_COLLECTION_21_016: [The toJsonElement shall return a JsonElement with the information in this class in a JSON format.] */


### PR DESCRIPTION
Twin depth limits may be arbitrarily changed by services, so there is no reason to validate them on the SDK side. It happened once already when the Iot Hub's max depth went from 5 to 10, and the SDK became inconsistent.

Fixes issue #699 