### PR TITLE
fix(iot-dev): Fix issue where MQTT didn't url encode application properties correctly

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MessageProperty.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MessageProperty.java
@@ -31,12 +31,6 @@ public final class MessageProperty {
     public static final String IOTHUB_SECURITY_INTERFACE_ID = "iothub-interface-id";
     public static final String IOTHUB_SECURITY_INTERFACE_ID_VALUE = "urn:azureiot:Security:SecurityAgent:1";
 
-    //Note this list includes the characters for tab and space.
-    private static final String BANNED_NON_ALPHANUMERIC_CHARACTERS = "()<>@,;:\"\\[]?={} \t";
-    private static final int ASCII_LOWER_BOUND = 32;
-    private static final int ASCII_UPPER_BOUND = 127;
-
-
     static {
         HashSet<String> reservedPropertyNames = new HashSet<>();
         reservedPropertyNames.add("iothub-enqueuedtime");
@@ -92,22 +86,9 @@ public final class MessageProperty {
             throw new IllegalArgumentException("Property argument 'value' cannot be null.");
         }
 
-        // Codes_SRS_MESSAGEPROPERTY_11_002: [If the name contains a character that is not in US-ASCII, the function shall throw an IllegalArgumentException.]
-        if (!usesValidChars(name)) {
-            String errMsg = String.format("%s is not a valid IoT Hub message property name. Characters in property keys must fall within ASCII value range %d and %d but excluding the set %s", name, ASCII_LOWER_BOUND, ASCII_UPPER_BOUND, BANNED_NON_ALPHANUMERIC_CHARACTERS);
-            throw new IllegalArgumentException(errMsg);
-        }
-
         // Codes_SRS_MESSAGEPROPERTY_11_008: [If the name is a reserved property name, the function shall throw an IllegalArgumentException.]
         if (RESERVED_PROPERTY_NAMES.contains(name)) {
             String errMsg = String.format("%s is a reserved IoT Hub message property name.%n", name);
-            throw new IllegalArgumentException(errMsg);
-        }
-
-        // Codes_SRS_MESSAGEPROPERTY_11_003: [If the value contains a character that is not in US-ASCII, the function shall throw an IllegalArgumentException.]
-        if (!usesValidChars(value))
-        {
-            String errMsg = String.format("%s is not a valid IoT Hub message property value. Characters in property values must fall within ASCII value range %d and %d but excluding the set %s", value, ASCII_LOWER_BOUND, ASCII_UPPER_BOUND, BANNED_NON_ALPHANUMERIC_CHARACTERS);
             throw new IllegalArgumentException(errMsg);
         }
 
@@ -163,17 +144,9 @@ public final class MessageProperty {
      *
      * @return whether the property is a valid application property.
      */
-    public static boolean isValidAppProperty(String name, String value) {
-        boolean propertyIsValid = false;
-
-        // Codes_SRS_MESSAGEPROPERTY_11_007: [The function shall return true if and only if the name and value only use characters in US-ASCII and the name is not a reserved property name.]
-        if (!RESERVED_PROPERTY_NAMES.contains(name)
-                && usesValidChars(name)
-                && usesValidChars(value)) {
-            propertyIsValid = true;
-        }
-
-        return propertyIsValid;
+    public static boolean isValidAppProperty(String name, String value)
+    {
+        return !RESERVED_PROPERTY_NAMES.contains(name);
     }
 
     /**
@@ -185,35 +158,9 @@ public final class MessageProperty {
      *
      * @return whether the property is a valid system property.
      */
-    public static boolean isValidSystemProperty(String name, String value) {
-        boolean propertyIsValid = false;
-
-        if (RESERVED_PROPERTY_NAMES.contains(name)
-                && usesValidChars(name)
-                && usesValidChars(value)) {
-            propertyIsValid = true;
-        }
-
-        return propertyIsValid;
-    }
-
-    private static boolean usesValidChars(String s) {
-        for (char c : s.toCharArray())
-        {
-            //Range of characters includes US alphanumeric characters, as well as a few special characters like '+' and ','
-            // Any characters outside of this range are banned
-            if (!(c > ASCII_LOWER_BOUND && c < ASCII_UPPER_BOUND))
-            {
-                return false;
-            }
-
-            if (BANNED_NON_ALPHANUMERIC_CHARACTERS.indexOf(c) != -1)
-            {
-                return false;
-            }
-        }
-
-        return true;
+    public static boolean isValidSystemProperty(String name, String value)
+    {
+        return RESERVED_PROPERTY_NAMES.contains(name);
     }
 
     @SuppressWarnings("unused")

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
@@ -154,6 +154,7 @@ public class MqttMessaging extends Mqtt
 
                 if (isApplicationProperty)
                 {
+                    // URLEncoder.Encode incorrectly encodes space characters as '+'. For MQTT to work, we need to replace those '+' with "%20"
                     stringBuilder.append(URLEncoder.encode(propertyKey, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20"));
                 }
                 else
@@ -162,6 +163,8 @@ public class MqttMessaging extends Mqtt
                 }
 
                 stringBuilder.append(MESSAGE_PROPERTY_KEY_VALUE_SEPARATOR);
+
+                // URLEncoder.Encode incorrectly encodes space characters as '+'. For MQTT to work, we need to replace those '+' with "%20"
                 stringBuilder.append(URLEncoder.encode(propertyValue, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20"));
 
                 return true;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
@@ -136,7 +136,7 @@ public class MqttMessaging extends Mqtt
     /**
      * Appends the property to the provided stringbuilder if the property value is not null.
      * @param stringBuilder the builder to build upon
-     * @param separatorNeeded if a seperator should precede the new property
+     * @param separatorNeeded if a separator should precede the new property
      * @param propertyKey the mqtt topic string property key
      * @param propertyValue the property value (message id, correlation id, etc.)
      * @return true if a separator will be needed for any later properties appended on
@@ -154,7 +154,7 @@ public class MqttMessaging extends Mqtt
 
                 if (isApplicationProperty)
                 {
-                    stringBuilder.append(URLEncoder.encode(propertyKey, StandardCharsets.UTF_8.name()));
+                    stringBuilder.append(URLEncoder.encode(propertyKey, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20"));
                 }
                 else
                 {
@@ -162,7 +162,7 @@ public class MqttMessaging extends Mqtt
                 }
 
                 stringBuilder.append(MESSAGE_PROPERTY_KEY_VALUE_SEPARATOR);
-                stringBuilder.append(URLEncoder.encode(propertyValue, StandardCharsets.UTF_8.name()));
+                stringBuilder.append(URLEncoder.encode(propertyValue, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20"));
 
                 return true;
             }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessagePropertyTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessagePropertyTest.java
@@ -59,16 +59,6 @@ public class MessagePropertyTest
         assertThat(testValue, is(expectedValue));
     }
     
-    // Tests_SRS_MESSAGEPROPERTY_11_002: [If the name contains a character that is not in US-ASCII the function shall throw an IllegalArgumentException.]
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorRejectsInvalidPropertyName()
-    {
-        final String invalidName = "Price in £"; 
-        final String value = "test-value";
-
-        new MessageProperty(invalidName, value);
-    }
-
     // Tests_SRS_MESSAGEPROPERTY_11_008: [If the name is a reserved property name, the function shall throw an IllegalArgumentException.]
     @Test(expected = IllegalArgumentException.class)
     public void constructorRejectsReservedPropertyName()
@@ -77,16 +67,6 @@ public class MessagePropertyTest
         final String value = "test-value";
 
         new MessageProperty(invalidName, value);
-    }
-
-    // Tests_SRS_MESSAGEPROPERTY_11_003: [If the value contains a character that is not in US-ASCII, the function shall throw an IllegalArgumentException.]
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorRejectsInvalidPropertyValue()
-    {
-        final String name = "test-,name";
-        final String invalidValue = "t\u0130est-value";
-
-        new MessageProperty(name, invalidValue);
     }
 
     // Tests_SRS_MESSAGEPROPERTY_11_006: [The function shall return true if and only if the property has the given name, where the names are compared in a case-insensitive manner.]
@@ -133,20 +113,6 @@ public class MessagePropertyTest
 
     // Tests_SRS_MESSAGEPROPERTY_11_007: [The function shall return true if and only if the name and value only use characters in: US-ASCII and the name is not a reserved property name.]
     @Test
-    public void isValidAppPropertyReturnsFalseForInvalidAppProperty()
-    {
-        final String name = "test-name";
-        final String illegalValue = "परीक्षण"; // Unicode is not supported in MessageProperty value
-
-        boolean testIsValidAppProperty =
-                MessageProperty.isValidAppProperty(name, illegalValue);
-
-        final boolean expectedIsValidAppProperty = false;
-        assertThat(testIsValidAppProperty, is(expectedIsValidAppProperty));
-    }
-
-    // Tests_SRS_MESSAGEPROPERTY_11_007: [The function shall return true if and only if the name and value only use characters in: US-ASCII and the name is not a reserved property name.]
-    @Test
     public void isValidAppPropertyReturnsFalseForReservedProperty()
     {
         final String reservedName = "iothub-to";
@@ -157,49 +123,5 @@ public class MessagePropertyTest
 
         final boolean expectedIsValidAppProperty = false;
         assertThat(testIsValidAppProperty, is(expectedIsValidAppProperty));
-    }
-
-    @Test
-    public void isValidAppPropertyReturnsTrueForUnusualAppPropertyKey()
-    {
-        final String name = "Test1234!#$%&'*+-.^_`|~";
-        final String value = "test-value";
-
-        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
-
-        assertTrue(isValidProperty);
-    }
-
-    @Test
-    public void isValidAppPropertyReturnsTrueForUnusualAppPropertyValue()
-    {
-        final String name = "test-key";
-        final String value = "Test1234!#$%&'*+-.^_`|~";
-
-        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
-
-        assertTrue(isValidProperty);
-    }
-
-    @Test
-    public void isValidAppPropertyReturnsFalseForUnusualAppPropertyKey()
-    {
-        final String name = "Test1234 Test1234";
-        final String value = "test-value";
-
-        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
-
-        assertFalse(isValidProperty);
-    }
-
-    @Test
-    public void isValidAppPropertyReturnsFalseForUnusualAppPropertyValue()
-    {
-        final String name = "test-key";
-        final String value = "\"someQuotedValue\"";
-
-        boolean isValidProperty = MessageProperty.isValidAppProperty(name, value);
-
-        assertFalse(isValidProperty);
     }
 }

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/telemetry/SendMessagesTests.java
@@ -93,7 +93,8 @@ public class SendMessagesTests extends SendMessagesCommon
         Message msg = new Message("asdf");
 
         //All of these characters should be allowed within application properties
-        msg.setProperty("TestKey1234!#$%&'*+-^_`|~", "TestValue1234!#$%&'*+-^_`|~");
+        msg.setProperty("TestKey1234!#$%&'*+-^_`|~", "TestValue1234!#$%&'*+-^_`|~()<>@,;:\\\"[]?={} \t");
+        // ()<>@,;:\"[]?={}
         IotHubServicesCommon.sendMessageAndWaitForResponse(this.testInstance.client, new MessageAndResult(msg, IotHubStatusCode.OK_EMPTY), RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, testInstance.protocol);
         this.testInstance.client.closeNow();
     }


### PR DESCRIPTION
URLEncoder.Encode encodes the space character ' ' as '+' instead of the expected '%20', so I've added a manual replace step for this character. This is most important for MQTT because that protocol doesn't allow topic strings with the '+' character

Also removing all character validation for application property keys and values now that this MQTT bug is fixed. There is no longer a device-side reason to validate these values as all protocols are encoding them correctly now such that the protocol doesn't throw an exception. Iot Hub will be the validator, not the client.

Hub does allow these previously banned characters, provided they are encoded correctly for each protocol.