### PR TITLE
Fix flakey twin e2e tests

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
@@ -91,8 +91,6 @@ public class TransportClientTests extends IntegrationTest
     private static final String METHOD_NAME = "methodName";
     private static final String METHOD_PAYLOAD = "This is a good payload";
 
-    private static DeviceTwin sCDeviceTwin;
-
     private static final String PROPERTY_KEY = "Key";
     private static final String PROPERTY_VALUE = "Value";
     private static final String PROPERTY_VALUE_UPDATE = "Update";
@@ -141,6 +139,7 @@ public class TransportClientTests extends IntegrationTest
         private FileUploadState[] fileUploadState;
         private MessageState[] messageStates;
         private FileUploadNotificationReceiver fileUploadNotificationReceiver;
+        private DeviceTwin deviceTwinClient;
 
         public TransportClientTestInstance(IotHubClientProtocol protocol) throws InterruptedException, IOException, IotHubException, URISyntaxException
         {
@@ -151,6 +150,8 @@ public class TransportClientTests extends IntegrationTest
         {
             fileUploadNotificationReceiver = serviceClient.getFileUploadNotificationReceiver();
             Assert.assertNotNull(fileUploadNotificationReceiver);
+
+            deviceTwinClient = DeviceTwin.createFromConnectionString(iotHubConnectionString);
 
             String uuid = UUID.randomUUID().toString();
 
@@ -445,7 +446,7 @@ public class TransportClientTests extends IntegrationTest
                 desiredProperties.add(new Pair(PROPERTY_KEY + j, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
             }
             testInstance.devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.deviceTwinClient.updateTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
 
             // assert
@@ -915,8 +916,6 @@ public class TransportClientTests extends IntegrationTest
         TransportClient transportClient = null;
         try
         {
-            sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
-
             for (int i = 0; i < MAX_DEVICES; i++)
             {
                 DeviceState deviceState = new DeviceState();
@@ -945,7 +944,7 @@ public class TransportClientTests extends IntegrationTest
                 testInstance.devicesUnderTest[i].deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), testInstance.devicesUnderTest[i], testInstance.devicesUnderTest[i].dCDeviceForTwin, testInstance.devicesUnderTest[i]);
                 testInstance.devicesUnderTest[i].deviceTwinStatus = SUCCESS;
                 testInstance.devicesUnderTest[i].sCDeviceForTwin = new DeviceTwinDevice(testInstance.devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
-                sCDeviceTwin.getTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
+                testInstance.deviceTwinClient.getTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
                 Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
             }
         }
@@ -968,8 +967,6 @@ public class TransportClientTests extends IntegrationTest
             // No need to fail the test just because cleanup failed.
             e.printStackTrace();
         }
-
-        sCDeviceTwin = null;
     }
 
     private void setUpFileUploadState() throws Exception
