### PR TITLE
fix(iot-dev): Fix issue where amqp layer didn't recognize an ack to a subscription message that it sent

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperations.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsDeviceOperations.java
@@ -394,7 +394,7 @@ public abstract class AmqpsDeviceOperations
         if (linkName.equals(this.getSenderLinkTag()))
         {
             this.amqpsSendLinkState = AmqpsDeviceOperationLinkState.OPENED;
-            this.log.debug("{} sender link with link correlation id {} was successfully opened {}", getLinkInstanceType(), this.linkCorrelationId);
+            this.log.debug("{} sender link with link correlation id {} was successfully opened", getLinkInstanceType(), this.linkCorrelationId);
             return true;
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -692,7 +692,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
                     else if (this.inProgressSubscriptionMessages.containsKey(deliveryTag))
                     {
                         SubscriptionType subscriptionType = this.inProgressSubscriptionMessages.remove(deliveryTag);
-                        log.debug("Successfully re-sent amqp subscription message of type {}", subscriptionType);
+                        log.debug("Successfully sent amqp subscription message of type {}", subscriptionType);
                     }
                     else
                     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -43,7 +43,7 @@ import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
  * a message, and logic to re-establish the connection with the IoTHub in case it gets lost.
  */
 @Slf4j
-public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler implements IotHubTransportConnection
+public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler implements IotHubTransportConnection, SubscriptionMessageRequestSentCallback
 {
     private static final int MAX_WAIT_TO_CLOSE_CONNECTION = 60 * 1000; // 60 second timeout
     private static final int MAX_WAIT_TO_OPEN_CBS_LINKS = 20 * 1000; // 20 second timeout
@@ -66,6 +66,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
     private final static int MAX_MESSAGE_PAYLOAD_SIZE = 256*1024; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at least that much space
     private final Boolean useWebSockets;
     private final Map<Integer, com.microsoft.azure.sdk.iot.device.Message> inProgressMessages = new ConcurrentHashMap<>();
+    private final Map<Integer, SubscriptionType> inProgressSubscriptionMessages = new ConcurrentHashMap<>();
     private final Map<com.microsoft.azure.sdk.iot.device.Message, AmqpsMessage> sendAckMessages = new ConcurrentHashMap<>();
     public String connectionId;
     public AmqpsSessionManager amqpsSessionManager;
@@ -139,7 +140,7 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_006: [The constructor shall set its state to DISCONNECTED.]
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
-        this.amqpsSessionManager = new AmqpsSessionManager(this.deviceClientConfig);
+        this.amqpsSessionManager = new AmqpsSessionManager(this.deviceClientConfig, this);
 
         log.trace("AmqpsIotHubConnection object is created successfully and will use port {}", useWebSockets ? AMQP_WEB_SOCKET_PORT : AMQP_PORT);
     }
@@ -687,6 +688,11 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
                             transportException.setRetryable(true);
                             this.listener.onMessageSent(inProgressMessages.remove(deliveryTag), transportException);
                         }
