### PR TITLE
refactor(iot-dev): Remove unused executor service

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -69,7 +69,6 @@ public class IotHubTransport implements IotHubListener
 
     final private Object reconnectionLock = new Object();
 
-    private ScheduledExecutorService scheduledExecutorService;
     private static final int POOL_SIZE = 1;
 
     // State lock used to communicate to the IotHubSendTask thread when a message needs to be sent or a callback needs to be invoked.
@@ -355,12 +354,6 @@ public class IotHubTransport implements IotHubListener
         if (this.taskScheduler != null)
         {
             this.taskScheduler.shutdown();
-        }
-
-        if (this.scheduledExecutorService != null)
-        {
-            this.scheduledExecutorService.shutdownNow();
-            this.scheduledExecutorService = null;
         }
 
         //Codes_SRS_IOTHUBTRANSPORT_34_024: [This function shall close the connection.]
@@ -745,8 +738,6 @@ public class IotHubTransport implements IotHubListener
      */
     private void openConnection() throws TransportException
     {
-        scheduledExecutorService = Executors.newScheduledThreadPool(POOL_SIZE);
-
         if (this.iotHubTransportConnection == null)
         {
             switch (defaultConfig.getProtocol()) {
@@ -776,7 +767,7 @@ public class IotHubTransport implements IotHubListener
         this.iotHubTransportConnection.setListener(this);
 
         //Codes_SRS_IOTHUBTRANSPORT_34_039: [This function shall open the iotHubTransportConnection object with the saved list of configs.]
-        this.iotHubTransportConnection.open(this.deviceClientConfigs, scheduledExecutorService);
+        this.iotHubTransportConnection.open(this.deviceClientConfigs);
 
         //Codes_SRS_IOTHUBTRANSPORT_34_040: [This function shall invoke the method updateStatus with status CONNECTED,
         // reason CONNECTION_OK, and a null throwable.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportConnection.java
@@ -26,10 +26,9 @@ public interface IotHubTransportConnection
      * Opens the transport connection object
      * @param deviceClientConfigs The list of configs to use. If more than 1 configs are in this list, multiplexing
      *                            will be used
-     * @param scheduledExecutorService the executor service to use when spawning threads
      * @throws TransportException If any exceptions are encountered while opening the connection
      */
-    void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService) throws TransportException;
+    void open(Queue<DeviceClientConfig> deviceClientConfigs) throws TransportException;
 
     /**
      * Sets a listener into the Transport Connection object. This listener updates the Transport layer of connection status

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -107,7 +107,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         log.trace("AmqpsIotHubConnection object is created successfully and will use port {}", this.deviceClientConfig.isUseWebsocket() ? WEB_SOCKET_PORT : AMQP_PORT);
     }
 
-    public void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService) throws TransportException
+    public void open(Queue<DeviceClientConfig> deviceClientConfigs) throws TransportException
     {
         log.debug("Opening amqp layer...");
         reconnectionScheduled = false;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -292,7 +292,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
     }
 
     @Override
-    public void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService)
+    public void open(Queue<DeviceClientConfig> deviceClientConfigs)
     {
 
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -101,7 +101,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
      *
      * @throws TransportException if a connection could not to be established.
      */
-    public void open(Queue<DeviceClientConfig> deviceClientConfigs, ScheduledExecutorService scheduledExecutorService) throws TransportException
+    public void open(Queue<DeviceClientConfig> deviceClientConfigs) throws TransportException
     {
         connectionId = UUID.randomUUID().toString();
         if (deviceClientConfigs.size() > 1)

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -785,14 +785,13 @@ public class IotHubTransportTest
         Deencapsulation.invoke(transport, "openConnection");
 
         //assert
-        final ScheduledExecutorService scheduledExecutorService = Deencapsulation.getField(transport, "scheduledExecutorService");
         new Verifications()
         {
             {
                 mockedHttpsIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedHttpsIotHubConnection.open(configs, scheduledExecutorService);
+                mockedHttpsIotHubConnection.open(configs);
                 times = 1;
 
                 Deencapsulation.invoke(transport, "updateStatus",
@@ -826,14 +825,13 @@ public class IotHubTransportTest
         Deencapsulation.invoke(transport, "openConnection");
 
         //assert
-        final ScheduledExecutorService scheduledExecutorService = Deencapsulation.getField(transport, "scheduledExecutorService");
         new Verifications()
         {
             {
                 mockedMqttIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedMqttIotHubConnection.open(configs, scheduledExecutorService);
+                mockedMqttIotHubConnection.open(configs);
                 times = 1;
             }
         };
@@ -863,14 +861,13 @@ public class IotHubTransportTest
         Deencapsulation.invoke(transport, "openConnection");
 
         //assert
-        final ScheduledExecutorService scheduledExecutorService = Deencapsulation.getField(transport, "scheduledExecutorService");
         new Verifications()
         {
             {
                 mockedMqttIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedMqttIotHubConnection.open(configs, scheduledExecutorService);
+                mockedMqttIotHubConnection.open(configs);
                 times = 1;
             }
         };
@@ -890,8 +887,6 @@ public class IotHubTransportTest
             {
                 mockedConfig.getProtocol();
                 result = IotHubClientProtocol.AMQPS;
-                Executors.newScheduledThreadPool(1);
-                result = mockedScheduledExecutorService;
                 new AmqpsIotHubConnection(mockedConfig);
                 result = mockedAmqpsIotHubConnection;
             }
@@ -901,14 +896,13 @@ public class IotHubTransportTest
         Deencapsulation.invoke(transport, "openConnection");
 
         //assert
-        final ScheduledExecutorService scheduledExecutorService = Deencapsulation.getField(transport, "scheduledExecutorService");
         new Verifications()
         {
             {
                 mockedAmqpsIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedAmqpsIotHubConnection.open(configs, scheduledExecutorService);
+                mockedAmqpsIotHubConnection.open(configs);
                 times = 1;
             }
         };
@@ -928,8 +922,6 @@ public class IotHubTransportTest
             {
                 mockedConfig.getProtocol();
                 result = IotHubClientProtocol.AMQPS_WS;
-                Executors.newScheduledThreadPool(1);
-                result = mockedScheduledExecutorService;
                 new AmqpsIotHubConnection(mockedConfig);
                 result = mockedAmqpsIotHubConnection;
             }
@@ -939,14 +931,13 @@ public class IotHubTransportTest
         Deencapsulation.invoke(transport, "openConnection");
 
         //assert
-        final ScheduledExecutorService scheduledExecutorService = Deencapsulation.getField(transport, "scheduledExecutorService");
         new Verifications()
         {
             {
                 mockedAmqpsIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedAmqpsIotHubConnection.open(configs, scheduledExecutorService);
+                mockedAmqpsIotHubConnection.open(configs);
                 times = 1;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -277,7 +277,7 @@ public class AmqpsIotHubConnectionTest {
         AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
 
         //act
-        connection.open(mockedQueue, mockScheduledExecutorService);
+        connection.open(mockedQueue);
     }
 
     // Tests_SRS_AMQPSIOTHUBCONNECTION_12_001: [The constructor shall initialize the AmqpsIotHubConnection member variable with the given config.]
@@ -349,7 +349,7 @@ public class AmqpsIotHubConnectionTest {
 
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
 
-        connection.open(mockedQueue, mockScheduledExecutorService);
+        connection.open(mockedQueue);
 
         new Verifications()
         {
@@ -387,7 +387,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         // act
-        connection.open(mockedQueue, mockScheduledExecutorService);
+        connection.open(mockedQueue);
     }
 
     @Test
@@ -414,7 +414,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         // act
-        connection.open(mockedQueue, mockScheduledExecutorService);
+        connection.open(mockedQueue);
     }
 
     // Tests_SRS_AMQPSIOTHUBCONNECTION_15_011: [If any exception is thrown while attempting to trigger the reactor, the function shall closeNow the connection and throw an IOException.]
@@ -435,7 +435,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         // act
-        connection.open(mockedQueue, mockScheduledExecutorService);
+        connection.open(mockedQueue);
     }
 
     // Tests_SRS_AMQPSIOTHUBCONNECTION_15_009: [The function shall trigger the Reactor (Proton) to begin running.]
@@ -464,7 +464,7 @@ public class AmqpsIotHubConnectionTest {
         //act
         try
         {
-            connection.open(mockedQueue, mockScheduledExecutorService);
+            connection.open(mockedQueue);
         }
         catch (TransportException e)
         {
@@ -507,7 +507,7 @@ public class AmqpsIotHubConnectionTest {
         //act
         try
         {
-            connection.open(mockedQueue, mockScheduledExecutorService);
+            connection.open(mockedQueue);
         }
         catch (TransportException e)
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -2175,7 +2175,7 @@ public class HttpsIotHubConnectionTest
     public void openAndCloseDoNothing() throws IOException, TransportException
     {
         HttpsIotHubConnection connection = new HttpsIotHubConnection(mockConfig);
-        connection.open(null, mockedScheduledExecutorService);
+        connection.open(null);
         connection.close();
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
@@ -287,7 +287,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         final String actualIotHubUserName = Deencapsulation.getField(connection, "iotHubUserName");
 
@@ -334,7 +334,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         final String actualIotHubUserName = Deencapsulation.getField(connection, "iotHubUserName");
 
@@ -386,7 +386,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         final String actualIotHubUserName = Deencapsulation.getField(connection, "iotHubUserName");
 
@@ -433,7 +433,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         final String actualIotHubUserName = Deencapsulation.getField(connection, "iotHubUserName");
 
@@ -475,7 +475,7 @@ public class MqttIotHubConnectionTest
         try
         {
             MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
-            connection.open(mockedQueue, mockedScheduledExecutorService);
+            connection.open(mockedQueue);
         }
         catch (Exception e)
         {
@@ -539,7 +539,7 @@ public class MqttIotHubConnectionTest
         try
         {
             MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
-            connection.open(mockedQueue, mockedScheduledExecutorService);
+            connection.open(mockedQueue);
         }
         catch (TransportException e)
         {
@@ -596,7 +596,7 @@ public class MqttIotHubConnectionTest
         try
         {
             MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
-            connection.open(mockedQueue, mockedScheduledExecutorService);
+            connection.open(mockedQueue);
         }
         catch (Exception e)
         {
@@ -623,8 +623,8 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
+        connection.open(mockedQueue);
 
         new Verifications()
         {
@@ -645,7 +645,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         connection.close();
 
         IotHubConnectionStatus expectedState = IotHubConnectionStatus.DISCONNECTED;
@@ -686,7 +686,7 @@ public class MqttIotHubConnectionTest
         configs.add(mockConfig);
 
         //act
-        connection.open(configs, mockedScheduledExecutorService);
+        connection.open(configs);
     }
 
     //Tests_SRS_MQTTIOTHUBCONNECTION_34_021: [If a TransportException is encountered while closing the three clients, this function shall set this object's state to closed and then rethrow the exception.]
@@ -699,7 +699,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         new NonStrictExpectations()
         {
@@ -762,7 +762,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         connection.close();
         connection.close();
 
@@ -802,7 +802,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(mockedMessage);
 
         assertEquals(IotHubStatusCode.OK_EMPTY, result);
@@ -826,7 +826,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(null);
 
         assertEquals(IotHubStatusCode.BAD_FORMAT, result);
@@ -852,7 +852,7 @@ public class MqttIotHubConnectionTest
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(null);
 
         assertEquals(IotHubStatusCode.BAD_FORMAT, result);
@@ -875,7 +875,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(mockedMessage);
 
         assertEquals(IotHubStatusCode.BAD_FORMAT, result);
@@ -918,7 +918,7 @@ public class MqttIotHubConnectionTest
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         connection.close();
         connection.sendMessage(mockedMessage);
     }
@@ -943,7 +943,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(mockDeviceTwinMsg);
 
         assertEquals(IotHubStatusCode.OK_EMPTY, result);
@@ -983,7 +983,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         IotHubStatusCode result = connection.sendMessage(mockDeviceMethodMsg);
 
         assertEquals(IotHubStatusCode.OK_EMPTY, result);
@@ -1024,7 +1024,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         Message message = Deencapsulation.invoke(connection, "receiveMessage");
         byte[] actualMessageBody = message.getBytes();
@@ -1065,7 +1065,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         Message message = Deencapsulation.invoke(connection, "receiveMessage");
         byte[] actualMessageBody = message.getBytes();
@@ -1104,7 +1104,7 @@ public class MqttIotHubConnectionTest
 
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         Message message = Deencapsulation.invoke(connection, "receiveMessage");
         byte[] actualMessageBody = message.getBytes();
@@ -1153,7 +1153,7 @@ public class MqttIotHubConnectionTest
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         //act
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         //assert
         new Verifications()
@@ -1202,7 +1202,7 @@ public class MqttIotHubConnectionTest
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         //act
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         //assert
         new Verifications()
@@ -1238,7 +1238,7 @@ public class MqttIotHubConnectionTest
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         //act
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         //assert
         new Verifications()
@@ -1290,7 +1290,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         Map<IotHubTransportMessage, Integer> receivedMessagesToAcknowledge = new ConcurrentHashMap<>();
         Deencapsulation.setField(connection, "receivedMessagesToAcknowledge", receivedMessagesToAcknowledge);
 
@@ -1308,7 +1308,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         //act
         connection.sendMessageResult(null, expectedResult);
@@ -1324,7 +1324,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
 
         //act
         connection.sendMessageResult(mockedTransportMessage, null);
@@ -1342,7 +1342,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         final int expectedMessageId = 12;
         Map<IotHubTransportMessage, Integer> receivedMessagesToAcknowledge = new ConcurrentHashMap<>();
         receivedMessagesToAcknowledge.put(mockedTransportMessage, expectedMessageId);
@@ -1397,7 +1397,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         final int expectedMessageId = 12;
         Map<IotHubTransportMessage, Integer> receivedMessagesToAcknowledge = new ConcurrentHashMap<>();
         receivedMessagesToAcknowledge.put(mockedTransportMessage, expectedMessageId);
@@ -1450,7 +1450,7 @@ public class MqttIotHubConnectionTest
         final IotHubMessageResult expectedResult = IotHubMessageResult.COMPLETE;
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         final int expectedMessageId = 12;
         Map<IotHubTransportMessage, Integer> receivedMessagesToAcknowledge = new ConcurrentHashMap<>();
         receivedMessagesToAcknowledge.put(mockedTransportMessage, expectedMessageId);
@@ -1506,7 +1506,7 @@ public class MqttIotHubConnectionTest
         openExpectations(null);
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         connection.setListener(mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         new Expectations()
         {
             {
@@ -1556,7 +1556,7 @@ public class MqttIotHubConnectionTest
         openExpectations(null);
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         connection.setListener(mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         new Expectations()
         {
             {
@@ -1595,7 +1595,7 @@ public class MqttIotHubConnectionTest
         openExpectations(null);
         MqttIotHubConnection connection = new MqttIotHubConnection(mockConfig);
         connection.setListener(mockedIotHubListener);
-        connection.open(mockedQueue, mockedScheduledExecutorService);
+        connection.open(mockedQueue);
         new Expectations()
         {
             {

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -127,7 +127,7 @@ jobs:
         continueOnError: true
         condition: always()
 
-  ### Android, Multi configuration build (12 different test groups to cover) ###
+  ### Android, Multi configuration build (Multiple different test groups to cover) ###
   - job: AndroidBuild
     timeoutInMinutes: 15
     pool:
@@ -241,14 +241,15 @@ jobs:
       - task: Bash@3
         condition: eq(variables['task.android.needToRunTestGroup'], 'yes')
         displayName: 'Start Android Emulator'
-        timeoutInMinutes: 10
+        timeoutInMinutes: 30
         continueOnError: false
         inputs:
           targetType: 'filePath'
           filePath: '$(Build.SourcesDirectory)/vsts/StartEmulator.sh'
 
       - task: Bash@3
-        condition: eq(variables['task.android.needToRunTestGroup'], 'yes')
+        #only run tests on emulator if tests should be run, and if the emulator boot up was successful
+        condition: and(succeeded(), eq(variables['task.android.needToRunTestGroup'], 'yes'))
         displayName: 'Run tests on emulator'
         timeoutInMinutes: 45
         inputs:


### PR DESCRIPTION
It spawned no threads and wasn't used anywhere, so it should be removed