@@ -1010,7 +1007,7 @@ public class TransportClientTests extends IntegrationTest
     {
         int totalCount = 0;
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
-        sCDeviceTwin.getTwin(deviceState.sCDeviceForTwin);
+        testInstance.deviceTwinClient.getTwin(deviceState.sCDeviceForTwin);
         Set<Pair> repProperties = deviceState.sCDeviceForTwin.getReportedProperties();
 
         for (Pair p : repProperties)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
@@ -91,6 +91,8 @@ public class TransportClientTests extends IntegrationTest
     private static final String METHOD_NAME = "methodName";
     private static final String METHOD_PAYLOAD = "This is a good payload";
 
+    private static DeviceTwin sCDeviceTwin;
+
     private static final String PROPERTY_KEY = "Key";
     private static final String PROPERTY_VALUE = "Value";
     private static final String PROPERTY_VALUE_UPDATE = "Update";
@@ -139,7 +141,6 @@ public class TransportClientTests extends IntegrationTest
         private FileUploadState[] fileUploadState;
         private MessageState[] messageStates;
         private FileUploadNotificationReceiver fileUploadNotificationReceiver;
-        private DeviceTwin deviceTwinClient;
 
         public TransportClientTestInstance(IotHubClientProtocol protocol) throws InterruptedException, IOException, IotHubException, URISyntaxException
         {
@@ -150,8 +151,6 @@ public class TransportClientTests extends IntegrationTest
         {
             fileUploadNotificationReceiver = serviceClient.getFileUploadNotificationReceiver();
             Assert.assertNotNull(fileUploadNotificationReceiver);
-
-            deviceTwinClient = DeviceTwin.createFromConnectionString(iotHubConnectionString);
 
             String uuid = UUID.randomUUID().toString();
 
@@ -446,7 +445,7 @@ public class TransportClientTests extends IntegrationTest
                 desiredProperties.add(new Pair(PROPERTY_KEY + j, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
             }
             testInstance.devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            testInstance.deviceTwinClient.updateTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
+            sCDeviceTwin.updateTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
 
             // assert
@@ -916,6 +915,8 @@ public class TransportClientTests extends IntegrationTest
         TransportClient transportClient = null;
         try
         {
+            sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
+
             for (int i = 0; i < MAX_DEVICES; i++)
             {
                 DeviceState deviceState = new DeviceState();
@@ -944,7 +945,7 @@ public class TransportClientTests extends IntegrationTest
                 testInstance.devicesUnderTest[i].deviceClient.startDeviceTwin(new DeviceTwinStatusCallBack(), testInstance.devicesUnderTest[i], testInstance.devicesUnderTest[i].dCDeviceForTwin, testInstance.devicesUnderTest[i]);
                 testInstance.devicesUnderTest[i].deviceTwinStatus = SUCCESS;
                 testInstance.devicesUnderTest[i].sCDeviceForTwin = new DeviceTwinDevice(testInstance.devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
-                testInstance.deviceTwinClient.getTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
+                sCDeviceTwin.getTwin(testInstance.devicesUnderTest[i].sCDeviceForTwin);
                 Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
             }
         }
@@ -967,6 +968,8 @@ public class TransportClientTests extends IntegrationTest
             // No need to fail the test just because cleanup failed.
             e.printStackTrace();
         }
+
+        sCDeviceTwin = null;
     }
 
     private void setUpFileUploadState() throws Exception
@@ -1007,7 +1010,7 @@ public class TransportClientTests extends IntegrationTest
     {
         int totalCount = 0;
         Thread.sleep(MAXIMUM_TIME_TO_WAIT_FOR_IOTHUB_TWIN_OPERATION_MILLISECONDS);
-        testInstance.deviceTwinClient.getTwin(deviceState.sCDeviceForTwin);
+        sCDeviceTwin.getTwin(deviceState.sCDeviceForTwin);
         Set<Pair> repProperties = deviceState.sCDeviceForTwin.getReportedProperties();
 
         for (Pair p : repProperties)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -103,9 +103,9 @@ public class DeviceTwinCommon extends IntegrationTest
 
     // Max time to wait to see it on Hub
     protected static final long PERIODIC_WAIT_TIME_FOR_VERIFICATION = 1000; // 1 sec
-    protected static final long MAX_WAIT_TIME_FOR_VERIFICATION = 3000; // 30 sec
+    protected static final long MAX_WAIT_TIME_FOR_VERIFICATION_MILLISECONDS = 60 * 1000; // 1 minute
     protected static final long DELAY_BETWEEN_OPERATIONS = 200; // 0.2 sec
-    public static final long MULTITHREADED_WAIT_TIMEOUT_MILLISECONDS = 30 * 1000; // 30 seconds
+    public static final long MULTITHREADED_WAIT_TIMEOUT_MILLISECONDS = 60 * 1000; // 1 minute
 
     public static final long DESIRED_PROPERTIES_PROPAGATION_TIME_MILLISECONDS = 5 * 1000; //5 seconds
 
@@ -503,7 +503,7 @@ public class DeviceTwinCommon extends IntegrationTest
         {
             Thread.sleep(PERIODIC_WAIT_TIME_FOR_VERIFICATION);
             timeElapsed = System.currentTimeMillis() - startTime;
-            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION)
+            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION_MILLISECONDS)
             {
                 break;
             }
@@ -521,6 +521,7 @@ public class DeviceTwinCommon extends IntegrationTest
                 }
             }
         }
+
         assertEquals(buildExceptionMessage("Expected " + expectedReportedPropCount + " but had " + actualCount, internalClient), expectedReportedPropCount, actualCount);
     }
 
@@ -535,7 +536,7 @@ public class DeviceTwinCommon extends IntegrationTest
         {
             Thread.sleep(PERIODIC_WAIT_TIME_FOR_VERIFICATION);
             timeElapsed = System.currentTimeMillis() - startTime;
-            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION)
+            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION_MILLISECONDS)
             {
                 break;
             }
@@ -565,7 +566,7 @@ public class DeviceTwinCommon extends IntegrationTest
         {
             Thread.sleep(PERIODIC_WAIT_TIME_FOR_VERIFICATION);
             timeElapsed = System.currentTimeMillis() - startTime;
-            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION)
+            if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION_MILLISECONDS)
             {
                 break;
             }
@@ -612,7 +613,7 @@ public class DeviceTwinCommon extends IntegrationTest
             {
                 Thread.sleep(PERIODIC_WAIT_TIME_FOR_VERIFICATION);
                 timeElapsed = System.currentTimeMillis() - startTime;
-                if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION)
+                if (timeElapsed > MAX_WAIT_TIME_FOR_VERIFICATION_MILLISECONDS)
                 {
                     break;
                 }


### PR DESCRIPTION
A lot of scenarios had a 3 second timeout which is rather strict. Opening that timeout up to 1 minute so that the test isn't as flakey