+                    }
+                    else if (this.inProgressSubscriptionMessages.containsKey(deliveryTag))
+                    {
+                        SubscriptionType subscriptionType = this.inProgressSubscriptionMessages.remove(deliveryTag);
+                        log.debug("Successfully re-sent amqp subscription message of type {}", subscriptionType);
                     }
                     else
                     {
@@ -1322,6 +1328,12 @@ public final class AmqpsIotHubConnection extends ErrorLoggingBaseHandler impleme
         {
             latch.countDown();
         }
+    }
+
+    @Override
+    public void onSubscriptionMessageSent(int deliveryTag, SubscriptionType subscriptionType)
+    {
+        this.inProgressSubscriptionMessages.put(deliveryTag, subscriptionType);
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
@@ -29,6 +29,8 @@ public class AmqpsSessionDeviceOperation
 
     private List<UUID> cbsCorrelationIdList = Collections.synchronizedList(new ArrayList<UUID>());
 
+    private SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback;
+
     /**
      * Create logical device entity to handle all operation.
      *
@@ -36,7 +38,7 @@ public class AmqpsSessionDeviceOperation
      * @param amqpsDeviceAuthentication the authentication object associated with the device.
      * @throws IllegalArgumentException if deviceClientConfig or amqpsDeviceAuthentication is null
      */
-    public AmqpsSessionDeviceOperation(final DeviceClientConfig deviceClientConfig, AmqpsDeviceAuthentication amqpsDeviceAuthentication) throws IllegalArgumentException
+    public AmqpsSessionDeviceOperation(final DeviceClientConfig deviceClientConfig, AmqpsDeviceAuthentication amqpsDeviceAuthentication, SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback) throws IllegalArgumentException
     {
         // Codes_SRS_AMQPSESSIONDEVICEOPERATION_12_001: [The constructor shall throw IllegalArgumentException if the deviceClientConfig or the amqpsDeviceAuthentication parameter is null.]
         if (deviceClientConfig == null)
@@ -65,6 +67,8 @@ public class AmqpsSessionDeviceOperation
             // Codes_SRS_AMQPSESSIONDEVICEOPERATION_12_047[The constructor shall set the authentication state to authenticated if the authentication type is not CBS.]
             this.amqpsAuthenticatorState = AmqpsDeviceAuthenticationState.AUTHENTICATED;
         }
+
+        this.subscriptionMessageRequestSentCallback = subscriptionMessageRequestSentCallback;
     }
 
     /**
@@ -342,7 +346,8 @@ public class AmqpsSessionDeviceOperation
                     {
                         // since we have already checked the message type, we can safely cast it
                         AmqpsDeviceTwin deviceTwinOperations = (AmqpsDeviceTwin)entry.getValue();
-                        sendMessage(deviceTwinOperations.buildSubscribeToDesiredPropertiesProtonMessage(), entry.getKey(), deviceClientConfig.getDeviceId());
+                        int deliveryTag = sendMessage(deviceTwinOperations.buildSubscribeToDesiredPropertiesProtonMessage(), entry.getKey(), deviceClientConfig.getDeviceId());
+                        this.subscriptionMessageRequestSentCallback.onSubscriptionMessageSent(deliveryTag, SubscriptionMessageRequestSentCallback.SubscriptionType.DESIRED_PROPERTIES_SUBSCRIPTION);
                     }
 
                     return true;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperation.java
@@ -36,6 +36,7 @@ public class AmqpsSessionDeviceOperation
      *
      * @param deviceClientConfig the configuration of teh device.
      * @param amqpsDeviceAuthentication the authentication object associated with the device.
+     * @param subscriptionMessageRequestSentCallback the callback to fire each time a subscription message is sent
      * @throws IllegalArgumentException if deviceClientConfig or amqpsDeviceAuthentication is null
      */
     public AmqpsSessionDeviceOperation(final DeviceClientConfig deviceClientConfig, AmqpsDeviceAuthentication amqpsDeviceAuthentication, SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback) throws IllegalArgumentException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
@@ -31,6 +31,7 @@ public class AmqpsSessionManager
      *
      * @param deviceClientConfig the device configuration to use for 
      *                           session management.
+     * @param subscriptionMessageRequestSentCallback the callback to fire each time a subscription message is sent
      */
     public AmqpsSessionManager(DeviceClientConfig deviceClientConfig, SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback)
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManager.java
@@ -24,6 +24,7 @@ public class AmqpsSessionManager
 
     private AmqpsDeviceAuthentication amqpsDeviceAuthentication;
     private ArrayList<AmqpsSessionDeviceOperation> amqpsDeviceSessionList = new ArrayList<>();
+    private SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback;
 
     /**
      * Constructor that takes a device configuration.
@@ -31,7 +32,7 @@ public class AmqpsSessionManager
      * @param deviceClientConfig the device configuration to use for 
      *                           session management.
      */
