### PR TITLE
release(2020-03-30): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.20.2";
+    private static final String CLIENT_VERSION = "1.20.3";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.20.2') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.20.3') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.20.2</iot-device-client-version>
-        <iot-service-client-version>1.21.0</iot-service-client-version>
-        <iot-deps-version>0.9.2</iot-deps-version>
-        <provisioning-device-client-version>1.8.1</provisioning-device-client-version>
+        <iot-device-client-version>1.20.3</iot-device-client-version>
+        <iot-service-client-version>1.21.1</iot-service-client-version>
+        <iot-deps-version>0.9.3</iot-deps-version>
+        <provisioning-device-client-version>1.8.2</provisioning-device-client-version>
         <provisioning-service-client-version>1.6.1</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.1";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.2";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.21.0";
+    public static String serviceVersion = "1.21.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
old
{
    "device": "1.20.2",
    "service": "1.21.0",
    "deps": "0.9.2",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.1",
    "provisioningService": "1.6.1"
}

new
{
    "device": "1.20.3",
    "service": "1.21.1",
    "deps": "0.9.3",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.2",
    "provisioningService": "1.6.1"
}

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.21.0)

- Improve API documentation for key-based authentication for jobs APIs


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.20.2)

- Add support for CA signed X509 over MQTT_WS, and HTTPS

### Bug fixes
- Fix incorrect logging in AMQP session manager (#730)
- Fix issue where SDK didn't validate application properties in Messages properly


## Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.9.2)

- Add better logging to amqp layer used by provisioning device client


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.1)

- Add better logging to provisioning device client
