### PR TITLE
fix(e2e): Fix digital twin model definition json files

### DIFF
--- a/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/components/testinterface2_v2.json
+++ b/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/components/testinterface2_v2.json
@@ -195,5 +195,5 @@
 			"schema": "string"
 		}
 	}],
-	"@context": "http://azureiot.com/v1/contexts/Interface.json"
+	"@context": "http://azureiot.com/v1/contexts/IoTModel.json"
 }

--- a/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/components/testinterface_v1.json
+++ b/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/components/testinterface_v1.json
@@ -114,5 +114,5 @@
 			"schema": "string"
 		}
 	}],
-	"@context": "http://azureiot.com/v1/contexts/Interface.json"
+	"@context": "http://azureiot.com/v1/contexts/IoTModel.json"
 }

--- a/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/dcm/testinterface_cm_v2.json
+++ b/digital-twin/e2e-tests/digital-twin-e2e-tests-common/src/main/resources/dcm/testinterface_cm_v2.json
@@ -12,5 +12,5 @@
 			"schema": "urn:contoso:azureiot:sdk:testinterface2:2"
 		}
 	],
-	"@context": "http://azureiot.com/v1/contexts/CapabilityModel.json"
+	"@context": "http://azureiot.com/v1/contexts/IoTModel.json"
 }


### PR DESCRIPTION
model repo requires the context the be "IoTModel" instead of "Interface" or "CapabilityModel"