### PR TITLE
fix(e2e): Fix small logging issues

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IntegrationTest.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IntegrationTest.java
@@ -6,6 +6,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.helpers;
 
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -16,6 +17,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.rules.*;
 /**
  * Common rules and flags for all integration tests
  */
+@Slf4j
 public abstract class IntegrationTest
 {
     @Rule
@@ -23,12 +25,12 @@ public abstract class IntegrationTest
     {
         protected void starting(Description description)
         {
-            System.out.println("Starting test: " + description.getMethodName());
+            log.info("Starting test: {}", description.getMethodName());
         }
 
         protected void finished(Description description)
         {
-            System.out.println("Finished test: " + description.getMethodName());
+            log.info("Finished test: {}", description.getMethodName());
         }
     };
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/Tools.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/Tools.java
@@ -92,7 +92,7 @@ public class Tools
         }
         catch (ClassNotFoundException e)
         {
-            log.debug("Likely running the JVM tests, ignoring ClassNotFoundException");
+            log.debug("Likely running the JVM tests, ignoring ClassNotFoundException\n");
         }
 
         return envVariables;

--- a/iot-e2e-tests/common/src/test/resources/log4j.properties
+++ b/iot-e2e-tests/common/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@ log4j.rootLogger=ERROR, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.logger.tests.integration.com.microsoft.azure.sdk.* = DEBUG
+log4j.logger.tests.integration.com.microsoft.azure.sdk = DEBUG
 
 # Note that this statement works recursively. Any class in the com.microsoft.azure.sdk.iot package or its subpackages will be logged
 log4j.logger.com.microsoft.azure.sdk.iot = TRACE


### PR DESCRIPTION
log4j.properties doesn't recurse with star notation, it just recurses in this notation

The start/stop logs should be to our logger, not system.out. That way we get the logger timestamp for free on these two logs
