### PR TITLE
Bump package versions for release on 2020-03-13

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.20.1";
+    private static final String CLIENT_VERSION = "1.20.2";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.1'
+    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.2'
 }
 
 repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,17 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.20.1</iot-device-client-version>
-        <iot-service-client-version>1.20.1</iot-service-client-version>
-        <iot-deps-version>0.9.1</iot-deps-version>
-        <provisioning-device-client-version>1.8.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.6.0</provisioning-service-client-version>
+        <iot-device-client-version>1.20.2</iot-device-client-version>
+        <iot-service-client-version>1.21.0</iot-service-client-version>
+        <iot-deps-version>0.9.2</iot-deps-version>
+        <provisioning-device-client-version>1.8.1</provisioning-device-client-version>
+        <provisioning-service-client-version>1.6.1</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
-        <x509-provider-version>1.1.3</x509-provider-version>
+        <x509-provider-version>1.1.4</x509-provider-version>
     </properties>
     <build>
         <plugins>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.0";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.20.1";
+    public static String serviceVersion = "1.21.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.21.0)

- Enables new security functionality to specify how hub should authenticate when working with a storage account when running import/export devices jobs. Initially, this feature has limited availability, starting with 3 public cloud Azure regions. Since it is not yet widely available, this functionality must be explicitly enabled by the user. See below (1) for details.
  - New property `JobProperties.StorageAuthenticationType` for use in import/export devices jobs.
  - Added overloaded methods: `RegistryManager.importDevicesAsync`, `RegistryManager.importDevices`, `RegistryManager.exportDevicesAsync` and `RegistryManager.exportDevices`. The overloads take a `JobProperties` instance so the user can pass all required and any optional parameters.
  - Two factory methods to make it easier to call `importDevicesAsync`,  `importDevices`, `exportDevicesAsync` and  `exportDevices` making it clear which properties are required and which are optional. They are `JobProperties.createForImportJob` and `JobProperties.createForExportJob` respectively.
- Updated reference to com.microsoft.azure.sdk.iot:iot-deps

> (1) To enable this functionality, this version of the SDK will require setting an environment variable of `EnableStorageIdentity` to `1`. Once this feature is widely available, another SDK version will be released with this requirement removed.


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.20.2)

- Upgraded version of Azure Storage dependency
- Updated reference to com.microsoft.azure.sdk.iot:iot-deps


## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.9.2)

- New enum `StorageAuthenticationType` to specify key-based or identity-based authentication.
- Adding support for JobPropertiesParser for a new enum `StorageAuthenticationType`

## Java Provisioning Security x509 Provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:1.1.4)

- Upgraded version of bouncy castle dependency

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.1)

- Updated reference to com.microsoft.azure.sdk.iot.provisioning.security:x509-provider
- Updated reference to com.microsoft.azure.sdk.iot:iot-deps


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.6.1)

- Updated reference to com.microsoft.azure.sdk.iot.provisioning.security:x509-provider
- Updated reference to com.microsoft.azure.sdk.iot:iot-deps

Merge Pull Request
#717, #725, #726, #723 

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.20.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.21.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.9.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/x509-provider/1.1.4/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.8.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.6.1/jar

old
{
    "device": "1.20.1",
    "service": "1.20.1",
    "deps": "0.9.1",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.3",
    "provisioningDevice": "1.8.0",
    "provisioningService": "1.6.0"
}

new
{
    "device": "1.20.2",
    "service": "1.21.0",
    "deps": "0.9.2",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.1",
    "provisioningService": "1.6.1"
}