### PR TITLE
Add support for fully qualified error codes in service client HTTP exceptions

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ErrorCodeDescription.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ErrorCodeDescription.java
@@ -1,0 +1,193 @@
+package com.microsoft.azure.sdk.iot.deps.serializer;
+
+/**
+ * See https://docs.microsoft.com/en-us/rest/api/iothub/common-error-codes for additional details
+ */
+public enum ErrorCodeDescription
+{
+    // These descriptions belong to fully qualified status codes, such as 404001
+    UnclassifiedErrorCode,
+    InvalidProtocolVersion,
+    DeviceInvalidResultCount,
+    InvalidOperation,
+    ArgumentInvalid,
+    ArgumentNull,
+    IotHubFormatError,
+    DeviceStorageEntitySerializationError,
+    BlobContainerValidationError,
+    ImportWarningExistsError,
+    InvalidSchemaVersion,
+    DeviceDefinedMultipleTimes,
+    DeserializationError,
+    BulkRegistryOperationFailure,
+    CannotRegisterModuleToModule,
+    IotHubNotFound,
+    IotHubUnauthorizedAccess,
+    IotHubUnauthorized,
+    IotHubSuspended,
+    IotHubQuotaExceeded,
+    JobQuotaExceeded,
+    DeviceMaximumQueueDepthExceeded,
+    IotHubMaxCbsTokenExceeded,
+    DeviceNotFound,
+    JobNotFound,
+    PartitionNotFound,
+    ModuleNotFound,
+    DeviceAlreadyExists,
+    ModuleAlreadyExistsOnDevice,
+    DeviceMessageLockLost,
+    MessageTooLarge,
+    TooManyDevices,
+    TooManyModulesOnDevice,
+    ThrottleBacklogLimitExceeded,
+    InvalidThrottleParameter,
+    ServerError,
+    JobCancelled,
+    ConnectionForcefullyClosedOnNewConnection,
+    DeviceNotOnline,
+    DeviceConnectionClosedRemotely,
+
+    // These descriptions belong to 3 digit http response codes such as 404.
+    BadFormat,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Conflict,
+
+    /**
+     * Represents status code for 429 and for status code 429001
+     */
+    PreconditionFailed,
+
+    RequestEntityTooLarge,
+
+    /**
+     * Represents status code for 429 and 429001
+     */
+    ThrottlingException,
+    InternalServerError,
+
+    /**
+     * Defined for status code 503 and 503001
+     */
+    ServiceUnavailable;
+
+
+    /**
+     * Get the ErrorCodeDescription tied to the provided errorCode
+     * @param errorCode the service error code, such as 404, or 429001
+     * @return the corresponding ErrorCodeDescription
+     */
+    public static ErrorCodeDescription Parse(int errorCode)
+    {
+        switch (errorCode)
+        {
+            case(400001):
+                return InvalidProtocolVersion;
+            case(400002):
+                return DeviceInvalidResultCount;
+            case(400003):
+                return InvalidOperation;
+            case(400004):
+                return ArgumentInvalid;
+            case(400005):
+                return ArgumentNull;
+            case(400006):
+                return IotHubFormatError;
+            case(400007):
+                return DeviceStorageEntitySerializationError;
+            case(400008):
+                return BlobContainerValidationError;
+            case(400009):
+                return ImportWarningExistsError;
+            case(400010):
+                return InvalidSchemaVersion;
+            case(400011):
+                return DeviceDefinedMultipleTimes;
+            case(400012):
+                return DeserializationError;
+            case(400013):
+                return BulkRegistryOperationFailure;
+            case (400027):
+                return ConnectionForcefullyClosedOnNewConnection;
+            case(400301):
+                return CannotRegisterModuleToModule;
+            case(401001):
+                return IotHubNotFound;
+            case(401002):
+                return IotHubUnauthorizedAccess;
+            case(401003):
+                return IotHubUnauthorized;
+            case(403001):
+                return IotHubSuspended;
+            case(403002):
+                return IotHubQuotaExceeded;
+            case(403003):
+                return JobQuotaExceeded;
+            case(403004):
+                return DeviceMaximumQueueDepthExceeded;
+            case(403005):
+                return IotHubMaxCbsTokenExceeded;
+            case(404001):
+                return DeviceNotFound;
+            case(404002):
+                return JobNotFound;
+            case(404003):
+                return PartitionNotFound;
+            case(404010):
+                return ModuleNotFound;
+            case (404103):
+                return DeviceNotOnline;
+            case (404104):
+                return DeviceConnectionClosedRemotely;
+            case(409001):
+                return DeviceAlreadyExists;
+            case(409301):
+                return ModuleAlreadyExistsOnDevice;
+            case(412001):
+                return PreconditionFailed;
+            case(412002):
+                return DeviceMessageLockLost;
+            case(413001):
+                return MessageTooLarge;
+            case(413002):
+                return TooManyDevices;
+            case(413003):
+                return TooManyModulesOnDevice;
+            case(429001):
+                return ThrottlingException;
+            case(429002):
+                return ThrottleBacklogLimitExceeded;
+            case(429003):
+                return InvalidThrottleParameter;
+            case(500001):
+                return ServerError;
+            case(500002):
+                return JobCancelled;
+            case(503001):
+                return ServiceUnavailable;
+            case (400):
+                return BadFormat;
+            case (401):
+                return Unauthorized;
+            case (403):
+                return Forbidden;
+            case (404):
+                return NotFound;
+            case (409):
+                return Conflict;
+            case (412):
+                return PreconditionFailed;
+            case (413):
+                return RequestEntityTooLarge;
+            case (429):
+                return ThrottlingException;
+            case (500):
+                return InternalServerError;
+            case (503):
+                return ServiceUnavailable;
+            default:
+                return UnclassifiedErrorCode;
+        }
+    }
+}

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ErrorMessageParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ErrorMessageParser.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.azure.sdk.iot.deps.serializer;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -81,5 +79,45 @@ public class ErrorMessageParser
         }
 
         return rootMessage;
