### PR TITLE
feat(device-client): Add configuration for amqp authentication and device session timeouts

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -735,7 +735,7 @@ public final class DeviceClient extends InternalClient implements Closeable
         else if (value == null)
         {
             // Codes_SRS_DEVICECLIENT_12_026: [The function shall trow IllegalArgumentException if the value is null.]
-            throw new IllegalArgumentException("optionValue is null");
+            throw new IllegalArgumentException("value is null");
         }
 
         switch (optionName)
@@ -817,7 +817,6 @@ public final class DeviceClient extends InternalClient implements Closeable
             {
                 setOption_SetAmqpOpenAuthenticationSessionTimeout(value);
                 return;
-
             }
             case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -710,6 +710,16 @@ public final class DeviceClient extends InternalClient implements Closeable
      *         made by this client. By default, this value is 0 (no connect timeout).
      *         The value is expected to be of type {@code int}.
      *
+     *      - <b>SetAmqpOpenAuthenticationSessionTimeout</b> - this option is applicable for AMQP with SAS token authentication.
+     *         This option specifies the timeout in seconds to wait to open the authentication session.
+     *         By default, this value is 20 seconds.
+     *         The value is expected to be of type {@code int}.
+     *
+     *      - <b>SetAmqpOpenDeviceSessionsTimeout</b> - this option is applicable for AMQP.
+     *         This option specifies the timeout in seconds to open the device sessions.
+     *         By default, this value is 60 seconds.
+     *         The value is expected to be of type {@code int}.
+     *
      * @param optionName the option name to modify
      * @param value an object of the appropriate type for the option's value
      * @throws IllegalArgumentException if the provided optionName is null
@@ -725,7 +735,7 @@ public final class DeviceClient extends InternalClient implements Closeable
         else if (value == null)
         {
             // Codes_SRS_DEVICECLIENT_12_026: [The function shall trow IllegalArgumentException if the value is null.]
-            throw new IllegalArgumentException("optionName is null");
+            throw new IllegalArgumentException("optionValue is null");
         }
 
         switch (optionName)
@@ -802,6 +812,17 @@ public final class DeviceClient extends InternalClient implements Closeable
                     setOption_SetSASTokenExpiryTime(value);
                     return;
                 }
+            }
+            case SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT:
+            {
+                setOption_SetAmqpOpenAuthenticationSessionTimeout(value);
+                return;
+
+            }
+            case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
+            {
+                setOption_SetAmqpOpenDeviceSessionsTimeout(value);
+                return;
             }
             default:
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -46,21 +46,22 @@ public final class DeviceClientConfig
     @Setter(AccessLevel.PROTECTED)
     String modelId;
 
+    // Initialize all the timeout values here instead of the constructor as the constructor is not always called.
     @Getter
     @Setter
-    private int httpsReadTimeout;
+    private int httpsReadTimeout = DEFAULT_HTTPS_READ_TIMEOUT_MILLIS;
 
     @Getter
     @Setter
-    private int httpsConnectTimeout;
+    private int httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS;
 
     @Getter
     @Setter
-    private int amqpOpenAuthenticationSessionTimeout;
+    private int amqpOpenAuthenticationSessionTimeout = DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT_IN_SECONDS;
 
     @Getter
     @Setter
-    private int amqpOpenDeviceSessionsTimeout;
+    private int amqpOpenDeviceSessionsTimeout = DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT_IN_SECONDS;
 
     private IotHubAuthenticationProvider authenticationProvider;
 
@@ -276,10 +277,6 @@ public final class DeviceClientConfig
 
         this.productInfo = new ProductInfo();
         this.useWebsocket = false;
-        this.httpsReadTimeout = DEFAULT_HTTPS_READ_TIMEOUT_MILLIS;
-        this.httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS;
-        this.amqpOpenAuthenticationSessionTimeout = DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT_IN_SECONDS;
-        this.amqpOpenDeviceSessionsTimeout = DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT_IN_SECONDS;
     }
 
     private void assertConnectionStringIsX509(IotHubConnectionString iotHubConnectionString)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -31,8 +31,8 @@ public final class DeviceClientConfig
     private static final int DEFAULT_HTTPS_READ_TIMEOUT_MILLIS = 240000;
     private static final int DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS = 0; //no connect timeout
 
-    private static final int DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT = 20 * 1000; // 20 second timeout
-    private static final int DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT = 60 * 1000; // 60 second timeout
+    private static final int DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT_IN_SECONDS = 20;
+    private static final int DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT_IN_SECONDS = 60;
 
     /** The default value for messageLockTimeoutSecs. */
     private static final int DEFAULT_MESSAGE_LOCK_TIMEOUT_SECS = 180;
