### PR TITLE
refactor(iot-dev): Use wait and notify to cut down on useless thread creation in transport layer

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -191,6 +191,11 @@ public final class DeviceIO
         this.receiveTask = new IotHubReceiveTask(this.transport);
 
         this.taskScheduler = Executors.newScheduledThreadPool(2);
+
+        // Note that even though these threads are scheduled at a fixed interval, the sender/receiver threads will wait
+        // if no messages are available to process. These waiting threads will still count against the pool size defined above,
+        // so threads will not be needlessly scheduled during times when this SDK has no messages to process.
+
         // the scheduler waits until each execution is finished before
         // scheduling the next one, so executions of a given task
         // will never overlap.

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -6,6 +6,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.device;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.DeviceClientException;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubReceiveTask;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubSendTask;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransport;
@@ -69,7 +70,7 @@ public class DeviceIOTest
         new NonStrictExpectations()
         {
             {
-                new IotHubTransport(mockConfig);
+                new IotHubTransport(mockConfig, (IotHubConnectionStatusChangeCallback) any);
                 result = mockedTransport;
             }
         };
@@ -78,7 +79,7 @@ public class DeviceIOTest
                 new Class[] {DeviceClientConfig.class, long.class, long.class},
                 mockConfig, SEND_PERIOD_MILLIS, RECEIVE_PERIOD_MILLIS_AMQPS);
 
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
 
         return deviceIO;
     }
