### PR TITLE
fix(iot-dev): Fix issue with ordering of queue within amqp layer

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -530,18 +530,18 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private void sendQueuedMessages()
     {
         int messagesAttemptedToBeProcessed = 0;
-        boolean lastSendSucceeded = true;
         Message message = messagesToSend.poll();
-        while (message != null && messagesAttemptedToBeProcessed < MAX_MESSAGES_TO_SEND_PER_CALLBACK && lastSendSucceeded)
+        while (message != null && messagesAttemptedToBeProcessed < MAX_MESSAGES_TO_SEND_PER_CALLBACK)
         {
             messagesAttemptedToBeProcessed++;
-            lastSendSucceeded = sendQueuedMessage(message);
+            boolean lastSendSucceeded = sendQueuedMessage(message);
 
             if (!lastSendSucceeded)
             {
                 //message failed to send, likely due to lack of link credit available. Re-queue and try again later
                 log.trace("Amqp message failed to send, adding it back to messages to send queue ({})", message);
                 messagesToSend.add(message);
+                return;
             }
 
             message = messagesToSend.poll();


### PR DESCRIPTION
If two messages are queued, one for subscribing to twin, and one for getting a twin, and the latter is queued first, then the SDK gets stuck trying to send the get twin request repeatedly without trying to send the subscribe message first.

This change ensures that any message that fails to send is placed at the back of the queue and that the next message stays at the front of the queue. This helps to protect the SDK from states where some messages need to be sent before others, but never are

One of our edge e2e tests was occasionally failing due to this bug. 