@@ -278,8 +278,8 @@ public final class DeviceClientConfig
         this.useWebsocket = false;
         this.httpsReadTimeout = DEFAULT_HTTPS_READ_TIMEOUT_MILLIS;
         this.httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS;
-        this.amqpOpenAuthenticationSessionTimeout = DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT;
-        this.amqpOpenDeviceSessionsTimeout = DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT;
+        this.amqpOpenAuthenticationSessionTimeout = DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT_IN_SECONDS;
+        this.amqpOpenDeviceSessionsTimeout = DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT_IN_SECONDS;
     }
 
     private void assertConnectionStringIsX509(IotHubConnectionString iotHubConnectionString)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -31,6 +31,9 @@ public final class DeviceClientConfig
     private static final int DEFAULT_HTTPS_READ_TIMEOUT_MILLIS = 240000;
     private static final int DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS = 0; //no connect timeout
 
+    private static final int DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT = 20 * 1000; // 20 second timeout
+    private static final int DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT = 60 * 1000; // 60 second timeout
+
     /** The default value for messageLockTimeoutSecs. */
     private static final int DEFAULT_MESSAGE_LOCK_TIMEOUT_SECS = 180;
 
@@ -50,6 +53,14 @@ public final class DeviceClientConfig
     @Getter
     @Setter
     private int httpsConnectTimeout;
+
+    @Getter
+    @Setter
+    private int amqpOpenAuthenticationSessionTimeout;
+
+    @Getter
+    @Setter
+    private int amqpOpenDeviceSessionsTimeout;
 
     private IotHubAuthenticationProvider authenticationProvider;
 
@@ -267,6 +278,8 @@ public final class DeviceClientConfig
         this.useWebsocket = false;
         this.httpsReadTimeout = DEFAULT_HTTPS_READ_TIMEOUT_MILLIS;
         this.httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLIS;
+        this.amqpOpenAuthenticationSessionTimeout = DEFAULT_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT;
+        this.amqpOpenDeviceSessionsTimeout = DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT;
     }
 
     private void assertConnectionStringIsX509(IotHubConnectionString iotHubConnectionString)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -33,6 +33,8 @@ public class InternalClient
     static final String SET_CERTIFICATE_PATH = "SetCertificatePath";
 	static final String SET_CERTIFICATE_AUTHORITY = "SetCertificateAuthority";
     static final String SET_SAS_TOKEN_EXPIRY_TIME = "SetSASTokenExpiryTime";
+    static final String SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT = "SetAmqpOpenAuthenticationSessionTimeout";
+    static final String SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT = "SetAmqpOpenDeviceSessionsTimeout";
 
     static final String SET_HTTPS_CONNECT_TIMEOUT = "SetHttpsConnectTimeout";
     static final String SET_HTTPS_READ_TIMEOUT = "SetHttpsReadTimeout";
@@ -870,6 +872,51 @@ public class InternalClient
                         throw new IOError(e);
                     }
                 }
