### PR TITLE
refactor(vsts): Limit number of android test group runs in parallel to 6

### DIFF
--- a/vsts/determine_if_android_test_group_needs_to_run.ps1
+++ b/vsts/determine_if_android_test_group_needs_to_run.ps1
@@ -8,6 +8,19 @@ Write-Host "##vso[task.setvariable variable=task.android.needToRunTestGroup]no"
 # "TestGroup12", for instance
 $testGroupString = $env:TEST_GROUP_ID
 
+$isBasicTierHub = $env:IS_BASIC_TIER_HUB
+
+# Due to resource limitations on the SDK team, we can't afford the time it would take to run Android tests on standard tier iothubs
+# and basic tier iothubs, so we will skip testing basic tier hubs for now
+if ($isBasicTierHub.toLower() -eq "true")
+{
+    Write-Host "Currently skipping all Android testing on basic tier hubs"
+    Write-Host "##vso[task.setvariable variable=task.android.needToRunTestGroup]no"
+
+    # No more need to continue, basic tier hub testing is skipped for Android for now
+    exit 0
+}
+
 $testGroupImportPattern = $testGroupString + ";"
 $testGroupAnnotationPattern = "@" + $testGroupString
 

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -177,7 +177,7 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   strategy:
-    maxParallel: 12
+    maxParallel: 6
     matrix:
       TestGroup1:
         ANDROID_TEST_GROUP_ID: TestGroup1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -268,6 +268,7 @@ jobs:
       targetType: 'filePath'
       filePath: ./vsts/determine_if_android_test_group_needs_to_run.ps1
     env:
+      IS_BASIC_TIER_HUB: $(IS-BASIC-TIER-HUB)
       TEST_GROUP_ID: $(ANDROID_TEST_GROUP_ID)
       TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 


### PR DESCRIPTION
Our team has fewer parallel agents allowed right now, so to avoid hogging all the agents, we should limit our parallel android agents to 6