+    }
+
+    /**
+     * Get the fully qualified error code from the http response message errorReason, if one exists.
+     * @param fullErrorMessage the http response message error reason
+     * @return the fully qualified error code, or 0 if no error code was provided.
+     */
+    public static int bestErrorCode(String fullErrorMessage)
+    {
+        String errorCodeJsonKey = "errorCode";
+        if((fullErrorMessage == null) || fullErrorMessage.isEmpty())
+        {
+            return getDefaultErrorCode();
+        }
+
+        try
+        {
+            JsonObject errorMessageJson = new GsonBuilder().create().fromJson(fullErrorMessage, JsonObject.class);
+
+            if (errorMessageJson.has(errorCodeJsonKey) && errorMessageJson.get(errorCodeJsonKey).isJsonPrimitive())
+            {
+                JsonPrimitive errorCodeJson = errorMessageJson.getAsJsonPrimitive(errorCodeJsonKey);
+
+                if (errorCodeJson.isNumber())
+                {
+                    return errorCodeJson.getAsInt();
+                }
+            }
+        }
+        catch (JsonParseException e)
+        {
+            return getDefaultErrorCode();
+        }
+
+        return getDefaultErrorCode();
+    }
+
+    public static int getDefaultErrorCode()
+    {
+        return 0;
     }
 }

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ErrorMessageParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/ErrorMessageParserTest.java
@@ -3,6 +3,7 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.deps.serializer;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
 import com.microsoft.azure.sdk.iot.deps.serializer.ErrorMessageParser;
 import org.junit.Test;
 
@@ -27,6 +28,20 @@ public class ErrorMessageParserTest
 
         // assert
         assertEquals("ErrorCode:IotHubUnauthorizedAccess;Unauthorized Tracking ID:(tracking id)-TimeStamp:12/14/2016 03:15:17", bestMessage);
+    }
+
+    @Test
+    public void bestErrorCodeParse()
+    {
+        // arrange
+        int expectedErrorCode = 404001;
+        final String errorReason = "{\"errorCode\":" + expectedErrorCode + ",\"trackingId\":\"191306c3cfda487ebe0988aa7663fb0f-TimeStamp:05/21/2020 20:14:49\",\"message\":\"thisDeviceDoesNotExistObviously\",\"timestampUtc\":\"2020-05-21T20:14:49.3270481Z\"} ";
+
+        // act
+        int errorCodeDescription = ErrorMessageParser.bestErrorCode(errorReason);
+
+        // assert
+        assertEquals(expectedErrorCode, errorCodeDescription);
     }
 
     /* Codes_SRS_ERROR_MESSAGE_PARSER_21_002: [If the bestErrorMessage failed to parse the fullErrorMessage as json, it shall return the fullErrorMessage as is.] */

