### PR TITLE
refactor(iot-dev): Only spawn receive thread for HTTP clients

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -671,10 +671,8 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      This value sets the period (in milliseconds) that this SDK spawns threads to send queued messages.
      *	      Even if no message is queued, this thread will be spawned.
      *
-     *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
-     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
-     *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
+     *	    - <b>SetReceiveInterval</b> - this option is the same as {@code SetMinimumPollingInterval}.
+     *	      This setting has no effect when a client is using MQTT/MQTT_WS/AMQPS/AMQPS_WS
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -382,10 +382,8 @@ public class InternalClient
      *	      This value sets the period (in milliseconds) that this SDK spawns threads to send queued messages.
      *	      Even if no message is queued, this thread will be spawned.
      *
-     *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
-     *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
-     *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
+     *	    - <b>SetReceiveInterval</b> - this option is the same as {@code SetMinimumPollingInterval}.
+     *	      This setting has no effect when a client is using MQTT/MQTT_WS/AMQPS/AMQPS_WS
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.azure.sdk.iot.device.transport;
 
-import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -16,13 +15,6 @@ public final class IotHubReceiveTask implements Runnable
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubReceiveTask";
     private final IotHubTransport transport;
 
-    // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
-    // wait until a message has been received in that layer before continuing. This means that if the transport layer
-    // has no received messages to handle, then this thread will do nothing and cost nothing. This is useful
-    // as this SDK would otherwise periodically spawn new threads of this type that would do nothing. It is the IotHubTransport
-    // layer's responsibility to notify this thread when a message has been received so that this thread can handle it.
-    private final Object receiveThreadLock;
-
     public IotHubReceiveTask(IotHubTransport transport)
     {
         if (transport == null)
@@ -31,7 +23,6 @@ public final class IotHubReceiveTask implements Runnable
         }
 
         this.transport = transport;
-        this.receiveThreadLock = this.transport.getReceiveThreadLock();
     }
 
     public void run()
