### PR TITLE
refactor(e2e): Reduce unnecessary operations, simplify setup/teardown for methods tests

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceTestManager.java
@@ -50,29 +50,27 @@ public class DeviceTestManager
         }
     }
 
-    public void clearDevice()
+    public void clearStatistics()
     {
         this.deviceEmulator.clearStatistics();
     }
 
-    public void setup(boolean enableMethod, boolean enableTwin) throws IOException, InterruptedException
+    public void subscribe(boolean enableMethod, boolean enableTwin) throws IOException, InterruptedException
     {
-        this.deviceEmulator.setup();
-
         if (enableMethod)
         {
             /* Enable DeviceMethod on the device client using the callbacks from the DeviceEmulator */
-            deviceEmulator.enableDeviceMethod();
+            deviceEmulator.subscribeToDeviceMethod();
         }
 
         if (enableTwin)
         {
             /* Enable DeviceTwin on the device client using the callbacks from the DeviceEmulator */
-            deviceEmulator.enableDeviceTwin();
+            deviceEmulator.subscribeToDeviceTwin();
         }
     }
 
-    public void tearDown() throws IOException, InterruptedException
+    public void tearDown() throws IOException
     {
         deviceEmulator.tearDown();
     }
@@ -108,13 +106,13 @@ public class DeviceTestManager
         /* Create a emulator for the device client, and connect it to the IoTHub */
         deviceEmulator = new DeviceEmulator(this.client);
 
-        deviceEmulator.setup();
+        deviceEmulator.open();
 
         /* Enable DeviceMethod on the device client using the callbacks from the DeviceEmulator */
-        deviceEmulator.enableDeviceMethod();
+        deviceEmulator.subscribeToDeviceMethod();
 
         /* Enable DeviceTwin on the device client using the callbacks from the DeviceEmulator */
-        deviceEmulator.enableDeviceTwin();
+        deviceEmulator.subscribeToDeviceTwin();
     }
 
     public int getStatusOk()

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -44,7 +44,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     @StandardTierHubOnlyTest
     public void invokeMethodRecoveredFromTcpConnectionDrop() throws Exception
     {
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -60,7 +60,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.tcpConnectionDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -76,7 +76,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsSessionDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -98,7 +98,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSReqLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -120,7 +120,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsCBSRespLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -136,7 +136,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsD2CTelemetryLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -159,7 +159,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsC2DLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -182,7 +182,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodRespLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -205,7 +205,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsMethodRespLinkDropErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -220,7 +220,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.amqpsGracefulShutdownErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));
@@ -235,7 +235,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
             return;
         }
 
-        super.cleanToStart();
+        super.openDeviceClientAndSubscribeToMethods();
         this.errorInjectionTestFlow(ErrorInjectionHelper.mqttGracefulShutdownErrorInjectionMessage(
                 ErrorInjectionHelper.DefaultDelayInSec,
                 ErrorInjectionHelper.DefaultDurationInSec));

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/methods/DeviceMethodTests.java
@@ -15,7 +15,6 @@ import com.microsoft.azure.sdk.iot.service.devicetwin.MethodResult;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubGatewayTimeoutException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubNotFoundException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -25,7 +24,6 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceMethodCommon;
 
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -47,16 +45,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-    @Before
-    public void cleanToStart() throws Exception
-    {
-        super.cleanToStart();
-    }
-
     @Test
     @StandardTierHubOnlyTest
     public void invokeMethodSucceed() throws Exception
     {
+        super.openDeviceClientAndSubscribeToMethods();
         super.invokeMethodSucceed();
     }
 
@@ -66,6 +59,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodInvokeParallelSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         CountDownLatch cdl = new CountDownLatch(NUMBER_INVOKES_PARALLEL);
         List<RunnableInvoke> runs = new LinkedList<>();
 
