### PR TITLE
release(2020-07-07): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -13,7 +13,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION_PREVIEW = "2020-05-31-preview";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.23.0";
+    private static final String CLIENT_VERSION = "1.24.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.23.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.24.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.23.0</iot-device-client-version>
-        <iot-service-client-version>1.23.0</iot-service-client-version>
-        <iot-deps-version>0.9.5</iot-deps-version>
-        <provisioning-device-client-version>1.8.2</provisioning-device-client-version>
-        <provisioning-service-client-version>1.6.1</provisioning-service-client-version>
+        <iot-device-client-version>1.24.0</iot-device-client-version>
+        <iot-service-client-version>1.24.0</iot-service-client-version>
+        <iot-deps-version>0.9.6</iot-deps-version>
+        <provisioning-device-client-version>1.8.3</provisioning-device-client-version>
+        <provisioning-service-client-version>1.6.2</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <iot-device-client-version>1.24.0</iot-device-client-version>
         <iot-service-client-version>1.24.0</iot-service-client-version>
-        <iot-deps-version>0.9.6</iot-deps-version>
+        <iot-deps-version>0.10.0</iot-deps-version>
         <provisioning-device-client-version>1.8.3</provisioning-device-client-version>
         <provisioning-service-client-version>1.6.2</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.2";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.3";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.1";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.2";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.23.0";
+    public static String serviceVersion = "1.24.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
old
{
    "device": "1.23.0",
    "service": "1.23.0",
    "deps": "0.9.5",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.2",
    "provisioningService": "1.6.1"
}

new
{
    "device": "1.24.0",
    "service": "1.24.0",
    "deps": "0.10.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.3",
    "provisioningService": "1.6.2"
}


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.24.0)

- Add support for setting HTTP read and connect timeouts for registry manager operations (#815)


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.24.0)

- Add new File upload APIs for more granular control over the now deprecated file upload API (#808)
- Add PnP ModelId option to ModuleClient constructors
- Deprecated Client constructors that take x509 authentication through strings/file paths in favor of SSLContext
- Add message type (twin subscribe message, for instance) to log statements
- Cut down on needless spawning of send/receive threads. Now threads stop spawning until work becomes available (#826)


### Bug fixes
- Fix AMQP layer being too proactive when renewing sas tokens (#793)
- Fix AMQP layer not maintaining separate sas token renewal schedules per multiplexed client (#793)
- Fix bug where client library spawned send/receive threads even when in a reconnecting state (#826)

## Java Iot Deps (com.microsoft.azure.sdk.iot:iot-deps:1.10.0)

- Add new File upload APIs for more granular control over the now deprecated file upload API (#808)


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.3)

### Bug fixes
- Fix issue where HTTP requests didn't send content-length header (#833)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.6.2)

### Bug fixes
- Fix issue where HTTP requests didn't send content-length header (#833)
