### PR TITLE
fix(iot-dev): Fix issue where errors encountered at http message level were handled twice

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -151,11 +151,6 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
                 //Codes_SRS_HTTPSIOTHUBCONNECTION_34_067: [If the response from the service is OK or OK_EMPTY, this function shall notify its listener that a message was sent with no exception.]
                 this.listener.onMessageSent(transportMessage, null);
             }
-            else
-            {
-                //Codes_SRS_HTTPSIOTHUBCONNECTION_34_068: [If the response from the service not OK or OK_EMPTY, this function shall notify its listener that a message was with the mapped IotHubServiceException.]
-                this.listener.onMessageSent(transportMessage, IotHubStatusCode.getConnectionStatusException(status, ""));
-            }
 
             return status;
         }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -152,6 +152,9 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
                 this.listener.onMessageSent(transportMessage, null);
             }
 
+            // Status codes other than 200 and 204 have their errors handled in the IotHubTransport layer once this method returns,
+            // so there is no need to call "this.listener.onMessageSent(transportMessage, someException)" from this layer.
+
             return status;
         }
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -2112,50 +2112,6 @@ public class HttpsIotHubConnectionTest
         };
     }
 
-    //Tests_SRS_HTTPSIOTHUBCONNECTION_34_068: [If the response from the service not OK or OK_EMPTY, this function shall notify its listener that a message was with the mapped IotHubServiceException.]
-    @Test
-    public void sendMessageNotifiesListenerOfIotHubServiceExceptionOnMessageSent(final @Mocked IotHubEventUri mockUri) throws TransportException
-    {
-        //arrange
-        final String iotHubHostname = "test.iothub";
-        final String deviceId = "test-device-id";
-        final String eventUri = "test-event-uri";
-        new NonStrictExpectations()
-        {
-            {
-                mockConfig.getIotHubHostname();
-                result = iotHubHostname;
-                mockConfig.getDeviceId();
-                result = deviceId;
-                new IotHubEventUri(iotHubHostname, deviceId, null);
-                result = mockUri;
-                mockUri.toString();
-                result = eventUri;
-
-                mockRequest.send();
-                result = mockResponse;
-
-                mockResponse.getStatus();
-                result = 404;
-            }
-        };
-
-        HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
-        conn.setListener(mockedListener);
-
-        //act
-        conn.sendMessage(mockedMessage);
-
-        //assert
-        new Verifications()
-        {
-            {
-                mockedListener.onMessageSent((IotHubTransportMessage) any, (TransportException) any);
-                times = 1;
-            }
-        };
-    }
-
     //Tests_SRS_HTTPSIOTHUBCONNECTION_34_071: [This function shall return the empty string.]
     @Test
     public void getConnectionIdReturnsEmptyString()


### PR DESCRIPTION
This same logic took place at the IotHubTransport layer based on the result of this method call, so no need to include this logic in the HTTP layer

You can see this logic here:
https://github.com/Azure/azure-iot-sdk-java/blob/5867a9311ec7f30102e37106b3a26ec7f769c802/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java#L1026