-    public AmqpsSessionManager(DeviceClientConfig deviceClientConfig)
+    public AmqpsSessionManager(DeviceClientConfig deviceClientConfig, SubscriptionMessageRequestSentCallback subscriptionMessageRequestSentCallback)
     {
         // Codes_SRS_AMQPSESSIONMANAGER_12_001: [The constructor shall throw IllegalArgumentException if the deviceClientConfig parameter is null.]
         if (deviceClientConfig == null)
@@ -55,6 +56,8 @@ public class AmqpsSessionManager
                 break;
         }
 
+        this.subscriptionMessageRequestSentCallback = subscriptionMessageRequestSentCallback;
+
         // Codes_SRS_AMQPSESSIONMANAGER_12_007: [The constructor shall add the create a AmqpsSessionDeviceOperation with the given deviceClientConfig.]
         this.addDeviceOperationSession(this.deviceClientConfig);
     }
@@ -73,7 +76,7 @@ public class AmqpsSessionManager
         }
 
         // Codes_SRS_AMQPSESSIONMANAGER_12_009: [The function shall create a new  AmqpsSessionDeviceOperation with the given deviceClientConfig and add it to the session list.]
-        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(deviceClientConfig, this.amqpsDeviceAuthentication);
+        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(deviceClientConfig, this.amqpsDeviceAuthentication, this.subscriptionMessageRequestSentCallback);
         this.amqpsDeviceSessionList.add(amqpsSessionDeviceOperation);
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/SubscriptionMessageRequestSentCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/SubscriptionMessageRequestSentCallback.java
@@ -1,0 +1,13 @@
+package com.microsoft.azure.sdk.iot.device.transport.amqps;
+
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
+
+public interface SubscriptionMessageRequestSentCallback
+{
+    void onSubscriptionMessageSent(int deliveryTag, SubscriptionType deviceOperationType);
+
+    enum SubscriptionType
+    {
+        DESIRED_PROPERTIES_SUBSCRIPTION
+    }
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/SubscriptionMessageRequestSentCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/SubscriptionMessageRequestSentCallback.java
@@ -4,7 +4,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations;
 
 public interface SubscriptionMessageRequestSentCallback
 {
-    void onSubscriptionMessageSent(int deliveryTag, SubscriptionType deviceOperationType);
+    void onSubscriptionMessageSent(int deliveryTag, SubscriptionType subscriptionType);
 
     enum SubscriptionType
     {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -623,7 +623,7 @@ public class AmqpsIotHubConnectionTest {
                 new CountDownLatch(anyInt);
                 result = mockAuthLatch;
 
-                new AmqpsSessionManager(mockConfig);
+                new AmqpsSessionManager(mockConfig, (SubscriptionMessageRequestSentCallback) any);
                 result = mockAmqpsSessionManager;
 
                 mockAuthLatch.await(anyLong, TimeUnit.MILLISECONDS);
@@ -670,7 +670,7 @@ public class AmqpsIotHubConnectionTest {
                 new CountDownLatch(anyInt);
                 result = mockAuthLatch;
 
-                new AmqpsSessionManager(mockConfig);
+                new AmqpsSessionManager(mockConfig, (SubscriptionMessageRequestSentCallback) any);
                 result = mockAmqpsSessionManager;
 
                 mockAuthLatch.await(anyLong, TimeUnit.MILLISECONDS);
@@ -2451,7 +2451,7 @@ public class AmqpsIotHubConnectionTest {
                 new CountDownLatch(anyInt);
                 result = mockAuthLatch;
 
-                new AmqpsSessionManager(mockConfig);
+                new AmqpsSessionManager(mockConfig, (SubscriptionMessageRequestSentCallback) any);
                 result = mockAmqpsSessionManager;
 
                 mockAuthLatch.await(anyLong, TimeUnit.MILLISECONDS);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionDeviceOperationTest.java
@@ -99,6 +99,9 @@ public class AmqpsSessionDeviceOperationTest
 
     @Mocked
     Event mockEvent;
+    
+    @Mocked
+    SubscriptionMessageRequestSentCallback mockedSubscriptionMessageRequestSentCallback;
 
 
     // Tests_SRS_AMQPSESSIONDEVICEOPERATION_12_001: [The constructor shall throw IllegalArgumentException if the deviceClientConfig or the amqpsDeviceAuthentication parameter is null.]
@@ -107,7 +110,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         // act
-        new AmqpsSessionDeviceOperation(null, mockAmqpsDeviceAuthentication);
+        new AmqpsSessionDeviceOperation(null, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
     }
 
     // Tests_SRS_AMQPSESSIONDEVICEOPERATION_12_001: [The constructor shall throw IllegalArgumentException if the deviceClientConfig or the amqpsDeviceAuthentication parameter is null.]
@@ -116,7 +119,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         // act
-        new AmqpsSessionDeviceOperation(mockDeviceClientConfig, null);
+        new AmqpsSessionDeviceOperation(mockDeviceClientConfig, null, mockedSubscriptionMessageRequestSentCallback);
     }
 
     // Tests_SRS_AMQPSESSIONDEVICEOPERATION_12_002: [The constructor shall save the deviceClientConfig and amqpsDeviceAuthentication parameter value to a member variable.]
@@ -126,7 +129,7 @@ public class AmqpsSessionDeviceOperationTest
     public void constructorSuccessSAS() throws IllegalArgumentException, TransportException
     {
         // act
-        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS);
+        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS, mockedSubscriptionMessageRequestSentCallback);
 
         // assert
         DeviceClientConfig actualDeviceClientConfig = Deencapsulation.getField(amqpsSessionDeviceOperation, "deviceClientConfig");
@@ -174,7 +177,7 @@ public class AmqpsSessionDeviceOperationTest
         };
 
         // act
-        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS);
+        AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS, mockedSubscriptionMessageRequestSentCallback);
 
         // assert
         DeviceClientConfig actualDeviceClientConfig = Deencapsulation.getField(amqpsSessionDeviceOperation, "deviceClientConfig");
@@ -203,7 +206,7 @@ public class AmqpsSessionDeviceOperationTest
     public void close() throws TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "deviceClientConfig", mockDeviceClientConfig);
 
         // act
