### PR TITLE
fix(iot-dev): Upgrade mqtt Paho dependency version

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -47,12 +47,6 @@
             <version>0.23</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.qpid</groupId>
-            <artifactId>proton-j</artifactId>
-            <version>0.30.0</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
             <artifactId>${iot-deps-artifact-id}</artifactId>
             <version>${iot-deps-version}</version>
@@ -61,11 +55,6 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
             <version>8.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.paho</groupId>
-            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>


### PR DESCRIPTION
Fixes #596

Here are the release notes from this new Paho version: https://github.com/eclipse/paho.mqtt.java/releases/tag/v1.2.3