### PR TITLE
Fix android sample's file upload issue

### DIFF
--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.iothub.azure.microsoft.com.androidsample"
-        minSdkVersion 19
+        minSdkVersion 26
         targetSdkVersion 27
         multiDexEnabled true
         versionCode 1
@@ -44,7 +44,13 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api 'com.microsoft.azure.sdk.iot:iot-device-client:1.20.2'
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.20.2') {
+        exclude module: 'slf4j-api'
+        exclude module:'azure-storage'
+    }
+    implementation 'org.slf4j:slf4j-android:1.7.29'
+    implementation 'com.microsoft.azure.android:azure-storage-android:2.0.0'
+    implementation 'org.apache.commons:commons-lang3:3.6'
 }
 
 repositories {


### PR DESCRIPTION
The Azure storage service has separate SDKs for Android Java and regular Java, so this sample needs to use the Android SDK and exclude the normal Java SDK.

Also, this sample needs to manually include apache commons as outlined in issue #519

fixes #684 and #519