### PR TITLE
refactor(e2e): Add sdk logging to all test runs

### DIFF
--- a/iot-e2e-tests/common/src/test/resources/log4j.properties
+++ b/iot-e2e-tests/common/src/test/resources/log4j.properties
@@ -6,3 +6,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.logger.tests.integration.com.microsoft.azure.sdk.* = DEBUG 
+log4j.logger.com.microsoft.azure.sdk.iot = TRACE
+log4j.appender.stdout.layout.ConversionPattern=%d %p (%t) [%c] - %m%n

--- a/iot-e2e-tests/common/src/test/resources/log4j.properties
+++ b/iot-e2e-tests/common/src/test/resources/log4j.properties
@@ -5,6 +5,10 @@ log4j.rootLogger=ERROR, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.logger.tests.integration.com.microsoft.azure.sdk.* = DEBUG 
+log4j.logger.tests.integration.com.microsoft.azure.sdk.* = DEBUG
+
+# Note that this statement works recursively. Any class in the com.microsoft.azure.sdk.iot package or its subpackages will be logged
 log4j.logger.com.microsoft.azure.sdk.iot = TRACE
+
+# This adds a timestamp to each logged statement. Useful for seeing where tests stall.
 log4j.appender.stdout.layout.ConversionPattern=%d %p (%t) [%c] - %m%n


### PR DESCRIPTION
While system.out will get very busy thanks to our tests running in parallel, Azure Devops is smart enough to allow you to view the logs for each individual test run without other test run's logs getting in the mix.

We'll need this level of logging in place to understand the recent transient issues that we've been seeing and haven't been able to reproduce