### PR TITLE
fix(vsts): Make pom.xml count as package changes

### DIFF
--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -32,6 +32,13 @@ ForEach ($line in $($GitDiff -split "`r`n"))
     }
 	else
 	{
+	    # If code changes were made to vsts pipeline
+		if ($line.toLower().Contains("vsts"))
+		{
+            $Env:runIotHubTests = "true"
+            $Env:runProvisioningTests = "true"
+		}
+
 	    # If code changes were made to provisioning sdk code or to provisioning e2e tests
 		if ($line.toLower().Contains("provisioning"))
 		{
@@ -46,21 +53,21 @@ ForEach ($line in $($GitDiff -split "`r`n"))
 		}
 
 		# If code changes were made to device client
-		if ($line.toLower().Contains("iot-device-client/src/main"))
+		if ($line.toLower().Contains("iot-device-client/src/main") -or $line.toLower().Contains("iot-device-client/pom.xml"))
 		{
 		    $Env:runIotHubTests = "true"
 		    $Env:runProvisioningTests = "true"
 		}
 
         # If code changes were made to service client
-        if ($line.toLower().Contains("iot-service-client/src/main"))
+        if ($line.toLower().Contains("iot-service-client/src/main") -or $line.toLower().Contains("iot-service-client/pom.xml"))
         {
             $Env:runIotHubTests = "true"
             $Env:runProvisioningTests = "true"
         }
 
         # Both provisioning and iot hub depend on deps package
-		if ($line.toLower().Contains("deps/src/main"))
+		if ($line.toLower().Contains("deps/src/main") -or $line.toLower().Contains("deps/pom.xml"))
 		{
 			$Env:runIotHubTests = "true"
 			$Env:runProvisioningTests = "true"


### PR DESCRIPTION
changes to deps pom.xml should force run of iothub and provisioning, for instance

Changes made to vsts pipeline should force all tests to be run, considering that possible changes to that folder include environment variable mistakes