### PR TITLE
release(2020-08-13): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -13,7 +13,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION_PREVIEW = "2020-05-31-preview";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.24.0";
+    private static final String CLIENT_VERSION = "1.25.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.24.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.25.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.24.0</iot-device-client-version>
-        <iot-service-client-version>1.24.0</iot-service-client-version>
+        <iot-device-client-version>1.25.0</iot-device-client-version>
+        <iot-service-client-version>1.25.0</iot-service-client-version>
         <iot-deps-version>0.10.0</iot-deps-version>
         <provisioning-device-client-version>1.8.3</provisioning-device-client-version>
         <provisioning-service-client-version>1.6.2</provisioning-service-client-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.24.0";
+    public static String serviceVersion = "1.25.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
old
{
    "device": "1.24.0",
    "service": "1.24.0",
    "deps": "0.10.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.3",
    "provisioningService": "1.6.2"
}
new
{
    "device": "1.25.0",
    "service": "1.25.0",
    "deps": "0.10.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.3",
    "provisioningService": "1.6.2"
}


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.25.0)

- #890 Fix charset bug in IotHubServiceSasToken buildToken method. 

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.25.0)

- #889 Add support for batch event messages for HTTPS protocol.

# Bug fixes
- #888 Fix issue where amqp layer ignored delivery state of sent messages
- #891 Fix issue where errors encountered at http message level were handled twice 
- #871 Fix device client not sending user agent string with proxy tunnel request 
- #869 Change thread scheduling pattern in deviceIO layer 
- #858 Fix issue with ordering of queue within amqp layer 
- #893 Fix issue where re-queued messages don't wake up the send thread

Maven packages
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.25.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.25.0/jar
