### PR TITLE
fix(e2e): Tests failing with "Runnable returns null without exception information"

### DIFF
--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -144,13 +144,6 @@
                         <!--By default, only test files that end in ___Test.java are recognized as tests. This statement extends that to ___Tests.java files-->
                         <include>*Tests.java</include>
                     </includes>
-                    <forkCount>1</forkCount>
-
-                    <!--Tests can be run in parallel with tests within their own test class as well as in parallel with tests from other test classes-->
-                    <parallel>both</parallel>
-
-                    <!--Maven will spawn up as many threads as it wants/can while running tests in parallel-->
-                    <useUnlimitedThreads>true</useUnlimitedThreads>
                 </configuration>
             </plugin>
             <plugin>

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -144,6 +144,13 @@
                         <!--By default, only test files that end in ___Test.java are recognized as tests. This statement extends that to ___Tests.java files-->
                         <include>*Tests.java</include>
                     </includes>
+                    <forkCount>1</forkCount>
+
+                    <!--Tests can be run in parallel with tests within their own test class as well as in parallel with tests from other test classes-->
+                    <parallel>classes</parallel>
+
+                    <!--Maven will spawn up as many threads as it wants/can while running tests in parallel-->
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
So it turns out that tests running in parallel within a class is closing device client for the same instance used in other tests within devicemethod class. This impacts our device method tests, it may be impacting some other tests too.

Check line 295 in DeviceMethodCommon.java which is called after each test
@ After
    public void afterTest()
    {
        this.testInstance.dispose();
    }