@@ -74,11 +68,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
             RunnableInvoke runnableInvoke;
             if (testInstance.identity instanceof Module)
             {
-                runnableInvoke = new RunnableInvoke(methodServiceClient, testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(),"Thread" + i, cdl);
+                runnableInvoke = new RunnableInvoke(testInstance.methodServiceClient, testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(),"Thread" + i, cdl);
             }
             else
             {
-                runnableInvoke = new RunnableInvoke(methodServiceClient, testInstance.identity.getDeviceId(), null,"Thread" + i, cdl);
+                runnableInvoke = new RunnableInvoke(testInstance.methodServiceClient, testInstance.identity.getDeviceId(), null,"Thread" + i, cdl);
             }
             new Thread(runnableInvoke).start();
             runs.add(runnableInvoke);
@@ -101,17 +95,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodStandardTimeoutSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, null, null, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, null, null, PAYLOAD_STRING);
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, null, null, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, null, null, PAYLOAD_STRING);
         }
 
         deviceTestManger.waitIotHub(1, 10);
@@ -129,17 +124,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodNullPayloadSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -156,17 +152,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodNumberSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -183,17 +180,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodThrowsNumberFormatExceptionFailed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -209,17 +207,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodUnknownFailed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_UNKNOWN, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_UNKNOWN, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_UNKNOWN, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_UNKNOWN, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -236,17 +235,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodRecoverFromTimeoutSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         try
         {
             if (testInstance.identity instanceof Module)
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
             }
             else
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
             }
             assert true;
         }
@@ -259,11 +259,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, "100");
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -280,17 +280,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodDefaultResponseTimeoutSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, null, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, null, CONNECTION_TIMEOUT, "100");
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, null, CONNECTION_TIMEOUT, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, null, CONNECTION_TIMEOUT, "100");
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -307,17 +308,18 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodDefaultConnectionTimeoutSucceed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, null, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, null, "100");
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, null, "100");
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, RESPONSE_TIMEOUT, null, "100");
         }
         deviceTestManger.waitIotHub(1, 10);
 
@@ -334,14 +336,16 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodResponseTimeoutFailed() throws Exception
     {
         // Arrange
+        this.openDeviceClientAndSubscribeToMethods();
+
         // Act
         if (testInstance.identity instanceof Module)
         {
-            methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
+            testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
         }
         else
         {
-            methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
+            testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_DELAY_IN_MILLISECONDS, (long)5, CONNECTION_TIMEOUT, "7000");
         }
     }
 