--- a/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/main/java/com/microsoft/azure/sdk/iot/common/tests/iothub/methods/DeviceMethodTests.java
@@ -44,7 +44,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
     {
         super.cleanToStart();
     }
-/*
+
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void invokeMethodSucceed() throws Exception
@@ -379,7 +379,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
             deviceTestManger.restartDevice(registryManager.getDeviceConnectionString((Device) testInstance.identity), testInstance.protocol, testInstance.publicKeyCert, testInstance.privateKey);
         }
     }
-*/
+
     @Test
     @ConditionalIgnoreRule.ConditionalIgnore(condition = StandardTierOnlyRule.class)
     public void invokeMethodOnOfflineDevice() throws Exception

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadFormatException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadFormatException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create bad message format exception
  */
@@ -14,8 +16,14 @@ public class IotHubBadFormatException extends IotHubException
     {
         this(null);
     }
+
     public IotHubBadFormatException(String message)
     {
         super(message);
+    }
+
+    IotHubBadFormatException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadGatewayException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubBadGatewayException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create bad gateway exception (device sent malformed response)
  */
@@ -14,8 +16,14 @@ public class IotHubBadGatewayException extends IotHubException
     {
         this(null);
     }
+
     public IotHubBadGatewayException(String message)
     {
         super(message);
+    }
+
+    IotHubBadGatewayException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubConflictException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubConflictException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * 409 Conflict
  * Likely caused by trying to create a resource that already exists
@@ -19,5 +21,10 @@ public class IotHubConflictException extends IotHubException
     public IotHubConflictException(String message)
     {
         super(message);
+    }
+
+    IotHubConflictException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceMaximumQueueDepthExceededException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceMaximumQueueDepthExceededException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub device maximum queue depth exceeded exception
  */
@@ -18,5 +20,10 @@ public class IotHubDeviceMaximumQueueDepthExceededException extends IotHubExcept
     public IotHubDeviceMaximumQueueDepthExceededException(String message)
     {
         super(message);
+    }
+
+    IotHubDeviceMaximumQueueDepthExceededException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceNotFoundException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubDeviceNotFoundException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub not found exception
  */
@@ -18,5 +20,10 @@ public class IotHubDeviceNotFoundException extends IotHubException
     public IotHubDeviceNotFoundException(String message)
     {
         super(message);
+    }
+
+    IotHubDeviceNotFoundException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubException.java
@@ -5,14 +5,50 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorMessageParser;
+import lombok.Getter;
+
 /**
  * Super class for IotHub exceptions
  */
 public class IotHubException extends Exception
 {
-    public IotHubException() { super(); }
+    public IotHubException()
+    {
+        this(null);
+    }
+
     public IotHubException(String message)
     {
-        super(((message == null) || message.isEmpty()) ? "" : message);
+        this(message, ErrorMessageParser.getDefaultErrorCode(), ErrorCodeDescription.UnclassifiedErrorCode);
     }
+
+    IotHubException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message);
+        this.errorCodeDescription = errorCodeDescription;
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * <p>Provides the HTTP error code, if applicable.</p>
+     *
+     * <p>This value will be a 6 digital error code such as 404001 if the service provided one in response message to the HTTP request.
+     * Otherwise it will be a 3 digit status code such as 404.</p>
+     *
+     * <p>For AMQP operations such as sending cloud to device messages,
+     * receiving message feedback, and getting file upload notifications, this field will not be populated.</p>
+     */
+    @Getter
+    protected int errorCode;
+
+    /**
+     * <p>Provides the HTTP error code description, if applicable.</p>
+     *
+     * <p>For AMQP operations such as sending cloud to device messages,
+     * receiving message feedback, and getting file upload notifications, this field will not be populated.</p>
+     */
+    @Getter
+    protected ErrorCodeDescription errorCodeDescription;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManager.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
 import com.microsoft.azure.sdk.iot.deps.serializer.ErrorMessageParser;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
 
@@ -49,61 +50,71 @@ public class IotHubExceptionManager
 
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_21_013: [If the httpresponse contains a reason message, the function must print this reason in the error message]
         String errorMessage = ErrorMessageParser.bestErrorMessage(new String(httpResponse.getErrorReason(), StandardCharsets.UTF_8));
