### PR TITLE
feat(iot-dev): Add setOption API for setting https request read and connect timeouts

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -547,20 +547,33 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      option specifies the interval in milliseconds between calls to
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
+     *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
+     *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.
      *	      The value is expected to be of type {@code String}.
+     *
      *      - <b>SetSASTokenExpiryTime</b> - this option is applicable for HTTP/
      *         AMQP/MQTT. This option specifies the interval in seconds after which
      *         SASToken expires. If the transport is already open then setting this
      *         option will restart the transport with the updated expiry time, and
      *         will use that expiry time length for all subsequently generated sas tokens.
      *         The value is expected to be of type {@code long}.
+     *
+     *      - <b>SetHttpsReadTimeout</b> - this option is applicable for HTTPS.
+     *         This option specifies the read timeout in milliseconds per https request
+     *         made by this client. By default, this value is 4 minutes.
+     *         The value is expected to be of type {@code int}.
+     *
+     *      - <b>SetHttpsConnectTimeout</b> - this option is applicable for HTTPS.
+     *         This option specifies the connect timeout in milliseconds per https request
+     *         made by this client. By default, this value is 0 (no connect timeout).
+     *         The value is expected to be of type {@code int}.
      *
      * @param optionName the option name to modify
      * @param value an object of the appropriate type for the option's value

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -11,6 +11,8 @@ import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderTpm;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderX509;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLContext;
@@ -25,8 +27,9 @@ import java.util.Map;
 @Slf4j
 public final class DeviceClientConfig
 {
-    /** The default value for readTimeoutMillis. */
-    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 240000;
+    private static final int DEFAULT_HTTPS_READ_TIMEOUT_MILLIS = 240000;
+    private static final int DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS = 0; //no connect timeout
+
     /** The default value for messageLockTimeoutSecs. */
     private static final int DEFAULT_MESSAGE_LOCK_TIMEOUT_SECS = 180;
 
@@ -34,6 +37,14 @@ public final class DeviceClientConfig
 
     private boolean useWebsocket;
     private ProxySettings proxySettings;
+
+    @Getter
+    @Setter
+    private int httpsReadTimeout;
+
+    @Getter
+    @Setter
+    private int httpsConnectTimeout;
 
     private IotHubAuthenticationProvider authenticationProvider;
 
@@ -229,6 +240,8 @@ public final class DeviceClientConfig
 
         this.productInfo = new ProductInfo();
         this.useWebsocket = false;
+        this.httpsReadTimeout = DEFAULT_HTTPS_READ_TIMEOUT_MILLIS;
+        this.httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS;
     }
 
     private void assertConnectionStringIsX509(IotHubConnectionString iotHubConnectionString)
