### PR TITLE
fix(iot-dev): Fix issue where clients couldn't queue messages while reconnecting

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -400,7 +400,7 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
     /**
      * Getter for the connection state.
      *
-     * @return a boolean true if the connection is open, or false if it is closed.
+     * @return a boolean true if the connection is open or reconnecting, and false otherwise.
      */
     public boolean isOpen()
     {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -827,4 +827,19 @@ public class DeviceIOTest
             }
         };
     }
+    @Test
+    public void isOpenWhenReconnecting()
+            throws IOException
+    {
+        // arrange
+        final DeviceIO deviceIO = newDeviceIO();
+        openDeviceIO(deviceIO, mockedTransport, mockExecutors, mockScheduler);
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.DISCONNECTED_RETRYING, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
+
+        // act
+        boolean isOpen = Deencapsulation.invoke(deviceIO, "isOpen" );
+
+        // assert
+        assertTrue(isOpen);
+    }
 }

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -242,6 +242,7 @@ jobs:
         condition: eq(variables['task.android.needToRunTestGroup'], 'yes')
         displayName: 'Start Android Emulator'
         timeoutInMinutes: 10
+        continueOnError: false
         inputs:
           targetType: 'filePath'
           filePath: '$(Build.SourcesDirectory)/vsts/StartEmulator.sh'


### PR DESCRIPTION
InternalClient methods such as subscribeToTwinDesiredProperties check this ```isOpen()``` method before queueing messages.

The previous behavior was to allow users to queue messages and send subscription messages even when the client is in a reconnecting state.