+        int errorCode = ErrorMessageParser.bestErrorCode(errorMessage);
+
+        if (errorCode == ErrorMessageParser.getDefaultErrorCode())
+        {
+            //Some error messages contain a full error code such as 404001, but others do not.
+            //if no error code was found in body of error message, default to the http response status code.
+            errorCode = responseStatus;
+        }
+
+        ErrorCodeDescription errorCodeDescription = ErrorCodeDescription.Parse(errorCode);
 
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_001: [The function shall throw IotHubBadFormatException if the Http response status equal 400]
         if (400 == responseStatus)
         {
-            throw new IotHubBadFormatException(errorMessage);
+            throw new IotHubBadFormatException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_002: [The function shall throw IotHubUnathorizedException if the Http response status equal 401]
         else if (401 == responseStatus)
         {
-            throw new IotHubUnathorizedException(errorMessage);
+            throw new IotHubUnathorizedException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_003: [The function shall throw IotHubTooManyDevicesException if the Http response status equal 403]
         else if (403 == responseStatus)
         {
-            throw new IotHubTooManyDevicesException(errorMessage);
+            throw new IotHubTooManyDevicesException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_004: [The function shall throw IotHubNotFoundException if the Http response status equal 404]
         else if (404 == responseStatus)
         {
-            throw new IotHubNotFoundException(errorMessage);
+            throw new IotHubNotFoundException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_34_018: [The function shall throw IotHubConflictException if the Http response status equal 409]
         else if (409 == responseStatus)
         {
-            throw new IotHubConflictException(errorMessage);
+            throw new IotHubConflictException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_005: [The function shall throw IotHubPreconditionFailedException if the Http response status equal 412]
         else if (412 == responseStatus)
         {
-            throw new IotHubPreconditionFailedException(errorMessage);
+            throw new IotHubPreconditionFailedException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_006: [The function shall throw IotHubTooManyRequestsException if the Http response status equal 429]
         else if (429 == responseStatus)
         {
-            throw new IotHubTooManyRequestsException(errorMessage);
+            throw new IotHubTooManyRequestsException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_007: [The function shall throw IotHubInternalServerErrorException if the Http response status equal 500]
         else if (500 == responseStatus)
         {
-            throw new IotHubInternalServerErrorException(errorMessage);
+            throw new IotHubInternalServerErrorException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_21_008: [The function shall throw IotHubBadGatewayException if the Http response status equal 502]
         else if (502 == responseStatus)
         {
-            throw new IotHubBadGatewayException(errorMessage);
+            throw new IotHubBadGatewayException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_009: [The function shall throw IotHubServerBusyException if the Http response status equal 503]
         else if (503 == responseStatus)
         {
-            throw new IotHubServerBusyException(errorMessage);
+            throw new IotHubServerBusyException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_21_010: [The function shall throw IotHubGatewayTimeoutException if the Http response status equal 504]
         else if (504 == responseStatus)
         {
-            throw new IotHubGatewayTimeoutException(errorMessage);
+            throw new IotHubGatewayTimeoutException(errorMessage, errorCode, errorCodeDescription);
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_011: [The function shall throw IotHubException if the Http response status none of them above and greater than 300 copying the error Http reason to the exception]
         else if (responseStatus > 300)
@@ -114,7 +125,7 @@ public class IotHubExceptionManager
             }
             else
             {
-                throw new IotHubException(errorMessage);
+                throw new IotHubException(errorMessage, errorCode, errorCodeDescription);
             }
         }
         // Codes_SRS_SERVICE_SDK_JAVA_IOTHUBEXCEPTIONMANAGER_12_012: [The function shall return without exception if the response status equal or less than 300]

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubGatewayTimeoutException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubGatewayTimeoutException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create gateway timeout exception (device does not answer in time)
  */
@@ -14,8 +16,14 @@ public class IotHubGatewayTimeoutException extends IotHubException
     {
         this(null);
     }
+
     public IotHubGatewayTimeoutException(String message)
     {
         super(message);
+    }
+
+    IotHubGatewayTimeoutException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInternalServerErrorException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInternalServerErrorException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create internal server error exception
  */
@@ -14,8 +16,14 @@ public class IotHubInternalServerErrorException extends IotHubException
     {
         this(null);
     }
+
     public IotHubInternalServerErrorException(String message)
     {
         super(message);
+    }
+
+    IotHubInternalServerErrorException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInvalidOperationException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubInvalidOperationException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub invalid operation exception
  */
@@ -18,5 +20,10 @@ public class IotHubInvalidOperationException extends IotHubException
     public IotHubInvalidOperationException(String message)
     {
         super(message);
+    }
+
+    IotHubInvalidOperationException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubMessageTooLargeException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubMessageTooLargeException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub Message too large exception
  */
@@ -18,5 +20,10 @@ public class IotHubMessageTooLargeException extends IotHubException
     public IotHubMessageTooLargeException(String message)
     {
         super(message);
+    }
+
+    IotHubMessageTooLargeException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotFoundException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotFoundException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub not found exception
  */
@@ -18,5 +20,10 @@ public class IotHubNotFoundException extends IotHubException
     public IotHubNotFoundException(String message)
     {
         super(message);
+    }
+
+    IotHubNotFoundException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotSupportedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubNotSupportedException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create iot hub not found exception
  */
@@ -18,5 +20,10 @@ public class IotHubNotSupportedException extends IotHubException
     public IotHubNotSupportedException(String message)
     {
         super(message);
+    }
+
+    IotHubNotSupportedException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubPreconditionFailedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubPreconditionFailedException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create precondition failed exception
  */
@@ -14,8 +16,14 @@ public class IotHubPreconditionFailedException extends IotHubException
     {
         this(null);
     }
+
     public IotHubPreconditionFailedException(String message)
     {
         super(message);
+    }
+
+    IotHubPreconditionFailedException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubServerBusyException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubServerBusyException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create server busy exception
  */
@@ -14,8 +16,14 @@ public class IotHubServerBusyException extends IotHubException
     {
         this(null);
     }
+
     public IotHubServerBusyException(String message)
     {
         super(message);
+    }
+
+    IotHubServerBusyException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyDevicesException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyDevicesException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create too many devices exception
  */
@@ -14,8 +16,14 @@ public class IotHubTooManyDevicesException extends IotHubException
     {
         this(null);
     }
+
     public IotHubTooManyDevicesException(String message)
     {
         super(message);
+    }
+
+    IotHubTooManyDevicesException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyRequestsException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubTooManyRequestsException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create too many requests exception
  */
@@ -14,8 +16,14 @@ public class IotHubTooManyRequestsException extends IotHubException
     {
         this(null);
     }
+
     public IotHubTooManyRequestsException(String message)
     {
         super(message);
+    }
+
+    IotHubTooManyRequestsException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubUnathorizedException.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubUnathorizedException.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.sdk.iot.service.exceptions;
 
+import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
+
 /**
  * Create unauthorized exception
  */
@@ -18,5 +20,10 @@ public class IotHubUnathorizedException extends IotHubException
     public IotHubUnathorizedException(String message)
     {
         super(message);
+    }
+
+    IotHubUnathorizedException(String message, int errorCode, ErrorCodeDescription errorCodeDescription)
+    {
+        super(message, errorCode, errorCodeDescription);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -266,7 +266,15 @@ public class AmqpSendHandler extends AmqpConnectionHandler
             {
                 //By closing the link locally, proton-j will fire an event onLinkLocalClose. Within ErrorLoggingBaseHandlerWithCleanup,
                 // onLinkLocalClose closes the session locally and eventually the connection and reactor
-                log.debug("Closing amqp cloud to device message sender link since the message was delivered");
+                if (remoteState.getClass().equals(Accepted.class))
+                {
+                    log.debug("Closing AMQP cloud to device message sender link since the message was delivered");
+                }
+                else
+                {
+                    log.debug("Closing AMQP cloud to device message sender link since the message failed to be delivered");
+                }
+
                 snd.close();
             }
         }


### PR DESCRIPTION
Previously, the service client ignored the fully qualified status codes embedded in the error message for cases where the service threw a 404/500/etc.

Customer's need to have some granularity in treating a 404001 (deviceNotFound) from a 404010 (moduleNotFound) from a 404103 (deviceNotOnline) as these are all potential error cases when invoking a method on a module.

Now all of our service side exception types have dedicated fields for error code and error code description.

The error code will be the 6 digit code (404001, for instance) if the service gave the SDK that code, or it will be the 3 digit error code that we always get in the http response object (404, for instance)