### PR TITLE
refactor(javadocs): Add more files to gh-pages gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,7 @@ vertx.log.lck
 
 #Whitelist, will allow changes to log4j.properties files to be tracked via source control
 !log4j.properties
+
+javadoc-options-javadoc-resources.xml
+iot-e2e-tests
+.flattened-pom.xml


### PR DESCRIPTION
flattened poms are generated during the javadoc creation process, but we don't want to check them in. Similarly, the javadoc options files aren't relevant enough to commit to this branch. Lastly, the e2e tests folder should be completely ignored since we do not publish any jars from that folder much less any javadocs.