### PR TITLE
refactor(e2e): Remove shorter, test specific timeouts

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
@@ -104,7 +104,7 @@ public class RegistryManagerTests extends IntegrationTest
         proxyServer.stop();
     }
     
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     public void deviceLifecycle() throws Exception
     {
         //-Create-//
@@ -130,7 +130,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     public void deviceLifecycleWithProxy() throws Exception
     {
         Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
@@ -160,7 +160,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     public void crud_device_e2e_X509_CA_signed() throws Exception
     {
         //-Create-//
@@ -191,7 +191,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), deviceWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     public void crud_device_e2e_X509_self_signed() throws Exception
     {
         //-Create-//
@@ -235,7 +235,7 @@ public class RegistryManagerTests extends IntegrationTest
         Tools.getStatisticsWithRetry(registryManager);
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     public void crud_module_e2e() throws Exception
     {
@@ -272,7 +272,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId, testInstance.moduleId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     @ContinuousIntegrationTest
     public void crud_module_e2e_X509_CA_signed() throws Exception
@@ -307,7 +307,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId, testInstance.moduleId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     @ContinuousIntegrationTest
     public void crud_module_e2e_X509_self_signed() throws Exception
@@ -350,7 +350,7 @@ public class RegistryManagerTests extends IntegrationTest
         assertTrue(buildExceptionMessage("", hostName), moduleWasDeletedSuccessfully(testInstance.registryManager, testInstance.deviceId, testInstance.moduleId));
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     public void crud_adm_configuration_e2e() throws Exception
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
@@ -106,14 +106,14 @@ public class ServiceClientTests extends IntegrationTest
         proxyServer.stop();
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     public void cloudToDeviceTelemetry() throws Exception
     {
         cloudToDeviceTelemetry(false);
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @StandardTierHubOnlyTest
     public void cloudToDeviceTelemetryWithProxy() throws Exception
     {
@@ -173,7 +173,7 @@ public class ServiceClientTests extends IntegrationTest
         registryManager.close();
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @ContinuousIntegrationTest
     public void serviceClientValidatesRemoteCertificateWhenSendingTelemetry() throws IOException
     {
@@ -198,7 +198,7 @@ public class ServiceClientTests extends IntegrationTest
         assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @ContinuousIntegrationTest
     public void serviceClientValidatesRemoteCertificateWhenGettingFeedbackReceiver() throws IOException
     {
@@ -225,7 +225,7 @@ public class ServiceClientTests extends IntegrationTest
         assertTrue(buildExceptionMessage("Expected an exception due to service presenting invalid certificate", hostName), expectedExceptionWasCaught);
     }
 
-    @Test (timeout=MAX_TEST_MILLISECONDS)
+    @Test
     @ContinuousIntegrationTest
     public void serviceClientValidatesRemoteCertificateWhenGettingFileUploadFeedbackReceiver() throws IOException
     {


### PR DESCRIPTION
These tests are timing out since they rely on registry manager operations which may take a while to execute since only one thread can do a registry manager operation at a time and most tests need to do at least one registry manager operation.

For instance: https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/results?buildId=65369&view=ms.vss-test-web.build-test-results-tab&runId=1579266&resultId=103226&paneView=debug