### PR TITLE
refactor(e2e): Use GPU for android emulation

### DIFF
--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -20,7 +20,7 @@ $ANDROID_HOME/emulator/emulator -list-avds
 
 echo ''
 echo "Starting emulator in background thread"
-nohup $ANDROID_HOME/emulator/emulator -avd $avdName -no-snapshot > /dev/null 2>&1 &
+nohup $ANDROID_HOME/emulator/emulator -avd $avdName -gpu auto -no-snapshot > /dev/null 2>&1 &
 
 echo ''
 echo 'Waiting for emulator to boot up...'


### PR DESCRIPTION
Adding the GPU flag to our android emulator startup. There are times when the emulator takes ~20 minutes to start up. With this change, it seems consistently faster

https://developer.android.com/studio/run/emulator-acceleration#command-gpu