### PR TITLE
fix(prov-dev, prov-serv): Fix provisioning clients not sending content length with http requests

### DIFF
--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttp.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttp.java
@@ -46,6 +46,7 @@ public class ContractAPIHttp extends ProvisioningDeviceClientContract
     private static final String ACCEPT_VALUE = "application/json";
     private static final String ACCEPT_CHARSET = "charset=utf-8";
     private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_LENGTH = "Content-Length";
     private static final Integer DEFAULT_HTTP_TIMEOUT_MS = Integer.MAX_VALUE;
     private static final Integer ACCEPTABLE_NONCE_HTTP_STATUS = 401;
 
@@ -126,6 +127,7 @@ public class ContractAPIHttp extends ProvisioningDeviceClientContract
         request.setHeaderField(USER_AGENT, userAgentValue);
         request.setHeaderField(ACCEPT, ACCEPT_VALUE);
         request.setHeaderField(CONTENT_TYPE, ACCEPT_VALUE + "; " + ACCEPT_CHARSET);
+        request.setHeaderField(CONTENT_LENGTH, payload != null ? String.valueOf(payload.length) : "0");
         if (headersMap != null)
         {
             for (Map.Entry<String, String> header : headersMap.entrySet())

--- a/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttpTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttpTest.java
@@ -117,7 +117,7 @@ public class ContractAPIHttpTest
                 new HttpRequest((URL)any, method, (byte[])any);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 3 + headerSize;
+                times = 4 + headerSize;
             }
         };
     }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttp.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttp.java
@@ -68,6 +68,7 @@ public class ContractApiHttp
     private static final String HEADER_FIELD_NAME_REQUEST_ID = "Request-Id";
     private static final String HEADER_FIELD_NAME_ACCEPT = "Accept";
     private static final String HEADER_FIELD_NAME_CONTENT_TYPE = "Content-Type";
+    private static final String HEADER_FIELD_NAME_CONTENT_LENGTH = "Content-Length";
     private static final String HEADER_FIELD_NAME_CHARSET = "charset";
 
     private static final String HEADER_FIELD_VALUE_REQUEST_ID = "1001";
@@ -183,6 +184,7 @@ public class ContractApiHttp
         request.setHeaderField(HEADER_FIELD_NAME_ACCEPT, HEADER_FIELD_VALUE_ACCEPT);
         request.setHeaderField(HEADER_FIELD_NAME_CONTENT_TYPE, HEADER_FIELD_VALUE_CONTENT_TYPE);
         request.setHeaderField(HEADER_FIELD_NAME_CHARSET, HEADER_FIELD_VALUE_CHARSET);
+        request.setHeaderField(HEADER_FIELD_NAME_CONTENT_LENGTH, payload != null ? String.valueOf(payload.length) : "0");
 
         /* SRS_HTTP_DEVICE_REGISTRATION_CLIENT_21_013: [The request shall add the headerParameters to the http header, if provided.] */
         if(headerParameters != null)

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttpTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttpTest.java
@@ -428,6 +428,8 @@ public class ContractApiHttpTest
                 times = 1;
                 mockedHttpRequest.setHeaderField("Content-Type", "application/json");
                 times = 1;
+                mockedHttpRequest.setHeaderField("Content-Length", String.valueOf(VALID_PAYLOAD.length()));
+                times = 1;
                 mockedHttpRequest.setHeaderField("charset", "utf-8");
                 times = 1;
             }


### PR DESCRIPTION
DPS would occasionally return a 411 error because this wasn't being sent on registration requests and enrollment creations

It doesn't appear to be a hard requirement since tests usually pass without them, but just to be safe we should send them. The 411 failures seem to disappear once this change is made.