@@ -352,11 +356,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
     {
         if (testInstance.identity instanceof Module)
         {
-            methodServiceClient.invoke(testInstance.identity.getDeviceId(), "someModuleThatDoesNotExistOnADeviceThatDoesExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), "someModuleThatDoesNotExistOnADeviceThatDoesExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         else
         {
-            methodServiceClient.invoke("someDeviceThatDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            testInstance.methodServiceClient.invoke("someDeviceThatDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
     }
 
@@ -366,6 +370,7 @@ public class DeviceMethodTests extends DeviceMethodCommon
     public void invokeMethodResetDeviceFailed() throws Exception
     {
         // Arrange
+        super.openDeviceClientAndSubscribeToMethods();
         DeviceTestManager deviceTestManger = this.testInstance.deviceTestManager;
 
         // Act
@@ -373,12 +378,12 @@ public class DeviceMethodTests extends DeviceMethodCommon
         {
             if (testInstance.identity instanceof Module)
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_RESET, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_RESET, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
                 deviceTestManger.restartDevice(getModuleConnectionString((Module) testInstance.identity), testInstance.protocol, testInstance.publicKeyCert, testInstance.privateKey);
             }
             else
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_RESET, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_RESET, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
                 deviceTestManger.restartDevice(registryManager.getDeviceConnectionString((Device) testInstance.identity), testInstance.protocol, testInstance.publicKeyCert, testInstance.privateKey);
             }
 
@@ -418,11 +423,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
 
             if (testInstance.identity instanceof Module)
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
             }
             else
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
             }
 
             Assert.fail(buildExceptionMessage("Invoking method on device or module that wasn't online should have thrown an exception", testInstance.deviceTestManager.client));
@@ -450,11 +455,11 @@ public class DeviceMethodTests extends DeviceMethodCommon
         {
             if (testInstance.identity instanceof Module)
             {
-                methodServiceClient.invoke(testInstance.identity.getDeviceId(), "ThisModuleDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), "ThisModuleDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
             }
             else
             {
-                methodServiceClient.invoke("ThisDeviceDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
+                testInstance.methodServiceClient.invoke("ThisDeviceDoesNotExist", DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, null);
             }
 
             Assert.fail(buildExceptionMessage("Invoking method on device or module that doesn't exist should have thrown an exception", testInstance.deviceTestManager.client));

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/methods/DeviceMethodTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/methods/DeviceMethodTests.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.service.Device;
 import com.microsoft.azure.sdk.iot.service.Module;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethod;
 import com.microsoft.azure.sdk.iot.service.devicetwin.MethodResult;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubGatewayTimeoutException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubNotFoundException;
@@ -66,13 +67,16 @@ public class DeviceMethodTests extends DeviceMethodCommon
         for (int i = 0; i < NUMBER_INVOKES_PARALLEL; i++)
         {
             RunnableInvoke runnableInvoke;
+            // Create one methodServiceClient per thread since each method service client only allows one method invoke
+            // at a time. This limitation exists because the invokeMethod method is synchronized with itself
+            DeviceMethod methodServiceClient = DeviceMethod.createFromConnectionString(iotHubConnectionString);
             if (testInstance.identity instanceof Module)
             {
-                runnableInvoke = new RunnableInvoke(testInstance.methodServiceClient, testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(),"Thread" + i, cdl);
+                runnableInvoke = new RunnableInvoke(methodServiceClient, testInstance.identity.getDeviceId(), ((Module) testInstance.identity).getId(),"Thread" + i, cdl);
             }
             else
             {
-                runnableInvoke = new RunnableInvoke(testInstance.methodServiceClient, testInstance.identity.getDeviceId(), null,"Thread" + i, cdl);
+                runnableInvoke = new RunnableInvoke(methodServiceClient, testInstance.identity.getDeviceId(), null,"Thread" + i, cdl);
             }
             new Thread(runnableInvoke).start();
             runs.add(runnableInvoke);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/JobClientTests.java
@@ -77,7 +77,7 @@ public class JobClientTests extends IntegrationTest
         {
             testDevice = Tools.addDeviceWithRetry(registryManager, Device.createFromId(DEVICE_ID_NAME.concat("-" + i + "-" + uuid), DeviceStatus.Enabled, null));
             DeviceTestManager testManager = new DeviceTestManager(new DeviceClient(registryManager.getDeviceConnectionString(testDevice), IotHubClientProtocol.AMQPS));
-            testManager.setup(true, true);
+            testManager.subscribe(true, true);
             devices.add(testManager);
         }
     }
@@ -139,7 +139,7 @@ public class JobClientTests extends IntegrationTest
     {
         for (DeviceTestManager device:devices)
         {
-            device.clearDevice();
+            device.clearStatistics();
         }
 
         System.out.println("Waiting for all previously scheduled jobs to finish...");

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -59,7 +59,6 @@ public class DeviceMethodCommon extends IntegrationTest
 
     protected static String iotHubConnectionString = "";
 
-    protected static DeviceMethod methodServiceClient;
     protected static RegistryManager registryManager;
 
     protected static final Long RESPONSE_TIMEOUT = TimeUnit.SECONDS.toSeconds(200);
@@ -85,7 +84,6 @@ public class DeviceMethodCommon extends IntegrationTest
         String privateKey = certificateGenerator.getPrivateKey();
         String x509Thumbprint = certificateGenerator.getX509Thumbprint();
 
-        methodServiceClient = DeviceMethod.createFromConnectionString(iotHubConnectionString);
         registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         Collection<Object[]> inputs = new ArrayList<>();
 
@@ -143,6 +141,7 @@ public class DeviceMethodCommon extends IntegrationTest
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
+        public DeviceMethod methodServiceClient;
 
         protected DeviceMethodTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
         {
@@ -152,6 +151,7 @@ public class DeviceMethodCommon extends IntegrationTest
             this.publicKeyCert = publicKeyCert;
             this.privateKey = privateKey;
             this.x509Thumbprint = x509Thumbprint;
+            this.methodServiceClient = DeviceMethod.createFromConnectionString(iotHubConnectionString);
         }
 
         public void setup() throws Exception {
@@ -245,7 +245,6 @@ public class DeviceMethodCommon extends IntegrationTest
     {
         try
         {
-            methodServiceClient = DeviceMethod.createFromConnectionString(iotHubConnectionString);
             registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
         }
         catch (IOException e)
@@ -255,36 +254,19 @@ public class DeviceMethodCommon extends IntegrationTest
         }
     }
 
-    public void cleanToStart() throws Exception
+    public void openDeviceClientAndSubscribeToMethods() throws Exception
     {
         testInstance.setup();
-        actualStatusUpdates = new ArrayList<Pair<IotHubConnectionStatus, Throwable>>();
-        setConnectionStatusCallBack(actualStatusUpdates);
+        testInstance.deviceTestManager.client.open();
 
         try
         {
-            this.testInstance.deviceTestManager.tearDown();
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-        catch (InterruptedException e)
-        {
-            e.printStackTrace();
-        }
-
-        this.testInstance.deviceTestManager.clearDevice();
-
-        try
-        {
-            this.testInstance.deviceTestManager.setup(true, false);
-            IotHubServicesCommon.confirmOpenStabilized(actualStatusUpdates, 120000, this.testInstance.deviceTestManager.client);
+            this.testInstance.deviceTestManager.subscribe(true, false);
         }
         catch (IOException | InterruptedException e)
         {
             e.printStackTrace();
-            fail(buildExceptionMessage("Unexpected exception occurred during sending reported properties: " + Tools.getStackTraceFromThrowable(e), this.testInstance.deviceTestManager.client));
+            fail(buildExceptionMessage("Unexpected exception occurred during subscribe: " + Tools.getStackTraceFromThrowable(e), this.testInstance.deviceTestManager.client));
         }
         catch (UnsupportedOperationException e)
         {
@@ -329,7 +311,6 @@ public class DeviceMethodCommon extends IntegrationTest
                 if (moduleId != null)
                 {
                     result = methodServiceClient.invoke(deviceId, moduleId, DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, testName);
-
                 }
                 else
                 {
@@ -390,11 +371,11 @@ public class DeviceMethodCommon extends IntegrationTest
         MethodResult result;
         if (testInstance.identity instanceof Module)
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module)testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), ((Module)testInstance.identity).getId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
         else
         {
-            result = methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
+            result = testInstance.methodServiceClient.invoke(testInstance.identity.getDeviceId(), DeviceEmulator.METHOD_LOOPBACK, RESPONSE_TIMEOUT, CONNECTION_TIMEOUT, PAYLOAD_STRING);
         }
 
         deviceTestManger.waitIotHub(1, 10);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -72,8 +72,6 @@ public class DeviceMethodCommon extends IntegrationTest
     //How many milliseconds between retry
     protected static final Integer RETRY_MILLISECONDS = 100;
 
-    private List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates;
-
     protected DeviceMethodTestInstance testInstance;
     protected static final long ERROR_INJECTION_WAIT_TIMEOUT_MILLISECONDS = 1 * 60 * 1000; // 1 minute
 


### PR DESCRIPTION
Each deviceMethods client only allows one method invocation at a time, but some tests deliberately have the method invocation take multiple seconds. This commit splits the static device method client so that each test instance has its own direct method client instead. That minimizes any cross-test interference that the above synchronization could cause. Note that I suspect this is one of the possible causes of the device method test timeouts that we've been seeing lately.

Fixed the device method tests not waiting for the methods subscription message to be acknowledged on the device before invoking the method

Previously test setup always created and opened a device client instance regardless of if the test actually needs it. Now that setup is opt-in with a call to super.openDeviceClientAndSubscribeToMethods(...)

Also, test setup used to include calls to close the device client under test even though the client is never open before the test. I have removed that to reduce unnecessary code.