### PR TITLE
refactor(vsts): Automate javadoc generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ vertx.log.lck
 
 #Whitelist, will allow changes to log4j.properties files to be tracked via source control
 !log4j.properties
+
+apidocs

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -162,6 +162,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>deps</destDir>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -144,6 +144,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>device</destDir>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -108,6 +108,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/provisioning-device-client</destDir>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -99,6 +99,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/provisioning-service-client</destDir>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -104,6 +104,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/dice-provider-emulator</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -104,6 +104,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/dice-provider</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -94,6 +94,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/security-provider</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -109,6 +109,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/tpm-provider-emulator</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -109,6 +109,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/tpm-provider</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -110,6 +110,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>provisioning/security/x509-provider</destDir>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -128,6 +128,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--This configures the "mvn javadoc:javadoc" created artifacts are outputted to <reportOutputDirectory>/<destDir>-->
+                    <reportOutputDirectory>${session.executionRootDirectory}/apidocs</reportOutputDirectory>
+                    <destDir>service</destDir>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -20,7 +20,7 @@ $ANDROID_HOME/emulator/emulator -list-avds
 
 echo ''
 echo "Starting emulator in background thread"
-nohup $ANDROID_HOME/emulator/emulator -avd $avdName -no-snapshot > /dev/null 2>&1 &
+nohup $ANDROID_HOME/emulator/emulator -avd $avdName -gpu auto -no-snapshot > /dev/null 2>&1 &
 
 echo ''
 echo 'Waiting for emulator to boot up...'

