### PR TITLE
fix(iot-device): Allow http proxy to work over http 1.0

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
@@ -43,7 +43,9 @@ public class ProxiedSSLSocket extends SSLSocket
     private String proxyUsername;
     private char[] proxyPassword;
 
-    private static final String HTTP_VERSION_1_1 = "HTTP/1.1";
+    private static final String HTTP = "HTTP/";
+    private static final String HTTP_VERSION_1_1 = HTTP + "1.1";
+
 
     protected ProxiedSSLSocket(SSLSocketFactory socketFactory, Socket proxySocket, String proxyUsername, char[] proxyPassword)
     {
@@ -122,10 +124,10 @@ public class ProxiedSSLSocket extends SSLSocket
 
         //Expects the same http version in the response as the request
         String firstLine = connectResponseLines[connectResponseStart];
-        if (!firstLine.startsWith(HTTP_VERSION_1_1))
+        if (!firstLine.startsWith(HTTP))
         {
             tunnel.close();
-            throw new IOException(String.format("Unable to tunnel through %s:%d.  Expected first response line to start with %s, but proxy returns \"%s\"", host, port, HTTP_VERSION_1_1, firstLine));
+            throw new IOException(String.format("Unable to tunnel through %s:%d.  Expected first response line to start with %s, but proxy returns \"%s\"", host, port, HTTP, firstLine));
         }
 
         String[] replyStrParts = firstLine.split(" ");


### PR DESCRIPTION
Sending a connect request with http version 1.1 to a server may result in server responded with a 1.0 response. SDK used to require 1.1 response, but there is no practical difference to the SDK whether we get 1.0 or 1.1, so the SDK should ignore this response version

Fixes #715 