### PR TITLE
fix(iot-device): Fix issue where SDK didn't validate application properties correctly

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MessageProperty.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MessageProperty.java
@@ -31,6 +31,11 @@ public final class MessageProperty {
     public static final String IOTHUB_SECURITY_INTERFACE_ID = "iothub-interface-id";
     public static final String IOTHUB_SECURITY_INTERFACE_ID_VALUE = "urn:azureiot:Security:SecurityAgent:1";
 
+    //Note this list includes the characters for tab and space.
+    private static final String BANNED_NON_ALPHANUMERIC_CHARACTERS = "()<>@,;:\"\\[]?={} \t";
+    private static final int ASCII_LOWER_BOUND = 32;
+    private static final int ASCII_UPPER_BOUND = 127;
+
 
     static {
         HashSet<String> reservedPropertyNames = new HashSet<>();
@@ -89,7 +94,7 @@ public final class MessageProperty {
 
         // Codes_SRS_MESSAGEPROPERTY_11_002: [If the name contains a character that is not in US-ASCII, the function shall throw an IllegalArgumentException.]
         if (!usesValidChars(name)) {
-            String errMsg = String.format("%s is not a valid IoT Hub message property name. %n", name);
+            String errMsg = String.format("%s is not a valid IoT Hub message property name. Characters in property keys must fall within ASCII value range %d and %d but excluding the set %s", name, ASCII_LOWER_BOUND, ASCII_UPPER_BOUND, BANNED_NON_ALPHANUMERIC_CHARACTERS);
             throw new IllegalArgumentException(errMsg);
         }
 
@@ -102,7 +107,7 @@ public final class MessageProperty {
         // Codes_SRS_MESSAGEPROPERTY_11_003: [If the value contains a character that is not in US-ASCII, the function shall throw an IllegalArgumentException.]
         if (!usesValidChars(value))
         {
-            String errMsg = String.format("%s is not a valid IoT Hub message property value.%n", value);
+            String errMsg = String.format("%s is not a valid IoT Hub message property value. Characters in property values must fall within ASCII value range %d and %d but excluding the set %s", value, ASCII_LOWER_BOUND, ASCII_UPPER_BOUND, BANNED_NON_ALPHANUMERIC_CHARACTERS);
             throw new IllegalArgumentException(errMsg);
         }
 
@@ -192,22 +197,23 @@ public final class MessageProperty {
         return propertyIsValid;
     }
 
-    /**
-     * Returns true if the string only uses US-ASCII 
-     *
-     * @param s the string.
-     *
-     * @return whether the string only uses US-ASCII 
-     */
     private static boolean usesValidChars(String s) {
-        boolean isValid = false;
-
-        if (s.matches("\\p{ASCII}*"))
+        for (char c : s.toCharArray())
         {
-            isValid = true;
+            //Range of characters includes US alphanumeric characters, as well as a few special characters like '+' and ','
+            // Any characters outside of this range are banned
+            if (!(c > ASCII_LOWER_BOUND && c < ASCII_UPPER_BOUND))
+            {
+                return false;
+            }
+
+            if (BANNED_NON_ALPHANUMERIC_CHARACTERS.indexOf(c) != -1)
+            {
+                return false;
+            }
         }
 
-        return isValid;
+        return true;
     }
 
     @SuppressWarnings("unused")

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
@@ -102,24 +102,24 @@ public class MqttMessaging extends Mqtt
         //Codes_SRS_MqttMessaging_34_032: [If the message has a content type, this method shall append that to publishTopic before publishing using the key name `$.ct`.]
         //Codes_SRS_MqttMessaging_34_032: [If the message has a content encoding, this method shall append that to publishTopic before publishing using the key name `$.ce`.]
         //Codes_SRS_MqttMessaging_34_034: [If the message has a creation time utc, this method shall append that to publishTopic before publishing using the key name `$.ctime`.]
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, MESSAGE_ID, message.getMessageId());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CORRELATION_ID, message.getCorrelationId());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, USER_ID, message.getUserId());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, TO, message.getTo());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, OUTPUT_NAME, message.getOutputName());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONNECTION_DEVICE_ID, message.getConnectionDeviceId());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONNECTION_MODULE_ID, message.getConnectionModuleId());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONTENT_ENCODING, message.getContentEncoding());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONTENT_TYPE, message.getContentType());
-        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CREATION_TIME_UTC, message.getCreationTimeUTCString());
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, MESSAGE_ID, message.getMessageId(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CORRELATION_ID, message.getCorrelationId(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, USER_ID, message.getUserId(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, TO, message.getTo(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, OUTPUT_NAME, message.getOutputName(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONNECTION_DEVICE_ID, message.getConnectionDeviceId(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONNECTION_MODULE_ID, message.getConnectionModuleId(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONTENT_ENCODING, message.getContentEncoding(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CONTENT_TYPE, message.getContentType(), false);
+        separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, CREATION_TIME_UTC, message.getCreationTimeUTCString(), false);
         if (message.isSecurityMessage())
         {
-            separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, MQTT_SECURITY_INTERFACE_ID, MessageProperty.IOTHUB_SECURITY_INTERFACE_ID_VALUE);
+            separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, MQTT_SECURITY_INTERFACE_ID, MessageProperty.IOTHUB_SECURITY_INTERFACE_ID_VALUE, false);
         }
 
         for (MessageProperty property : message.getProperties())
         {
-            separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, property.getName(), property.getValue());
+            separatorNeeded = appendPropertyIfPresent(stringBuilder, separatorNeeded, property.getName(), property.getValue(), true);
         }
 
         if (this.moduleId != null && !this.moduleId.isEmpty())
@@ -141,7 +141,7 @@ public class MqttMessaging extends Mqtt
      * @param propertyValue the property value (message id, correlation id, etc.)
      * @return true if a separator will be needed for any later properties appended on
      */
-    private boolean appendPropertyIfPresent(StringBuilder stringBuilder, boolean separatorNeeded, String propertyKey, String propertyValue) throws TransportException
+    private boolean appendPropertyIfPresent(StringBuilder stringBuilder, boolean separatorNeeded, String propertyKey, String propertyValue, boolean isApplicationProperty) throws TransportException
     {
         try
         {
@@ -152,7 +152,15 @@ public class MqttMessaging extends Mqtt
                     stringBuilder.append(MESSAGE_PROPERTY_SEPARATOR);
                 }
 
-                stringBuilder.append(propertyKey);
+                if (isApplicationProperty)
+                {
+                    stringBuilder.append(URLEncoder.encode(propertyKey, StandardCharsets.UTF_8.name()));
+                }
+                else
+                {
+                    stringBuilder.append(propertyKey);
+                }
+
                 stringBuilder.append(MESSAGE_PROPERTY_KEY_VALUE_SEPARATOR);
                 stringBuilder.append(URLEncoder.encode(propertyValue, StandardCharsets.UTF_8.name()));
 
@@ -163,7 +171,7 @@ public class MqttMessaging extends Mqtt
         }
         catch (UnsupportedEncodingException e)
         {
-            throw new TransportException("Could not utf-8 encode the mqtt property", e);
+            throw new TransportException("Could not utf-8 encode the property with name " + propertyKey + " and value " + propertyValue, e);
         }
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessagePropertyTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessagePropertyTest.java
@@ -7,7 +7,7 @@ import com.microsoft.azure.sdk.iot.device.MessageProperty;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * Unit test for Message Property class.
@@ -59,19 +59,6 @@ public class MessagePropertyTest
         assertThat(testValue, is(expectedValue));
     }
     
-    @Test
-    public void constructorSavesPropertyValueTab()
-    {
-        final String name = "names";
-        final String value = "First Name"+"\t"+"\t"+"Last Name";
-        
-        MessageProperty property = new MessageProperty(name, value);
-        String testValue = property.getValue();
-
-        final String expectedValue = value;
-        assertThat(testValue, is(expectedValue));
-    }
-
     // Tests_SRS_MESSAGEPROPERTY_11_002: [If the name contains a character that is not in US-ASCII the function shall throw an IllegalArgumentException.]
     @Test(expected = IllegalArgumentException.class)
     public void constructorRejectsInvalidPropertyName()
@@ -170,5 +157,49 @@ public class MessagePropertyTest
 
         final boolean expectedIsValidAppProperty = false;
         assertThat(testIsValidAppProperty, is(expectedIsValidAppProperty));
+    }
+
+    @Test
+    public void isValidAppPropertyReturnsTrueForUnusualAppPropertyKey()
+    {
+        final String name = "Test1234!#$%&'*+-.^_`|~";
+        final String value = "test-value";
+
+        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
+
+        assertTrue(isValidProperty);
+    }
+
+    @Test
+    public void isValidAppPropertyReturnsTrueForUnusualAppPropertyValue()
+    {
+        final String name = "test-key";
+        final String value = "Test1234!#$%&'*+-.^_`|~";
+
+        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
+
+        assertTrue(isValidProperty);
+    }
+
+    @Test
+    public void isValidAppPropertyReturnsFalseForUnusualAppPropertyKey()
+    {
+        final String name = "Test1234 Test1234";
+        final String value = "test-value";
+
+        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
+
+        assertFalse(isValidProperty);
+    }
+
+    @Test
+    public void isValidAppPropertyReturnsFalseForUnusualAppPropertyValue()
+    {
+        final String name = "test-key";
+        final String value = "\"someQuotedValue\"";
+
+        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
+
+        assertFalse(isValidProperty);
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethodsTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceMethodsTest.java
@@ -521,7 +521,7 @@ public class AmqpsDeviceMethodsTest
         final String correlationId = "correlationId";
         final String messageId = "messageId";
         final String to = "to";
-        final byte[] bytes = new byte[] {1, 2};
+        final byte[] bytes = new byte[] {50,51};
         final Object messageContext = "context";
 
         AmqpsMessage amqpsMessage = new AmqpsMessage();

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetryTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTelemetryTest.java
@@ -529,7 +529,12 @@ public class AmqpsDeviceTelemetryTest
     // Tests_SRS_AMQPSDEVICETELEMETRY_34_052: [If the amqp message contains an application property of
     // "x-opt-input-name", this function shall assign its value to the IotHub message's input name.]
     @Test
-    public void protonMessageToIoTHubMessageWithInputName(@Mocked final MessageImpl mockMessage, @Mocked final MessageAnnotations mockedAnnotations, @Mocked final Data mockData)
+    public void protonMessageToIoTHubMessageWithInputName(
+            @Mocked final MessageImpl mockMessage,
+            @Mocked final MessageAnnotations mockedAnnotations,
+            @Mocked final Data mockData,
+            @Mocked final Properties mockProperties,
+            @Mocked final Binary mockBinary)
     {
         //arrange
         final String expectedInputName = "some input name";
@@ -543,6 +548,15 @@ public class AmqpsDeviceTelemetryTest
 
                 mockMessage.getMessageAnnotations();
                 result = mockedAnnotations;
+
+                mockMessage.getProperties();
+                result = mockProperties;
+
+                mockProperties.getUserId();
+                result = mockBinary;
+
+                mockBinary.toString();
+                result = "someUserId";
 
                 mockedAnnotations.getValue();
                 result = mockedAnnotationsMap;

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceTwinTest.java
@@ -1170,10 +1170,10 @@ public class AmqpsDeviceTwinTest
         String deviceId = "deviceId";
         final String messageId = "messageId";
         final String to = "to";
-        final byte[] bytes = new byte[] {1, 2};
+        final byte[] bytes = new byte[] {50, 51};
         final Object messageContext = "context";
 
-        AmqpsMessage amqpsMessage = new AmqpsMessage();
+        final AmqpsMessage amqpsMessage = new AmqpsMessage();
         final Binary userId = new Binary(bytes);
         Section section = new Data(userId);
         amqpsMessage.setBody(section);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
@@ -1215,7 +1215,7 @@ public class MqttTest
     {
         //arrange
         final byte[] payload = {0x61, 0x62, 0x63};
-        final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=69ea4caf-d83e-454b-81f2-caafda4c81c8&%24.exp=0&%24.to=%2Fdevices%2FdeviceID%2Fmessages%2FdeviceBound&%24.cid=169c34b3-99b0-49f9-b0f6-8fa9d2c99345&iothub-ack=full&property1=%24&property2=%26&%25=%22&finalProperty=%3d";
+        final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=69ea4caf-d83e-454b-81f2-caafda4c81c8&%24.exp=0&%24.to=%2Fdevices%2FdeviceID%2Fmessages%2FdeviceBound&%24.cid=169c34b3-99b0-49f9-b0f6-8fa9d2c99345&iothub-ack=full&property1=%24&property2=%26&%25=_&finalProperty=.";
         baseConstructorExpectations();
         baseConnectExpectation();
         new MockUp<MqttMessaging>()
@@ -1253,8 +1253,8 @@ public class MqttTest
         assertEquals("$", receivedMessage.getProperties()[0].getValue());
         assertEquals("&", receivedMessage.getProperties()[1].getValue());
         assertEquals("%", receivedMessage.getProperties()[2].getName());
-        assertEquals("\"", receivedMessage.getProperties()[2].getValue());
-        assertEquals("=", receivedMessage.getProperties()[3].getValue());
+        assertEquals("_", receivedMessage.getProperties()[2].getValue());
+        assertEquals(".", receivedMessage.getProperties()[3].getValue());
     }
 
     //Tests_SRS_Mqtt_34_057: [This function shall parse the messageId, correlationId, outputname, content encoding and content type from the provided property string]
@@ -1270,7 +1270,7 @@ public class MqttTest
         final String contentType = "application/json";
         final String outputName = "outputChannel1";
         final String to = "/devices/deviceID/messages/deviceBound";
-        final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=" + msgId + "&%24.exp=" + expTime + "&%24.to=" + URLEncoder.encode(to, StandardCharsets.UTF_8.name()) + "&%24.cid=" + corId + "&iothub-ack=full&%24.ce=" + contentEncoding + "&%24.ct=" + URLEncoder.encode(contentType, StandardCharsets.UTF_8.name()) + "&%24.on=" + outputName + "&property1=%24&property2=%26&%25=%22&finalProperty=%3d";
+        final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=" + msgId + "&%24.exp=" + expTime + "&%24.to=" + URLEncoder.encode(to, StandardCharsets.UTF_8.name()) + "&%24.cid=" + corId + "&iothub-ack=full&%24.ce=" + contentEncoding + "&%24.ct=" + URLEncoder.encode(contentType, StandardCharsets.UTF_8.name()) + "&%24.on=" + outputName + "&property1=%24&property2=%26&%25=_&finalProperty=.";
         baseConstructorExpectations();
         baseConnectExpectation();
         new MockUp<MqttMessaging>()

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
@@ -7,7 +7,10 @@ package com.microsoft.azure.sdk.iot.common.tests.iothub.telemetry;
 
 import com.microsoft.azure.sdk.iot.common.helpers.*;
 import com.microsoft.azure.sdk.iot.common.setup.iothub.SendMessagesCommon;
-import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceClient;
+import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.service.Device;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
@@ -25,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.microsoft.azure.sdk.iot.common.helpers.SasTokenGenerator.generateSasTokenForIotDevice;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.*;
-import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
 /**
@@ -65,6 +67,19 @@ public class SendMessagesTests extends SendMessagesCommon
         this.testInstance.setup();
 
         IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+    }
+
+    @Test
+    public void sendMessagesWithUnusualApplicationProperties() throws Exception
+    {
+        this.testInstance.setup();
+        this.testInstance.client.open();
+        Message msg = new Message("asdf");
+
+        //All of these characters should be allowed within application properties
+        msg.setProperty("TestKey1234!#$%&'*+-^_`|~", "TestValue1234!#$%&'*+-^_`|~");
+        IotHubServicesCommon.sendMessageAndWaitForResponse(this.testInstance.client, new MessageAndResult(msg, IotHubStatusCode.OK_EMPTY), RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, testInstance.protocol);
+        this.testInstance.client.closeNow();
     }
 
     @Test


### PR DESCRIPTION
Normally the SDK wouldn't validate something like this, but if a user tries to send an application property with an invalid character in it, the different protocols react in different and unintuitive ways. MQTT will sever the connection with no error message while AMQPS and HTTPS will allow it.

I'm also taking this opportunity to fix a hack tied to URL encoding. URLEncoder doesn't handle encoding spaces correctly, but URIUtil from apache commons does

Lastly, the application property key should be encoded just like the value is when using mqtt, so I've fixed that too

fixes #724