### PR TITLE
Do not accept HTTP urls in Https connection constructor

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
@@ -70,10 +70,10 @@ public class HttpsConnection
     {
         // Codes_SRS_HTTPSCONNECTION_11_022: [If the URI given does not use the HTTPS or HTTP protocol, the constructor shall throw an IllegalArgumentException.]
         final String protocol = url.getProtocol();
-        if (!protocol.equalsIgnoreCase("HTTPS") && !protocol.equalsIgnoreCase("HTTP"))
+        if (!protocol.equalsIgnoreCase("HTTPS"))
         {
             String errMsg = String.format("Expected URL that uses protocol "
-                            + "HTTPS or HTTP but received one that uses "
+                            + "HTTPS but received one that uses "
                             + "protocol '%s'.%n",
                     protocol);
             throw new IllegalArgumentException(errMsg);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
@@ -115,7 +115,6 @@ public class HttpsRequest
             connection.setSSLContext(this.sslContext);
         }
 
-
         if (this.connectionTimeout != 0)
         {
             connection.setReadTimeoutMillis(this.connectionTimeout);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
@@ -395,7 +395,7 @@ public class HttpsConnectionTest
 
     //Tests_SRS_HTTPSCONNECTION_34_026: [If this object uses HTTP, this function shall throw an UnsupportedOperationException.]
     @Test (expected = IllegalArgumentException.class)
-    public void setSSLContextThrowsIfHttp(@Mocked final SSLContext mockedContext) throws IOException, TransportException
+    public void HttpsConnectionConstructorThrowsIfHttp(@Mocked final SSLContext mockedContext) throws IOException, TransportException
     {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final String field = "test-field";

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
@@ -394,27 +394,21 @@ public class HttpsConnectionTest
     }
 
     //Tests_SRS_HTTPSCONNECTION_34_026: [If this object uses HTTP, this function shall throw an UnsupportedOperationException.]
-    @Test (expected = UnsupportedOperationException.class)
+    @Test (expected = IllegalArgumentException.class)
     public void setSSLContextThrowsIfHttp(@Mocked final SSLContext mockedContext) throws IOException, TransportException
     {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final String field = "test-field";
         final String value = "test-value";
         final int timeout = 1;
-        new NonStrictExpectations()
+        new Expectations()
         {
             {
                 mockUrl.getProtocol();
                 result = "http";
-                mockUrl.openConnection();
-                result = mockHttpURLConnection;
-                mockUrlConn.getRequestMethod();
-                result = httpsMethod.name();
             }
         };
         final HttpsConnection conn = new HttpsConnection(mockUrl, httpsMethod);
-
-        Deencapsulation.invoke(conn, "setSSLContext", mockedContext);
     }
 
 
@@ -426,15 +420,11 @@ public class HttpsConnectionTest
         final String field = "test-field";
         final String value = "test-value";
         final int timeout = 1;
-        new NonStrictExpectations()
+        new Expectations()
         {
             {
                 mockUrl.getProtocol();
                 result = "https";
-                mockUrl.openConnection();
-                result = mockUrlConn;
-                mockUrlConn.getRequestMethod();
-                result = httpsMethod.name();
             }
         };
         final HttpsConnection conn = new HttpsConnection(mockUrl, httpsMethod);
@@ -448,7 +438,7 @@ public class HttpsConnectionTest
     {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = { 1, 2 };
-        new NonStrictExpectations()
+        new Expectations()
         {
             {
                 mockUrl.getProtocol();


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
[HTTP plaintext communication Java SDK](https://msazure.visualstudio.com/One/_workitems/edit/5867818)

# Description of the problem
IoT Hub Java SDK allows unencrypted (HTTP) communication within an https constructor

# Description of the solution
We will not accept an HTTP method in an HTTPS connection constructor