### PR TITLE
fix(iot-dev): Fix bug in amqpws, raise max message size from 1 kb to 16 kb

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>qpid-proton-j-extensions</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -63,7 +63,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
     //sending messages is done on reactor thread, but we don't want to hog that thread indefinitely, so there is a limit
     // on how many messages to send per reactor callback
     private final static int MAX_MESSAGES_TO_SEND_PER_CALLBACK = 1000;
-    private final static int MAX_MESSAGE_PAYLOAD_SIZE = 256*1000; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at least that much space
+    private final static int MAX_MESSAGE_PAYLOAD_SIZE = 256*1024; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at least that much space
     private final Boolean useWebSockets;
     private final Map<Integer, com.microsoft.azure.sdk.iot.device.Message> inProgressMessages = new ConcurrentHashMap<>();
     private final Map<com.microsoft.azure.sdk.iot.device.Message, AmqpsMessage> sendAckMessages = new ConcurrentHashMap<>();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -50,9 +50,6 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
     private static final int MAX_WAIT_TO_OPEN_WORKER_LINKS = 60 * 1000; // 60 second timeout
     private static final int MAX_WAIT_TO_TERMINATE_EXECUTOR = 30;
     private static final int SEND_MESSAGES_PERIOD_MILLIS = 50; //every 50 seconds, the method onTimerTask will fire to send queued messages
-    /**
-     * The {@link Delivery} tag.
-     */
     private static final String WEB_SOCKET_PATH = "/$iothub/websocket";
     private static final String WEB_SOCKET_SUB_PROTOCOL = "AMQPWSB10";
     private static final String WEBSOCKET_QUERY = "iothub-no-client-cert=true";
@@ -66,6 +63,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
     //sending messages is done on reactor thread, but we don't want to hog that thread indefinitely, so there is a limit
     // on how many messages to send per reactor callback
     private final static int MAX_MESSAGES_TO_SEND_PER_CALLBACK = 1000;
+    private final static int MAX_MESSAGE_PAYLOAD_SIZE = 256*1000; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at least that much space
     private final Boolean useWebSockets;
     private final Map<Integer, com.microsoft.azure.sdk.iot.device.Message> inProgressMessages = new ConcurrentHashMap<>();
     private final Map<com.microsoft.azure.sdk.iot.device.Message, AmqpsMessage> sendAckMessages = new ConcurrentHashMap<>();
