### PR TITLE
release(2020-06-12): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -13,7 +13,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION_PREVIEW = "2020-05-31-preview";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.22.0";
+    private static final String CLIENT_VERSION = "1.23.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.22.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.23.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.22.0</iot-device-client-version>
-        <iot-service-client-version>1.22.0</iot-service-client-version>
-        <iot-deps-version>0.9.4</iot-deps-version>
+        <iot-device-client-version>1.23.0</iot-device-client-version>
+        <iot-service-client-version>1.23.0</iot-service-client-version>
+        <iot-deps-version>0.9.5</iot-deps-version>
         <provisioning-device-client-version>1.8.2</provisioning-device-client-version>
         <provisioning-service-client-version>1.6.1</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.22.0";
+    public static String serviceVersion = "1.23.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
### Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.23.0)

- Make all service client APIs use new Service API Version (#788)
- Add support for fully qualified error codes in service client HTTP exceptions (#782)


### Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.23.0)

- Add Client Options to enable users to supply model id on MQTT (#791)

**Bug Fixes:**

- Fix issue where creationTimeUTC used local timezone during stringification (#784)

### Java SDK Dependency (com.microsoft.azure.sdk.iot:iot-deps:0.9.5)

- Add support for fully qualified error codes in service client HTTP exceptions (#782)

