### PR TITLE
refactor(prov-dev, deps): Add better logging to provisioning device client

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpDeviceOperations.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpDeviceOperations.java
@@ -79,30 +79,22 @@ public class AmqpDeviceOperations
     /**
      * Open the Session links for session
      * @param session the {@link Session} endpoint.
-     * @throws IOException if the function failed to open the links for the provided session.
      * @throws IllegalArgumentException if the session is {@code null}.
      */
-    public void openLinks(Session session) throws IOException, IllegalArgumentException
+    public void openLinks(Session session) throws IllegalArgumentException
     {
         if (session == null)
         {
             throw new IllegalArgumentException("The session cannot be null.");
         }
 
-        try
-        {
-            this.receiverLink = session.receiver(this.receiverLinkTag);
-            this.receiverLink.setProperties(this.amqpProperties);
-            this.receiverLink.open();
+        this.receiverLink = session.receiver(this.receiverLinkTag);
+        this.receiverLink.setProperties(this.amqpProperties);
+        this.receiverLink.open();
 
-            this.senderLink = session.sender(this.senderLinkTag);
-            this.senderLink.setProperties(this.amqpProperties);
-            this.senderLink.open();
-        }
-        catch (Exception e)
-        {
-            throw new IOException("Proton exception", e);
-        }
+        this.senderLink = session.sender(this.senderLinkTag);
+        this.senderLink.setProperties(this.amqpProperties);
+        this.senderLink.open();
     }
 
     /**
@@ -126,34 +118,26 @@ public class AmqpDeviceOperations
      * Initializes the link's other endpoint according to its type
      * @param link The link which shall be initialize.
      * @throws IllegalArgumentException if link argument is null
-     * @throws IOException if Proton throws
      */
-    public synchronized void initLink(Link link) throws IOException, IllegalArgumentException
+    public synchronized void initLink(Link link) throws IllegalArgumentException
     {
         if (link == null)
         {
             throw new IllegalArgumentException("The link cannot be null.");
         }
 
-        try
+        if (link.getName().equals(this.senderLinkTag))
         {
-            if (link.getName().equals(this.senderLinkTag))
-            {
-                Target target = new Target();
-                target.setAddress(this.amqpLinkAddress);
-                link.setTarget(target);
-                link.setSenderSettleMode(SenderSettleMode.UNSETTLED);
-            }
-            if (link.getName().equals(this.receiverLinkTag))
-            {
-                Source source = new Source();
-                source.setAddress(this.amqpLinkAddress);
-                link.setSource(source);
-            }
+            Target target = new Target();
+            target.setAddress(this.amqpLinkAddress);
+            link.setTarget(target);
+            link.setSenderSettleMode(SenderSettleMode.UNSETTLED);
         }
-        catch (Exception e)
+        else if (link.getName().equals(this.receiverLinkTag))
         {
-            throw new IOException("Proton exception: " + e.getMessage());
+            Source source = new Source();
+            source.setAddress(this.amqpLinkAddress);
+            link.setSource(source);
         }
     }
 

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpListener.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpListener.java
@@ -13,4 +13,6 @@ public interface AmqpListener
     void connectionLost();
 
     void messageSent();
+
+    void messageSendFailed(String exceptionMessage);
 }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -5,9 +5,9 @@
 
 package com.microsoft.azure.sdk.iot.deps.transport.amqp;
 
-import com.microsoft.azure.sdk.iot.deps.util.CustomLogger;
 import com.microsoft.azure.sdk.iot.deps.util.ObjectLock;
 import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.util.concurrent.*;
 
