### PR TITLE
release(2020-02-11): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.19.1";
+    private static final String CLIENT_VERSION = "1.20.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.19.1'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.0'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.19.1</iot-device-client-version>
-        <iot-service-client-version>1.19.0</iot-service-client-version>
-        <iot-deps-version>0.8.6</iot-deps-version>
+        <iot-device-client-version>1.20.0</iot-device-client-version>
+        <iot-service-client-version>1.20.0</iot-service-client-version>
+        <iot-deps-version>0.9.0</iot-deps-version>
         <provisioning-device-client-version>1.7.1</provisioning-device-client-version>
-        <provisioning-service-client-version>1.5.2</provisioning-service-client-version>
+        <provisioning-service-client-version>1.6.0</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.5.2";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.19.0";
+    public static String serviceVersion = "1.20.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
(Note that this release is after an LTS release, so all bumped versions are minor bumps)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.20.0)
**Bug Fixes**
•	Removed SDK side validation of max twin depth (#699)


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.12.0)
**Bug Fixes**
•	Removed SDK side validation of max twin depth (#699)

## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.9.0)
**Bug Fixes**
•	Removed SDK side validation of max twin depth (#699)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.6.0)
**Bug Fixes**
•	Removed SDK side validation of max twin depth (#699)



## Merge Pull Request
#703

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.12.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.12.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.9.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.6.0/jar