--- a/vsts/generate_javadocs_branch.ps1
+++ b/vsts/generate_javadocs_branch.ps1
@@ -1,0 +1,115 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# This script generates javadocs for the currently checked out branch and creates a new git branch based off of the current
+# gh-pages branch. This new branch will contain the generated javadocs. After running this script, you will manually
+# need to create a pull request from the new branch ("gh-pages-<current date>") to "gh-pages".
+
+# This script is designed to be used only by an Azure Devops release pipeline. Running it locally will not work
+# due to some assumptions this script makes about working directory.
+
+function TestLastExitCode {
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Last exit code is ($LASTEXITCODE)"
+    }
+}
+
+function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources) {
+    if ($([string]::IsNullOrWhiteSpace($GitHubName) -eq $true)) {
+        throw "GitHubName is null or empty"
+    }
+
+    if ($([string]::IsNullOrWhiteSpace($GitHubEmail) -eq $true)) {
+        throw "GitHubEmail is null or empty"
+    }
+
+    Set-Location $Sources -ErrorAction Stop
+
+    #Some local samples rely on packages we don't publish publicly, so install everything locally before generating javadocs
+    Write-Host "Installing jars locally"
+    mvn `-DskipTests `-Dmaven.javadoc.skip=true install -T 2C
+
+    Write-Host "Generating javadocs, placing them in apidocs folder at the root of the repository"
+    mvn javadoc:javadoc -T 2C
+
+    $date = Get-Date -UFormat '%Y-%m-%d'
+    $newBranchName = "gh-pages-" + $date
+
+    git.exe config user.email $GitHubEmail
+    git.exe config user.name $GitHubName
+
+    Write-Output "Create new branch '$newBranchName' based on gh-pages branch"
+    git.exe checkout gh-pages
+
+    # Create a new gh-pages merge branch based off of the original gh-pages branch
+    git.exe checkout -b $newBranchName gh-pages
+    TestLastExitCode  # stop if we can't create the branch
+
+    Write-Host "Copying generated javadocs to replace current javadocs"
+    Set-Location apidocs
+    Remove-Item ..\deps -Force -Recurse
+    Copy-Item -Force -Path .\deps\* -Destination ..\deps
+    Copy-Item -Recurse -Force -Path .\deps\com -Destination ..\deps
+
+    Remove-Item ..\device -Force -Recurse
+    Copy-Item -Force -Path .\device\* -Destination ..\device
+    Copy-Item -Recurse -Force -Path .\device\com -Destination ..\device
+
+    Remove-Item ..\service -Force -Recurse
+    Copy-Item -Force -Path .\service\* -Destination ..\service
+    Copy-Item -Recurse -Force -Path .\service\com -Destination ..\service
+
+    Remove-Item ..\provisioning -Force -Recurse
+    New-Item -Path '../provisioning' -ItemType Directory
+    New-Item -Path '../provisioning/provisioning-device-client' -ItemType Directory
+    New-Item -Path '../provisioning/provisioning-service-client' -ItemType Directory
+    New-Item -Path '../provisioning/security' -ItemType Directory
+    New-Item -Path '../provisioning/security/dice-provider' -ItemType Directory
+    New-Item -Path '../provisioning/security/dice-provider-emulator' -ItemType Directory
+    New-Item -Path '../provisioning/security/security-provider' -ItemType Directory
+    New-Item -Path '../provisioning/security/tpm-provider' -ItemType Directory
+    New-Item -Path '../provisioning/security/tpm-provider-emulator' -ItemType Directory
+    New-Item -Path '../provisioning/security/x509-provider' -ItemType Directory
+
+    Copy-Item -Force -Path .\provisioning\provisioning-device-client\* -Destination ..\provisioning\provisioning-device-client
+    Copy-Item -Recurse -Force -Path .\provisioning\provisioning-device-client\com -Destination ..\provisioning\provisioning-device-client
+
+    Copy-Item -Force -Path .\provisioning\provisioning-service-client\* -Destination ..\provisioning\provisioning-service-client
+    Copy-Item -Recurse -Force -Path .\provisioning\provisioning-service-client\com -Destination ..\provisioning\provisioning-service-client
+
+    Copy-Item -Force -Path .\provisioning\security\tpm-provider-emulator\* -Destination ..\provisioning\security\tpm-provider-emulator
+    Copy-Item -Recurse -Force -Path .\provisioning\security\tpm-provider-emulator\com -Destination ..\provisioning\security\tpm-provider-emulator
+
+    Copy-Item -Force -Path .\provisioning\security\tpm-provider\* -Destination ..\provisioning\security\tpm-provider
+    Copy-Item -Recurse -Force -Path .\provisioning\security\tpm-provider\com -Destination ..\provisioning\security\tpm-provider
+
+    Copy-Item -Force -Path .\provisioning\security\dice-provider-emulator\* -Destination ..\provisioning\security\dice-provider-emulator
+    Copy-Item -Recurse -Force -Path .\provisioning\security\dice-provider-emulator\com -Destination ..\provisioning\security\dice-provider-emulator
+
+    Copy-Item -Force -Path .\provisioning\security\dice-provider\* -Destination ..\provisioning\security\dice-provider
+    Copy-Item -Recurse -Force -Path .\provisioning\security\dice-provider\com -Destination ..\provisioning\security\dice-provider
+
+    Copy-Item -Force -Path .\provisioning\security\security-provider\* -Destination ..\provisioning\security\security-provider
+    Copy-Item -Recurse -Force -Path .\provisioning\security\security-provider\com -Destination ..\provisioning\security\security-provider
+
+    Copy-Item -Force -Path .\provisioning\security\x509-provider\* -Destination ..\provisioning\security\x509-provider
+    Copy-Item -Recurse -Force -Path .\provisioning\security\x509-provider\com -Destination ..\provisioning\security\x509-provider
+
+    Set-Location ..
+
+    Write-Host "Removing temporary apidocs folder"
+    Remove-Item ./apidocs -Recurse
+
+    git.exe add .
+    TestLastExitCode  # stop if we can't add the changes
+
+    $commitMessage = "release($date): Update javadocs to latest"
+    Write-Host "Committing to new javadocs release branch"
+    git.exe commit -m $commitMessage
+    TestLastExitCode  # stop if we can't commit the changes
+
+    Write-Output "Push changes to origin"
+    git.exe push --tags -u origin $newBranchName
+    TestLastExitCode  # stop if push to remote fails
+}


### PR DESCRIPTION
generateJavadocs.ps1 will generate javadocs for the checked out branch (configurable to master, preview, etc as needed) then create a new branch based on the current gh-pages branch that contains the up to date javadocs. We'll still have to manually create a PR to merge that branch into gh-pages.

TODO is for me to update our internal repo's release notes to include this new step, and to point to the release pipeline that will use this new generateJavadocs.ps1 script. Once this PR is merged in, I'll take care of that