### PR TITLE
Bump package versions for release on 2020-02-20

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.20.0";
+    private static final String CLIENT_VERSION = "1.20.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.0'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.1'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.20.0</iot-device-client-version>
-        <iot-service-client-version>1.20.0</iot-service-client-version>
-        <iot-deps-version>0.9.0</iot-deps-version>
-        <provisioning-device-client-version>1.7.1</provisioning-device-client-version>
+        <iot-device-client-version>1.20.1</iot-device-client-version>
+        <iot-service-client-version>1.20.1</iot-service-client-version>
+        <iot-deps-version>0.9.1</iot-deps-version>
+        <provisioning-device-client-version>1.8.0</provisioning-device-client-version>
         <provisioning-service-client-version>1.6.0</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.7.1";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.20.0";
+    public static String serviceVersion = "1.20.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.20.1)
**Bug Fixes**
•	 Adjust which amqp exceptions are retryable to improve retry logic
•	 Fix bug where device client using mqtt_ws failed to tunnel through http proxy if proxy response used Http/1.0 (#715)


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.20.1)
•	 Added better logging to feedback receiver, cloud to device sender, and file upload notification receiver

**Bug Fixes**
•	 Fixed bug where file upload notification receiver did not clean up its sockets if connection failed (#549)
•	 Fixed bug where file upload notification receiver and feedback receiver both silently swallowed messages occasionally (#720)


## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.9.1)
•	 Add better logging to amqp layer, and better cleanup logic for error cases
•	 Upgrade qpid proton-j extensions library to latest version


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.0)
•	 Add better logging to amqp layer, and better cleanup logic for error cases


## Merge Pull Request
#716, #717, #713, #718

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.20.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.20.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.9.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.8.0/jar


Note that the provisioning device client version bump is a minor bump, since this is the first release of that package since the last LTS release

old
{
    "device": "1.20.0",
    "service": "1.20.0",
    "deps": "0.9.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.3",
    "provisioningDevice": "1.7.1",
    "provisioningService": "1.6.0"
}


new
{
    "device": "1.20.1",
    "service": "1.20.1",
    "deps": "0.9.1",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.3",
    "provisioningDevice": "1.8.0",
    "provisioningService": "1.6.0"
}