@@ -230,7 +233,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final int MAX_WAIT_TO_AUTHENTICATE = 10*1000;
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "deviceClientConfig", mockDeviceClientConfig);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "cbsCorrelationIdList", mockListUUID);
 
@@ -267,7 +270,7 @@ public class AmqpsSessionDeviceOperationTest
     public void openLinks() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         // act
@@ -288,7 +291,7 @@ public class AmqpsSessionDeviceOperationTest
     public void closeLinks() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
 
         // act
         Deencapsulation.invoke(amqpsSessionDeviceOperation, "closeLinks");
@@ -308,7 +311,7 @@ public class AmqpsSessionDeviceOperationTest
     public void initLink() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         // act
@@ -329,7 +332,7 @@ public class AmqpsSessionDeviceOperationTest
     public void sendMessageNotAuthenticated() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATING);
 
         // act
@@ -344,7 +347,7 @@ public class AmqpsSessionDeviceOperationTest
     public void sendMessageDeviceIdMismatch() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -372,7 +375,7 @@ public class AmqpsSessionDeviceOperationTest
     public void sendMessageNoDelivery() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
         final byte[] bytes = new byte[1024];
         new NonStrictExpectations()
@@ -417,7 +420,7 @@ public class AmqpsSessionDeviceOperationTest
     public void sendMessageSuccess() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
         final byte[] bytes = new byte[1024];
         new NonStrictExpectations()
@@ -461,7 +464,7 @@ public class AmqpsSessionDeviceOperationTest
     public void sendMessageDoublesBufferIfEncodeThrowsBufferOverflowException() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
         final byte[] bytes = new byte[1024];
         new NonStrictExpectations()
