### PR TITLE
Run TPM tests in serial

### DIFF
--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -93,6 +93,12 @@
             <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -373,7 +373,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    public void tearDownTwin(DeviceState deviceState) throws IOException
+    public void tearDownTwin(DeviceState deviceState)
     {
         // tear down twin on device client
         if (deviceState != null)
@@ -394,7 +394,14 @@ public class DeviceTwinCommon extends IntegrationTest
         }
         if (internalClient != null)
         {
-            internalClient.closeNow();
+            try
+            {
+                internalClient.closeNow();
+            }
+            catch (IOException e)
+            {
+                // Ignore, the test isn't about being able to close the client
+            }
             internalClient = null;
         }
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -373,7 +373,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    public void tearDownTwin(DeviceState deviceState)
+    public void tearDownTwin(DeviceState deviceState) throws IOException
     {
         // tear down twin on device client
         if (deviceState != null)
@@ -394,14 +394,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
         if (internalClient != null)
         {
-            try
-            {
-                internalClient.closeNow();
-            }
-            catch (IOException e)
-            {
-                // Ignore, the test isn't about being able to close the client
-            }
+            internalClient.closeNow();
             internalClient = null;
         }
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
@@ -26,7 +26,7 @@ public class ProvisioningTPMTests extends ProvisioningCommon
         super(protocol, attestationType);
     }
 
-    //This overrides the inputs defined in the super class. This is done to split this large test group into symmetric key and x509 runners.
+    //This overrides the inputs defined in the super class. This is done to only run the TPM tests.
     @Parameterized.Parameters(name = "{0}_{1}")
     public static Collection inputs()
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 @NotThreadSafe
 @DeviceProvisioningServiceTest
 @RunWith(Parameterized.class)
-public class ProvisioningTPMTests extends ProvisioningCommon
+public class ProvisioningTPMTests extends ProvisioningTests
 {
     public ProvisioningTPMTests(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTPMTests.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package tests.integration.com.microsoft.azure.sdk.iot.provisioning;
+
+
+import com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientTransportProtocol;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.DeviceProvisioningServiceTest;
+import tests.integration.com.microsoft.azure.sdk.iot.provisioning.setup.ProvisioningCommon;
+
+import java.util.Collection;
+
+// TPM tests cannot be parallelized because each test consumes the TPM and only releases it when the test is done.
+@NotThreadSafe
+@DeviceProvisioningServiceTest
+@RunWith(Parameterized.class)
+public class ProvisioningTPMTests extends ProvisioningCommon
+{
+    public ProvisioningTPMTests(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
+    {
+        super(protocol, attestationType);
+    }
+
+    //This overrides the inputs defined in the super class. This is done to split this large test group into symmetric key and x509 runners.
+    @Parameterized.Parameters(name = "{0}_{1}")
+    public static Collection inputs()
+    {
+        return ProvisioningCommon.inputs(AttestationType.TPM);
+    }
+}

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -141,18 +141,29 @@ public class ProvisioningCommon extends IntegrationTest
         }
         else if (attestationType == AttestationType.TPM && !isPullRequest)
         {
-            //TODO TPM tests are flakey, so only run them for CI and nightly builds
-            return Arrays.asList(
-                    new Object[][]
-                            {
-                                    {ProvisioningDeviceClientTransportProtocol.HTTPS, attestationType},
-                                    {ProvisioningDeviceClientTransportProtocol.AMQPS, attestationType},
-                                    {ProvisioningDeviceClientTransportProtocol.AMQPS_WS, attestationType}
+            if (!isPullRequest)
+            {
+                //TODO TPM tests are flakey, so only run them for CI and nightly builds
+                return Arrays.asList(
+                        new Object[][]
+                                {
+                                        {ProvisioningDeviceClientTransportProtocol.HTTPS, attestationType},
+                                        {ProvisioningDeviceClientTransportProtocol.AMQPS, attestationType},
+                                        {ProvisioningDeviceClientTransportProtocol.AMQPS_WS, attestationType}
 
-                                    //MQTT/MQTT_WS does not support tpm attestation
-                                    //{ProvisioningDeviceClientTransportProtocol.MQTT, attestationType},
-                                    //{ProvisioningDeviceClientTransportProtocol.MQTT_WS, attestationType},
-                            });
+                                        //MQTT/MQTT_WS does not support tpm attestation
+                                        //{ProvisioningDeviceClientTransportProtocol.MQTT, attestationType},
+                                        //{ProvisioningDeviceClientTransportProtocol.MQTT_WS, attestationType},
+                                });
+            }
+            else
+            {
+                return Arrays.asList(
+                        new Object[][]
+                                {
+                                        //no tests to run for pull request builds
+                                });
+            }
         }
         else
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -139,8 +139,9 @@ public class ProvisioningCommon extends IntegrationTest
                                     {ProvisioningDeviceClientTransportProtocol.MQTT_WS, attestationType}
                             });
         }
-        else if (attestationType == AttestationType.TPM)
+        else if (attestationType == AttestationType.TPM && !isPullRequest)
         {
+            //TODO TPM tests are flakey, so only run them for CI and nightly builds
             return Arrays.asList(
                     new Object[][]
                             {
@@ -176,12 +177,10 @@ public class ProvisioningCommon extends IntegrationTest
                                     {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.SYMMETRIC_KEY},
                                     {ProvisioningDeviceClientTransportProtocol.AMQPS_WS, AttestationType.SYMMETRIC_KEY},
                                     {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.SYMMETRIC_KEY},
-                                    {ProvisioningDeviceClientTransportProtocol.MQTT_WS, AttestationType.SYMMETRIC_KEY},
+                                    {ProvisioningDeviceClientTransportProtocol.MQTT_WS, AttestationType.SYMMETRIC_KEY}
 
-                                    //TODO tpm tests are flakey, so skip them for PR runs
-                                    //{ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.TPM},
-                                    //{ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.TPM},
-                                    //{ProvisioningDeviceClientTransportProtocol.AMQPS_WS, AttestationType.TPM}
+                                    // Intentionally not doing TPM tests here. There is a separate class for running those
+                                    // tests in serial
                             });
         }
         else
@@ -199,10 +198,10 @@ public class ProvisioningCommon extends IntegrationTest
                                     {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.SYMMETRIC_KEY},
                                     {ProvisioningDeviceClientTransportProtocol.AMQPS_WS, AttestationType.SYMMETRIC_KEY},
                                     {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.SYMMETRIC_KEY},
-                                    {ProvisioningDeviceClientTransportProtocol.MQTT_WS, AttestationType.SYMMETRIC_KEY},
-                                    {ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.TPM},
-                                    {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.TPM},
-                                    {ProvisioningDeviceClientTransportProtocol.AMQPS_WS, AttestationType.TPM}
+                                    {ProvisioningDeviceClientTransportProtocol.MQTT_WS, AttestationType.SYMMETRIC_KEY}
+
+                                    // Intentionally not doing TPM tests here. There is a separate class for running those
+                                    // tests in serial
                             });
         }
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -139,7 +139,7 @@ public class ProvisioningCommon extends IntegrationTest
                                     {ProvisioningDeviceClientTransportProtocol.MQTT_WS, attestationType}
                             });
         }
-        else if (attestationType == AttestationType.TPM && !isPullRequest)
+        else if (attestationType == AttestationType.TPM)
         {
             if (!isPullRequest)
             {


### PR DESCRIPTION
~~Two small e2e test changes~~. The TPM tests need to run in serial since they each need exclusive access to the tpm simulator in order to pass.

~~The twin tear down logic should never throw an exception that causes the test to fail since the teardown logic is part of what's being tested~~