@@ -572,7 +570,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
     private void addWebsocketLayer(Transport transport)
     {
         // Codes_SRS_AMQPSIOTHUBCONNECTION_25_049: [If websocket enabled the event handler shall configure the transport layer for websocket.]
-        WebSocketImpl webSocket = new WebSocketImpl();
+        WebSocketImpl webSocket = new WebSocketImpl(MAX_MESSAGE_PAYLOAD_SIZE);
         webSocket.configure(this.hostName, WEB_SOCKET_PATH, WEBSOCKET_QUERY, WEBSOCKET_PORT, WEB_SOCKET_SUB_PROTOCOL, null, null);
         ((TransportInternal) transport).addTransportLayer(webSocket);
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -1289,7 +1289,7 @@ public class AmqpsIotHubConnectionTest {
                 result = mockConnection;
                 mockConnection.getTransport();
                 result = mockTransportInternal;
-                new WebSocketImpl();
+                new WebSocketImpl(anyInt);
                 result = mockWebSocket;
                 mockWebSocket.configure(anyString, anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
                 mockTransportInternal.addTransportLayer(mockWebSocket);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -1252,7 +1252,7 @@ public class AmqpsIotHubConnectionTest {
                 result = mockConnection;
                 mockConnection.getTransport();
                 result = mockTransportInternal;
-                new WebSocketImpl();
+                new WebSocketImpl(anyInt);
                 result = mockWebSocket;
                 mockWebSocket.configure(anyString, anyString, anyString, anyInt, anyString, (Map<String, String>) any, (WebSocketHandler) any);
                 mockTransportInternal.addTransportLayer(mockWebSocket);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/iothub/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/iothub/SendMessagesCommon.java
@@ -50,6 +50,13 @@ public class SendMessagesCommon extends IotHubIntegrationTest
     //How many keys each message will cary.
     protected static final Integer NUM_KEYS_PER_MESSAGE = 3;
 
+    // Max IoT Hub message size is 256 kb, but that includes headers, not just payload
+    protected static final int MAX_MESSAGE_PAYLOAD_SIZE = 255*1000;
+
+    // https://github.com/Azure/azure-iot-sdk-java/issues/742
+    // Sending messages over 15 kb over AMQPS_WS causes the connection to drop, likely an issue with proton-j-extensions
+    protected static final int MAX_MESSAGE_PAYLOAD_SIZE_AMQPS_WS = 15*1000;
+
     // How much to wait until a message makes it to the server, in milliseconds
     protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60 * 1000;
 
@@ -62,6 +69,8 @@ public class SendMessagesCommon extends IotHubIntegrationTest
 
     //The messages to be sent in these tests. Some contain error injection messages surrounded by normal messages
     protected List<MessageAndResult> NORMAL_MESSAGES_TO_SEND = new ArrayList<>();
+    protected List<MessageAndResult> LARGE_MESSAGES_TO_SEND = new ArrayList<>();
+    protected List<MessageAndResult> LARGE_MESSAGES_TO_SEND_AMQPS_WS = new ArrayList<>();
     protected List<MessageAndResult> TCP_CONNECTION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> AMQP_CONNECTION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> AMQP_SESSION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
@@ -508,6 +517,8 @@ public class SendMessagesCommon extends IotHubIntegrationTest
          AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND = new ArrayList<>();
         AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND = new ArrayList<>();
         MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND = new ArrayList<>();
+        LARGE_MESSAGES_TO_SEND = new ArrayList<>();
+        LARGE_MESSAGES_TO_SEND_AMQPS_WS = new ArrayList<>();
 
         MessageAndResult normalMessageAndExpectedResult = new MessageAndResult(new Message("test message"), IotHubStatusCode.OK_EMPTY);
         for (int i = 0; i < NUM_MESSAGES_PER_CONNECTION; i++)
@@ -573,6 +584,8 @@ public class SendMessagesCommon extends IotHubIntegrationTest
             }
 
             NORMAL_MESSAGES_TO_SEND.add(new MessageAndResult(new Message("test message"), IotHubStatusCode.OK_EMPTY));
+            LARGE_MESSAGES_TO_SEND.add(new MessageAndResult(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE]), IotHubStatusCode.OK_EMPTY));
+            LARGE_MESSAGES_TO_SEND_AMQPS_WS.add(new MessageAndResult(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE_AMQPS_WS]), IotHubStatusCode.OK_EMPTY));
         }
     }
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/iothub/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/setup/iothub/SendMessagesCommon.java
@@ -51,7 +51,7 @@ public class SendMessagesCommon extends IotHubIntegrationTest
     protected static final Integer NUM_KEYS_PER_MESSAGE = 3;
 
     // Max IoT Hub message size is 256 kb, but that includes headers, not just payload
-    protected static final int MAX_MESSAGE_PAYLOAD_SIZE = 255*1000;
+    protected static final int MAX_MESSAGE_PAYLOAD_SIZE = 255*1024;
 
     // https://github.com/Azure/azure-iot-sdk-java/issues/742
     // Sending messages over 15 kb over AMQPS_WS causes the connection to drop, likely an issue with proton-j-extensions

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
@@ -70,6 +70,22 @@ public class SendMessagesTests extends SendMessagesCommon
     }
 
     @Test
+    public void sendLargestMessages() throws Exception
+    {
+        this.testInstance.setup();
+
+        if (this.testInstance.protocol == AMQPS_WS)
+        {
+            // AMQPS_WS still has a bug that limits message size to 16 kb. All other protocols can do 256 kb
+            IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, LARGE_MESSAGES_TO_SEND_AMQPS_WS, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+        }
+        else
+        {
+            IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, LARGE_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+        }
+    }
+
+    @Test
     public void sendMessagesWithUnusualApplicationProperties() throws Exception
     {
         this.testInstance.setup();


### PR DESCRIPTION
Max IoT Hub messsage size is 256 kb, so this is still a bug that you can only send 16 kb, but this is a good incremental change that will benefit customers

related to issue #742, but does not completely solve that issue. We'll need to continue investigating why amqps_ws still cannot send 256 kb messages