@@ -508,7 +511,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.NOT_AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -532,7 +535,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -556,7 +559,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -591,7 +594,7 @@ public class AmqpsSessionDeviceOperationTest
         final String propertyKey = "status-code";
         final Integer propertyValue = 200;
         final List<UUID> cbsCorrelationIdList = Collections.synchronizedList(new ArrayList<UUID>());
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATING);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthentication);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "cbsCorrelationIdList", cbsCorrelationIdList);
@@ -629,7 +632,7 @@ public class AmqpsSessionDeviceOperationTest
         final Integer propertyValue = 200;
         final List<UUID> cbsCorrelationIdList = Collections.synchronizedList(new ArrayList<UUID>());
         cbsCorrelationIdList.add(mockUUID);
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATING);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthentication);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "cbsCorrelationIdList", cbsCorrelationIdList);
@@ -671,7 +674,7 @@ public class AmqpsSessionDeviceOperationTest
         final Integer propertyValue = 200;
         final List<UUID> cbsCorrelationIdList = Collections.synchronizedList(new ArrayList<UUID>());
         cbsCorrelationIdList.add(mockUUID);
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.UNKNOWN);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TELEMETRY, mockAmqpsDeviceTelemetry);
@@ -706,7 +709,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -730,7 +733,7 @@ public class AmqpsSessionDeviceOperationTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsAuthenticatorState", AmqpsDeviceAuthenticationState.AUTHENTICATED);
 
         new NonStrictExpectations()
@@ -754,7 +757,7 @@ public class AmqpsSessionDeviceOperationTest
     public void convertToProtonSuccess() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
 
         new NonStrictExpectations()
         {
@@ -779,7 +782,7 @@ public class AmqpsSessionDeviceOperationTest
     public void convertFromProtonSuccess() throws IllegalArgumentException, TransportException
     {
         // arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
 
         new NonStrictExpectations()
         {
@@ -802,7 +805,7 @@ public class AmqpsSessionDeviceOperationTest
     public void handleAuthenticationMessageSuccess()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         List<UUID> cbsCorrelationIdList = Deencapsulation.getField(amqpsSessionDeviceOperation, "cbsCorrelationIdList");
         final UUID uuid = UUID.randomUUID();
         cbsCorrelationIdList.add(0, uuid);
@@ -826,7 +829,7 @@ public class AmqpsSessionDeviceOperationTest
     public void handleAuthenticationMessageWithNoSavedUUID()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
 
         //intentionally leave this list empty
         List<UUID> cbsCorrelationIdList = Deencapsulation.getField(amqpsSessionDeviceOperation, "cbsCorrelationIdList");
@@ -842,7 +845,7 @@ public class AmqpsSessionDeviceOperationTest
     public void handleAuthenticationMessageFailure()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         List<UUID> cbsCorrelationIdList = Deencapsulation.getField(amqpsSessionDeviceOperation, "cbsCorrelationIdList");
         final UUID uuid = UUID.randomUUID();
         cbsCorrelationIdList.add(0, uuid);
@@ -866,7 +869,7 @@ public class AmqpsSessionDeviceOperationTest
     public void getExpectedWorkerLinkCountWithTelemetry()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TELEMETRY, mockAmqpsDeviceTelemetry);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);
@@ -882,7 +885,7 @@ public class AmqpsSessionDeviceOperationTest
     public void getExpectedWorkerLinkCountWithTwin()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TWIN, mockAmqpsDeviceTwin);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);
@@ -898,7 +901,7 @@ public class AmqpsSessionDeviceOperationTest
     public void getExpectedWorkerLinkCountWithMethods()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_METHODS, mockAmqpsDeviceMethods);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);
@@ -914,7 +917,7 @@ public class AmqpsSessionDeviceOperationTest
     public void getExpectedWorkerLinkCountWithTelemetryAndMethods()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TELEMETRY, mockAmqpsDeviceTelemetry);
         amqpsDeviceOperationsMap.put(DEVICE_METHODS, mockAmqpsDeviceMethods);
@@ -931,7 +934,7 @@ public class AmqpsSessionDeviceOperationTest
     public void getExpectedWorkerLinkCountWithTelemetryAndMethodsAndTwin()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TELEMETRY, mockAmqpsDeviceTelemetry);
         amqpsDeviceOperationsMap.put(DEVICE_METHODS, mockAmqpsDeviceMethods);
