### PR TITLE
feat(iot-service): Add proxy support for service client operations

### DIFF
--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
@@ -126,8 +126,7 @@ public class RegistryManagerTests extends IotHubIntegrationTest
     {
         Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
         ProxyOptions proxyOptions = new ProxyOptions(testProxy);
-        RegistryManagerOptions registryManagerOptions = new RegistryManagerOptions();
-        registryManagerOptions.setProxyOptions(proxyOptions);
+        RegistryManagerOptions registryManagerOptions = RegistryManagerOptions.builder().proxyOptions(proxyOptions).build();
         RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance(registryManagerOptions);
 
         //-Create-//

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
@@ -67,7 +67,7 @@ public class RegistryManagerTests extends IotHubIntegrationTest
 
         public RegistryManagerTestInstance() throws InterruptedException, IOException, IotHubException, URISyntaxException
         {
-            this(null);
+            this(RegistryManagerOptions.builder().build());
         }
 
         public RegistryManagerTestInstance(RegistryManagerOptions options) throws InterruptedException, IOException, IotHubException, URISyntaxException

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
@@ -70,13 +70,13 @@ public class RegistryManagerTests extends IotHubIntegrationTest
             this(null);
         }
 
-        public RegistryManagerTestInstance(ProxyOptions proxyOptions) throws InterruptedException, IOException, IotHubException, URISyntaxException
+        public RegistryManagerTestInstance(RegistryManagerOptions options) throws InterruptedException, IOException, IotHubException, URISyntaxException
         {
             String uuid = UUID.randomUUID().toString();
             deviceId = deviceIdPrefix + uuid;
             moduleId = moduleIdPrefix + uuid;
             configId = configIdPrefix + uuid;
-            registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString, proxyOptions);
+            registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString, options);
         }
     }
 
@@ -126,7 +126,9 @@ public class RegistryManagerTests extends IotHubIntegrationTest
     {
         Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
         ProxyOptions proxyOptions = new ProxyOptions(testProxy);
-        RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance(proxyOptions);
+        RegistryManagerOptions registryManagerOptions = new RegistryManagerOptions();
+        registryManagerOptions.setProxyOptions(proxyOptions);
+        RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance(registryManagerOptions);
 
         //-Create-//
         Device deviceAdded = Device.createFromId(testInstance.deviceId, DeviceStatus.Enabled, null);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/RegistryManagerTests.java
@@ -67,11 +67,16 @@ public class RegistryManagerTests extends IotHubIntegrationTest
 
         public RegistryManagerTestInstance() throws InterruptedException, IOException, IotHubException, URISyntaxException
         {
+            this(null);
+        }
+
+        public RegistryManagerTestInstance(ProxyOptions proxyOptions) throws InterruptedException, IOException, IotHubException, URISyntaxException
+        {
             String uuid = UUID.randomUUID().toString();
             deviceId = deviceIdPrefix + uuid;
             moduleId = moduleIdPrefix + uuid;
             configId = configIdPrefix + uuid;
-            registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
+            registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString, proxyOptions);
         }
     }
 
@@ -119,9 +124,9 @@ public class RegistryManagerTests extends IotHubIntegrationTest
     @Test (timeout=MAX_TEST_MILLISECONDS)
     public void deviceLifecycleWithProxy() throws Exception
     {
-        RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance();
         Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-        testInstance.registryManager.setProxy(testProxy);
+        ProxyOptions proxyOptions = new ProxyOptions(testProxy);
+        RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance(proxyOptions);
 
         //-Create-//
         Device deviceAdded = Device.createFromId(testInstance.deviceId, DeviceStatus.Enabled, null);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
@@ -140,8 +140,7 @@ public class ServiceClientTests extends IotHubIntegrationTest
         {
             Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
             ProxyOptions proxyOptions = new ProxyOptions(testProxy);
-            serviceClientOptions = new ServiceClientOptions();
-            serviceClientOptions.setProxyOptions(proxyOptions);
+            serviceClientOptions = ServiceClientOptions.builder().proxyOptions(proxyOptions).build();
         }
 
         ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol, serviceClientOptions);

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
@@ -10,10 +10,16 @@ import com.microsoft.azure.sdk.iot.common.helpers.IotHubIntegrationTest;
 import com.microsoft.azure.sdk.iot.common.helpers.StandardTierOnlyRule;
 import com.microsoft.azure.sdk.iot.common.helpers.Tools;
 import com.microsoft.azure.sdk.iot.service.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +40,10 @@ public class ServiceClientTests extends IotHubIntegrationTest
     private static String deviceIdPrefix = "java-service-client-e2e-test";
     private static String content = "abcdefghijklmnopqrstuvwxyz1234567890";
     private static String hostName;
+
+    protected static HttpProxyServer proxyServer;
+    protected static String testProxyHostname = "127.0.0.1";
+    protected static int testProxyPort = 8869;
 
     private static final long MAX_TEST_MILLISECONDS = 1 * 60 * 1000;
 
@@ -75,9 +85,42 @@ public class ServiceClientTests extends IotHubIntegrationTest
         return inputs;
     }
 
+    @BeforeClass
+    public static void startProxy()
+    {
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                        .withPort(testProxyPort)
+                        .start();
+    }
+
+
+    @AfterClass
+    public static void stopProxy()
+    {
+        proxyServer.stop();
+    }
+
     @Test (timeout=MAX_TEST_MILLISECONDS)
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void cloudToDeviceTelemetry() throws Exception
+    {
+        cloudToDeviceTelemetry(false);
+    }
+
+    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
+    public void cloudToDeviceTelemetryWithProxy() throws Exception
+    {
+        if (testInstance.protocol != IotHubServiceClientProtocol.AMQPS_WS)
+        {
+            //Proxy support only exists for AMQPS_WS currently
+            return;
+        }
+
+        cloudToDeviceTelemetry(true);
+    }
+
+    public void cloudToDeviceTelemetry(boolean withProxy) throws Exception
     {
         // Arrange
 
@@ -92,7 +135,14 @@ public class ServiceClientTests extends IotHubIntegrationTest
         // Act
 
         // Create service client
-        ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol);
+        ProxyOptions proxyOptions = null;
+        if (withProxy)
+        {
+            Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
+            proxyOptions = new ProxyOptions(testProxy);
+        }
+
+        ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol, proxyOptions);
         CompletableFuture<Void> futureOpen = serviceClient.openAsync();
         futureOpen.get();
 

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
@@ -135,13 +135,14 @@ public class ServiceClientTests extends IotHubIntegrationTest
         // Act
 
         // Create service client
