### PR TITLE
fix(iot-dev): Fix issue where amqp layer ignored delivery state of sent messages

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsCbsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsCbsSessionHandler.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.*;
 
@@ -121,7 +122,7 @@ public class AmqpsCbsSessionHandler extends BaseHandler implements AmqpsLinkStat
     }
 
     @Override
-    public void onMessageAcknowledged(Message message, int deliveryTag)
+    public void onMessageAcknowledged(Message message, int deliveryTag, DeliveryState deliveryState)
     {
         // Do nothing. Users of this SDK don't care about this ack, and the SDK doesn't open any links or sessions
         // upon receiving this ack. The CBS receiver link receives a message with the actual status of the authentication.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsLinkStateCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsLinkStateCallback.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.sdk.iot.device.transport.amqps;
 
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.BaseHandler;
 
@@ -23,8 +24,9 @@ public interface AmqpsLinkStateCallback
      *
      * @param message     the message that was sent
      * @param deliveryTag the integer that identifies which delivery this acknowledgement was tied to
+     * @param deliveryState state information that describes if the message was accepted by the receiver or not.
      */
-    void onMessageAcknowledged(Message message, int deliveryTag);
+    void onMessageAcknowledged(Message message, int deliveryTag, DeliveryState deliveryState);
 
     /**
      * Executed when a message is received by a link in this session. This message should be acknowledged later.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
@@ -81,7 +81,7 @@ public abstract class AmqpsSenderLinkHandler extends BaseHandler
         }
         else
         {
-            this.amqpsLinkStateCallback.onMessageAcknowledged(acknowledgedIotHubMessage, deliveryTag);
+            this.amqpsLinkStateCallback.onMessageAcknowledged(acknowledgedIotHubMessage, deliveryTag, delivery.getRemoteState());
         }
 
         delivery.free();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -7,6 +7,7 @@ import com.microsoft.azure.sdk.iot.device.MessageType;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.*;
@@ -185,7 +186,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
 
             if (this.twinReceiverLinkOpened && this.explicitInProgressTwinSubscriptionMessage != null)
             {
-                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressTwinSubscriptionMessage);
+                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressTwinSubscriptionMessage, Accepted.getInstance());
                 this.explicitInProgressTwinSubscriptionMessage = null; //By setting this to null, this session can handle another twin subscription message
             }
         }
@@ -195,7 +196,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
 
             if (this.twinSenderLinkOpened && this.explicitInProgressTwinSubscriptionMessage != null)
             {
-                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressTwinSubscriptionMessage);
+                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressTwinSubscriptionMessage, Accepted.getInstance());
                 this.explicitInProgressTwinSubscriptionMessage = null; //By setting this to null, this session can handle another twin subscription message
             }
         }
@@ -205,7 +206,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
 
             if (this.methodsReceiverLinkOpened && this.explicitInProgressMethodsSubscriptionMessage != null)
             {
-                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressMethodsSubscriptionMessage);
+                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressMethodsSubscriptionMessage, Accepted.getInstance());
                 this.explicitInProgressMethodsSubscriptionMessage = null; //By setting this to null, this session can handle another method subscription message
             }
         }
@@ -215,14 +216,14 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
 
             if (this.methodsSenderLinkOpened && this.explicitInProgressMethodsSubscriptionMessage != null)
             {
-                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressMethodsSubscriptionMessage);
+                this.amqpsSessionStateCallback.onMessageAcknowledged(this.explicitInProgressMethodsSubscriptionMessage, Accepted.getInstance());
                 this.explicitInProgressMethodsSubscriptionMessage = null; //By setting this to null, this session can handle another method subscription message
             }
         }
     }
 
     @Override
-    public void onMessageAcknowledged(Message message, int deliveryTag)
+    public void onMessageAcknowledged(Message message, int deliveryTag, DeliveryState deliveryState)
     {
         if (this.implicitInProgressSubscriptionMessages.containsKey(deliveryTag))
         {
@@ -231,7 +232,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
         }
         else
         {
-            this.amqpsSessionStateCallback.onMessageAcknowledged(message);
+            this.amqpsSessionStateCallback.onMessageAcknowledged(message, deliveryState);
         }
     }
 
@@ -304,7 +305,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
                     if (this.methodsSenderLinkOpened && this.methodsReceiverLinkOpened)
                     {
                         // No need to do anything. Method links are already opened
-                        this.amqpsSessionStateCallback.onMessageAcknowledged(message);
+                        this.amqpsSessionStateCallback.onMessageAcknowledged(message, Accepted.getInstance());
                         return true;
                     }
 
@@ -330,7 +331,7 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
                     {
                         // No need to do anything. Twin links are already opened and desired properties subscription is automatically
                         // sent once the twin links are opened.
-                        this.amqpsSessionStateCallback.onMessageAcknowledged(message);
+                        this.amqpsSessionStateCallback.onMessageAcknowledged(message, Accepted.getInstance());
                         return true;
                     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionStateCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionStateCallback.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.sdk.iot.device.transport.amqps;
 import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 
 /**
@@ -28,8 +29,9 @@ interface AmqpsSessionStateCallback
      * Executed when a message sent in this connection was acknowledged by the service.
      *
      * @param message the message that was acknowledged.
+     * @param deliveryState state information that describes if the message was accepted by the receiver or not.
      */
-    void onMessageAcknowledged(Message message);
+    void onMessageAcknowledged(Message message, DeliveryState deliveryState);
 
     /**
      * Executed when a message was received by a session that this connection owns. This message should be acknowledged later.


### PR DESCRIPTION
fixes issue #887 

If the delivery state was anything other than Accepted, the SDK needs to either retry sending the message or bubble up that exception to the user