### PR TITLE
doc(all): Fix java devbox setup instructions

### DIFF
--- a/doc/java-devbox-setup.md
+++ b/doc/java-devbox-setup.md
@@ -136,7 +136,7 @@ Open a command prompt and use the following commands:
 	cd azure-iot-sdk-java/device
 	mvn install
 ```
-The compiled JAR file with all dependencies bundled in can then be found at:
+The compiled JAR file can then be found at:
 ```
 {IoT SDK for Java root}/device/iot-device-client/target/iot-device-client-{version}.jar
 ```


### PR DESCRIPTION
We don't have the shade plugin anymore, so this set of instructions shouldn't suggest that the compiled jars contain all dependencies

See #265 