### PR TITLE
fix(iot-dev): Fix issue with setOption for setting https settings

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -598,6 +598,8 @@ public final class DeviceClient extends InternalClient implements Closeable
             // Codes_SRS_DEVICECLIENT_02_016: ["SetMinimumPollingInterval" - time in milliseconds between 2 consecutive polls.]
             case SET_MINIMUM_POLLING_INTERVAL:
             case SET_RECEIVE_INTERVAL:
+            case SET_HTTPS_CONNECT_TIMEOUT:
+            case SET_HTTPS_READ_TIMEOUT:
             {
                 break;
             }


### PR DESCRIPTION
Worked for module clients, but not for device clients