@@ -89,20 +90,7 @@ public class DeviceIOTest
             final Executors executors,
             final ScheduledExecutorService scheduledExecutorService) throws IOException
     {
-        new NonStrictExpectations()
-        {
-            {
-                new IotHubSendTask(transport);
-                result = mockIotHubSendTask;
-                new IotHubReceiveTask(transport);
-                result = mockIotHubReceiveTask;
-                executors.newScheduledThreadPool(2);
-                result = scheduledExecutorService;
-            }
-        };
-
         Deencapsulation.invoke(deviceIO, "open");
-        assertEquals("OPEN", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
     /* Tests_SRS_DEVICE_IO_21_001: [The constructor shall store the provided protocol and config information.] */
@@ -131,7 +119,7 @@ public class DeviceIOTest
         // assert
         assertEquals(mockConfig, Deencapsulation.getField(deviceIO, "config"));
         assertEquals(protocol, Deencapsulation.getField(deviceIO, "protocol"));
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
         assertEquals(SEND_PERIOD_MILLIS, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
         assertEquals(RECEIVE_PERIOD_MILLIS_AMQPS, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 
@@ -181,7 +169,7 @@ public class DeviceIOTest
         // assert
         assertEquals(mockConfig, Deencapsulation.getField(deviceIO, "config"));
         assertEquals(protocol, Deencapsulation.getField(deviceIO, "protocol"));
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
         assertEquals(SEND_PERIOD_MILLIS, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
         assertEquals(RECEIVE_PERIOD_MILLIS_MQTT, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 
@@ -217,7 +205,7 @@ public class DeviceIOTest
         // assert
         assertEquals(mockConfig, Deencapsulation.getField(deviceIO, "config"));
         assertEquals(protocol, Deencapsulation.getField(deviceIO, "protocol"));
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
         assertEquals(SEND_PERIOD_MILLIS, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
         assertEquals(RECEIVE_PERIOD_MILLIS_HTTPS, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 
@@ -289,22 +277,6 @@ public class DeviceIOTest
         };
     }
 
-    /* Tests_SRS_DEVICE_IO_21_007: [If the client is already open, the open shall do nothing.] */
-    @Test
-    public void openDoesNothingIfCalledTwiceSuccess()
-            throws URISyntaxException, IOException
-    {
-        // arrange
-        final Object deviceIO = newDeviceIO();
-        openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
-
-        // act
-        Deencapsulation.invoke(deviceIO, "open");
-
-        // assert
-        assertEquals("OPEN", Deencapsulation.getField(deviceIO, "state").toString());
-    }
-
     /* Tests_SRS_DEVICE_IO_21_012: [The open shall open the transport to communicate with an IoT Hub.] */
     /* Tests_SRS_DEVICE_IO_21_013: [The open shall schedule send tasks to run every SEND_PERIOD_MILLIS milliseconds.] */
     /* Tests_SRS_DEVICE_IO_21_014: [The open shall schedule receive tasks to run every RECEIVE_PERIOD_MILLIS milliseconds.] */
@@ -317,18 +289,6 @@ public class DeviceIOTest
         configs.add(mockConfig);
         Deencapsulation.setField(deviceIO, "deviceClientConfigs", configs);
 
-        new NonStrictExpectations()
-        {
-            {
-                new IotHubSendTask(mockedTransport);
-                result = mockIotHubSendTask;
-                new IotHubReceiveTask(mockedTransport);
-                result = mockIotHubReceiveTask;
-                mockExecutors.newScheduledThreadPool(2);
-                result = mockScheduler;
-            }
-        };
-
         // act
         Deencapsulation.invoke(deviceIO, "open");
 
@@ -337,13 +297,6 @@ public class DeviceIOTest
         {
             {
                 mockedTransport.open(configs);
-                mockScheduler.scheduleAtFixedRate(mockIotHubSendTask,
-                        0, SEND_PERIOD_MILLIS,
-                        TimeUnit.MILLISECONDS);
-                mockScheduler.scheduleAtFixedRate(mockIotHubReceiveTask,
-                        0, RECEIVE_PERIOD_MILLIS_AMQPS,
-                        TimeUnit.MILLISECONDS);
-                assertEquals("OPEN", Deencapsulation.getField(deviceIO, "state").toString());
             }
         };
     }
@@ -370,30 +323,7 @@ public class DeviceIOTest
         Deencapsulation.invoke(deviceIO, "open");
 
         // assert
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
-    }
-
-    /* Tests_SRS_DEVICE_IO_21_017: [The closeNow shall finish all ongoing tasks.] */
-    /* Tests_SRS_DEVICE_IO_21_018: [The closeNow shall cancel all recurring tasks.] */
-    @Test
-    public void closeWaitsForTaskShutdownToFinishSuccess()
-            throws URISyntaxException, IOException
-    {
-        // arrange
-        final Object deviceIO = newDeviceIO();
-        openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
-
-        // act
-        Deencapsulation.invoke(deviceIO, "close");
-
-        // assert
-        new Verifications()
-        {
-            {
-                mockScheduler.shutdown();
-                times = 1;
-            }
-        };
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
     /* Tests_SRS_DEVICE_IO_21_019: [The close shall close the transport.] */
@@ -454,7 +384,7 @@ public class DeviceIOTest
         Deencapsulation.invoke(deviceIO, "close");
 
         // assert
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
     /* Tests_SRS_DEVICE_IO_21_021: [The closeNow shall set the `state` as `CLOSE`.] */
@@ -466,13 +396,13 @@ public class DeviceIOTest
         final Object deviceIO = newDeviceIO();
         openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
         Deencapsulation.invoke(deviceIO, "close");
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
 
         // act
         Deencapsulation.invoke(deviceIO, "close");
 
         // assert
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
     /* Tests_SRS_DEVICE_IO_21_021: [The closeNow shall set the `state` as `CLOSE`.] */
@@ -488,7 +418,7 @@ public class DeviceIOTest
         Deencapsulation.invoke(deviceIO, "close");
 
         // assert
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
     // Tests_SRS_DEVICE_IO_12_009: [THe function shall call close().]
@@ -509,7 +439,7 @@ public class DeviceIOTest
         Deencapsulation.invoke(deviceIO, "multiplexClose");
 
         // assert
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
     }
 
 
@@ -523,8 +453,9 @@ public class DeviceIOTest
     {
         // arrange
         final Map<String, Object> context = new HashMap<>();
-        final Object deviceIO = newDeviceIO();
+        final DeviceIO deviceIO = newDeviceIO();
         openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.CONNECTED, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
 
         // act
         Deencapsulation.invoke(deviceIO, "sendEventAsync",
@@ -588,7 +519,7 @@ public class DeviceIOTest
         final Object deviceIO = newDeviceIO();
         openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
         Deencapsulation.invoke(deviceIO, "close");
-        assertEquals("CLOSED", Deencapsulation.getField(deviceIO, "state").toString());
+        assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
 
         // act
         Deencapsulation.invoke(deviceIO, "sendEventAsync", new Class[] {Message.class, IotHubEventCallback.class, Object.class, String.class}, mockMsg, mockCallback, context, mockConfig.getDeviceId());
@@ -663,53 +594,13 @@ public class DeviceIOTest
         final long lastInterval = 4321L;
         final Object deviceIO = newDeviceIO();
         Deencapsulation.invoke(deviceIO, "setReceivePeriodInMilliseconds",  lastInterval);
-        new NonStrictExpectations()
-        {
-            {
-                new IotHubSendTask(mockedTransport);
-                result = mockIotHubSendTask;
-                new IotHubReceiveTask(mockedTransport);
-                result = mockIotHubReceiveTask;
-                mockExecutors.newScheduledThreadPool(2);
-                result = mockScheduler;
-            }
-        };
-
-        Deencapsulation.invoke(deviceIO, "open");
         assertEquals(lastInterval, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 
         // act
         Deencapsulation.invoke(deviceIO, "setReceivePeriodInMilliseconds",  interval);
 
         // assert
-        new Verifications()
-        {
-            {
-                mockScheduler.scheduleAtFixedRate(mockIotHubReceiveTask,
-                        0, lastInterval,
-                        TimeUnit.MILLISECONDS);
-                times = 1;
-                mockScheduler.scheduleAtFixedRate(mockIotHubReceiveTask,
-                        0, interval,
-                        TimeUnit.MILLISECONDS);
-                times = 1;
-            }
-        };
         assertEquals(interval, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
-    }
-
-    /* Tests_SRS_DEVICE_IO_21_029: [If the `receiveTask` is null, the setReceivePeriodInMilliseconds shall throw IOException.] */
-    @Test (expected = IOException.class)
-    public void setReceivePeriodInMillisecondsNullReceiveTaskThrows()
-            throws URISyntaxException, IOException, InterruptedException
-    {
-        // arrange
-        final Object deviceIO = newDeviceIO();
-        openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
-        Deencapsulation.setField(deviceIO, "receiveTask", null);
-
-        // act
-        Deencapsulation.invoke(deviceIO, "setReceivePeriodInMilliseconds",  1234L);
     }
 
     /* Tests_SRS_DEVICE_IO_21_030: [If the the provided interval is zero or negative, the setReceivePeriodInMilliseconds shall throw IllegalArgumentException.] */
@@ -780,17 +671,6 @@ public class DeviceIOTest
         final long lastInterval = 4321L;
         final Object deviceIO = newDeviceIO();
         Deencapsulation.invoke(deviceIO, "setSendPeriodInMilliseconds",  lastInterval);
-        new NonStrictExpectations()
-        {
-            {
-                new IotHubSendTask(mockedTransport);
-                result = mockIotHubSendTask;
-                new IotHubReceiveTask(mockedTransport);
-                result = mockIotHubReceiveTask;
-                mockExecutors.newScheduledThreadPool(2);
-                result = mockScheduler;
-            }
-        };
 
         Deencapsulation.invoke(deviceIO, "open");
         assertEquals(lastInterval, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
@@ -799,34 +679,7 @@ public class DeviceIOTest
         Deencapsulation.invoke(deviceIO, "setSendPeriodInMilliseconds",  interval);
 
         // assert
-        new Verifications()
-        {
-            {
-                mockScheduler.scheduleAtFixedRate(mockIotHubSendTask,
-                        0, lastInterval,
-                        TimeUnit.MILLISECONDS);
-                times = 1;
-                mockScheduler.scheduleAtFixedRate(mockIotHubSendTask,
-                        0, interval,
-                        TimeUnit.MILLISECONDS);
-                times = 1;
-            }
-        };
         assertEquals(interval, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
-    }
-
-    /* Tests_SRS_DEVICE_IO_21_035: [If the `sendTask` is null, the setSendPeriodInMilliseconds shall throw IOException.] */
-    @Test (expected = IOException.class)
-    public void setSendPeriodInMillisecondsNullSendTaskThrows()
-            throws URISyntaxException, IOException, InterruptedException
-    {
-        // arrange
-        final Object deviceIO = newDeviceIO();
-        openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
-        Deencapsulation.setField(deviceIO, "sendTask", null);
-
-        // act
-        Deencapsulation.invoke(deviceIO, "setSendPeriodInMilliseconds",  1234L);
     }
 
     /* Tests_SRS_DEVICE_IO_21_036: [If the the provided interval is zero or negative, the setSendPeriodInMilliseconds shall throw IllegalArgumentException.] */
@@ -859,8 +712,9 @@ public class DeviceIOTest
             throws URISyntaxException, IOException
     {
         // arrange
-        final Object deviceIO = newDeviceIO();
+        final DeviceIO deviceIO = newDeviceIO();
         openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.CONNECTED, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
 
         // act
         boolean isOpen = Deencapsulation.invoke(deviceIO, "isOpen" );

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -100,7 +100,7 @@ public class IotHubTransportTest
     public void constructorSucceeds()
     {
         //act
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //assert
         assertEquals(mockedConfig, Deencapsulation.getField(transport, "defaultConfig"));
@@ -113,7 +113,7 @@ public class IotHubTransportTest
     public void constructorThrowsForNullConfig()
     {
         //act
-        IotHubTransport transport = new IotHubTransport(null);
+        IotHubTransport transport = new IotHubTransport(null, mockedIotHubConnectionStatusChangeCallback);
     }
 
     //Tests_SRS_IOTHUBTRANSPORT_34_004: [This function shall retrieve a packet from the inProgressPackets queue with the message id from the provided message if there is one.]
@@ -122,7 +122,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndCallsHandleMessageExceptionForTransportException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -156,7 +156,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndAddsToCallbackForNoException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -191,7 +191,7 @@ public class IotHubTransportTest
     public void onMessageSentRetrievesFromInProgressAndCallsHandleMessageExceptionForNonTransportException()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final String messageId = "1234";
         final IOException nonTransportException = new IOException();
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
@@ -229,7 +229,7 @@ public class IotHubTransportTest
     public void onMessageReceivedWithMessageAndNoExceptionAddsToQueue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.onMessageReceived(mockedTransportMessage, null);
@@ -256,7 +256,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
@@ -288,7 +288,7 @@ public class IotHubTransportTest
                 fail("should not have called this method");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -325,7 +325,7 @@ public class IotHubTransportTest
                 methodsCalled.append("addReceivedMessagesOverHttpToReceivedQueue");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final IOException nonTransportException = new IOException();
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
@@ -362,7 +362,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final IOException nonTransportException = new IOException();
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
@@ -404,7 +404,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -428,7 +428,7 @@ public class IotHubTransportTest
     public void openThrowsForNullConfigList() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.open(null);
@@ -439,7 +439,7 @@ public class IotHubTransportTest
     public void openThrowsForEmptyConfigList() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.open(new ArrayList<DeviceClientConfig>());
@@ -450,7 +450,7 @@ public class IotHubTransportTest
     public void openThrowsIfConnectionStatusIsDisconnectedRetrying() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -472,7 +472,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -487,7 +487,7 @@ public class IotHubTransportTest
     {
         //arrange
         final StringBuilder verifier = new StringBuilder();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -525,7 +525,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -540,7 +540,7 @@ public class IotHubTransportTest
     public void closeThrowsForNullReason() throws DeviceClientException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.close(null, mockedTransportException);
@@ -580,7 +580,7 @@ public class IotHubTransportTest
         inProgressPackets.put("2", mockedPacket);
 
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
@@ -621,7 +621,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonWithNonTransportException()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, new IOException());
@@ -635,7 +635,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonWithRetryableTransportException()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         new NonStrictExpectations()
         {
@@ -664,7 +664,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         new Expectations()
         {
@@ -686,7 +686,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForAmqpUnauthorizedException(@Mocked final AmqpUnauthorizedAccessException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -711,7 +711,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForMqttUnauthorizedException(@Mocked final MqttUnauthorizedException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -737,7 +737,7 @@ public class IotHubTransportTest
     public void exceptionToStatusChangeReasonBadCredentialForGenericUnauthorizedException(@Mocked final UnauthorizedException mockedUnauthorizedException)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -765,7 +765,7 @@ public class IotHubTransportTest
     public void openConnectionWithHttp()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -807,7 +807,7 @@ public class IotHubTransportTest
     public void openConnectionWithMqtt() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -844,7 +844,7 @@ public class IotHubTransportTest
     public void openConnectionWithMqttWS() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -881,7 +881,7 @@ public class IotHubTransportTest
     public void openConnectionWithAmqps() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -919,7 +919,7 @@ public class IotHubTransportTest
     public void openConnectionWithAmqpsWS() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Queue<DeviceClientConfig> configs = new ConcurrentLinkedQueue<>();
         configs.add(mockedConfig);
         Deencapsulation.setField(transport, "deviceClientConfigs", configs);
@@ -960,7 +960,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -982,7 +982,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         waitingPacketsQueue.add(mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1004,7 +1004,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         inProgressPackets.put("asdf", mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1026,7 +1026,7 @@ public class IotHubTransportTest
         final Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         callbackPacketsQueue.add(mockedPacket);
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1043,7 +1043,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutTrue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -1064,7 +1064,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutReturnsFalseIfProvidedTimeIsZero()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -1085,7 +1085,7 @@ public class IotHubTransportTest
     public void hasOperationTimedOutFalse()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -1106,7 +1106,7 @@ public class IotHubTransportTest
     public void addMessageThrowsIfDisconnected()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
 
         //act
@@ -1118,7 +1118,7 @@ public class IotHubTransportTest
     public void addMessageAddsMessage()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
@@ -1143,7 +1143,7 @@ public class IotHubTransportTest
     public void sendMessagesDoesNothingIfNotConnected()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         waitingPacketsQueue.add(mockedPacket);
@@ -1170,7 +1170,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final int MAX_MESSAGES_TO_SEND_PER_THREAD = Deencapsulation.getField(transport, "MAX_MESSAGES_TO_SEND_PER_THREAD");
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -1194,7 +1194,7 @@ public class IotHubTransportTest
     public void invokeCallbacksInvokesAllCallbacks(final @Mocked IotHubStatusCode mockedStatus)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         callbackPacketsQueue.add(mockedPacket);
         callbackPacketsQueue.add(mockedPacket);
@@ -1241,7 +1241,7 @@ public class IotHubTransportTest
                 fail("should not have called this method");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1279,7 +1279,7 @@ public class IotHubTransportTest
                 methodsCalled.append("addReceivedMessagesOverHttpToReceivedQueue");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1314,7 +1314,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1334,7 +1334,7 @@ public class IotHubTransportTest
     public void registerConnectionStateCallbackThrowsForNullCallback()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.registerConnectionStateCallback(null, new Object());
@@ -1345,7 +1345,7 @@ public class IotHubTransportTest
     public void registerConnectionStateCallbackSavesProvidedCallbackAndContext()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Object context = new Object();
 
         //act
@@ -1361,7 +1361,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackThrowsForNullCallback()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         transport.registerConnectionStatusChangeCallback(null, new Object());
@@ -1372,7 +1372,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackDoesNotThrowForNullCallbackIfContextIsAlsoNull()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         transport.registerConnectionStatusChangeCallback(mockedIotHubConnectionStatusChangeCallback, new Object());
         assertNotNull(Deencapsulation.getField(transport, "connectionStatusChangeCallback"));
         assertNotNull(Deencapsulation.getField(transport, "connectionStatusChangeCallbackContext"));
@@ -1391,7 +1391,7 @@ public class IotHubTransportTest
     public void registerConnectionStatusChangeCallbackSavesProvidedCallbackAndContext()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Object context = new Object();
 
         //act
@@ -1410,7 +1410,7 @@ public class IotHubTransportTest
     public void acknowledgeReceivedMessageSendsAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1446,7 +1446,7 @@ public class IotHubTransportTest
     public void acknowledgeReceivedMessageReQueuesFailedMessages() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1489,7 +1489,7 @@ public class IotHubTransportTest
     public void addReceivedMessagesOverHttpToReceivedQueueChecksForHttpMessages() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
 
         //act
@@ -1539,7 +1539,7 @@ public class IotHubTransportTest
                 methodsCalled.append("reconnect");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "handleDisconnection", mockedTransportException);
@@ -1563,7 +1563,7 @@ public class IotHubTransportTest
                 //do nothing
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations()
@@ -1587,7 +1587,7 @@ public class IotHubTransportTest
     public void singleReconnectAttemptReturnsEncounteredException() throws TransportException
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations(IotHubTransport.class)
@@ -1629,7 +1629,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         final long expectedDelay = 0;
         final long duration = 0;
@@ -1683,7 +1683,7 @@ public class IotHubTransportTest
                 return true;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1738,7 +1738,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1793,7 +1793,7 @@ public class IotHubTransportTest
                 return false;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -1861,7 +1861,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new Expectations()
         {
@@ -1912,7 +1912,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
 
         //act
@@ -1953,7 +1953,7 @@ public class IotHubTransportTest
                 return IotHubConnectionStatusChangeReason.BAD_CREDENTIAL;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
 
         //act
@@ -2003,7 +2003,7 @@ public class IotHubTransportTest
                 throw new TransportException("close failed");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new NonStrictExpectations()
         {
@@ -2037,7 +2037,7 @@ public class IotHubTransportTest
     public void isMessageValidWithMessageExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2075,7 +2075,7 @@ public class IotHubTransportTest
     public void isMessageValidWithMessageNotExpiredAndValidSasToken()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2132,7 +2132,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2174,7 +2174,7 @@ public class IotHubTransportTest
                 methodsCalled.append("invokeConnectionStatusChangeCallback");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
         Deencapsulation.setField(transport, "reconnectionAttemptStartTimeMillis", 5);
@@ -2198,7 +2198,7 @@ public class IotHubTransportTest
     public void updateStatusConnectionStatusNotChanged()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
         new Expectations(IotHubTransport.class)
@@ -2238,7 +2238,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
         Deencapsulation.setField(transport, "currentReconnectionAttempt", 5);
 
@@ -2258,7 +2258,7 @@ public class IotHubTransportTest
     public void invokeConnectionStatusChangeCallbackWithCallback()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatusChangeCallback", mockedIotHubConnectionStatusChangeCallback);
 
         //act
@@ -2285,7 +2285,7 @@ public class IotHubTransportTest
     public void invokeConnectionStatusChangeCallbackWithNullCallback()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Deencapsulation.setField(transport, "connectionStatusChangeCallback", null);
 
         //act
@@ -2313,7 +2313,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeIsSasTokenAndExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2336,7 +2336,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeIsSasTokenAndNotExpired()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2359,7 +2359,7 @@ public class IotHubTransportTest
     public void isSasTokenExpiredAuthenticationTypeNotSasToken()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2382,7 +2382,7 @@ public class IotHubTransportTest
     public void addToCallbackQueuePacketHasCallback(@Mocked final IotHubEventCallback mockCallback)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2405,7 +2405,7 @@ public class IotHubTransportTest
     public void addToCallbackQueuePacketNoCallback(@Mocked final IotHubEventCallback mockCallback)
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         new NonStrictExpectations()
         {
             {
@@ -2435,7 +2435,7 @@ public class IotHubTransportTest
             }
         };
         final MqttUnauthorizedException testException = new MqttUnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2465,7 +2465,7 @@ public class IotHubTransportTest
         };
 
         final UnauthorizedException testException = new UnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2495,7 +2495,7 @@ public class IotHubTransportTest
         };
 
         final AmqpUnauthorizedAccessException testException = new AmqpUnauthorizedAccessException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2524,7 +2524,7 @@ public class IotHubTransportTest
             }
         };
         final UnauthorizedException testException = new UnauthorizedException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2553,7 +2553,7 @@ public class IotHubTransportTest
             }
         };
         final TransportException testException = new TransportException();
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2575,7 +2575,7 @@ public class IotHubTransportTest
     public void sendPacketHappyPathWithAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -2618,7 +2618,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -2650,7 +2650,7 @@ public class IotHubTransportTest
     public void sendPacketHappyPathWithoutAck() throws TransportException
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2700,7 +2700,7 @@ public class IotHubTransportTest
                 methodsCalled.append("handleMessageException");
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2746,7 +2746,7 @@ public class IotHubTransportTest
                 }
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -2781,7 +2781,7 @@ public class IotHubTransportTest
     public void handleMessageExceptionChecksForAmqpThrottling()
     {
         //arrange
-        final IotHubTransport transport = new IotHubTransport(mockedConfig);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
 
         //act
         Deencapsulation.invoke(transport, "handleMessageException", new Class[] {IotHubTransportPacket.class, TransportException.class}, mockedPacket, new AmqpConnectionThrottledException());
@@ -2800,7 +2800,7 @@ public class IotHubTransportTest
     public void sendMessagesChecksForExpiredMessagesInWaitingQueue()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -2840,7 +2840,7 @@ public class IotHubTransportTest
     public void sendMessagesChecksForExpiredMessagesInInProgressPackets()
     {
         //arrange
-        IotHubTransport transport = new IotHubTransport(mockedConfig);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
The current design of the device client library periodically spawns threads to handle sending and receiving messages as well as invoking callbacks. The device client will spawn these threads regardless of if any messages actually need to be sent/received, though.

With this change, the send/receive threads will instead wait until a message requires them to wake up. This will cut down on thread creation during less busy times without sacrificing performance during busy times

The second commit for this PR makes our DeviceIO layer more responsive to connection change events. Previously, if the transport layer went into reconnecting mode, the device IO layer would still spawn send/receive threads repeatedly even though they would be unable to send/receive anything since the transport isn't connected.