### PR TITLE
doc(iot-dev): Add missing javadoc explaining SetSendInterval for setOption API

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -549,7 +549,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      is expected to be of type {@code long}.
      *
      *	    - <b>SetSendInterval</b> - this option is applicable to all protocols.
-     *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
+     *	      This value sets the period (in milliseconds) that this SDK spawns threads to send queued messages.
      *	      Even if no message is queued, this thread will be spawned.
      *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -548,6 +548,10 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
      *
+     *      - <b>SetSendInterval</b> - this option is applicable to all protocols.
+     *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
+     *	      Even if no message is queued, this thread will be spawned.
+     *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -548,7 +548,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
      *
-     *      - <b>SetSendInterval</b> - this option is applicable to all protocols.
+     *	    - <b>SetSendInterval</b> - this option is applicable to all protocols.
      *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
      *	      Even if no message is queued, this thread will be spawned.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -360,6 +360,10 @@ public class InternalClient
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
      *
+     *      - <b>SetSendInterval</b> - this option is applicable to all protocols.
+     *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
+     *	      Even if no message is queued, this thread will be spawned.
+     *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -360,7 +360,7 @@ public class InternalClient
      *	      the service checking for availability of new messages. The value
      *	      is expected to be of type {@code long}.
      *
-     *      - <b>SetSendInterval</b> - this option is applicable to all protocols.
+     *	    - <b>SetSendInterval</b> - this option is applicable to all protocols.
      *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
      *	      Even if no message is queued, this thread will be spawned.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -361,7 +361,7 @@ public class InternalClient
      *	      is expected to be of type {@code long}.
      *
      *	    - <b>SetSendInterval</b> - this option is applicable to all protocols.
-     *	      This value sets the period (in milliseconds) that this SDK spawns a thread to send a queued message.
+     *	      This value sets the period (in milliseconds) that this SDK spawns threads to send queued messages.
      *	      Even if no message is queued, this thread will be spawned.
      *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols


### PR DESCRIPTION
This was missing from the list of options, even though it is a valid option that users can set