### PR TITLE
fix(iot-dev): Fix issue where notfiy call was not wrapped by synchronization block

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -950,7 +950,10 @@ public class IotHubTransport implements IotHubListener
             this.waitingPacketsQueue.add(this.transportPacket);
 
             // Wake up send messages thread so that it can send this message
-            this.sendThreadLock.notifyAll();
+            synchronized (this.sendThreadLock)
+            {
+                this.sendThreadLock.notifyAll();
+            }
         }
     }
 


### PR DESCRIPTION
All notify calls must be wrapped in synchronization blocks on the object that will be notified. Otherwise the notify call will throw an IllegalMonitorStateException and won't wake up the send thread as expected.

This PR just adds that synchronization block so that when the message is requeued, it will wake up the send thread