### PR TITLE
fix(docs): Add the team as the owners to the code base

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owner for repo
-*   @prmathur @davilu @timtay-microsoft @jasmineymlo
+*   @prmathur-microsoft @timtay-microsoft @azabbasi @vinagesh @drwill-ms @abhipsaMirsa @bikamani @barustum


### PR DESCRIPTION
Adding the team members to the code owners 