@@ -403,19 +416,6 @@ public final class DeviceClientConfig
     {
         // Codes_SRS_DEVICECLIENTCONFIG_34_050: [This function return the saved moduleId.]
         return this.authenticationProvider.getModuleId();
-    }
-
-    /**
-     * Getter for the timeout, in milliseconds, after a connection is
-     * established for the server to respond to the request.
-     *
-     * @return the timeout, in milliseconds, after a connection is established
-     * for the server to respond to the request.
-     */
-    public int getReadTimeoutMillis()
-    {
-        // Codes_SRS_DEVICECLIENTCONFIG_11_012: [The function shall return 240000ms.]
-        return DEFAULT_READ_TIMEOUT_MILLIS;
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -33,6 +33,9 @@ public class InternalClient
 	static final String SET_CERTIFICATE_AUTHORITY = "SetCertificateAuthority";
     static final String SET_SAS_TOKEN_EXPIRY_TIME = "SetSASTokenExpiryTime";
 
+    static final String SET_HTTPS_CONNECT_TIMEOUT = "SetHttpsConnectTimeout";
+    static final String SET_HTTPS_READ_TIMEOUT = "SetHttpsReadTimeout";
+
     DeviceClientConfig config;
     DeviceIO deviceIO;
 
@@ -356,20 +359,33 @@ public class InternalClient
      *	      option specifies the interval in milliseconds between calls to
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
+     *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
+     *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.
      *	      The value is expected to be of type {@code String}.
+     *
      *      - <b>SetSASTokenExpiryTime</b> - this option is applicable for HTTP/
      *         AMQP/MQTT. This option specifies the interval in seconds after which
      *         SASToken expires. If the transport is already open then setting this
      *         option will restart the transport with the updated expiry time, and
      *         will use that expiry time length for all subsequently generated sas tokens.
      *         The value is expected to be of type {@code long}.
+     *
+     *      - <b>SetHttpsReadTimeout</b> - this option is applicable for HTTPS.
+     *         This option specifies the read timeout in milliseconds per https request
+     *         made by this client. By default, this value is 4 minutes.
+     *         The value is expected to be of type {@code int}.
+     *
+     *      - <b>SetHttpsConnectTimeout</b> - this option is applicable for HTTPS.
+     *         This option specifies the connect timeout in milliseconds per https request
+     *         made by this client. By default, this value is 0 (no connect timeout).
+     *         The value is expected to be of type {@code int}.
      *
      * @param optionName the option name to modify
      * @param value an object of the appropriate type for the option's value
@@ -452,6 +468,16 @@ public class InternalClient
                 case SET_SAS_TOKEN_EXPIRY_TIME:
                 {
                     setOption_SetSASTokenExpiryTime(value);
+                    break;
+                }
+                case SET_HTTPS_CONNECT_TIMEOUT:
+                {
+                    setOption_SetHttpsConnectTimeout(value);
+                    break;
+                }
+                case SET_HTTPS_READ_TIMEOUT:
+                {
+                    setOption_SetHttpsReadTimeout(value);
                     break;
                 }
                 default:
@@ -654,6 +680,46 @@ public class InternalClient
         if (value != null)
         {
             this.config.getAuthenticationProvider().setPathToIotHubTrustedCert((String) value);
+        }
+    }
+
+    void setOption_SetHttpsConnectTimeout(Object value)
+    {
+        if (value != null)
+        {
+            if (this.config.getProtocol() != HTTPS)
+            {
+                throw new UnsupportedOperationException("Cannot set the https connect timeout when using protocol " + this.config.getProtocol());
+            }
+
+            if (value instanceof Integer)
+            {
+                this.config.setHttpsConnectTimeout((int) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("value is not int = " + value);
+            }
+        }
+    }
+
+    void setOption_SetHttpsReadTimeout(Object value)
+    {
+        if (value != null)
+        {
+            if (this.config.getProtocol() != HTTPS)
+            {
+                throw new UnsupportedOperationException("Cannot set the https read timeout when using protocol " + this.config.getProtocol());
+            }
+
+            if (value instanceof Integer)
+            {
+                this.config.setHttpsReadTimeout((int) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("value is not int = " + value);
+            }
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
@@ -182,10 +182,19 @@ public class HttpsConnection
      *
      * @param timeout the read timeout.
      */
-    public void setReadTimeoutMillis(int timeout)
+    public void setReadTimeout(int timeout)
     {
         // Codes_SRS_HTTPSCONNECTION_11_023: [The function shall set the read timeout to the given value.]
         this.connection.setReadTimeout(timeout);
+    }
+
+    /**
+     * Sets the connect timeout in milliseconds.
+     * @param timeout the connect timeout in milliseconds.
+     */
+    public void setConnectTimeout(int timeout)
+    {
+        this.connection.setConnectTimeout(timeout);
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -440,7 +440,8 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
 
     private HttpsResponse sendRequest(HttpsRequest request) throws TransportException
     {
-        request.setReadTimeoutMillis(this.config.getReadTimeoutMillis());
+        request.setReadTimeout(this.config.getHttpsReadTimeout());
+        request.setConnectTimeout(this.config.getHttpsConnectTimeout());
 
         if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
@@ -22,7 +22,8 @@ public class HttpsRequest
     private HttpsMethod method;
     private URL url;
     private Map<String, List<String>> headers;
-    private int connectionTimeout;
+    private int readTimeout;
+    private int connectTimeout;
     private SSLContext sslContext;
     private ProxySettings proxySettings;
 
@@ -115,9 +116,14 @@ public class HttpsRequest
             connection.setSSLContext(this.sslContext);
         }
 
-        if (this.connectionTimeout != 0)
+        if (this.readTimeout != 0)
         {
-            connection.setReadTimeoutMillis(this.connectionTimeout);
+            connection.setReadTimeout(this.readTimeout);
+        }
+
+        if (this.connectTimeout != 0)
+        {
+            connection.setConnectTimeout(this.connectTimeout);
         }
 
         int responseStatus = -1;
@@ -174,10 +180,23 @@ public class HttpsRequest
      *
      * @return itself, for fluent setting.
      */
-    public HttpsRequest setReadTimeoutMillis(int timeout)
+    public HttpsRequest setReadTimeout(int timeout)
     {
         // Codes_SRS_HTTPSREQUEST_11_014: [The function shall set the read timeout for the request to the given value.]
-        this.connectionTimeout = timeout;
+        this.readTimeout = timeout;
+        return this;
+    }
+
+    /**
+     * Sets the connect timeout, in milliseconds, for the request.
+     *
+     * @param timeout the connect timeout in milliseconds.
+     *
+     * @return itself, for fluent setting.
+     */
+    public HttpsRequest setConnectTimeout(int timeout)
+    {
+        this.connectTimeout = timeout;
         return this;
     }
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientConfigTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientConfigTest.java
@@ -513,9 +513,9 @@ public class DeviceClientConfigTest
         assertThat(testContextDM, is(expectedDMContext));
         assertEquals(config.getDeviceMethodsMessageCallback(), mockCallback);
     }
-    // Tests_SRS_DEVICECLIENTCONFIG_11_012: [The function shall return 240000ms.]
+
     @Test
-    public void getReadTimeoutMillisReturnsConstant() throws URISyntaxException, IOException
+    public void getReadTimeoutMillis()
     {
         final String iotHubHostname = "test.iothubhostname";
         final String deviceId = "test-deviceid";
@@ -530,10 +530,42 @@ public class DeviceClientConfigTest
                         sharedAccessToken);
 
         DeviceClientConfig config = Deencapsulation.newInstance(DeviceClientConfig.class, iotHubConnectionString);
-        int testReadTimeoutMillis = config.getReadTimeoutMillis();
+        int testReadTimeoutMillis = config.getHttpsReadTimeout();
 
-        final int expectedReadTimeoutMillis = 240000;
-        assertThat(testReadTimeoutMillis, is(expectedReadTimeoutMillis));
+        final int expectedDefaultReadTimeoutMillis = 240000;
+        assertThat(testReadTimeoutMillis, is(expectedDefaultReadTimeoutMillis));
+
+        int newValue = 444;
+        config.setHttpsReadTimeout(newValue);
+
+        assertThat(config.getHttpsReadTimeout(), is(newValue));
+    }
+
+    @Test
+    public void getConnectTimeoutMillis()
+    {
+        final String iotHubHostname = "test.iothubhostname";
+        final String deviceId = "test-deviceid";
+        final String deviceKey = "test-devicekey";
+        final String sharedAccessToken = null;
+        final IotHubConnectionString iotHubConnectionString =
+                Deencapsulation.newInstance(IotHubConnectionString.class,
+                        new Class[] {String.class, String.class, String.class, String.class},
+                        iotHubHostname,
+                        deviceId,
+                        deviceKey,
+                        sharedAccessToken);
+
+        DeviceClientConfig config = Deencapsulation.newInstance(DeviceClientConfig.class, iotHubConnectionString);
+        int testConnectTimeoutMillis = config.getHttpsConnectTimeout();
+
+        final int expectedDefaultConnectTimeoutMillis = 0;
+        assertThat(testConnectTimeoutMillis, is(expectedDefaultConnectTimeoutMillis));
+
+        int newValue = 444;
+        config.setHttpsConnectTimeout(newValue);
+
+        assertThat(config.getHttpsConnectTimeout(), is(newValue));
     }
 
     //Tests_SRS_DEVICECLIENTCONFIG_25_038: [The function shall save useWebsocket.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -2152,6 +2152,66 @@ public class InternalClientTest
         };
     }
 
+    @Test
+    public void setOptionSetConnectTimeoutSucceeds()
+    {
+        // arrange
+        new Expectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.HTTPS;
+            }
+        };
+
+        final IotHubClientProtocol protocol = IotHubClientProtocol.HTTPS;
+
+        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD);
+        final int connectTimeout = 60;
+
+        // act
+        client.setOption("SetHttpsConnectTimeout", connectTimeout);
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockConfig.setHttpsConnectTimeout(connectTimeout);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void setOptionSetReadTimeoutSucceeds()
+    {
+        // arrange
+        new Expectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.HTTPS;
+            }
+        };
+
+        final IotHubClientProtocol protocol = IotHubClientProtocol.HTTPS;
+
+        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD);
+        final int connectTimeout = 60;
+
+        // act
+        client.setOption("SetHttpsReadTimeout", connectTimeout);
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockConfig.setHttpsReadTimeout(connectTimeout);
+                times = 1;
+            }
+        };
+    }
+
     /*Tests_SRS_INTERNALCLIENT_25_024: ["SetSASTokenExpiryTime" shall restart the transport
                                     1. If the device currently uses device key and
                                     2. If transport is already open

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
@@ -318,13 +318,44 @@ public class HttpsConnectionTest
         };
         HttpsConnection conn = new HttpsConnection(mockUrl, httpsMethod);
 
-        conn.setReadTimeoutMillis(timeout);
+        conn.setReadTimeout(timeout);
 
         final int expectedTimeout = timeout;
         new Verifications()
         {
             {
                 mockUrl.openConnection().setReadTimeout(expectedTimeout);
+            }
+        };
+    }
+
+    @Test
+    public void setConnectTimeoutSetsConnectTimeout() throws IOException, TransportException
+    {
+        final HttpsMethod httpsMethod = HttpsMethod.POST;
+        final String field = "test-field";
+        final String value = "test-value";
+        final int timeout = 1;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "https";
+                mockUrl.openConnection();
+                result = mockUrlConn;
+                mockUrlConn.getRequestMethod();
+                result = httpsMethod.name();
+            }
+        };
+        HttpsConnection conn = new HttpsConnection(mockUrl, httpsMethod);
+
+        conn.setConnectTimeout(timeout);
+
+        final int expectedTimeout = timeout;
+        new Verifications()
+        {
+            {
+                mockUrl.openConnection().setConnectTimeout(expectedTimeout);
             }
         };
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -228,7 +228,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
@@ -243,7 +243,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockRequest.setReadTimeoutMillis(expectedReadTimeoutMillis);
+                mockRequest.setReadTimeout(expectedReadTimeoutMillis);
             }
         };
     }
@@ -655,7 +655,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
             }
         };
@@ -667,7 +667,33 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockRequest.setReadTimeoutMillis(expectedReadTimeoutMillis);
+                mockRequest.setReadTimeout(expectedReadTimeoutMillis);
+            }
+        };
+    }
+
+    @Test
+    public void sendHttpsMessageSetsConnectTimeout(@Mocked final IotHubUri mockUri) throws TransportException
+    {
+        final int readTimeoutMillis = 10;
+        final String uriPath = "/files";
+        final HttpsMethod httpsMethod = HttpsMethod.POST;
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getHttpsConnectTimeout();
+                result = readTimeoutMillis;
+            }
+        };
+
+        HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
+        conn.sendHttpsMessage(mockMsg, httpsMethod, uriPath, new HashMap<String, String>());
+
+        final int expectedReadTimeoutMillis = readTimeoutMillis;
+        new Verifications()
+        {
+            {
+                mockRequest.setConnectTimeout(expectedReadTimeoutMillis);
             }
         };
     }
@@ -935,7 +961,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
             }
         };
@@ -947,7 +973,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockRequest.setReadTimeoutMillis(expectedReadTimeoutMillis);
+                mockRequest.setReadTimeout(expectedReadTimeoutMillis);
             }
         };
     }
@@ -960,7 +986,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
                 mockConfig.getProxySettings();
                 result = mockProxySettings;
@@ -1627,7 +1653,7 @@ public class HttpsIotHubConnectionTest
                 result = IotHubStatusCode.OK_EMPTY;
                 mockResponse.getHeaderField(withMatch("(?i)etag"));
                 result = eTag;
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
             }
         };
@@ -1641,7 +1667,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockRequest.setReadTimeoutMillis(expectedReadTimeoutMillis);
+                mockRequest.setReadTimeout(expectedReadTimeoutMillis);
             }
         };
     }
@@ -1746,7 +1772,7 @@ public class HttpsIotHubConnectionTest
                 result = IotHubStatusCode.OK_EMPTY;
                 mockResponse.getHeaderField(withMatch("(?i)etag"));
                 result = eTag;
-                mockConfig.getReadTimeoutMillis();
+                mockConfig.getHttpsReadTimeout();
                 result = readTimeoutMillis;
                 mockConfig.getSasTokenAuthentication().getSSLContext();
                 result = mockedContext;

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
@@ -496,7 +496,7 @@ public class HttpsRequestTest
 
         HttpsRequest request =
                 new HttpsRequest(mockUrl, httpsMethod, body, "");
-        request.setReadTimeoutMillis(readTimeout);
+        request.setReadTimeout(readTimeout);
 
         final int expectedReadTimeout = readTimeout;
 
@@ -504,7 +504,39 @@ public class HttpsRequestTest
         new Verifications()
         {
             {
-                mockConn.setReadTimeoutMillis(expectedReadTimeout);
+                mockConn.setReadTimeout(expectedReadTimeout);
+            }
+        };
+    }
+
+    @Test
+    public void setConnectTimeoutSetsConnectTimeout(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
+    {
+        final HttpsMethod httpsMethod = HttpsMethod.POST;
+        final byte[] body = new byte[0];
+        final int readTimeout = 1;
+        new NonStrictExpectations()
+        {
+            {
+                new HttpsConnection(mockUrl, httpsMethod, null);
+                result = mockConn;
+
+                mockUrl.getProtocol();
+                result = "https";
+            }
+        };
+
+        HttpsRequest request =
+                new HttpsRequest(mockUrl, httpsMethod, body, "");
+        request.setConnectTimeout(readTimeout);
+
+        final int expectedConnectTimeout = readTimeout;
+
+        request.send();
+        new Verifications()
+        {
+            {
+                mockConn.setConnectTimeout(expectedConnectTimeout);
             }
         };
     }


### PR DESCRIPTION
Customer's don't like how we originally hard coded the read timeout to 4 minutes, so let's make these levers available to the customer. This PR does not change the default behavior of the SDK, but it does allow users to set new values for the read and connect timeouts