### PR TITLE
fix(iot-device): Fix issue where creationTimeUTC used local timezone during stringification

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/Message.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/Message.java
@@ -10,10 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 public class Message
@@ -25,6 +22,8 @@ public class Message
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd_HH:mm:ss.SSSSSSS";
 
     private static final String SECURITY_CLIENT_JSON_ENCODING = "application/json";
+
+    private static final String UTC_TIMEZONE = "UTC";
 
     // ----- Data Fields -----
 
@@ -645,9 +644,10 @@ public class Message
             return null;
         }
 
-        // Codes_SRS_MESSAGE_34_064: [The function shall return the saved creationTimeUTC as a string in the format "yyyy-MM-dd_HH:mm:ss.SSSSSSS".]
+        // Codes_SRS_MESSAGE_34_064: [The function shall return the saved creationTimeUTC as a string in the format "yyyy-MM-dd_HH:mm:ss.SSSSSSSZ".]
         SimpleDateFormat sdf = new SimpleDateFormat(DATE_TIME_FORMAT);
-        return sdf.format(this.creationTimeUTC).replace("_", "T");
+        sdf.setTimeZone(TimeZone.getTimeZone(UTC_TIMEZONE));
+        return sdf.format(this.creationTimeUTC).replace("_", "T") + "Z";
     }
 
     public final void setCreationTimeUTC(Date creationTimeUTC)

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessageTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/MessageTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -386,7 +387,8 @@ public class MessageTest
         final Date testTime = new Date();
         final String DATE_TIME_FORMAT = Deencapsulation.getField(Message.class, "DATE_TIME_FORMAT");
         SimpleDateFormat sdf = new SimpleDateFormat(DATE_TIME_FORMAT);
-        String expectedCreationTimeUtcString = sdf.format(testTime).replace("_", "T");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String expectedCreationTimeUtcString = sdf.format(testTime).replace("_", "T") + "Z";
         Message message = new Message();
         message.setCreationTimeUTC(testTime);
 


### PR DESCRIPTION
During this conversion, the simple date formatter assumed local time, when it should be using UTC time