### PR TITLE
fix(iot-dev): Fix NPE that occurs in AMQP layer if open fails due to …

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -702,7 +702,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             executorService = Executors.newFixedThreadPool(1);
         }
 
-        ReactorRunner reactorRunner = new ReactorRunner(new IotHubReactor(createReactor()), this.listener, this.connectionId);
+        this.reactor = createReactor();
+        ReactorRunner reactorRunner = new ReactorRunner(new IotHubReactor(this.reactor), this.listener, this.connectionId);
         executorService.submit(reactorRunner);
     }
 


### PR DESCRIPTION
…authentication links not opening

CloseAsync() assumed that the instance varaible holding the amqp connection was initialized, but that is not always the case

See #900 for further description 