+@Slf4j
 public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
 {
     private static final int MAX_WAIT_TO_OPEN_CLOSE_CONNECTION = 1*60*1000; // 1 minute timeout
@@ -61,8 +62,6 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
 
     private SSLContext sslContext;
 
-    private CustomLogger logger = new CustomLogger();
-
     /**
      * Constructor for the Amqp library
      * @param hostName Name of the AMQP Endpoint
@@ -95,24 +94,16 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
         this.closeLock  = new ObjectLock();
 
         this.sslContext = sslContext;
-        this.isOpen  = false;
+        this.isOpen = false;
         this.fullHostAddress = String.format("%s:%d", hostName, this.useWebSockets ? AMQP_WEB_SOCKET_PORT : AMQP_PORT );
         this.hostName = hostName;
 
         add(new Handshaker());
         add(new FlowController());
 
-        try
-        {
-            ReactorOptions options = new ReactorOptions();
-            options.setEnableSaslByDefault(false);
-            reactor = Proton.reactor(options, this);
-        }
-        catch (IOException e)
-        {
-            logger.LogError(e);
-            throw new IOException("Could not create Proton reactor", e);
-        }
+        ReactorOptions options = new ReactorOptions();
+        options.setEnableSaslByDefault(false);
+        reactor = Proton.reactor(options, this);
     }
 
     /**
@@ -139,6 +130,11 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             throw this.saslListener.getSavedException();
         }
 
+        if (this.protonJExceptionParser != null && this.protonJExceptionParser.getError() != null)
+        {
+            throw new IOException("Encountered exception during amqp connection: " + protonJExceptionParser.getError() + " with description " + protonJExceptionParser.getErrorDescription());
+        }
+
         return this.isOpen;
     }
 
@@ -148,18 +144,19 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
      */
     public void open() throws IOException
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
         if(!this.isOpen)
         {
             try
             {
+                log.debug("Opening amqp connection asynchronously");
                 openAmqpAsync();
             }
             catch(Exception e)
             {
-                logger.LogError(e);
+                String errorMessage = "Error opening Amqp connection: ";
+                log.error(errorMessage, e);
                 this.close();
-                throw new IOException("Error opening Amqp connection: ", e);
+                throw new IOException(errorMessage, e);
             }
 
             try
@@ -168,18 +165,21 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             }
             catch (InterruptedException e)
             {
-                logger.LogError(e);
+                String errorMessage = "Amqp connection was interrupted while opening.";
+                log.error(errorMessage, e);
                 this.close();
-                throw new IOException("Waited too long for the connection to open.");
+                throw new IOException(errorMessage, e);
             }
+        }
+        else
+        {
+            log.trace("Open called while amqp connection was already open");
         }
 
         if (!this.isOpen)
         {
-            throw new IOException("Failed to open the connection");
+            throw new IOException("Timed out  to open the amqp connection");
         }
-
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -188,8 +188,6 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
      */
     public void openAmqpAsync()
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-
         this.openLatch = new CountDownLatch(1);
 
         if (executorService == null)
@@ -197,11 +195,10 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             executorService = Executors.newFixedThreadPool(THREAD_POOL_MAX_NUMBER);
         }
 
+        log.debug("Starting amqp reactor thread...");
         AmqpReactor amqpReactor = new AmqpReactor(this.reactor);
-        ReactorRunner reactorRunner = new ReactorRunner(amqpReactor, this.logger);
+        ReactorRunner reactorRunner = new ReactorRunner(amqpReactor);
         executorService.submit(reactorRunner);
-
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -210,10 +207,9 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
      */
     public void close() throws IOException
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-
         if (this.isOpen)
         {
+            log.debug("Closing amqp connection");
             this.amqpDeviceOperations.closeLinks();
 
             // Close Proton
@@ -239,8 +235,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             }
             catch (InterruptedException e)
             {
-                logger.LogError(e);
-                throw new IOException("Waited too long for the connection to open.");
+                throw new IOException("Waited too long for the connection to close.", e);
             }
 
             if (this.executorService != null)
@@ -255,7 +250,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
                         // Wait a while for tasks to respond to being cancelled
                         if (!this.executorService.awaitTermination(MAX_WAIT_TO_TERMINATE_EXECUTOR, TimeUnit.SECONDS))
                         {
-                            logger.LogInfo("Pool did not terminate");
+                            log.info("Pool did not terminate");
                         }
                     }
                 }
