### PR TITLE
feat(iot-serv): Make http connect and read timeouts configurable on twin and methods clients

### DIFF
--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/DesiredPropertiesErrInjAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/DesiredPropertiesErrInjAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.DesiredPropertiesErrInjTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.Desir
 @RunWith(Parameterized.class)
 public class DesiredPropertiesErrInjAndroidRunner extends DesiredPropertiesErrInjTests
 {
-    public DesiredPropertiesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/GetTwinErrInjAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/GetTwinErrInjAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.GetTwinErrInjTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.GetTw
 @RunWith(Parameterized.class)
 public class GetTwinErrInjAndroidRunner extends GetTwinErrInjTests
 {
-    public GetTwinErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/ReportedPropertiesErrInjAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/errorinjection/twin/ReportedPropertiesErrInjAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.ReportedPropertiesErrInjTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.errorinjection.Repor
 @RunWith(Parameterized.class)
 public class ReportedPropertiesErrInjAndroidRunner extends ReportedPropertiesErrInjTests
 {
-    public ReportedPropertiesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/DesiredPropertiesAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/DesiredPropertiesAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.DesiredPropertiesTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.DesiredProperti
 @RunWith(Parameterized.class)
 public class DesiredPropertiesAndroidRunner extends DesiredPropertiesTests
 {
-    public DesiredPropertiesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/GetTwinAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/GetTwinAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.GetTwinTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.GetTwinTests;
 @RunWith(Parameterized.class)
 public class GetTwinAndroidRunner extends GetTwinTests
 {
-    public GetTwinAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/QueryTwinAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/QueryTwinAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.QueryTwinTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.QueryTwinTests;
 @RunWith(Parameterized.class)
 public class QueryTwinAndroidRunner extends QueryTwinTests
 {
-    public QueryTwinAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public QueryTwinAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/ReportedPropertiesAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/ReportedPropertiesAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.ReportedPropertiesTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.ReportedPropert
 @RunWith(Parameterized.class)
 public class ReportedPropertiesAndroidRunner extends ReportedPropertiesTests
 {
-    public ReportedPropertiesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/TwinTagsAndroidRunner.java
+++ b/iot-e2e-tests/android/app/src/androidTest/java/com/microsoft/azure/sdk/iot/android/iothub/twin/TwinTagsAndroidRunner.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.TwinTagsTests;
 
@@ -19,7 +21,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.TwinTagsTests;
 @RunWith(Parameterized.class)
 public class TwinTagsAndroidRunner extends TwinTagsTests
 {
-    public TwinTagsAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsAndroidRunner(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
@@ -22,6 +22,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinCommon;
 
+import java.io.IOException;
 import java.util.*;
 
 import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.AMQPS;
@@ -38,7 +39,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
 {
     private JsonParser jsonParser = new JsonParser();
 
-    public DesiredPropertiesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
         jsonParser = new JsonParser();
@@ -562,7 +563,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
         dp.add(p);
         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(dp);
 
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+        testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
 
         waitAndVerifyTwinStatusBecomesSuccess();
         waitAndVerifyDesiredPropertyCallback(update2Prefix, false);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
@@ -18,6 +18,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinCommon;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,7 +33,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
 @RunWith(Parameterized.class)
 public class GetTwinErrInjTests extends DeviceTwinCommon
 {
-    public GetTwinErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -20,6 +20,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinCommon;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +36,7 @@ import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationType.SELF_S
 @RunWith(Parameterized.class)
 public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesErrInjTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -59,10 +59,6 @@ public class DeviceTwinCommon extends IntegrationTest
         String privateKey = certificateGenerator.getPrivateKey();
         String x509Thumbprint = certificateGenerator.getX509Thumbprint();
 
-        sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
-        registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
-        scRawTwinQueryClient = RawTwinQuery.createFromConnectionString(iotHubConnectionString);
-
         List inputs = new ArrayList();
         for (ClientType clientType : ClientType.values())
         {
@@ -143,10 +139,7 @@ public class DeviceTwinCommon extends IntegrationTest
     protected static String moduleIdPrefix = "java-twin-e2e-test-module";
 
     // States of SDK
-    protected static RegistryManager registryManager;
     protected InternalClient internalClient;
-    protected static RawTwinQuery scRawTwinQueryClient;
-    protected static DeviceTwin sCDeviceTwin;
     protected DeviceState deviceUnderTest = null;
 
     protected DeviceState[] devicesUnderTest;
@@ -296,8 +289,8 @@ public class DeviceTwinCommon extends IntegrationTest
             String id = "java-device-twin-e2e-test-" + this.testInstance.protocol.toString() + UUID.randomUUID().toString();
             devicesUnderTest[i].sCDeviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(id, null, null);
             devicesUnderTest[i].sCModuleForRegistryManager = com.microsoft.azure.sdk.iot.service.Module.createFromId(id, "module", null);
-            devicesUnderTest[i].sCDeviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, devicesUnderTest[i].sCDeviceForRegistryManager);
-            devicesUnderTest[i].sCModuleForRegistryManager = Tools.addModuleWithRetry(registryManager, devicesUnderTest[i].sCModuleForRegistryManager);
+            devicesUnderTest[i].sCDeviceForRegistryManager = Tools.addDeviceWithRetry(testInstance.registryManager, devicesUnderTest[i].sCDeviceForRegistryManager);
+            devicesUnderTest[i].sCModuleForRegistryManager = Tools.addModuleWithRetry(testInstance.registryManager, devicesUnderTest[i].sCModuleForRegistryManager);
             setUpTwin(devicesUnderTest[i], openDeviceClients);
         }
 
@@ -309,7 +302,7 @@ public class DeviceTwinCommon extends IntegrationTest
         for (int i = 0; i < numberOfDevices; i++)
         {
             tearDownTwin(devicesUnderTest[i]);
-            registryManager.removeDevice(devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
+            testInstance.registryManager.removeDevice(devicesUnderTest[i].sCDeviceForRegistryManager.getDeviceId());
         }
     }
 
@@ -366,7 +359,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
 
         // set up twin on ServiceClient
-        if (sCDeviceTwin != null)
+        if (testInstance.twinServiceClient != null)
         {
             if (testInstance.clientType == ClientType.DEVICE_CLIENT)
             {
@@ -377,7 +370,7 @@ public class DeviceTwinCommon extends IntegrationTest
                 deviceState.sCDeviceForTwin = new DeviceTwinDevice(deviceState.sCDeviceForRegistryManager.getDeviceId(), deviceState.sCModuleForRegistryManager.getId());
             }
 
-            sCDeviceTwin.getTwin(deviceState.sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(deviceState.sCDeviceForTwin);
             Thread.sleep(DELAY_BETWEEN_OPERATIONS);
         }
     }
@@ -408,7 +401,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    public DeviceTwinCommon(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DeviceTwinCommon(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         this.testInstance = new DeviceTwinTestInstance(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -422,8 +415,12 @@ public class DeviceTwinCommon extends IntegrationTest
         public String x509Thumbprint;
         public String uuid;
         public ClientType clientType;
+        public DeviceTwin twinServiceClient;
+        public RegistryManager registryManager;
+        public RawTwinQuery rawTwinQueryClient;
 
-        public DeviceTwinTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+
+        public DeviceTwinTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
         {
             this.protocol = protocol;
             this.authenticationType = authenticationType;
@@ -431,31 +428,10 @@ public class DeviceTwinCommon extends IntegrationTest
             this.privateKey = privateKey;
             this.x509Thumbprint = x509Thumbprint;
             this.clientType = clientType;
-        }
-    }
+            this.twinServiceClient = DeviceTwin.createFromConnectionString(iotHubConnectionString);
 
-    @BeforeClass
-    public static void classSetup()
-    {
-        try
-        {
-            sCDeviceTwin = DeviceTwin.createFromConnectionString(iotHubConnectionString);
             registryManager = RegistryManager.createFromConnectionString(iotHubConnectionString);
-            scRawTwinQueryClient = RawTwinQuery.createFromConnectionString(iotHubConnectionString);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            fail("Unexpected exception encountered");
-        }
-    }
-
-    @AfterClass
-    public static void classTearDown()
-    {
-        if (registryManager != null)
-        {
-            registryManager.close();
+            rawTwinQueryClient = RawTwinQuery.createFromConnectionString(iotHubConnectionString);
         }
     }
 
@@ -485,11 +461,11 @@ public class DeviceTwinCommon extends IntegrationTest
         }
 
 
-        deviceUnderTest.sCDeviceForRegistryManager = Tools.addDeviceWithRetry(registryManager, deviceUnderTest.sCDeviceForRegistryManager);
+        deviceUnderTest.sCDeviceForRegistryManager = Tools.addDeviceWithRetry(testInstance.registryManager, deviceUnderTest.sCDeviceForRegistryManager);
 
         if (deviceUnderTest.sCModuleForRegistryManager != null)
         {
-            Tools.addModuleWithRetry(registryManager, deviceUnderTest.sCModuleForRegistryManager);
+            Tools.addModuleWithRetry(testInstance.registryManager, deviceUnderTest.sCModuleForRegistryManager);
         }
 
         Thread.sleep(2000);
@@ -503,7 +479,7 @@ public class DeviceTwinCommon extends IntegrationTest
         try
         {
             tearDownTwin(deviceUnderTest);
-            registryManager.removeDevice(deviceUnderTest.sCDeviceForRegistryManager.getDeviceId());
+            testInstance.registryManager.removeDevice(deviceUnderTest.sCDeviceForRegistryManager.getDeviceId());
         }
         catch (Exception e)
         {
@@ -528,7 +504,7 @@ public class DeviceTwinCommon extends IntegrationTest
             }
 
             actualCount = 0;
-            sCDeviceTwin.getTwin(deviceState.sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(deviceState.sCDeviceForTwin);
             Set<Pair> repProperties = deviceState.sCDeviceForTwin.getReportedProperties();
 
             for (Pair p : repProperties)
@@ -561,7 +537,7 @@ public class DeviceTwinCommon extends IntegrationTest
             }
 
             actualCount = 0;
-            sCDeviceTwin.getTwin(deviceState.sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(deviceState.sCDeviceForTwin);
             Set<Pair> repProperties = deviceState.sCDeviceForTwin.getReportedProperties();
 
             for (Pair p : repProperties)
@@ -695,7 +671,7 @@ public class DeviceTwinCommon extends IntegrationTest
             desiredProperties.add(new Pair(PROPERTY_KEY + i, propertyUpdateValue));
         }
         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+        testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
 
         // assert
         waitAndVerifyTwinStatusBecomesSuccess();
@@ -716,7 +692,7 @@ public class DeviceTwinCommon extends IntegrationTest
         this.internalClient.registerConnectionStatusChangeCallback(connectionStatusUpdateCallback, null);
     }
 
-    protected void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException
+    protected void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
     {
         // arrange
         Map<Property, com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair<TwinPropertyCallBack, Object>> desiredPropertiesCB = new HashMap<>();
@@ -736,7 +712,7 @@ public class DeviceTwinCommon extends IntegrationTest
             desiredProperties.add(new Pair(PROPERTY_KEY + i, PROPERTY_VALUE_UPDATE + UUID.randomUUID()));
         }
         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+        testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
         Thread.sleep(DELAY_BETWEEN_OPERATIONS);
 
         for (int i = 0; i < deviceUnderTest.dCDeviceForTwin.propertyStateList.length; i++)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
@@ -44,7 +44,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 {
     private JsonParser jsonParser = new JsonParser();
 
-    public DesiredPropertiesTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public DesiredPropertiesTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
         jsonParser = new JsonParser();
@@ -126,7 +126,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
             desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(PROPERTY_KEY + i, updatePropertyValue));
         }
         deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-        sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+        testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
 
         // assert
         waitAndVerifyTwinStatusBecomesSuccess();
@@ -189,7 +189,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
                             Set currentDesiredProperties = deviceUnderTest.sCDeviceForTwin.getDesiredProperties();
                             desiredProperties.addAll(currentDesiredProperties);
                             deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-                            sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+                            testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
                         }
                     }
                     catch (IotHubException | IOException e)
@@ -256,7 +256,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
             Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
             desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(PROPERTY_KEY + i, updatePropertyValue));
             deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(deviceUnderTest.sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(deviceUnderTest.sCDeviceForTwin);
             Thread.sleep(DELAY_BETWEEN_OPERATIONS);
         }
 
@@ -279,28 +279,28 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
             Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
             desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(PROPERTY_KEY + i, PROPERTY_VALUE + i));
             devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Update desired properties on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties();
             for (com.microsoft.azure.sdk.iot.service.devicetwin.Pair dp : desiredProperties)
             {
                 dp.setValue(PROPERTY_VALUE_UPDATE + i);
             }
             devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Read updates on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
             for (com.microsoft.azure.sdk.iot.service.devicetwin.Pair dp : devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties())
             {
@@ -314,21 +314,21 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         // Remove desired properties
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties();
             for (com.microsoft.azure.sdk.iot.service.devicetwin.Pair dp : desiredProperties)
             {
                 dp.setValue(null);
             }
             devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Read updates
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
             Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Desired properties were not deleted by setting to null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getDesiredProperties().size());
         }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/GetTwinTests.java
@@ -7,24 +7,26 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinClientOptions;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
-import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
-import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
-import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinCommon;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
-import java.util.Collection;
 
 /**
  * Test class containing all non error injection tests to be run on JVM and android pertaining to getDeviceTwin/getTwin.
@@ -33,21 +35,52 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 public class GetTwinTests extends DeviceTwinCommon
 {
-    public GetTwinTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public GetTwinTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-    @Before
-    public void setUpNewDeviceAndModule() throws IOException, IotHubException, URISyntaxException, InterruptedException, ModuleClientException, GeneralSecurityException
+    @Test
+    @StandardTierHubOnlyTest
+    public void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
     {
         super.setUpNewDeviceAndModule();
+        super.testGetDeviceTwin();
     }
 
     @Test
     @StandardTierHubOnlyTest
-    public void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException
+    public void testGetDeviceTwinWithProxy() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
     {
-        super.testGetDeviceTwin();
+        if (testInstance.protocol != IotHubClientProtocol.MQTT || testInstance.authenticationType != AuthenticationType.SAS || testInstance.clientType != ClientType.DEVICE_CLIENT)
+        {
+            // This test doesn't really care about the device side protocol or authentication, so just run it once
+            // when the device is using MQTT with SAS auth
+            return;
+        }
+
+        super.setUpNewDeviceAndModule();
+
+        String testProxyHostname = "127.0.0.1";
+        int testProxyPort = 8892;
+        HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(testProxyPort)
+                .start();
+
+        try
+        {
+            Proxy serviceSideProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
+
+            ProxyOptions proxyOptions = new ProxyOptions(serviceSideProxy);
+            DeviceTwinClientOptions options = DeviceTwinClientOptions.builder().proxyOptions(proxyOptions).build();
+
+            testInstance.twinServiceClient = DeviceTwin.createFromConnectionString(iotHubConnectionString, options);
+
+            super.testGetDeviceTwin();
+        }
+        finally
+        {
+            proxyServer.stop();
+        }
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/ReportedPropertiesTests.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class ReportedPropertiesTests extends DeviceTwinCommon
 {
-    public ReportedPropertiesTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public ReportedPropertiesTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/TwinTagsTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/TwinTagsTests.java
@@ -15,8 +15,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.ClientType;
-import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
-import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinCommon;
@@ -24,7 +22,6 @@ import tests.integration.com.microsoft.azure.sdk.iot.iothub.setup.DeviceTwinComm
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -39,7 +36,7 @@ import static tests.integration.com.microsoft.azure.sdk.iot.helpers.CorrelationD
 @RunWith(Parameterized.class)
 public class TwinTagsTests extends DeviceTwinCommon
 {
-    public TwinTagsTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint)
+    public TwinTagsTests(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, String publicKeyCert, String privateKey, String x509Thumbprint) throws IOException
     {
         super(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
@@ -67,14 +64,14 @@ public class TwinTagsTests extends DeviceTwinCommon
             desiredProperties.add(new Pair(PROPERTY_KEY + i, PROPERTY_VALUE + i));
             devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
 
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Update Tags and desired properties on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Set<Pair> tags = devicesUnderTest[i].sCDeviceForTwin.getTags();
             for (Pair tag : tags)
             {
@@ -89,14 +86,14 @@ public class TwinTagsTests extends DeviceTwinCommon
             }
             devicesUnderTest[i].sCDeviceForTwin.setDesiredProperties(desiredProperties);
 
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Read updates on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
@@ -127,7 +124,7 @@ public class TwinTagsTests extends DeviceTwinCommon
             Set<Pair> tags = new HashSet<>();
             tags.add(new Pair(TAG_KEY + i, TAG_VALUE + i));
             devicesUnderTest[i].sCDeviceForTwin.setTags(tags);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(DELAY_BETWEEN_OPERATIONS);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
@@ -135,7 +132,7 @@ public class TwinTagsTests extends DeviceTwinCommon
         // Read updates on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Thread.sleep(DELAY_BETWEEN_OPERATIONS);
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
@@ -159,28 +156,28 @@ public class TwinTagsTests extends DeviceTwinCommon
             Set<Pair> tags = new HashSet<>();
             tags.add(new Pair(TAG_KEY + i, TAG_VALUE + i));
             devicesUnderTest[i].sCDeviceForTwin.setTags(tags);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Update Tags on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Set<Pair> tags = devicesUnderTest[i].sCDeviceForTwin.getTags();
             for (Pair tag : tags)
             {
                 tag.setValue(TAG_VALUE_UPDATE + i);
             }
             devicesUnderTest[i].sCDeviceForTwin.setTags(tags);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Read updates on multiple devices
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
             for (Pair t : devicesUnderTest[i].sCDeviceForTwin.getTags())
             {
@@ -192,21 +189,21 @@ public class TwinTagsTests extends DeviceTwinCommon
         // Delete tags
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
             Set<Pair> tags = devicesUnderTest[i].sCDeviceForTwin.getTags();
             for (Pair tag : tags)
             {
                 tag.setValue(null);
             }
             devicesUnderTest[i].sCDeviceForTwin.setTags(tags);
-            sCDeviceTwin.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.updateTwin(devicesUnderTest[i].sCDeviceForTwin);
             devicesUnderTest[i].sCDeviceForTwin.clearTwin();
         }
 
         // Verify tags were deleted successfully
         for (int i = 0; i < MAX_DEVICES; i++)
         {
-            sCDeviceTwin.getTwin(devicesUnderTest[i].sCDeviceForTwin);
+            testInstance.twinServiceClient.getTwin(devicesUnderTest[i].sCDeviceForTwin);
 
             assertEquals(buildExceptionMessage("Tags were not deleted by being set null", internalClient), 0, devicesUnderTest[i].sCDeviceForTwin.getTags().size());
         }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -1,19 +1,20 @@
-package com.microsoft.azure.sdk.iot.service;
+package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.Builder;
 import lombok.Getter;
 
 /**
- * Configurable options for all registry manager operations
+ * Configurable options for all device method operations.
  */
 @Builder
-public class RegistryManagerOptions
+public class DeviceMethodClientOptions
 {
     protected static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
     protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
 
     /**
-     * The options that specify what proxy to tunnel through. If null, no proxy will be used
+     * The options that specify what proxy to tunnel through. If null, no proxy will be used.
      */
     @Getter
     private ProxyOptions proxyOptions;
@@ -30,8 +31,8 @@ public class RegistryManagerOptions
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
      * before the connection can be established, a java.net.SocketTimeoutException is thrown.
-     * A timeout of zero is interpreted as an infinite timeout.
-     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     * A timeout of zero is interpreted as an infinite timeout. Must be a non-negative value.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
     private int httpConnectTimeout;

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
@@ -62,25 +62,26 @@ public class DeviceOperations
         /* Codes_SRS_DEVICE_OPERATIONS_21_001: [The request shall throw IllegalArgumentException if the provided `iotHubConnectionString` is null.] */
         if(iotHubConnectionString == null)
         {
-            throw new IllegalArgumentException("Null ConnectionString");
+            throw new IllegalArgumentException("Http requests must provide a non-null connection string");
         }
 
         /* Codes_SRS_DEVICE_OPERATIONS_21_002: [The request shall throw IllegalArgumentException if the provided `url` is null.] */
         if(url == null)
         {
-            throw new IllegalArgumentException("Null URL");
+            throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
         /* Codes_SRS_DEVICE_OPERATIONS_21_003: [The request shall throw IllegalArgumentException if the provided `method` is null.] */
         if(method == null)
         {
-            throw new IllegalArgumentException("Null method");
+            throw new IllegalArgumentException("Http requests must provide a non-null http method");
         }
 
         /* Codes_SRS_DEVICE_OPERATIONS_21_004: [The request shall throw IllegalArgumentException if the provided `payload` is null.] */
         if(payload == null)
         {
-            throw new IllegalArgumentException("Null payload");
+            // This is an odd requirement, but since we won't use this API since its deprecation, it will stay.
+            throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
         /* Codes_SRS_DEVICE_OPERATIONS_99_018: [The request shall throw IllegalArgumentException if the provided `timeoutInMs` exceed Integer.MAX_VALUE.] */
@@ -169,19 +170,19 @@ public class DeviceOperations
             Proxy proxy)
             throws IOException, IotHubException, IllegalArgumentException
     {
-        if (iotHubConnectionString == null)
+        if(iotHubConnectionString == null)
         {
-            throw new IllegalArgumentException("Null ConnectionString");
+            throw new IllegalArgumentException("Http requests must provide a non-null connection string");
         }
 
-        if (url == null)
+        if(url == null)
         {
-            throw new IllegalArgumentException("Null URL");
+            throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
-        if (method == null)
+        if(method == null)
         {
-            throw new IllegalArgumentException("Null method");
+            throw new IllegalArgumentException("Http requests must provide a non-null http method");
         }
 
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -22,33 +23,49 @@ public class DeviceTwin
 {
     private IotHubConnectionString iotHubConnectionString = null;
     private Integer requestId = 0;
-    private final long USE_DEFAULT_TIMEOUT = 0;
     private final int DEFAULT_PAGE_SIZE = 100;
+    private DeviceTwinClientOptions options;
 
     /**
-     * Static constructor to create instance from connection string
+     * Static constructor to create instance from connection string.
      *
-     * @param connectionString The iot hub connection string
-     * @return The instance of DeviceTwin
-     * @throws IOException This exception is thrown if the object creation failed
+     * @param connectionString The iot hub connection string.
+     * @return The instance of DeviceTwin.
+     * @throws IOException This exception is thrown if the object creation failed.
      */
     public static DeviceTwin createFromConnectionString(String connectionString) throws IOException
     {
+        return createFromConnectionString(
+                connectionString,
+                DeviceTwinClientOptions.builder()
+                    .httpConnectTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                    .httpReadTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
+                    .build());
+    }
+
+    /**
+     * Static constructor to create instance from connection string.
+     *
+     * @param connectionString The iot hub connection string.
+     * @param options the configurable options for each operation on this client. May not be null.
+     * @return The instance of DeviceTwin.
+     * @throws IOException This exception is thrown if the object creation failed.
+     */
+    public static DeviceTwin createFromConnectionString(String connectionString, DeviceTwinClientOptions options) throws IOException
+    {
         if (connectionString == null || connectionString.length() == 0)
         {
-            /*
-            **Codes_SRS_DEVICETWIN_25_001: [** The constructor shall throw IllegalArgumentException if the input string is null or empty **]**
-             */
             throw new IllegalArgumentException("Connection string cannot be null or empty");
         }
-        /*
-        **Codes_SRS_DEVICETWIN_25_003: [** The constructor shall create a new DeviceTwin instance and return it **]**
-         */
+
+        if (options == null)
+        {
+            throw new IllegalArgumentException("options cannot be null");
+        }
+
         DeviceTwin deviceTwin = new DeviceTwin();
-        /*
-        **Codes_SRS_DEVICETWIN_25_002: [** The constructor shall create an IotHubConnectionStringBuilder object from the given connection string **]**
-         */
         deviceTwin.iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
+        deviceTwin.options = options;
         return deviceTwin;
     }
 
@@ -56,8 +73,8 @@ public class DeviceTwin
      * This method retrieves device twin for the specified device.
      *
      * @param device The device with a valid id for which device twin is to be retrieved.
-     * @throws IOException This exception is thrown if the IO operation failed
-     * @throws IotHubException This exception is thrown if the response verification failed
+     * @throws IOException This exception is thrown if the IO operation failed.
+     * @throws IotHubException This exception is thrown if the response verification failed.
      */
     public void getTwin(DeviceTwinDevice device) throws IotHubException, IOException
     {
@@ -104,7 +121,8 @@ public class DeviceTwin
          **Codes_SRS_DEVICETWIN_25_009: [** The function shall send the created request and get the response **]**
          **Codes_SRS_DEVICETWIN_25_010: [** The function shall verify the response status and throw proper Exception **]**
          */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[0], String.valueOf(requestId++), USE_DEFAULT_TIMEOUT);
+        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[0], String.valueOf(requestId++), options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
         String twin = new String(response.getBody(), StandardCharsets.UTF_8);
 
         /*
@@ -134,8 +152,8 @@ public class DeviceTwin
      * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a> for more details
      *
      * @param device The device with a valid id for which device twin is to be updated.
-     * @throws IOException This exception is thrown if the IO operation failed
-     * @throws IotHubException This exception is thrown if the response verification failed
+     * @throws IOException This exception is thrown if the IO operation failed.
+     * @throws IotHubException This exception is thrown if the response verification failed.
      */
     public synchronized void updateTwin(DeviceTwinDevice device) throws IotHubException, IOException
     {
@@ -196,7 +214,8 @@ public class DeviceTwin
 
         **Codes_SRS_DEVICETWIN_25_020: [** The function shall verify the response status and throw proper Exception **]**
          */
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PATCH, twinJson.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++),0);
+        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
+        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PATCH, twinJson.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++),options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
     }
 
     /**
@@ -204,7 +223,7 @@ public class DeviceTwin
      *
      * @param device The device with a valid id for which desired properties is to be updated.
      * @throws UnsupportedOperationException This exception is always thrown.
-     * @deprecated Use updateTwin() to update desired properties
+     * @deprecated Use updateTwin() to update desired properties.
      */
     @Deprecated
     public void updateDesiredProperties(DeviceTwinDevice device) throws UnsupportedOperationException
@@ -240,12 +259,13 @@ public class DeviceTwin
     }
 
     /**
-     * Sql style query for twin
-     * @param sqlQuery Sql query string to query IotHub for Twin
-     * @param pageSize Size to limit query response by
-     * @return Query Object to be used for looking up responses for this query
-     * @throws IotHubException If Query request was not successful at the IotHub
-     * @throws IOException If input parameters are invalid
+     * Sql style query for twin.
+     *
+     * @param sqlQuery Sql query string to query IotHub for Twin.
+     * @param pageSize Size to limit query response by.
+     * @return Query Object to be used for looking up responses for this query.
+     * @throws IotHubException If Query request was not successful at the IotHub.
+     * @throws IOException If input parameters are invalid.
      */
     public synchronized Query queryTwin(String sqlQuery, Integer pageSize) throws IotHubException, IOException
     {
@@ -266,16 +286,18 @@ public class DeviceTwin
 
         //Codes_SRS_DEVICETWIN_25_049: [ The method shall build the URL for this operation by calling getUrlTwinQuery ]
         //Codes_SRS_DEVICETWIN_25_051: [ The method shall send a Query Request to IotHub as HTTP Method Post on the query Object by calling sendQueryRequest.]
-        deviceTwinQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
+        deviceTwinQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
         return deviceTwinQuery;
     }
 
     /**
-     * Sql style query for twin
-     * @param sqlQuery Sql query string to query IotHub for Twin
-     * @return Query Object to be used for looking up responses for this query
-     * @throws IotHubException If Query request was not successful at the IotHub
-     * @throws IOException If input parameters are invalid
+     * Sql style query for twin.
+     *
+     * @param sqlQuery Sql query string to query IotHub for Twin.
+     * @return Query Object to be used for looking up responses for this query.
+     * @throws IotHubException If Query request was not successful at the IotHub.
+     * @throws IOException If input parameters are invalid.
      */
     public synchronized Query queryTwin(String sqlQuery) throws IotHubException, IOException
     {
@@ -285,11 +307,11 @@ public class DeviceTwin
 
     /**
      * Create a QueryCollection object that can be used to query whole pages of results at a time. QueryCollection objects
-     * also allow you to provide a continuation token for the query to pick up from
+     * also allow you to provide a continuation token for the query to pick up from.
      *
-     * @param sqlQuery the sql query to run
-     * @return the created QueryCollection object that can be used to query the service
-     * @throws MalformedURLException If twin query url is not correct
+     * @param sqlQuery the sql query to run.
+     * @return the created QueryCollection object that can be used to query the service.
+     * @throws MalformedURLException If twin query url is not correct.
      */
     public synchronized QueryCollection queryTwinCollection(String sqlQuery) throws MalformedURLException
     {
@@ -299,27 +321,29 @@ public class DeviceTwin
 
     /**
      * Create a QueryCollection object that can be used to query whole pages of results at a time. QueryCollection objects
-     * also allow you to provide a continuation token for the query to pick up from
+     * also allow you to provide a continuation token for the query to pick up from.
      *
-     * @param sqlQuery the sql query to run
-     * @param pageSize the number of results to return at a time
-     * @return the created QueryCollection object that can be used to query the service
-     * @throws MalformedURLException If twin query url is not correct
+     * @param sqlQuery the sql query to run.
+     * @param pageSize the number of results to return at a time.
+     * @return the created QueryCollection object that can be used to query the service.
+     * @throws MalformedURLException If twin query url is not correct.
      */
     public synchronized QueryCollection queryTwinCollection(String sqlQuery, Integer pageSize) throws MalformedURLException
     {
         //Codes_SRS_DEVICETWIN_34_070: [This function shall return a new QueryCollection object of type TWIN with the provided sql query and page size.]
-        return new QueryCollection(sqlQuery, pageSize, QueryType.TWIN, this.iotHubConnectionString, this.iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
+        return new QueryCollection(sqlQuery, pageSize, QueryType.TWIN, this.iotHubConnectionString, this.iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
     }
 
     /**
      * Returns the availability of next twin element upon query. If non was found,
      * Query is sent over again and response is updated accordingly until no response
      * for the query was found.
-     * @param deviceTwinQuery Query object returned upon creation of query
+     *
+     * @param deviceTwinQuery Query object returned upon creation of query.
      * @return True if next is available and false other wise.
-     * @throws IotHubException If IotHub could not respond back to the query successfully
-     * @throws IOException If input parameter is incorrect
+     * @throws IotHubException If IotHub could not respond back to the query successfully.
+     * @throws IOException If input parameter is incorrect.
      */
     public synchronized boolean hasNextDeviceTwin(Query deviceTwinQuery) throws IotHubException, IOException
     {
@@ -334,12 +358,13 @@ public class DeviceTwin
     }
 
     /**
-     * Returns the next device twin document
-     * @param deviceTwinQuery Object corresponding to the query in request
-     * @return Returns the next device twin document
-     * @throws IOException If input parameter is incorrect
-     * @throws IotHubException If a non successful response from IotHub is received
-     * @throws NoSuchElementException If no additional element was found
+     * Returns the next device twin document.
+     *
+     * @param deviceTwinQuery Object corresponding to the query in request.
+     * @return Returns the next device twin document.
+     * @throws IOException If input parameter is incorrect.
+     * @throws IotHubException If a non successful response from IotHub is received.
+     * @throws NoSuchElementException If no additional element was found.
      */
     public synchronized DeviceTwinDevice getNextDeviceTwin(Query deviceTwinQuery) throws IOException, IotHubException, NoSuchElementException
     {
@@ -366,9 +391,9 @@ public class DeviceTwin
 
     /**
      * Returns if the provided deviceTwinQueryCollection has a next page to query.
-     * @param deviceTwinQueryCollection the query to check
-     * @return True if the provided deviceTwinQueryCollection has a next page to query, false otherwise
-     * @throws IllegalArgumentException if the provided deviceTwinQueryCollection is null
+     * @param deviceTwinQueryCollection the query to check.
+     * @return True if the provided deviceTwinQueryCollection has a next page to query, false otherwise.
+     * @throws IllegalArgumentException if the provided deviceTwinQueryCollection is null.
      */
     public synchronized boolean hasNext(QueryCollection deviceTwinQueryCollection)
     {
@@ -388,8 +413,8 @@ public class DeviceTwin
      * <p>This function shall update a local continuation token continuously to continue the query so you don't need to re-supply the returned
      * continuation token.</p>
      *
-     * @param deviceTwinQueryCollection the query to run
-     * @return The page of query results and the continuation token for the next page of results. Return value shall be {@code null} if there is no next collection
+     * @param deviceTwinQueryCollection the query to run.
+     * @return The page of query results and the continuation token for the next page of results. Return value shall be {@code null} if there is no next collection.
      * @throws IotHubException If an IotHubException occurs when querying the service.
      * @throws IOException If an IotHubException occurs when querying the service or if the results of that query don't match expectations.
      */
@@ -409,7 +434,7 @@ public class DeviceTwin
      *
      * <p>The provided option's page size shall override any previously saved page size.</p>
      *
-     * @param deviceTwinQueryCollection the query to run
+     * @param deviceTwinQueryCollection the query to run.
      * @param options the query options to run the query with. If the continuation token in these options is null, the internally saved continuation token shall be used.
      *                The page size set in the options will override any previously set page size.
      * @return The page of query results and the continuation token for the next page of results. Return value shall be {@code null} if there is no next collection.
@@ -445,15 +470,15 @@ public class DeviceTwin
     }
 
     /**
-     * Creates a new Job to update twin tags and desired properties on one or multiple devices
+     * Creates a new Job to update twin tags and desired properties on one or multiple devices.
      *
-     * @param queryCondition Query condition to evaluate which devices to run the job on. It can be {@code null} or empty
-     * @param updateTwin Twin object to use for the update
-     * @param startTimeUtc Date time in Utc to start the job
-     * @param maxExecutionTimeInSeconds Max execution time in seconds, i.e., ttl duration the job can run
-     * @return a Job class that represent this job on IotHub
-     * @throws IOException if the function contains invalid parameters
-     * @throws IotHubException if the http request failed
+     * @param queryCondition Query condition to evaluate which devices to run the job on. It can be {@code null} or empty.
+     * @param updateTwin Twin object to use for the update.
+     * @param startTimeUtc Date time in Utc to start the job.
+     * @param maxExecutionTimeInSeconds Max execution time in seconds, i.e., ttl duration the job can run.
+     * @return a Job class that represent this job on IotHub.
+     * @throws IOException if the function contains invalid parameters.
+     * @throws IotHubException if the http request failed.
      */
     public Job scheduleUpdateTwin(String queryCondition,
                                   DeviceTwinDevice updateTwin,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -1,19 +1,20 @@
-package com.microsoft.azure.sdk.iot.service;
+package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.Builder;
 import lombok.Getter;
 
 /**
- * Configurable options for all registry manager operations
+ * Configurable options for all twin client operations.
  */
 @Builder
-public class RegistryManagerOptions
+public class DeviceTwinClientOptions
 {
     protected static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
     protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
 
     /**
-     * The options that specify what proxy to tunnel through. If null, no proxy will be used
+     * The options that specify what proxy to tunnel through. If null, no proxy will be used.
      */
     @Getter
     private ProxyOptions proxyOptions;

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
@@ -18,6 +18,7 @@ import mockit.*;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
@@ -427,7 +428,9 @@ public class DeviceMethodTest
                     HttpMethod method,
                     byte[] payload,
                     String requestId,
-                    long timeoutInMs)
+                    int httpConnectTimeout,
+                    int httpReadTimeout,
+                    Proxy proxy)
                     throws IOException, IotHubException, IllegalArgumentException
             {
                 throw new IotHubException();

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.*;
 
@@ -765,7 +766,10 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
+
 
         new Expectations()
         {
@@ -782,7 +786,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
                 times = 1;
             }
         };
@@ -839,14 +843,17 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
+
 
         new NonStrictExpectations()
         {
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.TWIN);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
                 result = new IotHubException();
             }
         };
@@ -862,7 +869,9 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
 
         new NonStrictExpectations()
         {
@@ -883,7 +892,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
                 times = 1;
             }
         };
@@ -944,7 +953,9 @@ public class DeviceTwinTest
         final Integer version = 15;
         final String etag = "validEtag";
         final String connectionString = "testString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
         final String expectedString = "testJsonAsNext";
         TwinCollection tags = new TwinCollection();
         tags.putFinal("tagsKey", "tagsValue");
@@ -990,7 +1001,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
                 times = 1;
             }
         };
@@ -1017,8 +1028,10 @@ public class DeviceTwinTest
         final String expectedModuleId = "someModuleId";
         final Integer version = 15;
         final String etag = "validEtag";
-        final String connectionString = "testString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        final String connectionString = "someConnectionString";
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
         final String expectedString = "testJsonAsNext";
         TwinCollection tags = new TwinCollection();
         tags.putFinal("tagsKey", "tagsValue");
@@ -1066,7 +1079,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
                 times = 1;
             }
         };
@@ -1379,6 +1392,10 @@ public class DeviceTwinTest
         //arrange
         String expectedSqlQuery = "some query";
         int expectedPageSize = 23;
+        final int connectTimeout = 1234;
+        final int readTimeout = 5678;
+        final String connectionString = "someConnectionString";
+        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
 
         new StrictExpectations()
         {
@@ -1386,16 +1403,15 @@ public class DeviceTwinTest
                 //returning mock URL seems to break this test for some reason
                 mockedConnectionString.getUrlTwinQuery();
                 result = null;
-                Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedSqlQuery, expectedPageSize, QueryType.TWIN, mockedConnectionString, null, HttpMethod.POST, 0);
+                Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, expectedSqlQuery, expectedPageSize, QueryType.TWIN, mockedConnectionString, null, HttpMethod.POST, connectTimeout, readTimeout, null);
                 result = mockQueryCollection;
             }
         };
 
