### PR TITLE
refactor(iot-service): Make all service operations use the latest service api version

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/IotHubConnectionString.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/IotHubConnectionString.java
@@ -41,7 +41,6 @@ public class IotHubConnectionString extends IotHubConnectionStringBuilder
     private static final String URL_PATH_DEVICES = "devices";
     private static final String URL_PATH_MODULES = "modules";
     private static final String URL_PATH_CONFIG = "configurations";
-    private static final String URL_API_VERSION_LIMITED_AVAILABILITY = "api-version=" + TransportUtils.IOTHUB_API_VERSION_LIMITED_AVAILIBILITY;
     private static final String URL_API_VERSION = "api-version=" + TransportUtils.IOTHUB_API_VERSION;
     private static final String URL_MAX_COUNT = "top=";
     private static final String URL_PATH_DEVICESTATISTICS = "statistics";
@@ -66,18 +65,7 @@ public class IotHubConnectionString extends IotHubConnectionStringBuilder
     // configurations
     private static final String URL_PATH_APPLY_CONTENT_CONFIGURATION = "applyConfigurationContent";
 
-    protected String storageIdentity;
-    boolean IsStorageIdentityEnabled;
-
     protected IotHubConnectionString() {
-
-        // For import/export devices jobs, a new parameter is available in a
-        // new api-version, which is only available in a few initial regions.
-        // Control access via an environment variable. If a user wishes to try it out,
-        // they can set "EnabledStorageIdentity" to "1". Otherwise, the SDK will still
-        // default to the latest, broadly-supported api-version used in this SDK.
-        storageIdentity = System.getenv().get("EnableStorageIdentity");
-        IsStorageIdentityEnabled = "1".equalsIgnoreCase(storageIdentity);
     }
 
     /**
@@ -647,19 +635,7 @@ public class IotHubConnectionString extends IotHubConnectionStringBuilder
         stringBuilder.append(URL_SEPARATOR_0);
         stringBuilder.append("create");
         stringBuilder.append(URL_SEPARATOR_1);
-        // The new api-version is only available in a few initial regions
-        // Control access via an environment variable. If a user wishes to try it out,
-        // they can set "EnabledStorageIdentity" to "1". Otherwise, the SDK will still
-        // default to the latest, broadly-supported api-version used in this SDK.
-        IotHubConnectionString iotHubConnectionString = new IotHubConnectionString();
-        if (iotHubConnectionString.IsStorageIdentityEnabled)
-        {
-            stringBuilder.append(URL_API_VERSION_LIMITED_AVAILABILITY);
-        }
-        else
-        {
-            stringBuilder.append(URL_API_VERSION);
-        }
+        stringBuilder.append(URL_API_VERSION);
         return new URL(stringBuilder.toString());
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/JobProperties.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/JobProperties.java
@@ -250,10 +250,7 @@ public class JobProperties
         this.inputBlobContainerUri = parser.getInputBlobContainerUri();
         this.failureReason = parser.getFailureReason();
         this.outputBlobContainerUri = parser.getOutputBlobContainerUri();
-        IotHubConnectionString iotHubConnectionString = new IotHubConnectionString();
-        if (iotHubConnectionString.IsStorageIdentityEnabled) {
-            this.storageAuthenticationType = parser.getStorageAuthenticationType();
-        }
+        this.storageAuthenticationType = parser.getStorageAuthenticationType();
         this.jobId = parser.getJobIdFinal();
         this.progress = parser.getProgress();
         this.startTimeUtc = parser.getStartTimeUtc();
@@ -282,10 +279,7 @@ public class JobProperties
         jobPropertiesParser.setFailureReason(this.failureReason);
         jobPropertiesParser.setInputBlobContainerUri(this.inputBlobContainerUri);
         jobPropertiesParser.setOutputBlobContainerUri(this.outputBlobContainerUri);
-        IotHubConnectionString iotHubConnectionString = new IotHubConnectionString();
-        if (iotHubConnectionString.IsStorageIdentityEnabled) {
-            jobPropertiesParser.setStorageAuthenticationType(this.storageAuthenticationType);
-        }
+        jobPropertiesParser.setStorageAuthenticationType(this.storageAuthenticationType);
         jobPropertiesParser.setJobId(this.jobId);
         jobPropertiesParser.setProgress(this.progress);
         jobPropertiesParser.setStartTimeUtc(this.startTimeUtc);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -15,6 +15,5 @@ public class TransportUtils
     private static String PROCESSOR_ARCHITECTURE = System.getProperty("os.arch");
 
     public static final String USER_AGENT_STRING = javaServiceClientIdentifier + serviceVersion + " (" + JAVA_RUNTIME + "; " + OPERATING_SYSTEM +"; " + PROCESSOR_ARCHITECTURE + ")";
-    public static final String IOTHUB_API_VERSION = "2019-10-01";
-    public static final String IOTHUB_API_VERSION_LIMITED_AVAILIBILITY = "2020-03-13";
+    public static final String IOTHUB_API_VERSION = "2020-03-13";
 }


### PR DESCRIPTION
This API version was only available in certain regions previously, but now that it is available in every region, we can make all service client operations use this

We can also get rid of the environment variable lookup that was previously used to toggle between a widely available service API version and the selectively available service api version