-        ServiceClientOptions serviceClientOptions = null;
+        ProxyOptions proxyOptions = null;
         if (withProxy)
         {
             Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-            ProxyOptions proxyOptions = new ProxyOptions(testProxy);
-            serviceClientOptions = ServiceClientOptions.builder().proxyOptions(proxyOptions).build();
+            proxyOptions = new ProxyOptions(testProxy);
         }
+
+        ServiceClientOptions serviceClientOptions = ServiceClientOptions.builder().proxyOptions(proxyOptions).build();
 
         ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol, serviceClientOptions);
         CompletableFuture<Void> futureOpen = serviceClient.openAsync();

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/serviceclient/ServiceClientTests.java
@@ -135,14 +135,16 @@ public class ServiceClientTests extends IotHubIntegrationTest
         // Act
 
         // Create service client
-        ProxyOptions proxyOptions = null;
+        ServiceClientOptions serviceClientOptions = null;
         if (withProxy)
         {
             Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-            proxyOptions = new ProxyOptions(testProxy);
+            ProxyOptions proxyOptions = new ProxyOptions(testProxy);
+            serviceClientOptions = new ServiceClientOptions();
+            serviceClientOptions.setProxyOptions(proxyOptions);
         }
 
-        ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol, proxyOptions);
+        ServiceClient serviceClient = ServiceClient.createFromConnectionString(iotHubConnectionString, testInstance.protocol, serviceClientOptions);
         CompletableFuture<Void> futureOpen = serviceClient.openAsync();
         futureOpen.get();
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
@@ -56,8 +56,6 @@ public class FeedbackReceiver extends Receiver
             throw new IllegalArgumentException("deviceId cannot be null or empty");
         }
         
-               
-        
         // Codes_SRS_SERVICE_SDK_JAVA_FEEDBACKRECEIVER_12_002: [The constructor shall store deviceId]
         this.deviceId = deviceId;
         // Codes_SRS_SERVICE_SDK_JAVA_FEEDBACKRECEIVER_12_003: [The constructor shall create a new instance of AmqpReceive object]
@@ -72,11 +70,26 @@ public class FeedbackReceiver extends Receiver
      * @param userName The iot hub user name
      * @param sasToken The iot hub SAS token for the given device
      * @param iotHubServiceClientProtocol protocol to be used
-     * 
+     *
      */
     public FeedbackReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
-        // Codes_SRS_SERVICE_SDK_JAVA_FEEDBACKRECEIVER_12_001: [The constructor shall throw IllegalArgumentException if any the input string is null or empty]
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, (ProxyOptions) null);
+    }
+
+    /**
+     * Constructor to verify initialization parameters
+     * Create instance of AmqpReceive
+     *
+     * @param hostName The iot hub host name
+     * @param userName The iot hub user name
+     * @param sasToken The iot hub SAS token for the given device
+     * @param iotHubServiceClientProtocol protocol to be used
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * 
+     */
+    public FeedbackReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
         if (Tools.isNullOrEmpty(hostName))
         {
             throw new IllegalArgumentException("hostName cannot be null or empty");
@@ -96,7 +109,7 @@ public class FeedbackReceiver extends Receiver
         }
                 
         // Codes_SRS_SERVICE_SDK_JAVA_FEEDBACKRECEIVER_12_003: [The constructor shall create a new instance of AmqpReceive object]
-        this.amqpReceive = new AmqpReceive(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        this.amqpReceive = new AmqpReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
     }
         
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
@@ -30,7 +30,20 @@ public class FileUploadNotificationReceiver extends Receiver
      */
     FileUploadNotificationReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
