### PR TITLE
release(2020-04-22): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2018-06-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.21.0";
+    private static final String CLIENT_VERSION = "1.21.1";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.21.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.21.1') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.21.0</iot-device-client-version>
+        <iot-device-client-version>1.21.1</iot-device-client-version>
         <iot-service-client-version>1.21.1</iot-service-client-version>
         <iot-deps-version>0.9.3</iot-deps-version>
         <provisioning-device-client-version>1.8.2</provisioning-device-client-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.21.1)
### Bug Fixes
- Fix bug where setOption API for setting https read and connect timeouts ("SetHttpsReadTimeout", "SetHttpsConnectTimeout") threw an exception


Pull Requests
#762

old
{
    "device": "1.21.0",
    "service": "1.21.1",
    "deps": "0.9.3",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.2",
    "provisioningService": "1.6.1"
}

new
{
    "device": "1.21.1",
    "service": "1.21.1",
    "deps": "0.9.3",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.2",
    "provisioningService": "1.6.1"
}