### PR TITLE
feat(iot-service): Add support for setting http read and connect timeouts for registry manager operations

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -589,7 +589,7 @@ public class RegistryManager
         String sasToken = new IotHubServiceSasToken(this.iotHubConnectionString).toString();
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_049: [The function shall create a new HttpRequest for removing the device from IotHub]
-        HttpRequest request = CreateRequest(url, HttpMethod.DELETE, new byte[0], sasToken); //TODO
+        HttpRequest request = CreateRequest(url, HttpMethod.DELETE, new byte[0], sasToken);
         request.setHeaderField("If-Match", etag);
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_050: [The function shall send the created request and get the response]

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -37,7 +37,6 @@ import java.util.concurrent.Executors;
  */
 public class RegistryManager
 {
-    private final Integer DEFAULT_HTTP_TIMEOUT_MS = 24000;
     private static final int EXECUTOR_THREAD_POOL_SIZE = 10;
     private ExecutorService executor;
     private IotHubConnectionString iotHubConnectionString;
@@ -54,7 +53,10 @@ public class RegistryManager
     {
         // This constructor was previously a default constructor that users could use because there was no other constructor declared.
         // However, we still prefer users use the createFromConnectionString method to build their clients.
-        options = RegistryManagerOptions.builder().build();
+        options = RegistryManagerOptions.builder()
+                .httpConnectTimeout(RegistryManagerOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .httpReadTimeout(RegistryManagerOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .build();
     }
 
     /**
@@ -66,7 +68,12 @@ public class RegistryManager
      */
     public static RegistryManager createFromConnectionString(String connectionString) throws IOException
     {
-        return createFromConnectionString(connectionString, RegistryManagerOptions.builder().build());
+        RegistryManagerOptions options = RegistryManagerOptions.builder()
+                .httpConnectTimeout(RegistryManagerOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .httpReadTimeout(RegistryManagerOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .build();
+
+        return createFromConnectionString(connectionString, options);
     }
 
     /**
@@ -582,9 +589,7 @@ public class RegistryManager
         String sasToken = new IotHubServiceSasToken(this.iotHubConnectionString).toString();
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_049: [The function shall create a new HttpRequest for removing the device from IotHub]
-        HttpRequest request = new HttpRequest(url, HttpMethod.DELETE, new byte[0]);
-        request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
-        request.setHeaderField("authorization", sasToken);
+        HttpRequest request = CreateRequest(url, HttpMethod.DELETE, new byte[0], sasToken); //TODO
         request.setHeaderField("If-Match", etag);
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_050: [The function shall send the created request and get the response]
@@ -1303,9 +1308,7 @@ public class RegistryManager
         String sasToken = new IotHubServiceSasToken(this.iotHubConnectionString).toString();
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_038: [The function shall create a new HttpRequest for removing the module from IotHub]
-        HttpRequest request = new HttpRequest(url, HttpMethod.DELETE, new byte[0]);
-        request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
-        request.setHeaderField("authorization", sasToken);
+        HttpRequest request = CreateRequest(url, HttpMethod.DELETE, new byte[0], sasToken);
         request.setHeaderField("If-Match", etag);
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_039: [The function shall send the created request and get the response]
@@ -1564,9 +1567,7 @@ public class RegistryManager
         String sasToken = new IotHubServiceSasToken(this.iotHubConnectionString).toString();
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_076: [The function shall create a new HttpRequest for removing the configuration from IotHub]
-        HttpRequest request = new HttpRequest(url, HttpMethod.DELETE, new byte[0]);
-        request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
-        request.setHeaderField("authorization", sasToken);
+        HttpRequest request = CreateRequest(url, HttpMethod.DELETE, new byte[0], sasToken);
         request.setHeaderField("If-Match", etag);
 
         // Codes_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_28_077: [The function shall send the created request and get the response]
@@ -1639,7 +1640,8 @@ public class RegistryManager
         }
 
         HttpRequest request = new HttpRequest(url, method, payload, proxy);
-        request.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
+        request.setReadTimeoutMillis(options.getHttpReadTimeout());
+        request.setConnectTimeoutMillis(options.getHttpConnectTimeout());
         request.setHeaderField("authorization", sasToken);
         request.setHeaderField("Request-Id", "1001");
         request.setHeaderField("Accept", "application/json");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -9,9 +9,18 @@ import lombok.Getter;
 @Builder
 public class RegistryManagerOptions
 {
+    protected static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
+    protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 0; // infinite
+
     /**
      * The options that specify what proxy to tunnel through. If null, no proxy will be used
      */
     @Getter
     private ProxyOptions proxyOptions;
+
+    @Getter
+    private int httpReadTimeout;
+
+    @Getter
+    private int httpConnectTimeout;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class RegistryManagerOptions
 {
     protected static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
-    protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 0; // infinite
+    protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
 
     /**
      * The options that specify what proxy to tunnel through. If null, no proxy will be used

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -18,9 +18,21 @@ public class RegistryManagerOptions
     @Getter
     private ProxyOptions proxyOptions;
 
+    /**
+     * The http read timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when reading from
+     * Input stream after a connection is established to a resource. If the timeout expires before there is data available
+     * for read, a java.net.SocketTimeoutException is raised. A timeout of zero is interpreted as an infinite timeout.
+     * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}
+     */
     @Getter
     private int httpReadTimeout;
 
+    /**
+     * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
+     * before the connection can be established, a java.net.SocketTimeoutException is thrown.
+     * A timeout of zero is interpreted as an infinite timeout.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}
+     */
     @Getter
     private int httpConnectTimeout;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnection.java
@@ -181,6 +181,17 @@ public class HttpConnection
     }
 
     /**
+     * Sets the connect timeout in milliseconds. The connect timeout
+     * is the allowed amount of time for the http connection to be established.
+     *
+     * @param timeout The connect timeout.
+     */
+    public void setConnectTimeoutMillis(int timeout)
+    {
+        this.connection.setConnectTimeout(timeout);
+    }
+
+    /**
      * Saves the body to be sent with the request.
      *
      * @param body The request body.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpRequest.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/http/HttpRequest.java
@@ -138,6 +138,18 @@ public class HttpRequest
         return this;
     }
 
+    /**
+     * Set the connect timeout, in milliseconds, for the request. The connect timeout
+     * is the allowed amount of time for the http connection to be established.
+     * @param timeout the connect timeout
+     * @return the object itself, for fluent setting.
+     */
+    public HttpRequest setConnectTimeoutMillis(int timeout)
+    {
+        this.connection.setConnectTimeoutMillis(timeout);
+        return this;
+    }
+
     protected HttpRequest()
     {
         this.connection = null;

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -945,7 +945,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlDevice(deviceId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -999,7 +999,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlDevice(deviceId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -1048,7 +1048,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlDevice(deviceId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -1888,7 +1888,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlModule(deviceId, moduleId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -2010,7 +2010,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlModule(deviceId, moduleId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -2333,7 +2333,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlConfiguration(configId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -2364,7 +2364,7 @@ public class RegistryManagerTest
             {
                 iotHubConnectionString.getUrlConfiguration(configId);
                 times = 1;
-                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0]);
+                new HttpRequest(mockUrl, HttpMethod.DELETE, new byte[0], (Proxy) any);
                 times = 1;
                 mockHttpRequest.setReadTimeoutMillis(anyInt);
                 mockHttpRequest.setHeaderField("authorization", anyString);
@@ -2439,6 +2439,53 @@ public class RegistryManagerTest
                 mockIotHubExceptionManager.httpResponseVerification(mockHttpResponse);
                 times = 1;
 
+            }
+        };
+    }
+
+    @Test
+    public void getDevicesWithCustomHttpTimeouts(@Mocked final IotHubConnectionString mockIotHubConnectionString,
+                                                    @Mocked final DeviceParser mockDeviceParser,
+                                                    @Mocked final Device mockDevice) throws IOException, IotHubException
+    {
+        // arrange
+        final int expectedHttpConnectTimeout = 1234;
+        final int expectedHttpReadTimeout = 5678;
+        final String mockDeviceId = "someDeviceToGet";
+
+        RegistryManagerOptions options = RegistryManagerOptions.builder()
+                .httpConnectTimeout(expectedHttpConnectTimeout)
+                .httpReadTimeout(expectedHttpReadTimeout)
+                .build();
+
+        String mockConnectionString = "someValidConnectionString";
+
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getUrlDevice(mockDeviceId);
+                result = mockUrl;
+                new HttpRequest(mockUrl, HttpMethod.GET, (byte[]) any, (Proxy) any);
+                result = mockHttpRequest;
+                new DeviceParser(anyString);
+                result = mockDeviceParser;
+                Deencapsulation.newInstance(Device.class, mockDeviceParser);
+                result = mockDevice;
+            }
+        };
+
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(mockConnectionString, options);
+        Deencapsulation.setField(registryManager, "iotHubConnectionString", mockIotHubConnectionString);
+
+        // act
+        registryManager.getDevice(mockDeviceId);
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockHttpRequest.setConnectTimeoutMillis(expectedHttpConnectTimeout);
+                mockHttpRequest.setReadTimeoutMillis(expectedHttpReadTimeout);
             }
         };
     }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnectionTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/http/HttpConnectionTest.java
@@ -364,6 +364,38 @@ public class HttpConnectionTest
         };
     }
 
+    @Test
+    public void setConnectTimeoutSetsRequestTimeout() throws IOException
+    {
+        // Arrange
+        final HttpMethod httpsMethod = HttpMethod.POST;
+        final int timeout = 1;
+        final int expectedTimeout = timeout;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "https";
+                mockUrl.openConnection();
+                result = mockUrlConn;
+                mockUrlConn.getRequestMethod();
+                result = httpsMethod.name();
+            }
+        };
+        HttpConnection conn = new HttpConnection(mockUrl, httpsMethod);
+
+        // Act
+        conn.setConnectTimeoutMillis(timeout);
+
+        // Assert
+        new Verifications()
+        {
+            {
+                mockUrl.openConnection().setConnectTimeout(expectedTimeout);
+            }
+        };
+    }
+
     // Tests_SRS_SERVICE_SDK_JAVA_HTTPSCONNECTION_12_012: [The function shall save the body to be sent with the request.]
     // Assert
     @Test(expected = IllegalArgumentException.class)

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/http/HttpsRequestTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/transport/http/HttpsRequestTest.java
@@ -615,4 +615,31 @@ public class HttpsRequestTest
             }
         };
     }
+
+    @Test
+    public void setConnectTimeoutSetsConnectTimeout(@Mocked final HttpConnection mockConn, final @Mocked URL mockUrl) throws IOException
+    {
+        // Arrange
+        final HttpMethod httpsMethod = HttpMethod.POST;
+        final byte[] body = new byte[0];
+        final int readTimeout = 1;
+        final int expectedReadTimeout = readTimeout;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "http";
+            }
+        };
+        HttpRequest request = new HttpRequest(mockUrl, httpsMethod, body);
+        // Act
+        request.setConnectTimeoutMillis(readTimeout);
+        // Assert
+        new Verifications()
+        {
+            {
+                mockConn.setConnectTimeoutMillis(expectedReadTimeout);
+            }
+        };
+    }
 }


### PR DESCRIPTION
Adding them to the RegistryManagerOptions class so that they are set at constructor time