### PR TITLE
doc(iot-dev): Add clarification to startDeviceTwin() API docs

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -463,7 +463,16 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Starts the device twin.
+     * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback, this device client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * on the twin, and the PATCH will cause this device client to receive the full desired properties set. Similarly, the version
+     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
+     * have its version incremented from a PUT call.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
@@ -482,7 +491,16 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Starts the device twin.
+     * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback, this device client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * on the twin, and the PATCH will cause this device client to receive the full desired properties set. Similarly, the version
+     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
+     * have its version incremented from a PUT call.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -467,9 +467,10 @@ public final class DeviceClient extends InternalClient implements Closeable
      * reported properties and desired properties. After that callback, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
-     * on the twin, and the PATCH will cause this device client to receive the full desired properties set. Similarly, the version
-     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
-     * have its version incremented from a PUT call.
+     * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
+     * will cause this device client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
@@ -495,9 +496,10 @@ public final class DeviceClient extends InternalClient implements Closeable
      * reported properties and desired properties. After that callback, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
-     * on the twin, and the PATCH will cause this device client to receive the full desired properties set. Similarly, the version
-     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
-     * have its version incremented from a PUT call.
+     * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
+     * will cause this device client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -464,7 +464,7 @@ public final class DeviceClient extends InternalClient implements Closeable
 
     /**
      * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback, this device client will receive a callback
+     * reported properties and desired properties. After that callback is received, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
@@ -495,7 +495,7 @@ public final class DeviceClient extends InternalClient implements Closeable
 
     /**
      * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback, this device client will receive a callback
+     * reported properties and desired properties. After that callback is received, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -470,7 +470,9 @@ public final class DeviceClient extends InternalClient implements Closeable
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call.
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
@@ -499,7 +501,9 @@ public final class DeviceClient extends InternalClient implements Closeable
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call.
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -179,7 +179,19 @@ public class InternalClient
     }
 
     /**
-     * Subscribes to desired properties
+     * Subscribes to desired properties.
+     *
+     * This client will receive a callback each time a desired property is updated. That callback will either contain
+     * the full desired properties set, or only the updated desired property depending on how the desired property was changed.
+     * IoT Hub supports a PUT and a PATCH on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
+     * will cause this device client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param onDesiredPropertyChange the Map for desired properties and their corresponding callback and context. Can be {@code null}.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -406,7 +406,9 @@ public class ModuleClient extends InternalClient
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
      * will cause this module client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call.
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
@@ -435,7 +437,9 @@ public class ModuleClient extends InternalClient
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
      * will cause this module client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call.
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -399,7 +399,16 @@ public class ModuleClient extends InternalClient
     }
 
     /**
-     * Starts the device twin.
+     * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback, this module client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * on the twin, and the PATCH will cause this module client to receive the full desired properties set. Similarly, the version
+     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
+     * have its version incremented from a PUT call.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
      *
      * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
@@ -418,7 +427,16 @@ public class ModuleClient extends InternalClient
     }
 
     /**
-     * Starts the device twin.
+     * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback, this module client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * on the twin, and the PATCH will cause this module client to receive the full desired properties set. Similarly, the version
+     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
+     * have its version incremented from a PUT call.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
      *
      * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -403,9 +403,10 @@ public class ModuleClient extends InternalClient
      * reported properties and desired properties. After that callback, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
-     * on the twin, and the PATCH will cause this module client to receive the full desired properties set. Similarly, the version
-     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
-     * have its version incremented from a PUT call.
+     * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
+     * will cause this module client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
@@ -431,9 +432,10 @@ public class ModuleClient extends InternalClient
      * reported properties and desired properties. After that callback, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
-     * on the twin, and the PATCH will cause this module client to receive the full desired properties set. Similarly, the version
-     * of each desired property will be incremented from a PATCH call, and only the actually updated desired property will
-     * have its version incremented from a PUT call.
+     * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
+     * will cause this module client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call.
      *
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
      * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -400,7 +400,7 @@ public class ModuleClient extends InternalClient
 
     /**
      * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback, this module client will receive a callback
+     * reported properties and desired properties. After that callback is received, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
@@ -431,7 +431,7 @@ public class ModuleClient extends InternalClient
 
     /**
      * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback, this module client will receive a callback
+     * reported properties and desired properties. After that callback is received, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
      * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -127,6 +127,12 @@ public class DeviceTwin
     /**
      * This method updates device twin for the specified device.
      *
+     * This API uses the IoT Hub PATCH API when sending updates, but it sends the full twin with each patch update.
+     * As a result, devices subscribed to twin will receive notifications that each property is changed when this API is called, even
+     * if only some of the properties were changed.
+     *
+     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a> for more details
+     *
      * @param device The device with a valid id for which device twin is to be updated.
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed


### PR DESCRIPTION
See #772 

Customer's need a bit more help understanding how startDeviceTwin works, so I've beefed up the javadocs for it