-        DeviceTwin deviceTwin = new DeviceTwin();
-        Deencapsulation.setField(deviceTwin, "iotHubConnectionString", mockedConnectionString);
+        Deencapsulation.setField(testTwin, "iotHubConnectionString", mockedConnectionString);
 
         //act
-        deviceTwin.queryTwinCollection(expectedSqlQuery, expectedPageSize);
+        testTwin.queryTwinCollection(expectedSqlQuery, expectedPageSize);
     }
 
     //Tests_SRS_DEVICETWIN_34_075: [This function shall call next(deviceTwinQueryCollection, queryOptions) where queryOptions has the deviceTwinQueryCollection's current page size.]

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
@@ -17,6 +17,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 
@@ -207,7 +208,6 @@ public class QueryCollectionTest
         IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
-        long actualTimeout = Deencapsulation.getField(queryCollection, "timeout");
 
         assertEquals(expectedQuery, actualQuery);
         assertEquals(expectedPageSize, actualPageSize);
@@ -215,7 +215,6 @@ public class QueryCollectionTest
         assertTrue(actualIsSqlQuery);
         assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
-        assertEquals(actualTimeout, expectedTimeout);
         assertEquals(actualUrl, mockUrl);
     }
 
@@ -243,14 +242,12 @@ public class QueryCollectionTest
         IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
-        long actualTimeout = Deencapsulation.getField(queryCollection, "timeout");
 
         assertEquals(expectedPageSize, actualPageSize);
         assertEquals(expectedQueryType, actualQueryType);
         assertFalse(actualIsSqlQuery);
         assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
-        assertEquals(actualTimeout, expectedTimeout);
         assertEquals(actualUrl, mockUrl);
     }
 
@@ -325,7 +322,7 @@ public class QueryCollectionTest
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -373,7 +370,7 @@ public class QueryCollectionTest
         new NonStrictExpectations()
         {
             {
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, anyInt, anyInt, (Proxy) any);
                 result = mockHttpResponse;
 
                 mockHttpResponse.getHeaderFields();
@@ -393,7 +390,7 @@ public class QueryCollectionTest
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
 
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, expectedTimeout);
+                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -439,7 +436,7 @@ public class QueryCollectionTest
         new Verifications()
         {
             {
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);
+                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };


### PR DESCRIPTION
Basically the same as how the registry manager takes these options.

Making the read/connect timeouts configurable will help with speeding up our e2e tests, and this is a useful feature for customers anyways