-        // Codes_SRS_SERVICE_SDK_JAVA_FILEUPLOADNOTIFICATIONRECEIVER_25_001: [** The constructor shall throw IllegalArgumentException if any the input string is null or empty **]**
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Constructor to verify initialization parameters
+     * Create instance of AmqpReceive
+     * @param hostName The iot hub host name
+     * @param userName The iot hub user name
+     * @param sasToken The iot hub SAS token for the given device
+     * @param iotHubServiceClientProtocol The iot hub protocol name
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    FileUploadNotificationReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
         if (Tools.isNullOrEmpty(hostName))
         {
             throw new IllegalArgumentException("hostName cannot be null or empty");
@@ -49,7 +62,7 @@ public class FileUploadNotificationReceiver extends Receiver
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_FILEUPLOADNOTIFICATIONRECEIVER_25_002: [** The constructor shall create a new instance of AmqpFileUploadNotificationReceive object **]**
-        this.amqpFileUploadNotificationReceive = new AmqpFileUploadNotificationReceive(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        this.amqpFileUploadNotificationReceive = new AmqpFileUploadNotificationReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ProxyOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ProxyOptions.java
@@ -1,0 +1,67 @@
+package com.microsoft.azure.sdk.iot.service;
+
+import lombok.Getter;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+/**
+ * The settings supported by this SDK when communicating to IoT Hub through a proxy. HTTP proxies are supported by this SDK,
+ * but only if the proxy does not require authentication.
+ */
+public class ProxyOptions
+{
+    @Getter
+    private Proxy proxy;
+
+    /**
+     * Create the proxy options for connecting to a proxy
+     * @param proxy the proxy to communicate through
+     */
+    public ProxyOptions(Proxy proxy)
+    {
+        if (proxy == null)
+        {
+            throw new IllegalArgumentException("Proxy cannot be null");
+        }
+
+        if (proxy.type() != Proxy.Type.HTTP)
+        {
+            throw new IllegalArgumentException("Service proxy options only support using HTTP proxies");
+        }
+
+        this.proxy = proxy;
+    }
+
+    /**
+     * @return the saved proxy hostname
+     */
+    public String getHostName()
+    {
+        if (this.proxy.address() instanceof InetSocketAddress)
+        {
+            InetSocketAddress addr = (InetSocketAddress) this.proxy.address();
+            return addr.getHostName();
+        }
+        else
+        {
+            //Should only happen if proxy is of type DIRECT, which isn't supported
+            throw new UnsupportedOperationException("Unsupported proxy type, could not get host name. Proxy address was not an instance of java.net.InetSocketAddress.");
+        }
+    }
+
+    public int getPort()
+    {
+        if (this.proxy.address() instanceof InetSocketAddress)
+        {
+            InetSocketAddress addr = (InetSocketAddress) this.proxy.address();
+            return addr.getPort();
+        }
+        else
+        {
+            //Should only happen if proxy is of type DIRECT, which isn't supported
+            throw new UnsupportedOperationException("Unsupported proxy type, could not get port. Proxy address was not an instance of java.net.InetSocketAddress.");
+        }
+    }
+}
+

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -23,6 +23,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -1612,7 +1613,13 @@ public class RegistryManager
 
     private HttpRequest CreateRequest(URL url, HttpMethod method, byte[] payload, String sasToken) throws IOException
     {
-        HttpRequest request = new HttpRequest(url, method, payload, this.options != null && this.options.getProxyOptions() != null ? this.options.getProxyOptions().getProxy() : null);
+        Proxy proxy = null;
+        if (this.options != null && this.options.getProxyOptions() != null)
+        {
+            proxy = this.options.getProxyOptions().getProxy();
+        }
+
+        HttpRequest request = new HttpRequest(url, method, payload, proxy);
         request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
         request.setHeaderField("authorization", sasToken);
         request.setHeaderField("Request-Id", "1001");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -44,6 +44,10 @@ public class RegistryManager
 
     private RegistryManagerOptions options;
 
+    /**
+     * As of release 1.22.0, replaced by {@link #createFromConnectionString()}
+     */
+    @Deprecated
     public RegistryManager()
     {
         options = RegistryManagerOptions.builder().build();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -53,7 +53,7 @@ public class RegistryManager
      */
     public static RegistryManager createFromConnectionString(String connectionString) throws IOException
     {
-        return createFromConnectionString(connectionString, null);
+        return createFromConnectionString(connectionString, RegistryManagerOptions.builder().build());
     }
 
     /**
@@ -1614,7 +1614,7 @@ public class RegistryManager
     private HttpRequest CreateRequest(URL url, HttpMethod method, byte[] payload, String sasToken) throws IOException
     {
         Proxy proxy = null;
-        if (this.options != null && this.options.getProxyOptions() != null)
+        if (this.options.getProxyOptions() != null)
         {
             proxy = this.options.getProxyOptions().getProxy();
         }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -44,6 +44,11 @@ public class RegistryManager
 
     private RegistryManagerOptions options;
 
+    public RegistryManager()
+    {
+        options = RegistryManagerOptions.builder().build();
+    }
+
     /**
      * Static constructor to create instance from connection string
      *

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -45,11 +45,15 @@ public class RegistryManager
     private RegistryManagerOptions options;
 
     /**
-     * As of release 1.22.0, replaced by {@link #createFromConnectionString()}
+     * Previously was the java default constructor, should not be used.
+     *
+     * @deprecated As of release 1.22.0, replaced by {@link #createFromConnectionString(String)}
      */
     @Deprecated
     public RegistryManager()
     {
+        // This constructor was previously a default constructor that users could use because there was no other constructor declared.
+        // However, we still prefer users use the createFromConnectionString method to build their clients.
         options = RegistryManagerOptions.builder().build();
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -41,7 +41,7 @@ public class RegistryManager
     private ExecutorService executor;
     private IotHubConnectionString iotHubConnectionString;
 
-    private ProxyOptions proxyOptions;
+    private RegistryManagerOptions options;
 
     /**
      * Static constructor to create instance from connection string
@@ -59,11 +59,11 @@ public class RegistryManager
      * Static constructor to create instance from connection string
      *
      * @param connectionString The iot hub connection string
-     * @param proxyOptions The proxy options to use when connecting to the service. May be null if no proxy will be used.
+     * @param options The connection options to use when connecting to the service. May be null if no custom options will be used.
      * @return The instance of RegistryManager
      * @throws IOException This exception is thrown if the object creation failed
      */
-    public static RegistryManager createFromConnectionString(String connectionString, ProxyOptions proxyOptions) throws IOException
+    public static RegistryManager createFromConnectionString(String connectionString, RegistryManagerOptions options) throws IOException
     {
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_001: [The constructor shall throw IllegalArgumentException if the input string is null or empty]
         if (Tools.isNullOrEmpty(connectionString))
@@ -80,7 +80,7 @@ public class RegistryManager
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_34_090: [The function shall start this object's executor service]
         iotHubRegistryManager.executor = Executors.newFixedThreadPool(EXECUTOR_THREAD_POOL_SIZE);
 
-        iotHubRegistryManager.proxyOptions = proxyOptions;
+        iotHubRegistryManager.options = options;
 
         return iotHubRegistryManager;
     }
@@ -1612,7 +1612,7 @@ public class RegistryManager
 
     private HttpRequest CreateRequest(URL url, HttpMethod method, byte[] payload, String sasToken) throws IOException
     {
-        HttpRequest request = new HttpRequest(url, method, payload, this.proxyOptions != null ? this.proxyOptions.getProxy() : null);
+        HttpRequest request = new HttpRequest(url, method, payload, this.options != null && this.options.getProxyOptions() != null ? this.options.getProxyOptions().getProxy() : null);
         request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
         request.setHeaderField("authorization", sasToken);
         request.setHeaderField("Request-Id", "1001");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -84,6 +84,12 @@ public class RegistryManager
         {
             throw new IllegalArgumentException("The provided connection string cannot be null or empty");
         }
+
+        if (options == null)
+        {
+            throw new IllegalArgumentException("RegistryManagerOptions cannot be null for this constructor");
+        }
+
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_002: [The constructor shall create an IotHubConnectionString object from the given connection string]
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -2,7 +2,6 @@ package com.microsoft.azure.sdk.iot.service;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Configurable options for all registry manager operations

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -1,17 +1,18 @@
 package com.microsoft.azure.sdk.iot.service;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * Configurable options for all registry manager operations
  */
+@Builder
 public class RegistryManagerOptions
 {
     /**
      * The options that specify what proxy to tunnel through. If null, no proxy will be used
      */
     @Getter
-    @Setter
     private ProxyOptions proxyOptions;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -1,0 +1,17 @@
+package com.microsoft.azure.sdk.iot.service;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configurable options for all registry manager operations
+ */
+public class RegistryManagerOptions
+{
+    /**
+     * The options that specify what proxy to tunnel through. If null, no proxy will be used
+     */
+    @Getter
+    @Setter
+    private ProxyOptions proxyOptions;
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -280,7 +280,7 @@ public class ServiceClient
     
      public FeedbackReceiver getFeedbackReceiver()
     {
-        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
+        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions());
     }
 
     /**
@@ -290,7 +290,7 @@ public class ServiceClient
      */
     public FileUploadNotificationReceiver getFileUploadNotificationReceiver()
     {
-        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
+        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions());
     }
     
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -30,7 +30,7 @@ public class ServiceClient
     protected IotHubConnectionString iotHubConnectionString;
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
 
-    private ProxyOptions proxyOptions;
+    private ServiceClientOptions options;
 
     /**
      * Create ServiceClient from the specified connection string
@@ -48,11 +48,11 @@ public class ServiceClient
      * Create ServiceClient from the specified connection string
      * @param iotHubServiceClientProtocol  protocol to use
      * @param connectionString The connection string for the IotHub
-     * @param proxyOptions The proxy options to use when connecting to the service. May be null if no proxy will be used.
+     * @param options The connection options to use when connecting to the service. May be null if no custom options will be used.
      * @return The created ServiceClient object
      * @throws IOException This exception is thrown if the object creation failed
      */
-    public static ServiceClient createFromConnectionString(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions) throws IOException
+    public static ServiceClient createFromConnectionString(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ServiceClientOptions options) throws IOException
     {
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_001: [The constructor shall throw IllegalArgumentException if the input string is empty or null]
         if (Tools.isNullOrEmpty(connectionString))
@@ -64,7 +64,7 @@ public class ServiceClient
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_003: [The constructor shall create a new instance of ServiceClient using the created IotHubConnectionString object and return with it]
-        ServiceClient iotServiceClient = new ServiceClient(iotHubConnectionString, iotHubServiceClientProtocol, proxyOptions);
+        ServiceClient iotServiceClient = new ServiceClient(iotHubConnectionString, iotHubServiceClientProtocol, options);
         return iotServiceClient;
     }
 
@@ -85,7 +85,7 @@ public class ServiceClient
      * @param iotHubConnectionString The ConnectionString object for the IotHub
      * @param iotHubServiceClientProtocol protocol to use
      */
-    protected ServiceClient(IotHubConnectionString iotHubConnectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    protected ServiceClient(IotHubConnectionString iotHubConnectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ServiceClientOptions options)
     {
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_004: [The constructor shall throw IllegalArgumentException if the input object is null]
         if (iotHubConnectionString == null)
@@ -102,15 +102,15 @@ public class ServiceClient
         this.userName = iotHubConnectionString.getUserString();
         this.sasToken = iotHubServiceSasToken.toString();
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
-        this.proxyOptions = proxyOptions;
+        this.options = options;
 
-        if (this.proxyOptions != null && this.proxyOptions.getProxy() != null && this.iotHubServiceClientProtocol != IotHubServiceClientProtocol.AMQPS_WS)
+        if (this.options != null && this.options.getProxyOptions() != null && this.iotHubServiceClientProtocol != IotHubServiceClientProtocol.AMQPS_WS)
         {
             throw new UnsupportedOperationException("Proxies are only supported over AMQPS_WS");
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_007: [The constructor shall create a new instance of AmqpSend object]
-        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, proxyOptions);
+        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
     }
 
     /**
@@ -261,7 +261,7 @@ public class ServiceClient
      */
     @Deprecated public FeedbackReceiver getFeedbackReceiver(String deviceId)
     {
-        if (proxyOptions != null)
+        if (options != null)
         {
             throw new UnsupportedOperationException("This deprecated API does not support proxies. Use the non-deprecated version of this API for proxy enabled feedback receiving");
         }
@@ -280,7 +280,7 @@ public class ServiceClient
     
      public FeedbackReceiver getFeedbackReceiver()
     {
-        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
     }
 
     /**
@@ -290,7 +290,7 @@ public class ServiceClient
      */
     public FileUploadNotificationReceiver getFileUploadNotificationReceiver()
     {
-        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
     }
     
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -30,6 +30,8 @@ public class ServiceClient
     protected IotHubConnectionString iotHubConnectionString;
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
 
+    private ProxyOptions proxyOptions;
+
     /**
      * Create ServiceClient from the specified connection string
      * @param iotHubServiceClientProtocol  protocol to use
@@ -38,6 +40,19 @@ public class ServiceClient
      * @throws IOException This exception is thrown if the object creation failed
      */
     public static ServiceClient createFromConnectionString(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol) throws IOException
+    {
+        return createFromConnectionString(connectionString, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Create ServiceClient from the specified connection string
+     * @param iotHubServiceClientProtocol  protocol to use
+     * @param connectionString The connection string for the IotHub
+     * @param proxyOptions The proxy options to use when connecting to the service. May be null if no proxy will be used.
+     * @return The created ServiceClient object
+     * @throws IOException This exception is thrown if the object creation failed
+     */
+    public static ServiceClient createFromConnectionString(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions) throws IOException
     {
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_001: [The constructor shall throw IllegalArgumentException if the input string is empty or null]
         if (Tools.isNullOrEmpty(connectionString))
@@ -49,7 +64,7 @@ public class ServiceClient
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_003: [The constructor shall create a new instance of ServiceClient using the created IotHubConnectionString object and return with it]
-        ServiceClient iotServiceClient = new ServiceClient(iotHubConnectionString, iotHubServiceClientProtocol);
+        ServiceClient iotServiceClient = new ServiceClient(iotHubConnectionString, iotHubServiceClientProtocol, proxyOptions);
         return iotServiceClient;
     }
 
@@ -60,6 +75,17 @@ public class ServiceClient
      * @param iotHubServiceClientProtocol protocol to use
      */
     protected ServiceClient(IotHubConnectionString iotHubConnectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol)
+    {
+        this(iotHubConnectionString, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Initialize AMQP sender using given connection string
+     *
+     * @param iotHubConnectionString The ConnectionString object for the IotHub
+     * @param iotHubServiceClientProtocol protocol to use
+     */
+    protected ServiceClient(IotHubConnectionString iotHubConnectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_004: [The constructor shall throw IllegalArgumentException if the input object is null]
         if (iotHubConnectionString == null)
@@ -76,9 +102,15 @@ public class ServiceClient
         this.userName = iotHubConnectionString.getUserString();
         this.sasToken = iotHubServiceSasToken.toString();
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
+        this.proxyOptions = proxyOptions;
+
+        if (this.proxyOptions != null && this.proxyOptions.getProxy() != null && this.iotHubServiceClientProtocol != IotHubServiceClientProtocol.AMQPS_WS)
+        {
+            throw new UnsupportedOperationException("Proxies are only supported over AMQPS_WS");
+        }
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_007: [The constructor shall create a new instance of AmqpSend object]
-        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol);
+        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, proxyOptions);
     }
 
     /**
@@ -229,6 +261,11 @@ public class ServiceClient
      */
     @Deprecated public FeedbackReceiver getFeedbackReceiver(String deviceId)
     {
+        if (proxyOptions != null)
+        {
+            throw new UnsupportedOperationException("This deprecated API does not support proxies. Use the non-deprecated version of this API for proxy enabled feedback receiving");
+        }
+
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_017: [The function shall create a FeedbackReceiver object and returns with it. This API is deprecated.]
         FeedbackReceiver feedbackReceiver = new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, deviceId);
         return feedbackReceiver;
@@ -243,7 +280,7 @@ public class ServiceClient
     
      public FeedbackReceiver getFeedbackReceiver()
     {
-        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
     }
 
     /**
@@ -253,7 +290,7 @@ public class ServiceClient
      */
     public FileUploadNotificationReceiver getFileUploadNotificationReceiver()
     {
-        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
     }
     
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -41,7 +41,7 @@ public class ServiceClient
      */
     public static ServiceClient createFromConnectionString(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol) throws IOException
     {
-        return createFromConnectionString(connectionString, iotHubServiceClientProtocol, null);
+        return createFromConnectionString(connectionString, iotHubServiceClientProtocol, ServiceClientOptions.builder().build());
     }
 
     /**
@@ -76,7 +76,7 @@ public class ServiceClient
      */
     protected ServiceClient(IotHubConnectionString iotHubConnectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
-        this(iotHubConnectionString, iotHubServiceClientProtocol, null);
+        this(iotHubConnectionString, iotHubServiceClientProtocol, ServiceClientOptions.builder().build());
     }
 
     /**
@@ -104,20 +104,13 @@ public class ServiceClient
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.options = options;
 
-        if (this.options != null && this.options.getProxyOptions() != null && this.iotHubServiceClientProtocol != IotHubServiceClientProtocol.AMQPS_WS)
+        if (this.options.getProxyOptions() != null && this.iotHubServiceClientProtocol != IotHubServiceClientProtocol.AMQPS_WS)
         {
             throw new UnsupportedOperationException("Proxies are only supported over AMQPS_WS");
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_007: [The constructor shall create a new instance of AmqpSend object]
-        if (options != null)
-        {
-            this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, options.getProxyOptions());
-        }
-        else
-        {
-            this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol);
-        }
+        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, options.getProxyOptions());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -110,7 +110,14 @@ public class ServiceClient
         }
 
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_007: [The constructor shall create a new instance of AmqpSend object]
-        this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, options != null ? options.getProxyOptions() : null);
+        if (options != null)
+        {
+            this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol, options.getProxyOptions());
+        }
+        else
+        {
+            this.amqpMessageSender = new AmqpSend(hostName, userName, sasToken, this.iotHubServiceClientProtocol);
+        }
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -60,6 +60,11 @@ public class ServiceClient
             throw new IllegalArgumentException(connectionString);
         }
 
+        if (options == null)
+        {
+            throw new IllegalArgumentException("ServiceClientOptions cannot be null for this constructor");
+        }
+
         // Codes_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_002: [The constructor shall create IotHubConnectionString object using the IotHubConnectionStringBuilder]
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -261,7 +261,7 @@ public class ServiceClient
      */
     @Deprecated public FeedbackReceiver getFeedbackReceiver(String deviceId)
     {
-        if (options != null)
+        if (options.getProxyOptions() != null)
         {
             throw new UnsupportedOperationException("This deprecated API does not support proxies. Use the non-deprecated version of this API for proxy enabled feedback receiving");
         }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -1,17 +1,18 @@
 package com.microsoft.azure.sdk.iot.service;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * Configurable options for all service client operations
  */
+@Builder
 public class ServiceClientOptions
 {
     /**
      * The options that specify what proxy to tunnel through. If null, no proxy will be used
      */
     @Getter
-    @Setter
     private ProxyOptions proxyOptions;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -2,7 +2,6 @@ package com.microsoft.azure.sdk.iot.service;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Configurable options for all service client operations

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -1,0 +1,17 @@
+package com.microsoft.azure.sdk.iot.service;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configurable options for all service client operations
+ */
+public class ServiceClientOptions
+{
+    /**
+     * The options that specify what proxy to tunnel through. If null, no proxy will be used
+     */
+    @Getter
+    @Setter
+    private ProxyOptions proxyOptions;
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
@@ -5,10 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.transport.amqps;
 
-import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
-import com.microsoft.azure.sdk.iot.deps.transport.amqp.ErrorLoggingBaseHandler;
-import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
@@ -16,13 +14,10 @@ import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Released;
 import org.apache.qpid.proton.amqp.messaging.Source;
-import org.apache.qpid.proton.amqp.messaging.Target;
 import org.apache.qpid.proton.engine.*;
-import org.apache.qpid.proton.engine.impl.TransportInternal;
 import org.apache.qpid.proton.reactor.FlowController;
 import org.apache.qpid.proton.reactor.Handshaker;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,6 +37,7 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
     private AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent;
     private Receiver feedbackReceiverLink;
 
+
     /**
      * Constructor to set up connection parameters and initialize
      * handshaker and flow controller for transport
@@ -53,7 +49,22 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
      */
     public AmqpFeedbackReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize
+     * handshaker and flow controller for transport
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    public AmqpFeedbackReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
 
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
@@ -8,10 +8,10 @@ package com.microsoft.azure.sdk.iot.service.transport.amqps;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadNotificationParser;
 import com.microsoft.azure.sdk.iot.service.FileUploadNotification;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * Instance of the QPID-Proton-J BaseHandler class
@@ -27,6 +27,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
     private AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler;
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
     private FileUploadNotification fileUploadNotification;
+    private ProxyOptions proxyOptions;
 
     /**
      * Constructor to set up connection parameters
@@ -37,11 +38,25 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
      */
     public AmqpFileUploadNotificationReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    public AmqpFileUploadNotificationReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
         // Codes_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVE_25_001: [The constructor shall copy all input parameters to private member variables for event processing]
         this.hostName = hostName;
         this.userName = userName;
         this.sasToken = sasToken;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
+        this.proxyOptions = proxyOptions;
     }
 
     /**
@@ -53,7 +68,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
         // Codes_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVE_25_003: [The function shall create an AmqpsReceiveHandler object to handle reactor events]
         if (amqpReceiveHandler == null)
         {
-            amqpReceiveHandler = new AmqpFileUploadNotificationReceivedHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this);
+            amqpReceiveHandler = new AmqpFileUploadNotificationReceivedHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this, this.proxyOptions);
         }
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
@@ -5,21 +5,20 @@
 
 package com.microsoft.azure.sdk.iot.service.transport.amqps;
 
-import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
-import com.microsoft.azure.sdk.iot.deps.transport.amqp.ErrorLoggingBaseHandler;
-import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.messaging.*;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.engine.*;
-import org.apache.qpid.proton.engine.impl.TransportInternal;
 import org.apache.qpid.proton.reactor.FlowController;
 import org.apache.qpid.proton.reactor.Handshaker;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,7 +48,21 @@ public class AmqpFileUploadNotificationReceivedHandler extends AmqpConnectionHan
      */
     AmqpFileUploadNotificationReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize
+     * handshaker and flow controller for transport
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    AmqpFileUploadNotificationReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
 
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.service.transport.amqps;
 import com.microsoft.azure.sdk.iot.service.FeedbackBatch;
 import com.microsoft.azure.sdk.iot.service.FeedbackBatchMessage;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
     private AmqpFeedbackReceivedHandler amqpReceiveHandler;
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
     private FeedbackBatch feedbackBatch;
+    private ProxyOptions proxyOptions;
 
     /**
      * Constructor to set up connection parameters
@@ -36,11 +38,25 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      */
     public AmqpReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    public AmqpReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
         // Codes_SRS_SERVICE_SDK_JAVA_AMQPRECEIVE_12_001: [The constructor shall copy all input parameters to private member variables for event processing]
         this.hostName = hostName;
         this.userName = userName;
         this.sasToken = sasToken;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
+        this.proxyOptions = proxyOptions;
     }
 
     /**
@@ -48,7 +64,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      */
     public void open()
     {
-        amqpReceiveHandler = new AmqpFeedbackReceivedHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this);
+        amqpReceiveHandler = new AmqpFeedbackReceivedHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this, this.proxyOptions);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.service.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.Message;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ public class AmqpSend
     protected final String sasToken;
     protected AmqpSendHandler amqpSendHandler;
     protected IotHubServiceClientProtocol iotHubServiceClientProtocol;
+    private ProxyOptions proxyOptions;
 
     /**
      * Constructor to set up connection parameters
@@ -37,7 +39,19 @@ public class AmqpSend
      */
     public AmqpSend(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    public AmqpSend(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
         if (Tools.isNullOrEmpty(hostName))
         {
             throw new IllegalArgumentException("hostName can not be null or empty");
@@ -50,17 +64,17 @@ public class AmqpSend
         {
             throw new IllegalArgumentException("sasToken can not be null or empty");
         }
-        
+
         if (iotHubServiceClientProtocol == null)
         {
             throw new IllegalArgumentException("iotHubServiceClientProtocol cannot be null");
         }
 
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_002: [The constructor shall copy all input parameters to private member variables for event processing]
         this.hostName = hostName;
         this.userName = userName;
         this.sasToken = sasToken;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
+        this.proxyOptions = proxyOptions;
     }
 
     /**
@@ -69,7 +83,7 @@ public class AmqpSend
     public void open()
     {
         // Codes_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_004: [The function shall create an AmqpsSendHandler object to handle reactor events]
-        amqpSendHandler = new AmqpSendHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol);
+        amqpSendHandler = new AmqpSendHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this.proxyOptions);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.sdk.iot.service.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +45,6 @@ public class AmqpSendHandler extends AmqpConnectionHandler
 
     private int nextTag = 0;
 
-
     /**
      * Constructor to set up connection parameters and initialize handshaker for transport
      *
@@ -55,7 +55,21 @@ public class AmqpSendHandler extends AmqpConnectionHandler
      */
     public AmqpSendHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize handshaker for transport
+     *
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     */
+    public AmqpSendHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
         add(new Handshaker());
     }
 

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiverTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiverTest.java
@@ -5,6 +5,7 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service;
 
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.FileUploadNotification;
 import com.microsoft.azure.sdk.iot.service.FileUploadNotificationReceiver;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
@@ -21,6 +22,9 @@ public class FileUploadNotificationReceiverTest
 {
     @Mocked
     AmqpFileUploadNotificationReceive amqpFileUploadNotificationReceive;
+    
+    @Mocked
+    ProxyOptions mockedProxyOptions;
 
     // Tests_SRS_SERVICE_SDK_JAVA_FILEUPLOADNOTIFICATIONRECEIVER_25_001: [** The constructor shall throw IllegalArgumentException if any the input string is null or empty **]**
     // Assert
@@ -33,7 +37,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Assert
@@ -46,7 +50,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Assert
@@ -59,7 +63,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = null;
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Assert
@@ -72,7 +76,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = null;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
     
   
@@ -86,7 +90,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Assert
@@ -99,7 +103,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Assert
@@ -112,7 +116,7 @@ public class FileUploadNotificationReceiverTest
         final String sasToken = "";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_FILEUPLOADNOTIFICATIONRECEIVER_25_002: [** The constructor shall create a new instance of AmqpFileUploadNotificationReceive object **]**
@@ -126,12 +130,12 @@ public class FileUploadNotificationReceiverTest
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
 
         // Act
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         new Verifications()
         {
             {
-                new AmqpFileUploadNotificationReceive(anyString, anyString, anyString, iotHubServiceClientProtocol);
+                new AmqpFileUploadNotificationReceive(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
                 times = 1;
 
             }
@@ -147,7 +151,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         fileUploadNotificationReceiver.open();
@@ -171,7 +175,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         fileUploadNotificationReceiver.close();
@@ -195,7 +199,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         fileUploadNotificationReceiver.receive();
@@ -221,7 +225,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
         Deencapsulation.setField(fileUploadNotificationReceiver, "amqpFileUploadNotificationReceive", null);
         // Act
         fileUploadNotificationReceiver.receive(timeoutMs);
@@ -237,7 +241,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         fileUploadNotificationReceiver.receive(timeoutMs);
@@ -261,7 +265,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         CompletableFuture<Void> completableFuture = fileUploadNotificationReceiver.openAsync();
@@ -288,7 +292,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         CompletableFuture<Void> completableFuture = fileUploadNotificationReceiver.closeAsync();
@@ -315,7 +319,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
 
         // Act
         CompletableFuture<FileUploadNotification> completableFuture = fileUploadNotificationReceiver.receiveAsync();
@@ -343,7 +347,7 @@ public class FileUploadNotificationReceiverTest
         final String userName = "xxx";
         final String sasToken = "xxx";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol);
+        FileUploadNotificationReceiver fileUploadNotificationReceiver = Deencapsulation.newInstance(FileUploadNotificationReceiver.class, hostName, userName, sasToken, iotHubServiceClientProtocol, mockedProxyOptions);
         // Act
         CompletableFuture<FileUploadNotification> completableFuture = fileUploadNotificationReceiver.receiveAsync(timeoutMs);
         completableFuture.get();

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -1084,21 +1084,21 @@ public class RegistryManagerTest
     // Tests_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_058: [The function shall verify the response status and throw proper Exception]
     // Tests_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_059: [The function shall create a new RegistryStatistics object from the response and return with it]
     @Test
-    public void getStatistics_good_case(@Mocked Proxy mockProxy) throws Exception
+    public void getStatistics_good_case(@Mocked Proxy mockProxy, @Mocked ProxyOptions mockProxyOptions) throws Exception
     {
         String connectionString = "HostName=aaa.bbb.ccc;SharedAccessKeyName=XXX;SharedAccessKey=YYY";
         String deviceId = "somedevice";
 
         commonExpectations(connectionString, deviceId);
 
-        RegistryManager registryManager = RegistryManager.createFromConnectionString(connectionString);
-        registryManager.setProxy(mockProxy);
-        RegistryStatistics statistics = registryManager.getStatistics();
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(connectionString, mockProxyOptions);
 
-        new VerificationsInOrder()
+        new Expectations()
         {
             {
                 iotHubConnectionString.getUrlDeviceStatistics();
+                mockProxyOptions.getProxy();
+                result = mockProxy;
                 new HttpRequest(mockUrl, HttpMethod.GET, new byte[0], mockProxy);
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -1110,6 +1110,10 @@ public class RegistryManagerTest
                 mockIotHubExceptionManager.httpResponseVerification((HttpResponse) any);
             }
         };
+
+        // act
+        RegistryStatistics statistics = registryManager.getStatistics();
+
         assertNotNull(statistics);
     }
 

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -1084,19 +1084,21 @@ public class RegistryManagerTest
     // Tests_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_058: [The function shall verify the response status and throw proper Exception]
     // Tests_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_059: [The function shall create a new RegistryStatistics object from the response and return with it]
     @Test
-    public void getStatistics_good_case(@Mocked Proxy mockProxy, @Mocked ProxyOptions mockProxyOptions) throws Exception
+    public void getStatistics_good_case(@Mocked Proxy mockProxy, @Mocked ProxyOptions mockProxyOptions, @Mocked RegistryManagerOptions registryManagerOptions) throws Exception
     {
         String connectionString = "HostName=aaa.bbb.ccc;SharedAccessKeyName=XXX;SharedAccessKey=YYY";
         String deviceId = "somedevice";
 
         commonExpectations(connectionString, deviceId);
 
-        RegistryManager registryManager = RegistryManager.createFromConnectionString(connectionString, mockProxyOptions);
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(connectionString, registryManagerOptions);
 
         new Expectations()
         {
             {
                 iotHubConnectionString.getUrlDeviceStatistics();
+                registryManagerOptions.getProxyOptions();
+                result = mockProxyOptions;
                 mockProxyOptions.getProxy();
                 result = mockProxy;
                 new HttpRequest(mockUrl, HttpMethod.GET, new byte[0], mockProxy);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
@@ -107,7 +107,7 @@ public class ServiceClientTest
         {
             {
                 iotHubServiceSasToken = new IotHubServiceSasToken(withNotNull());
-                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
+                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol);
             }
         };
         // Act

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
@@ -107,7 +107,7 @@ public class ServiceClientTest
         {
             {
                 iotHubServiceSasToken = new IotHubServiceSasToken(withNotNull());
-                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol);
+                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
             }
         };
         // Act

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
@@ -107,7 +107,7 @@ public class ServiceClientTest
         {
             {
                 iotHubServiceSasToken = new IotHubServiceSasToken(withNotNull());
-                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol);
+                amqpSend = new AmqpSend(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
             }
         };
         // Act
@@ -522,7 +522,7 @@ public class ServiceClientTest
         new Expectations()
         {
             {
-                feedbackReceiver = new FeedbackReceiver(anyString, anyString, anyString, iotHubServiceClientProtocol);
+                feedbackReceiver = new FeedbackReceiver(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
             }
         };
         // Act

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandlerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandlerTest.java
@@ -94,7 +94,7 @@ public class AmqpFeedbackReceivedHandlerTest
         final String _sasToken = Deencapsulation.getField(amqpReceiveHandler, "sasToken");
         AmqpFeedbackReceivedEvent _amqpFeedbackReceivedEvent = Deencapsulation.getField(amqpReceiveHandler, "amqpFeedbackReceivedEvent");
         // Assert
-        assertEquals(hostName + ":5671", _hostName);
+        assertEquals(hostName, _hostName);
         assertEquals(userName, _userName);
         assertEquals(sasToken, _sasToken);
         assertEquals(amqpFeedbackReceivedEvent, _amqpFeedbackReceivedEvent);
@@ -189,7 +189,7 @@ public class AmqpFeedbackReceivedHandlerTest
                 result = transportInternal;
                 new WebSocketImpl();
                 result = webSocket;
-                webSocket.configure(anyString, anyString, 0, anyString, null, null);
+                webSocket.configure(anyString, anyString, 443, anyString, null, null);
                 transportInternal.addTransportLayer(webSocket);
                 sasl.plain(anyString, anyString);
                 Proton.sslDomain();
@@ -215,7 +215,6 @@ public class AmqpFeedbackReceivedHandlerTest
         final String hostName = "aaa";
         final String userName = "bbb";
         final String sasToken = "ccc";
-        final String hostAddr = hostName + ":5671";
         final String receiver_tag = "receiver";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         AmqpFeedbackReceivedHandler amqpReceiveHandler = new AmqpFeedbackReceivedHandler(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
@@ -224,7 +223,7 @@ public class AmqpFeedbackReceivedHandlerTest
         {
             {
                 connection = event.getConnection();
-                connection.setHostname(hostAddr);
+                connection.setHostname(hostName);
                 session = connection.session();
                 receiver = session.receiver(receiver_tag);
                 connection.open();

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandlerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandlerTest.java
@@ -6,6 +6,7 @@
 package tests.unit.com.microsoft.azure.sdk.iot.service.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpFeedbackReceivedEvent;
@@ -65,6 +66,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
     @Mocked Link link;
     @Mocked Source source;
     @Mocked ReadableBuffer readBuf;
+    @Mocked ProxyOptions mockedProxyOptions;
 
     AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent = (String feedbackJson) -> {};
 
@@ -88,14 +90,14 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
             }
         };
         // Act
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
 
         final String _hostName = Deencapsulation.getField(amqpReceiveHandler, "hostName");
         final String _userName = Deencapsulation.getField(amqpReceiveHandler, "userName");
         final String _sasToken = Deencapsulation.getField(amqpReceiveHandler, "sasToken");
         AmqpFeedbackReceivedEvent _amqpFeedbackReceivedEvent = Deencapsulation.getField(amqpReceiveHandler, "amqpFeedbackReceivedEvent");
         // Assert
-        assertEquals(hostName + ":5671", _hostName);
+        assertEquals(hostName, _hostName);
         assertEquals(userName, _userName);
         assertEquals(sasToken, _sasToken);
         assertEquals(amqpFeedbackReceivedEvent, _amqpFeedbackReceivedEvent);
@@ -151,7 +153,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
 
         // Act
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -164,7 +166,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
 
         // Act
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -177,7 +179,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
 
         // Act
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
     }
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVEDHANDLER_25_004: [The event handler shall get the Link, Receiver and Delivery (Proton) objects from the event]
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVEDHANDLER_25_005: [The event handler shall read the received buffer]
@@ -195,7 +197,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         final String hostAddr = hostName + ":5671";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         createProtonObjects();
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
         // Assert
         new Expectations()
         {
@@ -272,7 +274,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
                 result = transportInternal;
                 new WebSocketImpl();
                 result = webSocket;
-                webSocket.configure(anyString, anyString, 0, anyString, null, null);
+                webSocket.configure(anyString, anyString, 443, anyString, null, null);
                 transportInternal.addTransportLayer(webSocket);
                 sasl.plain(anyString, anyString);
                 Proton.sslDomain();
@@ -298,16 +300,15 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         final String hostName = "aaa";
         final String userName = "bbb";
         final String sasToken = "ccc";
-        final String hostAddr = hostName + ":5671";
         final String receiver_tag = "filenotificationreceiver";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
         // Assert
         new Expectations()
         {
             {
                 connection = event.getConnection();
-                connection.setHostname(hostAddr);
+                connection.setHostname(hostName);
                 session = connection.session();
                 receiver = session.receiver(receiver_tag);
                 connection.open();
@@ -332,7 +333,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         final String hostAddr = hostName + ":5671";
         final String endpoint = "/messages/serviceBound/filenotifications";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        Object amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
 
         // Assert
         new Expectations()
@@ -359,7 +360,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         String userName = "bbb";
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
 
         // Act
         amqpReceiveHandler.onLinkRemoteOpen(mockEvent);
@@ -377,7 +378,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         String userName = "bbb";
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
 
         Deencapsulation.setField(amqpReceiveHandler, "connectionOpenedRemotely", true);
         Deencapsulation.setField(amqpReceiveHandler, "sessionOpenedRemotely", true);
@@ -397,7 +398,7 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         String userName = "bbb";
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent);
+        AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler = Deencapsulation.newInstance(AmqpFileUploadNotificationReceivedHandler.class, hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, mockedProxyOptions);
 
         Deencapsulation.setField(amqpReceiveHandler, "connectionOpenedRemotely", false);
         Deencapsulation.setField(amqpReceiveHandler, "sessionOpenedRemotely", true);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandlerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandlerTest.java
@@ -105,7 +105,7 @@ public class AmqpSendHandlerTest
         String _sasToken = Deencapsulation.getField(amqpSendHandler, "sasToken");
         IotHubServiceClientProtocol _ioIotHubServiceClientProtocol = Deencapsulation.getField(amqpSendHandler, "iotHubServiceClientProtocol");
         // Assert
-        assertEquals(hostName + ":5671", _hostName);
+        assertEquals(hostName, _hostName);
         assertEquals(userName, _userName);
         assertEquals(sasToken, _sasToken);
         assertEquals(iotHubServiceClientProtocol, _ioIotHubServiceClientProtocol);
@@ -369,7 +369,7 @@ public class AmqpSendHandlerTest
                 result = transportInternal;
                 new WebSocketImpl();
                 result = webSocket;
-                webSocket.configure(anyString, anyString, 0, anyString, null, null);
+                webSocket.configure(anyString, anyString, 443, anyString, null, null);
                 transportInternal.addTransportLayer(webSocket);
                 sasl.plain(anyString, anyString);
                 Proton.sslDomain();
@@ -397,7 +397,6 @@ public class AmqpSendHandlerTest
         String hostName = "aaa";
         String userName = "bbb";
         String sasToken = "ccc";
-        String hostAddr = hostName + ":5671";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         AmqpSendHandler amqpSendHandler = new AmqpSendHandler(hostName, userName, sasToken, iotHubServiceClientProtocol);
         // Assert
@@ -405,7 +404,7 @@ public class AmqpSendHandlerTest
         {
             {
                 connection = event.getConnection();
-                connection.setHostname(hostAddr);
+                connection.setHostname(hostName);
                 session = connection.session();
                 sender = session.sender(anyString);
                 connection.open();
@@ -427,7 +426,6 @@ public class AmqpSendHandlerTest
         String hostName = "aaa";
         String userName = "bbb";
         String sasToken = "ccc";
-        String hostAddr = hostName + ":5671";
         String endpoint = "/messages/devicebound";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         AmqpSendHandler amqpSendHandler = new AmqpSendHandler(hostName, userName, sasToken, iotHubServiceClientProtocol);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendTest.java
@@ -46,7 +46,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
         String _hostName = Deencapsulation.getField(amqpSend, "hostName");
         String _userName = Deencapsulation.getField(amqpSend, "userName");
         String _sasToken = Deencapsulation.getField(amqpSend, "sasToken");
@@ -68,7 +68,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS_WS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
         String _hostName = Deencapsulation.getField(amqpSend, "hostName");
         String _userName = Deencapsulation.getField(amqpSend, "userName");
         String _sasToken = Deencapsulation.getField(amqpSend, "sasToken");
@@ -91,7 +91,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -105,7 +105,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -119,7 +119,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -133,7 +133,7 @@ public class AmqpSendTest
         String sasToken = "ccc";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -147,7 +147,7 @@ public class AmqpSendTest
         String sasToken = null;
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -161,7 +161,7 @@ public class AmqpSendTest
         String sasToken = "";
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
     
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_12_001: [The constructor shall throw IllegalArgumentException if any of the input parameter is null or empty]
@@ -176,7 +176,7 @@ public class AmqpSendTest
         
         IotHubServiceClientProtocol iotHubServiceClientProtocol = null;
         // Act
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_AMQPSEND_28_006: [The function shall create a binary message with the given content with deviceId only if moduleId is null]
@@ -191,7 +191,7 @@ public class AmqpSendTest
         String content = "abcdefghijklmnopqrst";
         Message message = new Message(content);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
         amqpSend.open();
 
         AmqpSendHandler handler = Deencapsulation.getField(amqpSend, "amqpSendHandler");
@@ -220,7 +220,7 @@ public class AmqpSendTest
         String content = "abcdefghijklmnopqrst";
         Message message = new Message(content);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
         amqpSend.open();
 
         AmqpSendHandler handler = Deencapsulation.getField(amqpSend, "amqpSendHandler");
@@ -250,7 +250,7 @@ public class AmqpSendTest
         String content = "abcdefghijklmnopqrst";
         Message message = new Message(content);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
-        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol);
+        AmqpSend amqpSend = new AmqpSend(hostName, userName, sasToken, iotHubServiceClientProtocol, null);
         // Act
         amqpSend.send(deviceId, moduleId, message);
     }


### PR DESCRIPTION
Now that registryManager has proxy support, this PR adds proxy support to the AMQP side of the service client, too.

