### PR TITLE
fix(vsts): Fix smart gate not recognizing changes to e2e helper code

### DIFF
--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -74,7 +74,7 @@ ForEach ($line in $($GitDiff -split "`r`n"))
 		}
 
         # E2E common code can be used in any test, so we must run every test
-		if ($line.toLower().Contains("iot-e2e-tests/common"))
+		if ($line.toLower().Contains("iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/helpers"))
         {
             $Env:runIotHubTests = "true"
             $Env:runProvisioningTests = "true"

--- a/vsts/determine_tests_to_run.ps1
+++ b/vsts/determine_tests_to_run.ps1
@@ -73,8 +73,8 @@ ForEach ($line in $($GitDiff -split "`r`n"))
 			$Env:runProvisioningTests = "true"
 		}
 
-        # Helpers can be used in any test, so we must run every test
-		if ($line.toLower().Contains("iot-e2e-tests/common/helpers"))
+        # E2E common code can be used in any test, so we must run every test
+		if ($line.toLower().Contains("iot-e2e-tests/common"))
         {
             $Env:runIotHubTests = "true"
             $Env:runProvisioningTests = "true"


### PR DESCRIPTION
The common code did not follow the path "iot-e2e-tests/common/helpers" but rather "iot-e2e-tests/common/src/..."