+            }
+        }
+    }
+
+    void setOption_SetAmqpOpenAuthenticationSessionTimeout(Object value)
+    {
+        if (value != null)
+        {
+            if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
+            {
+                throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using protocol " + this.config.getProtocol());
+            }
+
+            if (this.config.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN)
+            {
+                throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using authentication type " + this.config.getAuthenticationType());
+            }
+
+            if (value instanceof Integer)
+            {
+                this.config.setAmqpOpenAuthenticationSessionTimeout((int) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("value is not int = " + value);
+            }
+        }
+    }
+
+    void setOption_SetAmqpOpenDeviceSessionsTimeout(Object value)
+    {
+        if (value != null)
+        {
+            if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
+            {
+                throw new UnsupportedOperationException("Cannot set the open device session timeout when using protocol " + this.config.getProtocol());
+            }
+
+            if (value instanceof Integer)
+            {
+                this.config.setAmqpOpenDeviceSessionsTimeout((int) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("value is not int = " + value);
             }
         }
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -46,8 +46,6 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 {
     // Timeouts
     private static final int MAX_WAIT_TO_CLOSE_CONNECTION = 20 * 1000; // 20 second timeout
-    private static final int MAX_WAIT_TO_OPEN_AUTHENTICATION_SESSION = 20 * 1000; // 20 second timeout
-    private static final int MAX_WAIT_TO_OPEN_WORKER_SESSIONS = 60 * 1000; // 60 second timeout
     private static final int MAX_WAIT_TO_TERMINATE_EXECUTOR = 10;
 
     // Web socket constants
@@ -132,7 +130,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 this.openAsync();
 
                 log.trace("Waiting for authentication links to open...");
-                boolean authenticationSessionOpenTimedOut = !this.authenticationSessionOpenedLatch.await(MAX_WAIT_TO_OPEN_AUTHENTICATION_SESSION, TimeUnit.MILLISECONDS);
+                boolean authenticationSessionOpenTimedOut = !this.authenticationSessionOpenedLatch.await(this.deviceClientConfig.getAmqpOpenAuthenticationSessionTimeout(), TimeUnit.MILLISECONDS);
 
                 if (this.savedException != null)
                 {
@@ -145,7 +143,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 }
 
                 log.trace("Waiting for device sessions to open...");
-                boolean deviceSessionsOpenTimedOut = !this.deviceSessionsOpenedLatch.await(MAX_WAIT_TO_OPEN_WORKER_SESSIONS, TimeUnit.MILLISECONDS);
+                boolean deviceSessionsOpenTimedOut = !this.deviceSessionsOpenedLatch.await(this.deviceClientConfig.getAmqpOpenDeviceSessionsTimeout(), TimeUnit.MILLISECONDS);
 
                 if (this.savedException != null)
                 {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -130,7 +130,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 this.openAsync();
 
                 log.trace("Waiting for authentication links to open...");
-                boolean authenticationSessionOpenTimedOut = !this.authenticationSessionOpenedLatch.await(this.deviceClientConfig.getAmqpOpenAuthenticationSessionTimeout(), TimeUnit.MILLISECONDS);
+                boolean authenticationSessionOpenTimedOut = !this.authenticationSessionOpenedLatch.await(this.deviceClientConfig.getAmqpOpenAuthenticationSessionTimeout(), TimeUnit.SECONDS);
 
                 if (this.savedException != null)
                 {
@@ -143,7 +143,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 }
 
                 log.trace("Waiting for device sessions to open...");
-                boolean deviceSessionsOpenTimedOut = !this.deviceSessionsOpenedLatch.await(this.deviceClientConfig.getAmqpOpenDeviceSessionsTimeout(), TimeUnit.MILLISECONDS);
+                boolean deviceSessionsOpenTimedOut = !this.deviceSessionsOpenedLatch.await(this.deviceClientConfig.getAmqpOpenDeviceSessionsTimeout(), TimeUnit.SECONDS);
 
                 if (this.savedException != null)
                 {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -2062,7 +2062,7 @@ public class DeviceClientTest
             client.setOption("setAmqpOpenAuthenticationSessionTimeout", null);
         } catch (IllegalArgumentException expected) {
             //assert
-            assertEquals("optionValue is null", expected.getMessage());
+            assertEquals("value is null", expected.getMessage());
         }
     }
 
@@ -2242,7 +2242,7 @@ public class DeviceClientTest
             client.setOption("SetAmqpOpenDeviceSessionsTimeout", null);
         } catch (IllegalArgumentException expected) {
             //assert
-            assertEquals("optionValue is null", expected.getMessage());
+            assertEquals("value is null", expected.getMessage());
         }
     }
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -1988,6 +1988,364 @@ public class DeviceClientTest
 
     }
 
+    @Test
+    public void setAmqpOpenAuthenticationSessionTimeout()
+    {
+        //arrange
+        final int timeoutInSeconds = 10;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.AMQPS;
+
+                mockConfig.getAuthenticationType();
+                result = DeviceClientConfig.AuthType.SAS_TOKEN;
+            }
+        };
+
+        //act
+        client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+
+        //assert
+        new Verifications() {
+            {
+                Deencapsulation.invoke(mockConfig, "setAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void setAmqpWsOpenAuthenticationSessionTimeout()
+    {
+        //arrange
+        final int timeoutInSeconds = 10;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.AMQPS_WS;
+
+                mockConfig.getAuthenticationType();
+                result = DeviceClientConfig.AuthType.SAS_TOKEN;
+            }
+        };
+
+        //act
+        client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+
+        //assert
+        new Verifications() {
+            {
+                Deencapsulation.invoke(mockConfig, "setAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void setNullAmqpWsOpenAuthenticationSessionTimeoutThrows()
+    {
+        //arrange
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        try {
+            //act
+            client.setOption("setAmqpOpenAuthenticationSessionTimeout", null);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("optionValue is null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setIncorrectAmqpOpenAuthenticationSessionTimeoutThrows()
+    {
+        //arrange
+        String timeoutInSeconds = "ten";
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.AMQPS;
+
+                mockConfig.getAuthenticationType();
+                result = DeviceClientConfig.AuthType.SAS_TOKEN;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("value is not int = " + timeoutInSeconds, expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setAmqpOpenAuthenticationSessionTimeoutForHttpThrows()
+    {
+        //arrange
+        int timeoutInSeconds = 10;
+        final IotHubClientProtocol protocol = IotHubClientProtocol.HTTPS;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+        } catch (UnsupportedOperationException expected) {
+            //assert
+            assertEquals("Cannot set the open authentication session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setAmqpOpenAuthenticationSessionTimeoutForMqttThrows()
+    {
+        //arrange
+        int timeoutInSeconds = 10;
+        final IotHubClientProtocol protocol = IotHubClientProtocol.MQTT;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+        } catch (UnsupportedOperationException expected) {
+            //assert
+            assertEquals("Cannot set the open authentication session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setAmqpOpenAuthenticationSessionTimeoutForMqttWsThrows()
+    {
+        //arrange
+        int timeoutInSeconds = 10;
+        final IotHubClientProtocol protocol = IotHubClientProtocol.MQTT_WS;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+        } catch (UnsupportedOperationException expected) {
+            //assert
+            assertEquals("Cannot set the open authentication session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setAmqpOpenAuthenticationSessionTimeoutForX509Throws()
+    {
+        //arrange
+        int timeoutInSeconds = 10;
+        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
+        final DeviceClientConfig.AuthType authType = DeviceClientConfig.AuthType.X509_CERTIFICATE;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+
+                mockConfig.getAuthenticationType();
+                result = authType;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenAuthenticationSessionTimeout", timeoutInSeconds);
+        } catch (UnsupportedOperationException expected) {
+            //assert
+            assertEquals("Cannot set the open authentication session timeout when using authentication type " + authType, expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setOpenDeviceSessionsTimeout()
+    {
+        //arrange
+        final int timeoutInSeconds = 10;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.AMQPS;
+            }
+        };
+
+        //act
+        client.setOption("SetAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+
+        //assert
+        new Verifications() {
+            {
+                Deencapsulation.invoke(mockConfig, "setAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void setNullOpenDeviceSessionsTimeoutThrows()
+    {
+        //arrange
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenDeviceSessionsTimeout", null);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("optionValue is null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void setIncorrectOpenDeviceSessionsTimeoutThrows()
+    {
+        //arrange
+        String timeoutInSeconds = "ten";
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = IotHubClientProtocol.AMQPS;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("value is not int = " + timeoutInSeconds, expected.getMessage());
+        }
+    }
+
+    public void setOpenDeviceSessionsTimeoutForHttpThrows()
+    {
+        //arrange
+        String timeoutInSeconds = "ten";
+        final IotHubClientProtocol protocol = IotHubClientProtocol.HTTPS;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("Cannot set the open device session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
+    public void setOpenDeviceSessionsTimeoutForMqttThrows()
+    {
+        //arrange
+        String timeoutInSeconds = "ten";
+        final IotHubClientProtocol protocol = IotHubClientProtocol.MQTT;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("Cannot set the open device session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
+    public void setOpenDeviceSessionsTimeoutForMqttWsThrows()
+    {
+        //arrange
+        String timeoutInSeconds = "ten";
+        final IotHubClientProtocol protocol = IotHubClientProtocol.MQTT_WS;
+        DeviceClient client = Deencapsulation.newInstance(DeviceClient.class);
+        Deencapsulation.setField(client, "config", mockConfig);
+
+        new NonStrictExpectations()
+        {
+            {
+                mockConfig.getProtocol();
+                result = protocol;
+            }
+        };
+
+        try {
+            //act
+            client.setOption("SetAmqpOpenDeviceSessionsTimeout", timeoutInSeconds);
+        } catch (IllegalArgumentException expected) {
+            //assert
+            assertEquals("Cannot set the open device session timeout when using protocol " + protocol, expected.getMessage());
+        }
+    }
+
     // Tests_SRS_DEVICECLIENT_34_043: ["SetCertificateAuthority" - set the certificate to verify peer.]
     @Test
     public void setCertificateAuthoritySucceeds()

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -381,7 +381,7 @@ public class AmqpsIotHubConnectionTest {
                 new CountDownLatch(anyInt);
                 result = authLatch;
 
-                authLatch.await(anyLong, TimeUnit.MILLISECONDS);
+                authLatch.await(anyLong, TimeUnit.SECONDS);
                 result = true;
             }
         };
@@ -408,7 +408,7 @@ public class AmqpsIotHubConnectionTest {
                 new CountDownLatch(anyInt);
                 result = workerLinkLatch;
 
-                workerLinkLatch.await(anyLong, TimeUnit.MILLISECONDS);
+                workerLinkLatch.await(anyLong, TimeUnit.SECONDS);
                 result = true;
             }
         };


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/906

# Description of the problem
Adding user configurations for amqp timeouts