### PR TITLE
fix(e2e): Upgrade swagger-parser to 1.0.50

### DIFF
--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>28.2-jre</version>
+        </dependency>
+        
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
             <version>3.8.4</version>

--- a/iot-e2e-tests/edge-e2e/pom.xml
+++ b/iot-e2e-tests/edge-e2e/pom.xml
@@ -21,20 +21,23 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
-        </dependency>
+
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
             <version>3.8.4</version>
         </dependency>
+
         <dependency>
             <groupId>com.github.phiz71</groupId>
             <artifactId>vertx-swagger-router</artifactId>
             <version>1.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>1.0.50</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This change fixed a known code execution vulnerability in Swagger parser. Ran the Snyk tool before and after the change to ensure vulnerability fix.