@@ -949,7 +952,7 @@ public class AmqpsSessionDeviceOperationTest
     public void subscribeToMessageTypeForMethodsSavesInMapAndCallsOpenLinks()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);
 
@@ -979,7 +982,7 @@ public class AmqpsSessionDeviceOperationTest
     public void subscribeToMessageTypeForTwinSavesInMapAndCallsOpenLinks()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);
 
@@ -1009,7 +1012,7 @@ public class AmqpsSessionDeviceOperationTest
     public void subscribeToMessageTypeForTwinDoesNothingIfAlreadySubscribed()
     {
         //arrange
-        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication);
+        final AmqpsSessionDeviceOperation amqpsSessionDeviceOperation = new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthentication, mockedSubscriptionMessageRequestSentCallback);
         Map<MessageType, AmqpsDeviceOperations> amqpsDeviceOperationsMap = new HashMap<MessageType, AmqpsDeviceOperations>();
         amqpsDeviceOperationsMap.put(DEVICE_TWIN, mockAmqpsDeviceTwin);
         Deencapsulation.setField(amqpsSessionDeviceOperation, "amqpsDeviceOperationsMap", amqpsDeviceOperationsMap);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManagerTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionManagerTest.java
@@ -80,13 +80,16 @@ public class AmqpsSessionManagerTest
 
     @Mocked
     AmqpsConvertFromProtonReturnValue mockAmqpsConvertFromProtonReturnValue;
+    
+    @Mocked
+    SubscriptionMessageRequestSentCallback mockedSubscriptionMessageRequestSentCallback;
 
     // Tests_SRS_AMQPSESSIONMANAGER_12_001: [The constructor shall throw IllegalArgumentException if the deviceClientConfig parameter is null.]
     @Test (expected = IllegalArgumentException.class)
     public void constructorThrowsIfDeviceClientIsNull() throws IllegalArgumentException, TransportException
     {
         // act
-        new AmqpsSessionManager(null);
+        new AmqpsSessionManager(null, mockedSubscriptionMessageRequestSentCallback);
     }
 
     // Tests_SRS_AMQPSESSIONMANAGER_12_002: [The constructor shall save the deviceClientConfig parameter value to a member variable.]
@@ -94,7 +97,7 @@ public class AmqpsSessionManagerTest
     public void constructorSavesDeviceClientConfig() throws IllegalArgumentException, TransportException
     {
         // act
-        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
 
         // assert
         DeviceClientConfig actualDeviceClientConfig = Deencapsulation.getField(amqpsSessionManager, "deviceClientConfig");
@@ -110,7 +113,7 @@ public class AmqpsSessionManagerTest
         baseExpectationsSAS();
 
         // act
-        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
 
         // assert
         ArrayList<AmqpsSessionDeviceOperation> actualList =  Deencapsulation.getField(amqpsSessionManager, "amqpsDeviceSessionList");
@@ -122,7 +125,7 @@ public class AmqpsSessionManagerTest
     public void addDeviceOperationSessionSuccess() throws IllegalArgumentException, TransportException
     {
         // arrange
-        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         // act
@@ -135,7 +138,7 @@ public class AmqpsSessionManagerTest
         new Verifications()
         {
             {
-                new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS);
+                new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS, mockedSubscriptionMessageRequestSentCallback);
                 times = 1;
             }
         };
@@ -150,7 +153,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         baseExpectationsSAS();
-        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -197,7 +200,7 @@ public class AmqpsSessionManagerTest
     public void authenticateDoesNothing() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new NonStrictExpectations()
@@ -217,7 +220,7 @@ public class AmqpsSessionManagerTest
     public void authenticateSuccess() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -255,7 +258,7 @@ public class AmqpsSessionManagerTest
     public void openWorkerLinksDoesNothing() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", null);
 
