### PR TITLE
fix(iot-device):Introduce a new option for receive interval

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -548,9 +548,9 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
-     *        in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *        in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
-     *        between spawning a thread that dequeues a message from the SDK's queue of received messages.
+     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
+     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
+     *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -547,6 +547,10 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      option specifies the interval in milliseconds between calls to
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
+     *	      - <b>SetReceiveInterval</b> - this option is applicable to all protocols
+     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
+     *        in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
+     *        between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.
@@ -580,13 +584,8 @@ public final class DeviceClient extends InternalClient implements Closeable
         {
             // Codes_SRS_DEVICECLIENT_02_016: ["SetMinimumPollingInterval" - time in milliseconds between 2 consecutive polls.]
             case SET_MINIMUM_POLLING_INTERVAL:
+            case SET_RECEIVE_INTERVAL:
             {
-                // Codes_SRS_DEVICECLIENT_12_023: [If the client configured to use TransportClient the SetMinimumPollingInterval shall throw IOException.]
-                if (this.ioTHubConnectionType == IoTHubConnectionType.USE_TRANSPORTCLIENT)
-                {
-                    throw new IllegalStateException("setOption " + SET_MINIMUM_POLLING_INTERVAL +
-                            "only works with HTTP protocol");
-                }
                 break;
             }
             // Codes_SRS_DEVICECLIENT_21_040: ["SetSendInterval" - time in milliseconds between 2 consecutive message sends.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -547,8 +547,8 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      option specifies the interval in milliseconds between calls to
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
-     *	      - <b>SetReceiveInterval</b> - this option is applicable to all protocols
-     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
+     *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
+     *        in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
      *        in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
      *        between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *	    - <b>SetCertificatePath</b> - this option is applicable only

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -24,7 +24,10 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 @Slf4j
 public class InternalClient
 {
+    // SET_MINIMUM_POLLING_INTERVAL is used for setting the interval for https polling task.
     static final String SET_MINIMUM_POLLING_INTERVAL = "SetMinimumPollingInterval";
+    // SET_RECEIVE_INTERVAL is used for setting the interval for handling MQTT and AMQP receive task.
+    static final String SET_RECEIVE_INTERVAL = "SetReceiveInterval";
     static final String SET_SEND_INTERVAL = "SetSendInterval";
     static final String SET_CERTIFICATE_PATH = "SetCertificatePath";
 	static final String SET_CERTIFICATE_AUTHORITY = "SetCertificateAuthority";
@@ -386,22 +389,16 @@ public class InternalClient
             switch (optionName)
             {
                 case SET_MINIMUM_POLLING_INTERVAL:
+                case SET_RECEIVE_INTERVAL:
                 {
                     if (this.deviceIO.isOpen())
                     {
-                        throw new IllegalStateException("setOption " + SET_MINIMUM_POLLING_INTERVAL +
-                                "only works when the transport is closed");
+                        throw new IllegalStateException("setOption " + optionName +
+                                " only works when the transport is closed");
                     }
                     else
                     {
-                        if (this.deviceIO.getProtocol() == IotHubClientProtocol.HTTPS)
-                        {
-                            setOption_SetMinimumPollingInterval(value);
-                        }
-                        else
-                        {
-                            throw new IllegalArgumentException("optionName is unknown = " + optionName + " for " + this.deviceIO.getProtocol().toString());
-                        }
+                        setOption_SetMinimumPollingInterval(value);
                     }
 
                     break;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -24,9 +24,9 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 @Slf4j
 public class InternalClient
 {
-    // SET_MINIMUM_POLLING_INTERVAL is used for setting the interval for https polling task.
+    // SET_MINIMUM_POLLING_INTERVAL is used for setting the interval for https message polling.
     static final String SET_MINIMUM_POLLING_INTERVAL = "SetMinimumPollingInterval";
-    // SET_RECEIVE_INTERVAL is used for setting the interval for handling MQTT and AMQP receive task.
+    // SET_RECEIVE_INTERVAL is used for setting the interval for handling MQTT and AMQP messages.
     static final String SET_RECEIVE_INTERVAL = "SetReceiveInterval";
     static final String SET_SEND_INTERVAL = "SetSendInterval";
     static final String SET_CERTIFICATE_PATH = "SetCertificatePath";
@@ -356,6 +356,10 @@ public class InternalClient
      *	      option specifies the interval in milliseconds between calls to
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
+     *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
+     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
+     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods between
+     *	      spawning up threads that would read a message off of the connection and invoking the message callback.
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -358,8 +358,8 @@ public class InternalClient
      *	      is expected to be of type {@code long}.
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods between
-     *	      spawning up threads that would read a message off of the connection and invoking the message callback.
+     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
+     *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -626,29 +626,37 @@ public class DeviceClientTest
         client.setOption("thisIsNotAHandledOption", someMilliseconds);
     }
 
-    //Tests_SRS_DEVICECLIENT_02_017: [Available only for HTTP.]
-    @Test (expected = IllegalArgumentException.class)
-    public void setOptionMinimumPollingIntervalWithAMQPfails()
+    //Tests_SRS_DEVICECLIENT_02_017: [Available for all protocols]
+    @Test
+    public void setOptionSetReceiveIntervalWithMQTTsucceeds()
             throws IOException, URISyntaxException
     {
         // arrange
         final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;deviceId=testdevice;"
                 + "SharedAccessKey=adjkl234j52=";
-        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-        long someMilliseconds = 4;
+        final IotHubClientProtocol protocol = IotHubClientProtocol.MQTT;
+        final long someMilliseconds = 4L;
         new NonStrictExpectations()
         {
             {
                 mockDeviceIO.isOpen();
                 result = false;
                 mockDeviceIO.getProtocol();
-                result = IotHubClientProtocol.AMQPS;
+                result = IotHubClientProtocol.MQTT;
             }
         };
         DeviceClient client = new DeviceClient(connString, protocol);
 
         // act
-        client.setOption("SetMinimumPollingInterval", someMilliseconds);
+        client.setOption("SetReceiveInterval", someMilliseconds);
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockDeviceIO.setReceivePeriodInMilliseconds(someMilliseconds);
+            }
+        };
     }
 
     //Tests_SRS_DEVICECLIENT_02_018: [Value needs to have type long].
@@ -1483,20 +1491,6 @@ public class DeviceClientTest
 
         // act
         client.setOption("SetSendInterval", "thisIsNotALong");
-    }
-
-    // Tests_SRS_DEVICECLIENT_12_023: [If the client configured to use TransportClient the SetMinimumPollingInterval shall throw IOException.]
-    @Test (expected = IllegalStateException.class)
-    public void setOptionWithTransportClientThrowsSetMinimumPollingInterval()
-            throws URISyntaxException
-    {
-        // arrange
-        final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;deviceId=testdevice;"
-                + "SharedAccessKey=adjkl234j52=";
-        DeviceClient client = new DeviceClient(connString, mockTransportClient);
-
-        // act
-        client.setOption("SetMinimumPollingInterval", "thisIsNotALong");
     }
 
     //Tests_SRS_DEVICECLIENT_34_065: [""SetSASTokenExpiryTime" if this option is called when not using sas token authentication, an IllegalStateException shall be thrown.*]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -1853,15 +1853,15 @@ public class InternalClientTest
     }
 
     //Tests_SRS_INTERNALCLIENT_02_017: [Available only for HTTP.]
-    @Test (expected = IllegalArgumentException.class)
-    public void setOptionMinimumPollingIntervalWithAMQPfails()
+    @Test
+    public void setOptionSetReceiveIntervalWithAMQPsucceeds()
             throws IOException, URISyntaxException
     {
         // arrange
         final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;DeviceId=testdevice;"
                 + "SharedAccessKey=adjkl234j52=";
         final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-        long someMilliseconds = 4;
+        final long someMilliseconds = 4L;
         new NonStrictExpectations()
         {
             {
@@ -1874,7 +1874,15 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD);
 
         // act
-        client.setOption("SetMinimumPollingInterval", someMilliseconds);
+        client.setOption("SetReceiveInterval", someMilliseconds);
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockDeviceIO.setReceivePeriodInMilliseconds(someMilliseconds);
+            }
+        };
     }
 
     //Tests_SRS_INTERNALCLIENT_02_018: [Value needs to have type long].


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/739

# Description of the problem
The SDK needs a way to allow users to configure the receive interval for their connection oriented protocols (MQTT and AMQP)

# Description of the solution
We will expose a new option name that specifically calls out receive interval on the internal client.