### PR TITLE
feat(iot-dev): Fix file upload complete notification API

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -486,7 +486,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      *          empty or not valid, or if the callback is {@code null}.
      * @throws IOException if the client cannot create a instance of the FileUpload or the transport.
      * @deprecated Use {@link #getFileUploadSasUri(FileUploadSasUriRequest)} to get the SAS URI, use the azure storage SDK to upload a file
-     * to that SAS URI, and then use {@link #completeFileUploadAsync(FileUploadCompletionNotification)} to notify Iot Hub that
+     * to that SAS URI, and then use {@link #completeFileUpload(FileUploadCompletionNotification)} to notify Iot Hub that
      * your file upload has completed, successfully or otherwise. This method does all three of these tasks for you, but has limited configuration options.
      */
     @Deprecated
@@ -537,8 +537,20 @@ public final class DeviceClient extends InternalClient implements Closeable
      * Notify IoT Hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
      * @param notification The notification details, including if the file upload succeeded.
      * @throws IOException If this HTTPS request fails to send.
+     * @deprecated This function is not actually async, so use {@link #completeFileUpload(FileUploadCompletionNotification)} to avoid confusion
      */
+    @Deprecated
     public void completeFileUploadAsync(FileUploadCompletionNotification notification) throws IOException
+    {
+        this.completeFileUpload(notification);
+    }
+
+    /**
+     * Notify IoT Hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
+     * @param notification The notification details, including if the file upload succeeded.
+     * @throws IOException If this HTTPS request fails to send.
+     */
+    public void completeFileUpload(FileUploadCompletionNotification notification) throws IOException
     {
         if (this.fileUploadTask == null)
         {

--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
@@ -157,7 +157,7 @@ public class FileUploadSample
                 // SAS URIs can be generated. If a SAS URI is not freed through this API, then it will free itself eventually
                 // based on how long SAS URIs are configured to live on your IoT Hub.
                 FileUploadCompletionNotification completionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), false);
-                client.completeFileUploadAsync(completionNotification);
+                client.completeFileUpload(completionNotification);
                 System.out.println("Failed to upload file " + fileNameList.get(index));
                 e.printStackTrace();
                 return;
@@ -168,7 +168,7 @@ public class FileUploadSample
             }
 
             FileUploadCompletionNotification completionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), true);
-            client.completeFileUploadAsync(completionNotification);
+            client.completeFileUpload(completionNotification);
 
             System.out.println("Finished file upload for file " + fileNameList.get(index));
         }

--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
@@ -106,7 +106,7 @@ public class FileUploadSimpleSample
                 // SAS URIs can be generated. If a SAS URI is not freed through this API, then it will free itself eventually
                 // based on how long SAS URIs are configured to live on your IoT Hub.
                 FileUploadCompletionNotification completionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), false);
-                client.completeFileUploadAsync(completionNotification);
+                client.completeFileUpload(completionNotification);
 
                 System.out.println("Notified IoT Hub that the SAS URI can be freed and that the file upload was a failure.");
 
@@ -118,7 +118,7 @@ public class FileUploadSimpleSample
 
             System.out.println("Notifying IoT Hub that the SAS URI can be freed and that the file upload was a success.");
             FileUploadCompletionNotification completionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), true);
-            client.completeFileUploadAsync(completionNotification);
+            client.completeFileUpload(completionNotification);
             System.out.println("Successfully notified IoT Hub that the SAS URI can be freed, and that the file upload was a success");
         }
         catch (Exception e)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -343,7 +343,7 @@ public class FileUploadTests extends IntegrationTest
         fileUploadCompletionNotification.setSuccess(true);
         fileUploadCompletionNotification.setStatusDescription("Succeed to upload to storage.");
 
-        deviceClient.completeFileUploadAsync(fileUploadCompletionNotification);
+        deviceClient.completeFileUpload(fileUploadCompletionNotification);
 
         // assert
         assertEquals(buildExceptionMessage("File upload status should be SUCCESS but was " + testInstance.fileUploadState[0].fileUploadStatus, deviceClient), SUCCESS, testInstance.fileUploadState[0].fileUploadStatus);


### PR DESCRIPTION
completeFileUploadAsync does not behave asynchronously, so the name was a mistake. Deprecating that API and creating a new one without the Async suffix

#910 