### PR TITLE
fix(iot-service): Send if-match header in the request to updateTwin

### DIFF
--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup40.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/helper/TestGroup40.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestGroup40
+{
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
@@ -31,17 +31,10 @@ public class UpdateTwinDeviceAndroidRunner extends UpdateTwinTests
     @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    @BeforeClass
+    public static void setUp() throws IOException
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        return UpdateTwinTests.inputsCommon();
-    }
-
-    public UpdateTwinDeviceAndroidRunner(IotHubClientProtocol protocol)
-    {
-        super(protocol);
     }
 
     @After

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
@@ -9,23 +9,19 @@ import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
 import com.microsoft.azure.sdk.iot.android.helper.TestGroup40;
+import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
-import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.Collection;
 
 @TestGroup40
-@RunWith(Parameterized.class)
 public class UpdateTwinDeviceAndroidRunner extends UpdateTwinTests
 {
     @Rule

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.android.iothub.twin;
+
+import com.microsoft.appcenter.espresso.Factory;
+import com.microsoft.appcenter.espresso.ReportHelper;
+import com.microsoft.azure.sdk.iot.android.BuildConfig;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup24;
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
+import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
+import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collection;
+
+@TestGroup40
+@RunWith(Parameterized.class)
+public class UpdateTwinDeviceAndroidRunner extends UpdateTwinTests
+{
+    @Rule
+    public Rerun count = new Rerun(3);
+
+    @Rule
+    public ReportHelper reportHelper = Factory.getReportHelper();
+
+    public UpdateTwinDeviceAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    {
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+    }
+
+    //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
+    @Parameterized.Parameters(name = "{0}_{1}_{2}")
+    public static Collection inputsCommons() throws IOException, GeneralSecurityException
+    {
+        iotHubConnectionString = BuildConfig.IotHubConnectionString;
+        isBasicTierHub = Boolean.parseBoolean(BuildConfig.IsBasicTierHub);
+        return inputsCommon(ClientType.DEVICE_CLIENT);
+    }
+
+    @After
+    public void labelSnapshot()
+    {
+        reportHelper.label("Stopping App");
+    }
+}

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.sdk.iot.android.iothub.twin;
 import com.microsoft.appcenter.espresso.Factory;
 import com.microsoft.appcenter.espresso.ReportHelper;
 import com.microsoft.azure.sdk.iot.android.BuildConfig;
-import com.microsoft.azure.sdk.iot.android.helper.TestGroup24;
+import com.microsoft.azure.sdk.iot.android.helper.TestGroup40;
 import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.Rerun;
 import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/UpdateTwinDeviceAndroidRunner.java
@@ -29,23 +29,19 @@ import java.util.Collection;
 public class UpdateTwinDeviceAndroidRunner extends UpdateTwinTests
 {
     @Rule
-    public Rerun count = new Rerun(3);
-
-    @Rule
     public ReportHelper reportHelper = Factory.getReportHelper();
 
-    public UpdateTwinDeviceAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
-    {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-    }
-
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
-    @Parameterized.Parameters(name = "{0}_{1}_{2}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection inputsCommons() throws IOException, GeneralSecurityException
     {
         iotHubConnectionString = BuildConfig.IotHubConnectionString;
-        isBasicTierHub = Boolean.parseBoolean(BuildConfig.IsBasicTierHub);
-        return inputsCommon(ClientType.DEVICE_CLIENT);
+        return UpdateTwinTests.inputsCommon();
+    }
+
+    public UpdateTwinDeviceAndroidRunner(IotHubClientProtocol protocol)
+    {
+        super(protocol);
     }
 
     @After

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/UpdateTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/UpdateTwinTests.java
@@ -5,18 +5,20 @@
 
 package com.microsoft.azure.sdk.iot.common.tests.iothub.twin;
 
-import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.ConditionalIgnoreRule;
 import com.microsoft.azure.sdk.iot.common.helpers.StandardTierOnlyRule;
-import com.microsoft.azure.sdk.iot.common.setup.iothub.DeviceTwinCommon;
-import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
+import com.microsoft.azure.sdk.iot.common.tests.iothub.serviceclient.ServiceClientTests;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.devicetwin.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubPreconditionFailedException;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -27,57 +29,75 @@ import java.util.*;
  * Test class containing all tests to be run on JVM and android pertaining to Queries. Class needs to be extended
  * in order to run these tests as that extended class handles setting connection strings and certificate generation
  */
-public class UpdateTwinTests extends DeviceTwinCommon
+public class UpdateTwinTests
 {
-    public UpdateTwinTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
-    {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+    protected static String iotHubConnectionString = "";
+    private static String deviceIdPrefix = "java-service-client-e2e-test";
+    private static final int TEMPERATURE_RANGE = 100;
+    private static final int HUMIDITY_RANGE = 100;
+
+    public UpdateTwinTests(IotHubServiceClientProtocol protocol) {
+        this.testInstance = new ServiceClientITRunner(protocol);
     }
 
-    @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
-    {
-        super.setUpNewDeviceAndModule();
-    }
+    private class ServiceClientITRunner {
+        private IotHubServiceClientProtocol protocol;
+        private String deviceId;
 
-    @Test (expected = IotHubPreconditionFailedException.class)
-    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
-    public void UpdateTwin_WithMismatchingEtag_ExceptionThrown() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
-    {
-        final int numOfDevices = 1;
+        public ServiceClientITRunner(IotHubServiceClientProtocol protocol) {
+            this.protocol = protocol;
+            this.deviceId = deviceIdPrefix.concat("-" + UUID.randomUUID().toString());
 
-        addMultipleDevices(numOfDevices);
-
-        // set desired properties without specifying an etag
-        String queryProperty = PROPERTY_KEY_QUERY + UUID.randomUUID().toString();
-        String queryPropertyValue = PROPERTY_VALUE_QUERY + UUID.randomUUID().toString();
-        setDesiredProperties(queryProperty, queryPropertyValue, numOfDevices, null);
-
-        Thread.sleep(DESIRED_PROPERTIES_PROPAGATION_TIME_MILLIS);
-
-        // set desired properties with specifying an etag that mismatches the cloud twin
-        queryProperty = PROPERTY_KEY_QUERY + UUID.randomUUID().toString();
-        queryPropertyValue = PROPERTY_VALUE_QUERY + UUID.randomUUID().toString();
-        setDesiredProperties(queryProperty, queryPropertyValue, numOfDevices, "XXXXXXXXXXXX");
-
-        removeMultipleDevices(MAX_DEVICES);
-    }
-
-    public void setDesiredProperties(String queryProperty, String queryPropertyValue, int numberOfDevices, String etag) throws IOException, IotHubException
-    {
-        for (int i = 0; i < numberOfDevices; i++)
-        {
-            Set<Pair> desiredProperties = new HashSet<>();
-            desiredProperties.add(new Pair(queryProperty, queryPropertyValue));
-            devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-
-            // if an etag is provided, use it
-            if (etag != null) {
-                devicesUnderTest[i].sCDeviceForTwin.setETag(etag);
-            }
-
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
-            devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
+    }
+
+    private ServiceClientITRunner testInstance;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection inputsCommon() throws IOException {
+        List inputs = Arrays.asList(
+                new Object[][]
+                        {
+                                {IotHubServiceClientProtocol.AMQPS},
+                                {IotHubServiceClientProtocol.AMQPS_WS}
+                        }
+        );
+
+        return inputs;
+    }
+
+    @Test(expected = IotHubPreconditionFailedException.class)
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
+    public void UpdateTwin_WithMismatchingEtag_ExceptionThrown() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException {
+        // setup a new device in IoT Hub
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
+        Device deviceAdded = Device.createFromId(testInstance.deviceId, null, null);
+        Tools.addDeviceWithRetry(registryManager, deviceAdded);
+
+        // create the twin client and device
+        DeviceTwin twinClient = DeviceTwin.createFromConnectionString(iotHubConnectionString);
+        DeviceTwinDevice deviceTwin = new DeviceTwinDevice(testInstance.deviceId);
+
+        // change the properties of the device without specifying an etag
+        changeDesiredProperties(twinClient, deviceTwin, null);
+
+        // change the properties of the device with speciying an etag that mismatches the cloud twin
+        changeDesiredProperties(twinClient, deviceTwin, "XXXXXXXXXXXX");
+
+        registryManager.removeDevice(testInstance.deviceId);
+    }
+
+    private static void changeDesiredProperties(DeviceTwin twinClient, DeviceTwinDevice device, String etag) throws IOException, IotHubException {
+        Set<Pair> desiredProperties = new HashSet<Pair>();
+        desiredProperties.add(new Pair("temp", new Random().nextInt(TEMPERATURE_RANGE)));
+        desiredProperties.add(new Pair("hum", new Random().nextInt(HUMIDITY_RANGE)));
+        device.setDesiredProperties(desiredProperties);
+
+        // if an etag is provided, use it
+        if (etag != null) {
+            device.setETag(etag);
+        }
+
+        twinClient.updateTwin(device);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/UpdateTwinTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/twin/UpdateTwinTests.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.common.tests.iothub.twin;
+
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.ConditionalIgnoreRule;
+import com.microsoft.azure.sdk.iot.common.helpers.StandardTierOnlyRule;
+import com.microsoft.azure.sdk.iot.common.setup.iothub.DeviceTwinCommon;
+import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.*;
+import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.exceptions.IotHubPreconditionFailedException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.util.*;
+
+/**
+ * Test class containing all tests to be run on JVM and android pertaining to Queries. Class needs to be extended
+ * in order to run these tests as that extended class handles setting connection strings and certificate generation
+ */
+public class UpdateTwinTests extends DeviceTwinCommon
+{
+    public UpdateTwinTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    {
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+    }
+
+    @Before
+    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
+    {
+        super.setUpNewDeviceAndModule();
+    }
+
+    @Test (expected = IotHubPreconditionFailedException.class)
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
+    public void UpdateTwin_WithMismatchingEtag_ExceptionThrown() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    {
+        final int numOfDevices = 1;
+
+        addMultipleDevices(numOfDevices);
+
+        // set desired properties without specifying an etag
+        String queryProperty = PROPERTY_KEY_QUERY + UUID.randomUUID().toString();
+        String queryPropertyValue = PROPERTY_VALUE_QUERY + UUID.randomUUID().toString();
+        setDesiredProperties(queryProperty, queryPropertyValue, numOfDevices, null);
+
+        Thread.sleep(DESIRED_PROPERTIES_PROPAGATION_TIME_MILLIS);
+
+        // set desired properties with specifying an etag that mismatches the cloud twin
+        queryProperty = PROPERTY_KEY_QUERY + UUID.randomUUID().toString();
+        queryPropertyValue = PROPERTY_VALUE_QUERY + UUID.randomUUID().toString();
+        setDesiredProperties(queryProperty, queryPropertyValue, numOfDevices, "XXXXXXXXXXXX");
+
+        removeMultipleDevices(MAX_DEVICES);
+    }
+
+    public void setDesiredProperties(String queryProperty, String queryPropertyValue, int numberOfDevices, String etag) throws IOException, IotHubException
+    {
+        for (int i = 0; i < numberOfDevices; i++)
+        {
+            Set<Pair> desiredProperties = new HashSet<>();
+            desiredProperties.add(new Pair(queryProperty, queryPropertyValue));
+            devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
+
+            // if an etag is provided, use it
+            if (etag != null) {
+                devicesUnderTest[i].sCDeviceForTwin.setETag(etag);
+            }
+
+            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            devicesUnderTest[i].sCDeviceForTwin.clearTwin();
+        }
+    }
+}

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
+
+import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
+import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
+import com.microsoft.azure.sdk.iot.common.helpers.Tools;
+import com.microsoft.azure.sdk.iot.common.setup.iothub.DeviceTwinCommon;
+import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
+import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class UpdateTwinJVMRunner extends UpdateTwinTests
+{
+    public UpdateTwinJVMRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    {
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
+    }
+
+    //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
+    @Parameterized.Parameters(name = "{0} with {1} auth using {2}")
+    public static Collection inputs() throws Exception
+    {
+        iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
+        isBasicTierHub = Boolean.parseBoolean(Tools.retrieveEnvironmentVariableValue(TestConstants.IS_BASIC_TIER_HUB_ENV_VAR_NAME));
+        if (!isBasicTierHub)
+        {
+            return DeviceTwinCommon.inputsCommon();
+        }
+        else
+        {
+            return DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
+        }
+    }
+}

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
@@ -5,13 +5,10 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 
-import com.microsoft.azure.sdk.iot.common.helpers.ClientType;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
-import com.microsoft.azure.sdk.iot.common.setup.iothub.DeviceTwinCommon;
 import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
-import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -20,24 +17,16 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 public class UpdateTwinJVMRunner extends UpdateTwinTests
 {
-    public UpdateTwinJVMRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
-    {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
-    }
-
     //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
-    @Parameterized.Parameters(name = "{0} with {1} auth using {2}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        isBasicTierHub = Boolean.parseBoolean(Tools.retrieveEnvironmentVariableValue(TestConstants.IS_BASIC_TIER_HUB_ENV_VAR_NAME));
-        if (!isBasicTierHub)
-        {
-            return DeviceTwinCommon.inputsCommon();
-        }
-        else
-        {
-            return DeviceTwinCommon.inputsCommon(ClientType.DEVICE_CLIENT);
-        }
+        return UpdateTwinTests.inputsCommon();
+    }
+
+    public UpdateTwinJVMRunner(IotHubServiceClientProtocol protocol)
+    {
+        super(protocol);
     }
 }

--- a/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
+++ b/iot-e2e-tests/jvm/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/UpdateTwinJVMRunner.java
@@ -8,25 +8,13 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 import com.microsoft.azure.sdk.iot.common.helpers.TestConstants;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.common.tests.iothub.twin.UpdateTwinTests;
-import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.BeforeClass;
 
-import java.util.Collection;
-
-@RunWith(Parameterized.class)
 public class UpdateTwinJVMRunner extends UpdateTwinTests
 {
-    //This function is run before even the @BeforeClass annotation, so it is used as the @BeforeClass method
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection inputs() throws Exception
+    @BeforeClass
+    public static void setUp() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
-        return UpdateTwinTests.inputsCommon();
-    }
-
-    public UpdateTwinJVMRunner(IotHubServiceClientProtocol protocol)
-    {
-        super(protocol);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -173,7 +173,7 @@ public class DeviceTwin
          */
         TwinState twinState = new TwinState(device.getTagsMap(), device.getDesiredMap(), null);
 
-        // determine whether there is an explicit change in the etag. If there is, ensure updating the twinState and the request header before the update operation
+        // at this point, twinState does not have an eTag set. Therefore, add a if-match header with an etag that is either set explicitly by the user, or one that is already set on the device
         if (!Tools.isNullOrEmpty(device.getETag()))
         {
             twinState.setETag(device.getETag());

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -537,6 +537,8 @@ public class DeviceTwinTest
                 result = testMap;
                 Deencapsulation.invoke(mockedDevice, "getTagsMap");
                 result = testMap;
+                Deencapsulation.invoke(mockedDevice, "getETag");
+                result = "abc";
                 new TwinState((TwinCollection)any, (TwinCollection)any, null);
                 result = mockedTwinState;
                 mockedTwinState.toJsonElement().toString();
@@ -556,7 +558,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
             }

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -257,6 +257,8 @@ jobs:
         ANDROID_TEST_GROUP_ID: TestGroup38
       TestGroup39:
         ANDROID_TEST_GROUP_ID: TestGroup39
+      TestGroup40:
+        ANDROID_TEST_GROUP_ID: TestGroup40
       
   displayName: Android Test
   dependsOn: AndroidBuild


### PR DESCRIPTION
This pull request is a fix for [this]( https://github.com/Azure/azure-iot-sdk-java/issues/574) issue.

This change ensures an if-match header is sent along with the request to update the twin. This header ensures that the etag a user sets explicitly matches the one that is set in the twin. If both etags are different, the service should throw a IotHubPreconditionFailedException exception. Without the if-match header, a user can make updates to the device twin without knowing whether another update has been performed from a different client. 