@@ -269,7 +272,7 @@ public class AmqpsSessionManagerTest
     public void openWorkerLinksSuccess() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -296,7 +299,7 @@ public class AmqpsSessionManagerTest
     public void onConnectionInitOpensSession() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new NonStrictExpectations()
@@ -328,7 +331,7 @@ public class AmqpsSessionManagerTest
     public void onSessionRemoteOpenCallsAuthOpenLinks() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -350,7 +353,7 @@ public class AmqpsSessionManagerTest
     public void onSessionRemoteOpenCallsOpenWorkerLinksForX509() throws IllegalArgumentException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationX509);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -384,7 +387,7 @@ public class AmqpsSessionManagerTest
     public void onConnectionInitCallsDeviceSessionsOpenLinks() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new NonStrictExpectations()
@@ -413,7 +416,7 @@ public class AmqpsSessionManagerTest
     public void onConnectionBoundCallsAuthSetSslDomain() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -436,7 +439,7 @@ public class AmqpsSessionManagerTest
     public void onLinkInitCallsDeviceSessionInitLink() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -473,7 +476,7 @@ public class AmqpsSessionManagerTest
     public void onLinkInitCallsAuthInitLink() throws IllegalArgumentException, InterruptedException, TransportException
     {
         // arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -504,7 +507,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new NonStrictExpectations()
@@ -539,7 +542,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new Expectations()
@@ -566,7 +569,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -598,7 +601,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -630,7 +633,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new Expectations()
@@ -655,7 +658,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         new Expectations()
@@ -679,7 +682,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -716,7 +719,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -747,7 +750,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -785,7 +788,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String linkName = "linkName";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
 
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
@@ -814,7 +817,7 @@ public class AmqpsSessionManagerTest
     public void getExpectedWorkerLinkCountWithOneSession()
     {
         //arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
         sessionList.add(mockAmqpsSessionDeviceOperation);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceSessionList", sessionList);
@@ -838,7 +841,7 @@ public class AmqpsSessionManagerTest
     public void getExpectedWorkerLinkCountWithMultipleSession()
     {
         //arrange
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         ArrayList<AmqpsSessionDeviceOperation> sessionList = new ArrayList<>();
         sessionList.add(mockAmqpsSessionDeviceOperation);
         sessionList.add(mockAmqpsSessionDeviceOperation1);
@@ -868,7 +871,7 @@ public class AmqpsSessionManagerTest
         // arrange
         final String expectedDeviceId = "aDeviceId";
         final MessageType expectedMessageType = MessageType.DEVICE_TWIN;
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationX509);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -909,7 +912,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String expectedLinkName = "someTelemetryLink";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -944,7 +947,7 @@ public class AmqpsSessionManagerTest
     {
         // arrange
         final String expectedLinkName = "someTelemetryLink";
-        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig);
+        final AmqpsSessionManager amqpsSessionManager = new AmqpsSessionManager(mockDeviceClientConfig, mockedSubscriptionMessageRequestSentCallback);
         Deencapsulation.setField(amqpsSessionManager, "amqpsDeviceAuthentication", mockAmqpsDeviceAuthenticationCBS);
         Deencapsulation.setField(amqpsSessionManager, "session", mockSession);
 
@@ -992,7 +995,7 @@ public class AmqpsSessionManagerTest
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
                 new AmqpsDeviceAuthenticationCBS(mockDeviceClientConfig);
                 result = mockAmqpsDeviceAuthenticationCBS;
-                new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS);
+                new AmqpsSessionDeviceOperation(mockDeviceClientConfig, mockAmqpsDeviceAuthenticationCBS, mockedSubscriptionMessageRequestSentCallback);
                 result = mockAmqpsSessionDeviceOperation;
             }
         };


### PR DESCRIPTION
The recent twin array support changes introduced sending a desired properties subscription message each time the twin sender link opened. However, once the service acknowledges that message, our SDK logged an exception as it didn't correlate the ack back to the subscription message it sent. This PR adds a callback so that the top AMQP layer can be notified each time a lower level sends a subscription message