### PR TITLE
fix(e2e): Fix fault injection message tests

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
@@ -207,16 +207,6 @@ public class DeviceEmulator
         }
     }
 
-    public void sendMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
-    {
-        IotHubServicesCommon.sendMessageAndWaitForResponse(this.client, messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
-    }
-
-    public void sendErrorInjectionMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
-    {
-        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(this.client, messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
-    }
-
     /**
      * Clean all previous state to start a new test.
      */

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
@@ -212,6 +212,11 @@ public class DeviceEmulator
         IotHubServicesCommon.sendMessageAndWaitForResponse(this.client, messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
     }
 
+    public void sendErrorInjectionMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
+    {
+        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(this.client, messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
+    }
+
     /**
      * Clean all previous state to start a new test.
      */

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
@@ -131,14 +131,4 @@ public class DeviceTestManager
     {
         return deviceEmulator.getTwinChanges();
     }
-
-    public void sendMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
-    {
-        deviceEmulator.sendMessageAndWaitForResponse(messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
-    }
-
-    public void sendErrorInjectionMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
-    {
-        deviceEmulator.sendMessageAndWaitForResponse(messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
-    }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
@@ -136,4 +136,9 @@ public class DeviceTestManager
     {
         deviceEmulator.sendMessageAndWaitForResponse(messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
     }
+
+    public void sendErrorInjectionMessageAndWaitForResponse(MessageAndResult messageAndResult, int RETRY_MILLISECONDS, int SEND_TIMEOUT_MILLISECONDS, IotHubClientProtocol protocol)
+    {
+        deviceEmulator.sendMessageAndWaitForResponse(messageAndResult, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
+    }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ErrorInjectionHelper.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ErrorInjectionHelper.java
@@ -31,7 +31,7 @@ public class ErrorInjectionHelper
     public static final String FaultCloseReason_Boom = "Boom";
     public static final String FaultCloseReason_Bye = "byebye";
 
-    public static final int DefaultDelayInSec = 1;
+    public static final int DefaultDelayInSec = 5;
     public static final int DefaultDurationInSec = 5;
 
     public static Message tcpConnectionDropErrorInjectionMessage(int delayInSecs, int durationInSecs)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IotHubServicesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IotHubServicesCommon.java
@@ -23,11 +23,6 @@ import static tests.integration.com.microsoft.azure.sdk.iot.helpers.CorrelationD
  */
 public class IotHubServicesCommon
 {
-    protected static final Integer RETRY_MILLISECONDS = 100;
-    protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60000;
-
-    public static final int ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS = 200;
-
     //if error injection message has not taken effect after 1 minute, the test will timeout
     private final static long ERROR_INJECTION_MESSAGE_EFFECT_TIMEOUT_MILLISECONDS = 1 * 60 * 1000;
     private final static String TEST_ASC_SECURITY_MESSAGE = "{ \"AgentVersion\": \"0.0.1\", "
@@ -65,7 +60,7 @@ public class IotHubServicesCommon
                     //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
                     // we ensure that error injection message isn't resent to service too many times. The message will still likely
                     // be sent 3 or 4 times causing 3 or 4 disconnections, but the test should recover anyways.
-                    messagesToSend.get(i).message.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+                    messagesToSend.get(i).message.setExpiryTime(200);
                 }
 
                 sendMessageAndWaitForResponse(client, messagesToSend.get(i), RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, protocol);
@@ -388,32 +383,15 @@ public class IotHubServicesCommon
         return false;
     }
 
-    public static void waitForStabilizedConnection(List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates, long timeout, InternalClient client, MessageAndResult errorInjectionMsgAndRet) throws InterruptedException
+    public static void waitForStabilizedConnection(List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates, long timeout, InternalClient client) throws InterruptedException
     {
         //Wait until error injection takes effect
-        long millisecondsToWaitForErrorInjectionToHappen = 10 * 1000;
         long startTime = System.currentTimeMillis();
-        long timeErrorInjectionMessageSent = System.currentTimeMillis();
         while (!actualStatusUpdatesContainsStatus(actualStatusUpdates, IotHubConnectionStatus.DISCONNECTED_RETRYING))
         {
             Thread.sleep(200);
-            long timeElapsedSinceErrorInjectionMessageSent = System.currentTimeMillis() - timeErrorInjectionMessageSent;
-            if (timeElapsedSinceErrorInjectionMessageSent > millisecondsToWaitForErrorInjectionToHappen)
-            {
-                //Error injection message never took effect, likely because the message wasn't sent. Send it again and wait for the effect to take place.
-                // Extend the lifespan of the error injection message so it doesn't immediately expire
-                errorInjectionMsgAndRet.message.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
-                IotHubServicesCommon.sendMessageAndWaitForResponse(
-                        client,
-                        errorInjectionMsgAndRet,
-                        RETRY_MILLISECONDS,
-                        SEND_TIMEOUT_MILLISECONDS,
-                        client.getConfig().getProtocol());
-
-                timeErrorInjectionMessageSent = System.currentTimeMillis();
-            }
-
-            if (System.currentTimeMillis() - startTime > timeout)
+            long timeElapsed = System.currentTimeMillis() - startTime;
+            if (timeElapsed > timeout)
             {
                 Assert.fail(buildExceptionMessage("Timed out waiting for error injection message to take effect", client));
             }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
@@ -27,6 +27,7 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
+import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to DesiredProperties.
@@ -543,7 +544,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         subscribeToDesiredPropertiesAndVerify(1, propertyValue, updatePropertyValue, update1Prefix);
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
+        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(
             internalClient,
@@ -553,7 +554,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
             this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
         deviceUnderTest.dCDeviceForTwin.propertyStateList[0].callBackTriggered = false;
         Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Expected desired properties to be size 1, but was size " + deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size(), internalClient), 1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
         Set<Pair> dp = new HashSet<>();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
@@ -27,7 +27,6 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
-import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to DesiredProperties.
@@ -544,7 +543,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         subscribeToDesiredPropertiesAndVerify(1, propertyValue, updatePropertyValue, update1Prefix);
 
         // Act
-        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+        errorInjectionMessage.setExpiryTime(100);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(
             internalClient,
@@ -554,7 +553,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
             this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
         deviceUnderTest.dCDeviceForTwin.propertyStateList[0].callBackTriggered = false;
         Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Expected desired properties to be size 1, but was size " + deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size(), internalClient), 1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
         Set<Pair> dp = new HashSet<>();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
@@ -7,6 +7,7 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection;
 
 import com.google.gson.JsonParser;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -543,9 +544,8 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         subscribeToDesiredPropertiesAndVerify(1, propertyValue, updatePropertyValue, update1Prefix);
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
-        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
-        IotHubServicesCommon.sendMessageAndWaitForResponse(
+        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, IotHubStatusCode.OK_EMPTY);
+        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(
             internalClient,
             errorInjectionMsgAndRet,
             RETRY_MILLISECONDS,

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -250,11 +250,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
 
         // Act
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, IotHubStatusCode.OK_EMPTY);
-        this.testInstance.deviceTestManager.sendErrorInjectionMessageAndWaitForResponse(
-                errorInjectionMsgAndRet,
-                RETRY_MILLISECONDS,
-                SEND_TIMEOUT_MILLISECONDS,
-                this.testInstance.protocol);
+        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(this.testInstance.deviceTestManager.client, errorInjectionMsgAndRet, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, this.testInstance.protocol);
 
         // Assert
         IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, this.testInstance.deviceTestManager.client);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -8,6 +8,7 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection;
 
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -248,9 +249,8 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
         invokeMethodSucceed();
 
         // Act
-        errorInjectionMessage.setExpiryTime(200);
-        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
-        this.testInstance.deviceTestManager.sendMessageAndWaitForResponse(
+        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, IotHubStatusCode.OK_EMPTY);
+        this.testInstance.deviceTestManager.sendErrorInjectionMessageAndWaitForResponse(
                 errorInjectionMsgAndRet,
                 RETRY_MILLISECONDS,
                 SEND_TIMEOUT_MILLISECONDS,

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
-import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to Device methods.
@@ -249,7 +248,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
         invokeMethodSucceed();
 
         // Act
-        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+        errorInjectionMessage.setExpiryTime(200);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         this.testInstance.deviceTestManager.sendMessageAndWaitForResponse(
                 errorInjectionMsgAndRet,
@@ -258,7 +257,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, this.testInstance.deviceTestManager.client, errorInjectionMsgAndRet);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, this.testInstance.deviceTestManager.client);
         invokeMethodSucceed();
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
+import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to Device methods.
@@ -248,7 +249,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
         invokeMethodSucceed();
 
         // Act
-        errorInjectionMessage.setExpiryTime(200);
+        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         this.testInstance.deviceTestManager.sendMessageAndWaitForResponse(
                 errorInjectionMsgAndRet,
@@ -257,7 +258,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, this.testInstance.deviceTestManager.client);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, this.testInstance.deviceTestManager.client, errorInjectionMsgAndRet);
         invokeMethodSucceed();
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
@@ -27,7 +27,6 @@ import java.util.List;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
-import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to GetDeviceTwin/GetTwin.
@@ -253,7 +252,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
         testGetDeviceTwin();
 
         // Act
-        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+        errorInjectionMessage.setExpiryTime(100);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
@@ -262,7 +261,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
         for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
             PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
@@ -6,10 +6,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection;
 
 
-import com.microsoft.azure.sdk.iot.device.DeviceClient;
-import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.sdk.iot.device.Message;
-import com.microsoft.azure.sdk.iot.device.ModuleClient;
+import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.Test;
@@ -252,9 +249,8 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
         testGetDeviceTwin();
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
-        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
-        IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
+        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, IotHubStatusCode.OK_EMPTY);
+        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
                 RETRY_MILLISECONDS,
                 SEND_TIMEOUT_MILLISECONDS,

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
+import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to GetDeviceTwin/GetTwin.
@@ -252,7 +253,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
         testGetDeviceTwin();
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
+        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
@@ -261,7 +262,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
         for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)
         {
             PropertyState propertyState = deviceUnderTest.dCDeviceForTwin.propertyStateList[i];

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReceiveMessagesErrInjTests.java
@@ -224,11 +224,21 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         {
             testInstance.client.open();
 
-            //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
-            // we ensure that error injection message isn't resent to service too many times. The message will still likely
-            // be sent 3 or 4 times causing 3 or 4 disconnections, but the test should recover anyways.
-            errorInjectionMessage.setExpiryTime(200);
-            testInstance.client.sendEventAsync(errorInjectionMessage, new EventCallback(null), null);
+            IotHubStatusCode expectedStatusCode = IotHubStatusCode.OK_EMPTY;
+
+            if (testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS)
+            {
+                // error injection message will not be ack'd by service if sent over MQTT/MQTT_WS, so the SDK's
+                // retry logic will try to send it again after the connection drops. By setting expiry time,
+                // we ensure that error injection message isn't resent to service too many times. The message will still likely
+                // be sent 3 or 4 times causing 3 or 4 disconnections, but the test should recover anyways.
+                errorInjectionMessage.setExpiryTime(1000);
+
+                // Since the message won't be ack'd, then we don't need to validate the status code when this message's callback is fired
+                expectedStatusCode = null;
+            }
+
+            testInstance.client.sendEventAsync(errorInjectionMessage, new EventCallback(expectedStatusCode), null);
 
             //wait to send the message because we want to ensure that the tcp connection drop happens beforehand and we
             // want the connection to be re-established before sending anything from service client

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReceiveMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReceiveMessagesErrInjTests.java
@@ -28,7 +28,6 @@ import java.util.List;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.*;
 import static org.junit.Assert.assertTrue;
-import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to receiving messages.
@@ -192,7 +191,7 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
         this.errorInjectionTestFlow(ErrorInjectionHelper.mqttGracefulShutdownErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec));
     }
 
-    public void errorInjectionTestFlow(Message errorInjectionMessage) throws IOException, IotHubException, InterruptedException
+    public void errorInjectionTestFlow(com.microsoft.azure.sdk.iot.device.Message errorInjectionMessage) throws IOException, IotHubException, InterruptedException
     {
         List<Pair<IotHubConnectionStatus, Throwable>> connectionStatusUpdates = new ArrayList<>();
         testInstance.client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeCallback()
@@ -228,12 +227,12 @@ public class ReceiveMessagesErrInjTests extends ReceiveMessagesCommon
             //error injection message is not guaranteed to be ack'd by service so it may be re-sent. By setting expiry time,
             // we ensure that error injection message isn't resent to service too many times. The message will still likely
             // be sent 3 or 4 times causing 3 or 4 disconnections, but the test should recover anyways.
-            errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+            errorInjectionMessage.setExpiryTime(200);
             testInstance.client.sendEventAsync(errorInjectionMessage, new EventCallback(null), null);
 
             //wait to send the message because we want to ensure that the tcp connection drop happens beforehand and we
             // want the connection to be re-established before sending anything from service client
-            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT_MILLISECONDS, testInstance.client, new MessageAndResult(errorInjectionMessage, null));
+            IotHubServicesCommon.waitForStabilizedConnection(connectionStatusUpdates, ERROR_INJECTION_RECOVERY_TIMEOUT_MILLISECONDS, testInstance.client);
 
             if (testInstance.client instanceof DeviceClient)
             {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -7,6 +7,7 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection;
 
 
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
@@ -218,9 +219,8 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
         sendReportedPropertiesAndVerify(1);
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
-        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
-        IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
+        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, IotHubStatusCode.OK_EMPTY);
+        IotHubServicesCommon.sendErrorInjectionMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
                 RETRY_MILLISECONDS,
                 SEND_TIMEOUT_MILLISECONDS,

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -26,7 +26,6 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
-import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to ReportedProperties.
@@ -219,7 +218,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
         sendReportedPropertiesAndVerify(1);
 
         // Act
-        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
+        errorInjectionMessage.setExpiryTime(100);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
@@ -228,7 +227,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
         // add one new reported property
         deviceUnderTest.dCDeviceForTwin.createNewReportedProperties(1);
         internalClient.sendReportedProperties(deviceUnderTest.dCDeviceForTwin.getReportedProp());

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -26,6 +26,7 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS_WS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SAS;
 import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_SIGNED;
+import static tests.integration.com.microsoft.azure.sdk.iot.helpers.IotHubServicesCommon.ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS;
 
 /**
  * Test class containing all error injection tests to be run on JVM and android pertaining to ReportedProperties.
@@ -218,7 +219,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
         sendReportedPropertiesAndVerify(1);
 
         // Act
-        errorInjectionMessage.setExpiryTime(100);
+        errorInjectionMessage.setExpiryTime(ERROR_INJECTION_MESSAGE_TIMEOUT_MILLISECONDS);
         MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage, null);
         IotHubServicesCommon.sendMessageAndWaitForResponse(internalClient,
                 errorInjectionMsgAndRet,
@@ -227,7 +228,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
                 this.testInstance.protocol);
 
         // Assert
-        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient);
+        IotHubServicesCommon.waitForStabilizedConnection(actualStatusUpdates, ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS, internalClient, errorInjectionMsgAndRet);
         // add one new reported property
         deviceUnderTest.dCDeviceForTwin.createNewReportedProperties(1);
         internalClient.sendReportedProperties(deviceUnderTest.dCDeviceForTwin.getReportedProp());

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/SendMessagesErrInjTests.java
@@ -355,7 +355,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
         client.open();
 
         // Act
-        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage,null);
+        MessageAndResult errorInjectionMsgAndRet = new MessageAndResult(errorInjectionMessage,IotHubStatusCode.OK_EMPTY);
         IotHubServicesCommon.sendMessageAndWaitForResponse(
                 client,
                 errorInjectionMsgAndRet,

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -519,43 +519,43 @@ public class SendMessagesCommon extends IntegrationTest
             {
                 //messages that tests should recover from
                 Message tcpConnectionDropErrorInjectionMessage = ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                TCP_CONNECTION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(tcpConnectionDropErrorInjectionMessage, null));
+                TCP_CONNECTION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(tcpConnectionDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpConnectionDropErrorInjectionMessage = ErrorInjectionHelper.amqpsConnectionDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_CONNECTION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpConnectionDropErrorInjectionMessage, null));
+                AMQP_CONNECTION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpConnectionDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpSessionDropErrorInjectionMessage = ErrorInjectionHelper.amqpsSessionDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_SESSION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpSessionDropErrorInjectionMessage, null));
+                AMQP_SESSION_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpSessionDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpCbsRequestLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsCBSReqLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_CBS_REQUEST_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpCbsRequestLinkDropErrorInjectionMessage, null));
+                AMQP_CBS_REQUEST_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpCbsRequestLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpCbsResponseLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsCBSRespLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_CBS_RESPONSE_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpCbsResponseLinkDropErrorInjectionMessage, null));
+                AMQP_CBS_RESPONSE_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpCbsResponseLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpC2DLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsC2DLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_C2D_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpC2DLinkDropErrorInjectionMessage, null));
+                AMQP_C2D_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpC2DLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpD2CLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsD2CTelemetryLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_D2C_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpD2CLinkDropErrorInjectionMessage, null));
+                AMQP_D2C_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpD2CLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpMethodReqLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsMethodReqLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_METHOD_REQ_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpMethodReqLinkDropErrorInjectionMessage, null));
+                AMQP_METHOD_REQ_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpMethodReqLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpMethodRespLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsMethodRespLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_METHOD_RESP_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpMethodRespLinkDropErrorInjectionMessage, null));
+                AMQP_METHOD_RESP_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpMethodRespLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpTwinReqLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsTwinReqLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_TWIN_REQ_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpTwinReqLinkDropErrorInjectionMessage, null));
+                AMQP_TWIN_REQ_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpTwinReqLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpTwinRespLinkDropErrorInjectionMessage = ErrorInjectionHelper.amqpsTwinRespLinkDropErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpTwinRespLinkDropErrorInjectionMessage, null));
+                AMQP_TWIN_RESP_LINK_DROP_MESSAGES_TO_SEND.add(new MessageAndResult(amqpTwinRespLinkDropErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message amqpGracefulShutdownErrorInjectionMessage = ErrorInjectionHelper.amqpsGracefulShutdownErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND.add(new MessageAndResult(amqpGracefulShutdownErrorInjectionMessage, null));
+                AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND.add(new MessageAndResult(amqpGracefulShutdownErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
 
                 Message mqttGracefulShutdownErrorInjectionMessage = ErrorInjectionHelper.mqttGracefulShutdownErrorInjectionMessage(ErrorInjectionHelper.DefaultDelayInSec, ErrorInjectionHelper.DefaultDurationInSec);
-                MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND.add(new MessageAndResult(mqttGracefulShutdownErrorInjectionMessage, null));
+                MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND.add(new MessageAndResult(mqttGracefulShutdownErrorInjectionMessage, IotHubStatusCode.OK_EMPTY));
             }
             else
             {

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -242,6 +242,7 @@ jobs:
         condition: eq(variables['task.android.needToRunTestGroup'], 'yes')
         displayName: 'Start Android Emulator'
         timeoutInMinutes: 10
+        continueOnError: false
         inputs:
           targetType: 'filePath'
           filePath: '$(Build.SourcesDirectory)/vsts/StartEmulator.sh'


### PR DESCRIPTION
Iot Hub responds to fault injection messages differently for AMQP and MQTT. For AMQP, the fault injection message will be ack'd before the fault takes effect, but this isn't the case for MQTT. To make it more reliable that the fault injection message gets sent, AMQP tests should wait for this FI message to be ack'd. MQTT tests still need to provide an expiry time, but that time has been bumped up from .1 or .2 seconds to 1 second to increase the chances that it gets delivered at least once