@@ -266,7 +261,6 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             }
             this.isOpen = false;
         }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -276,21 +270,18 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onReactorInit(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
         event.getReactor().connectionToHost(this.hostName, this.useWebSockets ? AMQP_WEB_SOCKET_PORT : AMQP_PORT, this);
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     @Override
     public void onReactorFinal(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
+        super.onReactorFinal(event);
         this.reactor = null;
         synchronized (closeLock)
         {
             closeLock.notifyLock();
         }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -300,7 +291,6 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onConnectionInit(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
         this.connection = event.getConnection();
         this.connection.setHostname(this.fullHostAddress);
 
@@ -309,22 +299,14 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
         this.connection.open();
         this.session.open();
 
-        try
-        {
-            this.amqpDeviceOperations.openLinks(this.session);
-        }
-        catch (Exception e)
-        {
-            logger.LogDebug("openLinks has thrown exception: %s", e.getMessage());
-        }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
+        this.amqpDeviceOperations.openLinks(this.session);
     }
 
     /**
      * Create Proton SslDomain object from Address using the given Ssl mode
      * @return the created Ssl domain
      */
-    private SslDomain makeDomain() throws IOException
+    private SslDomain makeDomain()
     {
         SslDomain domain = Proton.sslDomain();
         domain.setPeerAuthentication(SslDomain.VerifyMode.VERIFY_PEER);
@@ -337,43 +319,34 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onConnectionBound(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
         Transport transport = event.getConnection().getTransport();
         if (transport != null)
         {
             if (this.saslListener != null)
             {
+                log.debug("Setting up sasl negotiator");
                 //Calling sasl here adds a transport layer for handling sasl negotiation
                 transport.sasl().setListener(this.saslListener);
             }
 
             if (this.useWebSockets)
             {
+                log.debug("Adding websocket layer");
                 WebSocketImpl webSocket = new WebSocketImpl();
                 webSocket.configure(this.hostName, WEB_SOCKET_PATH, 0, WEB_SOCKET_SUB_PROTOCOL, null, null);
                 ((TransportInternal)transport).addTransportLayer(webSocket);
             }
 
-            try
-            {
-                SslDomain domain = makeDomain();
-                transport.ssl(domain);
-            }
-            catch (IOException e)
-            {
-                logger.LogDebug("onConnectionBound has thrown exception while creating ssl context: %s", e.getMessage());
-            }
+            SslDomain domain = makeDomain();
+            transport.ssl(domain);
         }
-
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     @Override
     public void onConnectionUnbound(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
+        log.trace("Amqp connection unbound");
         this.isOpen = false;
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -383,17 +356,8 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onLinkInit(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-        try
-        {
-            Link link = event.getLink();
-            amqpDeviceOperations.initLink(link);
-        }
-        catch (Exception e)
-        {
-            logger.LogDebug("Exception in onLinkInit: %s", e.getMessage());
-        }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
+        Link link = event.getLink();
+        amqpDeviceOperations.initLink(link);
     }
 
     /**
@@ -404,7 +368,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onLinkRemoteOpen(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
+        super.onLinkRemoteOpen(event);
         String linkName = event.getLink().getName();
 
         if (amqpDeviceOperations.isReceiverLinkTag(linkName))
@@ -418,7 +382,6 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
                 openLatch.countDown();
             }
         }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -429,18 +392,10 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
      */
     public boolean sendAmqpMessage(AmqpMessage message) throws Exception
     {
-        if (this.saslListener != null && this.saslListener.getSavedException() != null)
-        {
-            throw this.saslListener.getSavedException();
-        }
-
-        boolean result;
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
-
         // credit, the function shall return -1.]
-        if (!this.isOpen)
+        if (!this.isConnected())
         {
-            result = false;
+            return false;
         }
         else
         {
@@ -476,15 +431,13 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
                 }
 
                 amqpDeviceOperations.sendMessage(tag, msgData, length, 0);
-                result = true;
+                return true;
             }
             else
             {
-                result = false;
+                return false;
             }
         }
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
-        return result;
     }
 
     /**
@@ -494,31 +447,45 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onDelivery(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
+        Link link = event.getLink();
 
-        AmqpMessage message = amqpDeviceOperations.receiverMessageFromLink(event.getLink().getName());
-        if (message == null)
+        if (link instanceof Sender)
         {
-            //Sender specific section for dispositions it receives
-            if (event.getType() == Event.Type.DELIVERY)
-            {
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_038: [If this link is the Sender link and the event type is DELIVERY, the event handler shall get the Delivery (Proton) object from the event.]
-                Delivery d = event.getDelivery();
-                DeliveryState remoteState = d.getRemoteState();
+            // Codes_SRS_AMQPSIOTHUBCONNECTION_15_038: [If this link is the Sender link and the event type is DELIVERY, the event handler shall get the Delivery (Proton) object from the event.]
+            Delivery d = event.getDelivery();
+            DeliveryState remoteState = d.getRemoteState();
 
-                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_039: [The event handler shall note the remote delivery state and use it and the Delivery (Proton) hash code to inform the AmqpsIotHubConnection of the message receipt.]
-                boolean state = remoteState.equals(Accepted.getInstance());
-                //let any listener know that the message was received by the server
-                // release the delivery object which created in sendMessage().
-                d.free();
+            // Codes_SRS_AMQPSIOTHUBCONNECTION_15_039: [The event handler shall note the remote delivery state and use it and the Delivery (Proton) hash code to inform the AmqpsIotHubConnection of the message receipt.]
+            boolean messageAcknowledgedAsSuccess = remoteState.equals(Accepted.getInstance());
+
+            if (!messageAcknowledgedAsSuccess)
+            {
+                String error = "Amqp message was not accepted by service, remote state was " + remoteState.getType();
+                this.msgListener.messageSendFailed(error);
+            }
+
+            //let any listener know that the message was received by the server
+            // release the delivery object which created in sendMessage().
+            d.free();
+        }
+        else if (link instanceof Receiver)
+        {
+            AmqpMessage message = amqpDeviceOperations.receiverMessageFromLink(event.getLink().getName());
+
+            if (message != null)
+            {
+                log.debug("Amqp connection received message");
+                msgListener.messageReceived(message);
+            }
+            else
+            {
+                log.warn("onDelivery executed on a receiver link but no message could be received");
             }
         }
         else
         {
-            msgListener.messageReceived(message);
+            log.warn("onDelivery executed on a link that is neither a sender or a receiver");
         }
-
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
     }
 
     /**
@@ -528,10 +495,8 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     @Override
     public void onLinkFlow(Event event)
     {
-        logger.LogDebug("Entered in method %s", logger.getMethodName());
         this.linkCredit = event.getLink().getCredit();
-        logger.LogDebug("The link credit value is %s, method name is %s", this.linkCredit, logger.getMethodName());
-        logger.LogDebug("Exited from method %s", logger.getMethodName());
+        log.trace("Amqp link received {} link credit", this.linkCredit);
     }
 
     /**
@@ -549,6 +514,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     public void onTransportHeadClosed(Event event)
     {
         this.openLatch.countDown();
+        log.trace("Amqp transport head closed");
     }
 
     /**
@@ -558,18 +524,17 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     {
         private final static String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
         private final AmqpReactor amqpReactor;
-        private final CustomLogger logger;
 
-        ReactorRunner(AmqpReactor reactor, CustomLogger logger)
+        ReactorRunner(AmqpReactor reactor)
         {
             this.amqpReactor = reactor;
-            this.logger = logger;
         }
 
         @Override
         public Object call()
         {
             Thread.currentThread().setName(THREAD_NAME);
+            log.trace("Amqp reactor thread {} has finished", THREAD_NAME);
 
             try
             {
@@ -577,9 +542,11 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
             }
             catch (HandlerException e)
             {
-                logger.LogError(e);
+                log.error("Encountered an exception while running the AMQP reactor", e);
                 throw e;
             }
+
+            log.trace("Amqp reactor thread {} has finished", THREAD_NAME);
 
             return null;
         }

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpConnectionTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpConnectionTest.java
@@ -303,34 +303,6 @@ public class AmqpConnectionTest
     }
 
     @Test
-    public void onConnectionInitThrowOnOpenLinks() throws IOException, InterruptedException
-    {
-        AmqpsConnection amqpsConnection = new AmqpsConnection(TEST_HOST_NAME, mockedProvisionOperations, null, null,  false);
-
-        new NonStrictExpectations()
-        {
-            {
-                mockedEvent.getConnection();
-                result = mockedConnection;
-
-                mockedConnection.session();
-                result = mockedSession;
-
-                mockedConnection.open();
-                mockedSession.open();
-
-                mockedProvisionOperations.openLinks(mockedSession);
-                result = new Exception();
-            }
-        };
-
-        // Act
-        amqpsConnection.onConnectionInit(mockedEvent);
-
-        //assert
-    }
-
-    @Test
     public void onConnectionInitSucceeds() throws IOException, InterruptedException
     {
         AmqpsConnection amqpsConnection = new AmqpsConnection(TEST_HOST_NAME, mockedProvisionOperations, null, null,  false);
@@ -408,25 +380,6 @@ public class AmqpConnectionTest
                 result = mockedLink;
 
                 mockedProvisionOperations.initLink(mockedLink);
-            }
-        };
-
-        // Act
-        amqpsConnection.onLinkInit(mockedEvent);
-
-        //assert
-    }
-
-    @Test
-    public void onLinkInitThrowsOnGetLink() throws IOException, InterruptedException
-    {
-        AmqpsConnection amqpsConnection = new AmqpsConnection(TEST_HOST_NAME, mockedProvisionOperations, null, null,  false);
-
-        new NonStrictExpectations()
-        {
-            {
-                mockedEvent.getLink();
-                result = new Exception();
             }
         };
 

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpDeviceOperationsTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpDeviceOperationsTest.java
@@ -232,26 +232,6 @@ public class AmqpDeviceOperationsTest
         //assert
     }
 
-    @Test (expected = IOException.class)
-    public void openLinksThrowsOnSessionReceiver() throws IOException, IllegalArgumentException
-    {
-        // Arrange
-        AmqpDeviceOperations amqpDeviceOperation = new AmqpDeviceOperations();
-
-        new NonStrictExpectations()
-        {
-            {
-                mockedSession.receiver(anyString);
-                result = new Exception();
-            }
-        };
-
-        // Act
-        amqpDeviceOperation.openLinks(mockedSession);
-
-        //assert
-    }
-
     @Test
     public void isRecieverLinkTagFalseSucceeds() throws IOException, IllegalArgumentException
     {

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -60,6 +60,17 @@
             <version>1.24</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.8</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClient.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClient.java
@@ -13,10 +13,12 @@ import com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.Provisi
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import com.microsoft.azure.sdk.iot.provisioning.device.AdditionalData;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+@Slf4j
 public class ProvisioningDeviceClient
 {
     private static final int MAX_THREADS_TO_RUN = 1;
@@ -98,6 +100,7 @@ public class ProvisioningDeviceClient
         this.provisioningDeviceClientConfig.setRegistrationCallback(provisioningDeviceClientRegistrationCallback, context);
 
         //SRS_ProvisioningDeviceClient_25_010: [ This method shall start the executor with the ProvisioningTask. ]
+        log.debug("Starting provisioning thread...");
         ProvisioningTask provisioningTask = new ProvisioningTask(this.provisioningDeviceClientConfig, this.provisioningDeviceClientContract);
         executor.submit(provisioningTask);
     }
@@ -123,6 +126,7 @@ public class ProvisioningDeviceClient
         this.provisioningDeviceClientConfig.setRegistrationCallback(provisioningDeviceClientRegistrationCallback, context);
 
         //SRS_ProvisioningDeviceClient_25_010: [ This method shall start the executor with the ProvisioningTask. ]
+        log.debug("Starting provisioning thread...");
         ProvisioningTask provisioningTask = new ProvisioningTask(this.provisioningDeviceClientConfig, this.provisioningDeviceClientContract);
         executor.submit(provisioningTask);
     }

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
@@ -96,7 +96,7 @@ public class ContractAPIMqtt extends ProvisioningDeviceClientContract implements
         catch (InterruptedException e)
         {
             // SRS_ProvisioningAmqpOperations_07_012: [This method shall throw ProvisioningDeviceClientException if any failure is encountered.]
-            throw new ProvisioningDeviceClientException("Provisioning service failed to reply is alloted time.");
+            throw new ProvisioningDeviceClientException("Provisioning service failed to reply is allotted time.");
         }
 
     }

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/exceptions/ProvisioningDeviceClientExceptionManager.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/exceptions/ProvisioningDeviceClientExceptionManager.java
@@ -18,38 +18,30 @@ public class ProvisioningDeviceClientExceptionManager
     {
         int responseStatus = httpResponse.getStatus();
 
-        String errorMessage = ErrorMessageParser.bestErrorMessage(new String(httpResponse.getErrorReason(), StandardCharsets.UTF_8));
+        byte[] errorReason = httpResponse.getErrorReason();
+
+        String errorMessage = httpResponse.getStatus() + " : " + new String(errorReason, StandardCharsets.UTF_8);
 
         switch (responseStatus)
         {
             case 400:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 401:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 403:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 404:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 412:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 429:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 500:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 502:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 503:
-                throw new ProvisioningDeviceHubException(errorMessage);
             case 504:
-                throw new ProvisioningDeviceHubException(errorMessage);
             default:
                 if (responseStatus > 300)
                 {
-                    throw new ProvisioningDeviceHubException(errorMessage);
+                    throw new ProvisioningDeviceHubException(httpResponse.getStatus() + " : " + errorMessage);
                 }
                 else
                 {
-                    // good case move forward
+                    // no error
                     break;
                 }
         }

--- a/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ProvisioningAmqpOperationsTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ProvisioningAmqpOperationsTest.java
@@ -382,6 +382,28 @@ public class ProvisioningAmqpOperationsTest
         //assert
     }
 
+    @Test (expected = ProvisioningDeviceClientException.class)
+    public void sendStatusMessageThrowsIfSendFails() throws Exception
+    {
+        //arrange
+        ProvisioningAmqpOperations provisioningAmqpOperations = new ProvisioningAmqpOperations(TEST_SCOPE_ID, TEST_HOST_NAME);
+        new NonStrictExpectations()
+        {
+            {
+                mockedAmqpConnection.setListener((AmqpListener)any);
+                mockedAmqpConnection.open();
+            }
+        };
+        provisioningAmqpOperations.open(TEST_REGISTRATION_ID, mockedSSLContext, null, false);
+
+        setupSendReceiveMocks();
+
+        Deencapsulation.setField(provisioningAmqpOperations, "messageSendFailedExceptionMessage", "someError");
+
+        //act
+        provisioningAmqpOperations.sendStatusMessage(TEST_OPERATION_ID, mockedResponseCallback, null);
+    }
+
     // SRS_ProvisioningAmqpOperations_07_018: [This method shall throw ProvisioningDeviceClientException if any failure is encountered.]
     @Test (expected = ProvisioningDeviceClientException.class)
     public void sendStatusMessageThrowsOnWaitLock() throws Exception
@@ -514,6 +536,33 @@ public class ProvisioningAmqpOperationsTest
 
         //assert
     }
+
+    @Test (expected = ProvisioningDeviceClientException.class)
+    public void sendRegisterMessageThrowsIfSendMessageFails() throws Exception
+    {
+        //arrange
+        ProvisioningAmqpOperations provisioningAmqpOperations = new ProvisioningAmqpOperations(TEST_SCOPE_ID, TEST_HOST_NAME);
+        new NonStrictExpectations()
+        {
+            {
+                mockedAmqpConnection.setListener((AmqpListener)any);
+                mockedAmqpConnection.open();
+                mockedAmqpConnection.isConnected();
+                result = true;
+            }
+        };
+        provisioningAmqpOperations.open(TEST_REGISTRATION_ID, mockedSSLContext, null, false);
+
+        setupSendReceiveMocks();
+
+        Deencapsulation.setField(provisioningAmqpOperations, "messageSendFailedExceptionMessage", "someError");
+
+        //act
+        provisioningAmqpOperations.sendRegisterMessage(mockedResponseCallback, null, null);
+
+        //assert
+    }
+
 
     // SRS_ProvisioningAmqpOperations_07_013: [This method shall add the message to a message queue.]
     // SRS_ProvisioningAmqpOperations_07_014: [This method shall then Notify the receiveLock.]


### PR DESCRIPTION
Also fixing an issue where provisioning device client didn't propagate up the error code if an http exception was returned from service

Also fixing a bug where if the provisioning device client ignored amqp messages getting rejected from service. Now the sdk responds and throws appropriately