### PR TITLE
release(2020-07-08): bump preview package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-05-31-preview";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client-preview";
-    private static final String CLIENT_VERSION = "1.0.1";
+    private static final String CLIENT_VERSION = "1.1.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
         <digital-twin-device-client-artifact-id>digital-twin-device-client-preview</digital-twin-device-client-artifact-id>
         <digital-twin-service-client-artifact-id>digital-twin-service-client-preview</digital-twin-service-client-artifact-id>
 
-        <iot-device-client-version>1.0.1</iot-device-client-version>
-        <iot-service-client-version>1.0.1</iot-service-client-version>
-        <iot-deps-version>1.0.1</iot-deps-version>
+        <iot-device-client-version>1.1.0</iot-device-client-version>
+        <iot-service-client-version>1.1.0</iot-service-client-version>
+        <iot-deps-version>1.1.0</iot-deps-version>
         <provisioning-device-client-version>1.0.1</provisioning-device-client-version>
         <provisioning-service-client-version>1.0.1</provisioning-service-client-version>
         <security-provider-version>1.0.1</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client-preview/";
-    public static String serviceVersion = "1.0.1";
+    public static String serviceVersion = "1.1.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
old
{
    "device": "1.0.1",
    "service": "1.0.1",
    "deps": "1.0.1",
}

new
{
    "device": "1.1.0",
    "service": "1.1.0",
    "deps": "1.1.0",
}

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client-preview:1.1.0)

- Add PnP Summer refresh model Id support
- Make http read and connect timeouts configurable for registry manager operations
- Add proxy support for registry manager and service client operations
- Add support for fully qualified error codes when provided by service
- Add twin array support
- Add support for identity based storage authentication for jobs

### Bug fixes

- Brought all bug fixes in from iot-service-client:1:24:0

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client-preview:1.1.0)

- Add PnP Summer refresh model Id support
- Stabilize AMQP layer with several bug fixes
- Fixed several performance issues
- Deprecate file upload APIs in favor of new, more granular APIs to allow for users to choose their Storage SDK dependency
- Fixed desired properties not being received over AMQP
- Add twin array support
- Add support for CA signed x509 certs over HTTPS and MQTT_WS

### Bug fixes

- Brought all bug fixes in from iot-device-client:1:24:0

## Java IotHub Deps (com.microsoft.azure.sdk.iot:iot-deps-preview:1.1.0)

- Remove SDK side validation of twin maximum depth
- Deprecate file upload APIs in favor of new, more granular APIs to allow for users to choose their Storage SDK dependency

### Bug fixes

- Brought all bug fixes in from iot-deps:1:10:0