@@ -40,23 +31,7 @@ public final class IotHubReceiveTask implements Runnable
 
         try
         {
-            // HTTP is the only protocol where the SDK must actively poll for received messages. Because of that, never
-            // wait on the IoTHubTransport layer to notify this thread that a received message is ready to be handled.
-            if (this.transport.getProtocol() != IotHubClientProtocol.HTTPS)
-            {
-                synchronized (this.receiveThreadLock)
-                {
-                    if (!this.transport.hasReceivedMessagesToHandle() && !this.transport.isClosed())
-                    {
-                        // AMQP and MQTT layers will notify the IoTHubTransport layer once a message arrives, and at
-                        // that time, this thread will be notified to handle them.
-                        this.receiveThreadLock.wait();
-                    }
-                }
-            }
-
-            this.transport.handleMessage();
-
+            this.transport.pollForReceivedMessage();
         }
         catch (Throwable e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -42,7 +42,7 @@ public final class IotHubSendTask implements Runnable
         {
             synchronized (this.sendThreadLock)
             {
-                if (!this.transport.hasMessagesToSend() && !this.transport.hasCallbacksToExecute() && !this.transport.isClosed())
+                if (!this.transport.hasMessagesToSend() && !this.transport.isClosed())
                 {
                     // IotHubTransport layer will notify this thread once a message is ready to be sent or a callback is ready
                     // to be executed. Until then, do nothing.
@@ -51,7 +51,6 @@ public final class IotHubSendTask implements Runnable
             }
 
             this.transport.sendMessages();
-            this.transport.invokeCallbacks();
         }
         catch (Throwable e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -225,7 +225,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
      *
      * @throws TransportException if the IoT Hub could not be reached.
      */
-    public IotHubTransportMessage receiveMessage() throws TransportException
+    public IotHubTransportMessage pollForReceivedMessage() throws TransportException
     {
         synchronized (HTTPS_CONNECTION_LOCK)
         {
@@ -325,7 +325,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
      *               {@link IotHubMessageResult#ABANDON}, or {@link IotHubMessageResult#REJECT}).
      *
      * @throws TransportException if {@code sendMessageResult} is called before
-     * {@link #receiveMessage()} is called.
+     * {@link #pollForReceivedMessage()} is called.
      * @throws TransportException if the IoT Hub could not be reached.
      */
 
@@ -337,7 +337,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
             this.log.trace("Checking if http layer can correlate the received iot hub message to a received etag {}", message);
             String messageEtag = this.messageToETagMap.get(message);
 
-            // Codes_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before receiveMessage() returns a message, the function shall throw an IllegalStateException.]
+            // Codes_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before pollForReceivedMessage() returns a message, the function shall throw an IllegalStateException.]
             if (messageEtag == null)
             {
                 throw new IllegalStateException("Cannot send a message "
@@ -400,7 +400,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
             }
 
             request.setHeaderField(HTTPS_PROPERTY_IOTHUB_TO_TAG, resultPath).
-                    // Codes_SRS_HTTPSIOTHUBCONNECTION_11_035: [The function shall set the header field 'if-match' to be the e-tag saved when receiveMessage() was previously called.]
+                    // Codes_SRS_HTTPSIOTHUBCONNECTION_11_035: [The function shall set the header field 'if-match' to be the e-tag saved when pollForReceivedMessage() was previously called.]
                             setHeaderField(HTTPS_PROPERTY_IF_MATCH_TAG, messageEtag);
 
             //Codes_SRS_HTTPSIOTHUBCONNECTION_34_062: [If this config is using x509 authentication, this function shall retrieve its sslcontext from its x509 Authentication object.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManager.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManager.java
@@ -154,7 +154,7 @@ public class HttpsTransportManager implements IotHubTransportManager
     {
         try
         {
-            return this.httpsIotHubConnection.receiveMessage();
+            return this.httpsIotHubConnection.pollForReceivedMessage();
         }
         catch (TransportException e)
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -575,6 +575,7 @@ public class DeviceIOTest
     {
         // arrange
         final Object deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "protocol", IotHubClientProtocol.HTTPS);
         assertEquals(RECEIVE_PERIOD_MILLIS_AMQPS, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 
         // act
@@ -593,6 +594,7 @@ public class DeviceIOTest
         final long interval = 1234L;
         final long lastInterval = 4321L;
         final Object deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "protocol", IotHubClientProtocol.HTTPS);
         Deencapsulation.invoke(deviceIO, "setReceivePeriodInMilliseconds",  lastInterval);
         assertEquals(lastInterval, Deencapsulation.getField(deviceIO, "receivePeriodInMilliseconds"));
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTaskTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTaskTest.java
@@ -27,20 +27,6 @@ public class IotHubReceiveTaskTest
     @Test
     public void runReceivesAllMessages() throws DeviceClientException
     {
-        final Object receiveThreadLock = new Object();
-        new Expectations()
-        {
-            {
-                mockTransport.getReceiveThreadLock();
-                result = receiveThreadLock;
-
-                mockTransport.hasReceivedMessagesToHandle();
-                result = true;
-
-                mockTransport.getProtocol();
-                result = IotHubClientProtocol.AMQPS;
-            }
-        };
         IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
 
         // act
@@ -49,32 +35,7 @@ public class IotHubReceiveTaskTest
         new Verifications()
         {
             {
-                mockTransport.handleMessage();
-            }
-        };
-    }
-
-    @Test
-    public void runReceivesAllMessagesHTTP()
-    {
-        new Expectations()
-        {
-            {
-                mockTransport.getProtocol();
-                result = IotHubClientProtocol.HTTPS;
-            }
-        };
-
-        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
-
-        // act
-        receiveTask.run();
-
-        new Verifications()
-        {
-            {
-                mockTransport.hasReceivedMessagesToHandle();
-                times = 0;
+                mockTransport.pollForReceivedMessage();
             }
         };
     }
@@ -86,7 +47,7 @@ public class IotHubReceiveTaskTest
         new NonStrictExpectations()
         {
             {
-                mockTransport.handleMessage();
+                mockTransport.pollForReceivedMessage();
                 result = new IOException();
             }
         };
@@ -102,7 +63,7 @@ public class IotHubReceiveTaskTest
         new NonStrictExpectations()
         {
             {
-                mockTransport.handleMessage();
+                mockTransport.pollForReceivedMessage();
                 result = new Throwable("Test if the receive task does not crash.");
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTaskTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTaskTest.java
@@ -59,9 +59,6 @@ public class IotHubSendTaskTest
                 result = sendThreadLock;
 
                 mockTransport.hasMessagesToSend();
-                result = false;
-
-                mockTransport.hasCallbacksToExecute();
                 result = true;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -926,7 +926,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final String expectedUrl = "https://" + messageUri;
         new Verifications()
@@ -942,7 +942,7 @@ public class HttpsIotHubConnectionTest
     public void receiveMessageSendsGetRequest(@Mocked final IotHubMessageUri mockUri) throws TransportException
     {
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final HttpsMethod expectedMethod = HttpsMethod.GET;
         new Verifications()
@@ -967,7 +967,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final int expectedReadTimeoutMillis = readTimeoutMillis;
         new Verifications()
@@ -996,7 +996,7 @@ public class HttpsIotHubConnectionTest
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
 
         // act
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         new Verifications()
         {
@@ -1029,7 +1029,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final String expectedTokenStr = tokenStr;
         new Verifications()
@@ -1055,7 +1055,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final String expectedPath = path;
         new Verifications()
@@ -1081,7 +1081,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         final String expectedMessageLockTimeoutSecs =
                 Integer.toString(messageLockTimeoutSecs);
@@ -1111,7 +1111,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         new Verifications()
         {
@@ -1146,7 +1146,7 @@ public class HttpsIotHubConnectionTest
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
 
         //act
-        Message actualMessage = conn.receiveMessage();
+        Message actualMessage = conn.pollForReceivedMessage();
 
         //assert
         assertEquals(actualMessage.getBytes(), mockedMessage.getBytes());
@@ -1173,7 +1173,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         new Verifications()
         {
@@ -1198,7 +1198,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        Message testMsg = conn.receiveMessage();
+        Message testMsg = conn.pollForReceivedMessage();
 
         Message expectedMsg = null;
         assertThat(testMsg, is(expectedMsg));
@@ -1217,7 +1217,7 @@ public class HttpsIotHubConnectionTest
         };
 
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
     }
 
     // Tests_SRS_HTTPSIOTHUBCONNECTION_11_024: [If the result is COMPLETE, the function shall send a request to the URL 'https://[iotHubHostname]/devices/[deviceId]/messages/devicebound/[eTag]?api-version=2016-02-03'.]
@@ -1718,7 +1718,7 @@ public class HttpsIotHubConnectionTest
         };
     }
 
-    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_035: [The function shall set the header field 'if-match' to be the e-tag saved when receiveMessage() was previously called.]
+    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_035: [The function shall set the header field 'if-match' to be the e-tag saved when pollForReceivedMessage() was previously called.]
     @Test
     public void sendMessageResultSetsIfMatchToEtag(@Mocked final IotHubRejectUri mockUri, final @Mocked IotHubStatusCode mockStatusCode) throws TransportException
     {
@@ -1847,7 +1847,7 @@ public class HttpsIotHubConnectionTest
         conn.sendMessageResult(mockedTransportMessage, IotHubMessageResult.REJECT);
     }
 
-    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before receiveMessage() returns a message, the function shall throw an IllegalStateException.]
+    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before pollForReceivedMessage() returns a message, the function shall throw an IllegalStateException.]
     @Test(expected = IllegalStateException.class)
     public void sendMessageResultFailsIfReceiveNotCalled(
             @Mocked final IotHubRejectUri mockUri) throws TransportException
@@ -1856,13 +1856,13 @@ public class HttpsIotHubConnectionTest
         conn.sendMessageResult(mockedMessage, IotHubMessageResult.REJECT);
     }
 
-    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before receiveMessage() returns a message, the function shall throw an IllegalStateException.]
+    // Tests_SRS_HTTPSIOTHUBCONNECTION_11_039: [If the function is called before pollForReceivedMessage() returns a message, the function shall throw an IllegalStateException.]
     @Test(expected = IllegalStateException.class)
     public void sendMessageResultFailsIfNoMessageReceived(
             @Mocked final IotHubRejectUri mockUri) throws TransportException
     {
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
         conn.sendMessageResult(mockedMessage, IotHubMessageResult.REJECT);
     }
 
@@ -1908,7 +1908,7 @@ public class HttpsIotHubConnectionTest
         HttpsIotHubConnection connection = new HttpsIotHubConnection(mockConfig);
 
         //act
-        connection.receiveMessage();
+        connection.pollForReceivedMessage();
 
         //assert
         new Verifications()
@@ -1992,7 +1992,7 @@ public class HttpsIotHubConnectionTest
         };
 
         //act
-        conn.receiveMessage();
+        conn.pollForReceivedMessage();
 
         //assert
         new Verifications()

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManagerTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManagerTest.java
@@ -369,7 +369,7 @@ public class HttpsTransportManagerTest
         Deencapsulation.invoke(httpsTransportManager, "send", new Class[] {IotHubTransportMessage.class, Map.class}, mockTransportMsg, new HashMap<String, String>());
     }
 
-    /* Tests_SRS_HTTPSTRANSPORTMANAGER_21_015: [The receive shall receive and bypass message from `HttpsIotHubConnection`, by calling `receiveMessage`.] */
+    /* Tests_SRS_HTTPSTRANSPORTMANAGER_21_015: [The receive shall receive and bypass message from `HttpsIotHubConnection`, by calling `pollForReceivedMessage`.] */
     @Test
     public void receiveSucceed() throws TransportException
     {
@@ -381,7 +381,7 @@ public class HttpsTransportManagerTest
             {
                 Deencapsulation.newInstance(HttpsIotHubConnection.class, new Class[] {DeviceClientConfig.class}, mockConfig);
                 result = httpsIotHubConnection;
-                httpsIotHubConnection.receiveMessage();
+                httpsIotHubConnection.pollForReceivedMessage();
                 result = mockedTransportMessage;
             }
         };
@@ -395,13 +395,13 @@ public class HttpsTransportManagerTest
         new Verifications()
         {
             {
-                httpsIotHubConnection.receiveMessage();
+                httpsIotHubConnection.pollForReceivedMessage();
                 times = 1;
             }
         };
     }
 
-    /* Tests_SRS_HTTPSTRANSPORTMANAGER_21_016: [If `receiveMessage` failed, the receive shall bypass the exception.] */
+    /* Tests_SRS_HTTPSTRANSPORTMANAGER_21_016: [If `pollForReceivedMessage` failed, the receive shall bypass the exception.] */
     @Test (expected = IOException.class)
     public void receiveReceiveMessageThrows() throws TransportException
     {
@@ -413,7 +413,7 @@ public class HttpsTransportManagerTest
             {
                 Deencapsulation.newInstance(HttpsIotHubConnection.class, new Class[] {DeviceClientConfig.class}, mockConfig);
                 result = httpsIotHubConnection;
-                httpsIotHubConnection.receiveMessage();
+                httpsIotHubConnection.pollForReceivedMessage();
                 result = new IOException();
             }
         };


### PR DESCRIPTION
AMQP and MQTT both can just callback to the user of device client directly when a message is received. Only HTTP requires a polling thread to receive cloud to device messages. This cuts down on thread count and state for the SDK