### PR TITLE
refactor(e2e): Remove proxy as parameter for tests

### DIFF
--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/messaging/SendMessagesErrInjAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/messaging/SendMessagesErrInjAndroidRunner.java
@@ -19,8 +19,8 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.SendM
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjAndroidRunner extends SendMessagesErrInjTests
 {
-    public SendMessagesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint, boolean useHttpProxy) throws Exception
+    public SendMessagesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
     {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint, useHttpProxy);
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/messaging/SendMessagesAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/messaging/SendMessagesAndroidRunner.java
@@ -19,8 +19,8 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.telemetry.SendMessag
 @RunWith(Parameterized.class)
 public class SendMessagesAndroidRunner extends SendMessagesTests
 {
-    public SendMessagesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint, boolean useHttpProxy) throws Exception
+    public SendMessagesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
     {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint, useHttpProxy);
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/SendMessagesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/SendMessagesErrInjTests.java
@@ -42,15 +42,15 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
 @RunWith(Parameterized.class)
 public class SendMessagesErrInjTests extends SendMessagesCommon
 {
-    public SendMessagesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint, boolean withProxy) throws Exception
+    public SendMessagesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
     {
-        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint, withProxy);
+        super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
     @Test
     public void sendMessagesWithTcpConnectionDrop() throws Exception
     {
-        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS) || testInstance.useHttpProxy)
+        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
         {
             //TCP connection is not maintained between device and service when using HTTPS, so this test case isn't applicable
             //MQTT_WS + x509 is not supported for sending messages
@@ -66,7 +66,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithConnectionDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -81,7 +81,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithSessionDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -96,7 +96,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithCbsRequestLinkDrop() throws Exception
     {
-        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS || testInstance.useHttpProxy)
+        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -117,7 +117,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithCbsResponseLinkDrop() throws Exception
     {
-        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS || testInstance.useHttpProxy)
+        if (testInstance.protocol != AMQPS && testInstance.protocol != AMQPS_WS)
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -138,7 +138,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithD2CLinkDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -153,7 +153,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesOverAmqpWithC2DLinkDrop() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || (testInstance.protocol == AMQPS_WS && testInstance.authenticationType == SAS)))
         {
             //This error injection test only applies for AMQPS with SAS and X509 and for AMQPS_WS with SAS
             return;
@@ -175,7 +175,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithThrottling() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -195,7 +195,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesWithThrottlingNoRetry() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -214,7 +214,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesWithAuthenticationError() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -233,7 +233,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesWithQuotaExceeded() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -250,7 +250,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverAmqpWithGracefulShutdown() throws Exception
     {
-        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == AMQPS || testInstance.protocol == AMQPS_WS))
         {
             //This error injection test only applies for AMQPS and AMQPS_WS
             return;
@@ -264,7 +264,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @Test
     public void sendMessagesOverMqttWithGracefulShutdown() throws Exception
     {
-        if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS) || testInstance.useHttpProxy)
+        if (!(testInstance.protocol == MQTT || testInstance.protocol == MQTT_WS))
         {
             //This error injection test only applies for MQTT and MQTT_WS
             return;
@@ -279,7 +279,7 @@ public class SendMessagesErrInjTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendMessagesWithTcpConnectionDropNotifiesUserIfRetryExpires() throws Exception
     {
-        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS) || testInstance.useHttpProxy)
+        if (testInstance.protocol == HTTPS || (testInstance.protocol == MQTT_WS && testInstance.authenticationType != SAS))
         {
             //TCP connection is not maintained between device and service when using HTTPS, so this test case isn't applicable
             //MQTT_WS + x509 is not supported for sending messages

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -22,8 +22,6 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.*;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -40,7 +38,7 @@ import static junit.framework.TestCase.fail;
  */
 public class SendMessagesCommon extends IntegrationTest
 {
-    @Parameterized.Parameters(name = "{0}_{1}_{2}_{6}")
+    @Parameterized.Parameters(name = "{0}_{1}_{2}")
     public static Collection inputs() throws Exception
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
@@ -60,23 +58,16 @@ public class SendMessagesCommon extends IntegrationTest
                 new Object[][]
                         {
                                 //sas token device client, no proxy
-                                {HTTPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {MQTT, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {AMQPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
+                                {HTTPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {MQTT, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {AMQPS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                 //x509 device client, no proxy
-                                {HTTPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                {AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-
-                                //sas token device client, with proxy
-                                {MQTT_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
-                                {AMQPS_WS, SAS, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
-
-                                //x509 device client, with proxy
-                                {HTTPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true}
+                                {HTTPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {MQTT, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                {AMQPS, SELF_SIGNED, ClientType.DEVICE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
                         }
         ));
 
@@ -86,18 +77,14 @@ public class SendMessagesCommon extends IntegrationTest
                     new Object[][]
                             {
                                     //sas token module client, no proxy
-                                    {MQTT, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                    {AMQPS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                    {MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                    {AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
+                                    {MQTT, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {AMQPS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
 
                                     //x509 module client, no proxy
-                                    {MQTT, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-                                    {AMQPS, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, false},
-
-                                    //sas token module client, with proxy
-                                    {MQTT_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true},
-                                    {AMQPS_WS, SAS, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint, true}
+                                    {MQTT, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
+                                    {AMQPS, SELF_SIGNED, ClientType.MODULE_CLIENT, publicKeyCert, privateKey, x509Thumbprint},
                             }
             ));
         }
@@ -157,13 +144,14 @@ public class SendMessagesCommon extends IntegrationTest
     protected static RegistryManager registryManager;
     protected static HttpProxyServer proxyServer;
     protected static String testProxyHostname = "127.0.0.1";
-    protected static int testProxyPort = 8899;
+    protected static int testProxyPortWithAuth = 8899;
+    protected static int testProxyPortWithoutAuth = 8799;
     protected static final String testProxyUser = "proxyUsername";
     protected static final char[] testProxyPass = "1234".toCharArray();
 
-    public SendMessagesCommon(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint, boolean withProxy) throws Exception
+    public SendMessagesCommon(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
     {
-        this.testInstance = new SendMessagesTestInstance(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint, withProxy);
+        this.testInstance = new SendMessagesTestInstance(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
     @BeforeClass
@@ -184,8 +172,12 @@ public class SendMessagesCommon extends IntegrationTest
     public static void startProxy()
     {
         proxyServer = DefaultHttpProxyServer.bootstrap()
-                .withPort(testProxyPort)
+                .withPort(testProxyPortWithAuth)
                 .withProxyAuthenticator(new BasicProxyAuthenticator(testProxyUser, testProxyPass))
+                .start();
+
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(testProxyPortWithoutAuth)
                 .start();
     }
 
@@ -205,9 +197,8 @@ public class SendMessagesCommon extends IntegrationTest
         public String publicKeyCert;
         public String privateKey;
         public String x509Thumbprint;
-        public boolean useHttpProxy;
 
-        public SendMessagesTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint, boolean useHttpProxy) throws Exception
+        public SendMessagesTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws Exception
         {
             this.protocol = protocol;
             this.authenticationType = authenticationType;
@@ -215,7 +206,6 @@ public class SendMessagesCommon extends IntegrationTest
             this.publicKeyCert = publicKeyCert;
             this.privateKey = privateKey;
             this.x509Thumbprint = x509Thumbprint;
-            this.useHttpProxy = useHttpProxy;
         }
 
         public void setup() throws Exception
@@ -227,7 +217,6 @@ public class SendMessagesCommon extends IntegrationTest
         public void setup(SSLContext customSSLContext) throws Exception
         {
             String TEST_UUID = UUID.randomUUID().toString();
-
             if (clientType == ClientType.DEVICE_CLIENT)
             {
                 if (authenticationType == SAS)
@@ -290,13 +279,6 @@ public class SendMessagesCommon extends IntegrationTest
                 {
                     throw new Exception("Test code has not been written for this path yet");
                 }
-            }
-
-            if (this.useHttpProxy)
-            {
-                Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-                ProxySettings proxySettings = new ProxySettings(testProxy, testProxyUser, testProxyPass);
-                this.client.setProxySettings(proxySettings);
             }
 
             Thread.sleep(2000);


### PR DESCRIPTION
Creating dedicated tests for proxies instead of running every sendMessagesTest with and without a proxy. Most tests in this suite don't exercise code paths were a proxy would make a difference, and this helps to cut down on some more registry identity creations.

By having dedicated tests for using proxies, we can also test proxies without authentication where we previously always used proxies with authentication

On top of that, all of the error injection tests just returned immediately if the proxy parameter was true. By un-parameterizing the proxy, we can remove this check at that start of each error injection test