### PR TITLE
fix(iot-dev): Fix possible null pointer issue in amqp layer

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslator.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsExceptionTranslator.java
@@ -14,6 +14,13 @@ public class AmqpsExceptionTranslator
 {
     static TransportException convertFromAmqpException(ErrorCondition error)
     {
+        if (error == null)
+        {
+            TransportException t = new TransportException("An unknown transport exception occurred");
+            t.setRetryable(true);
+            return t;
+        }
+
         String exceptionCode = error.getCondition() != null ? error.getCondition().toString() : "unknown";
         String description = error.getDescription();
 


### PR DESCRIPTION
Issue #900 has an example of our AmqpsExceptionTranslator throwing a null pointer when the passed in errorCode is null. This PR adds a null check to that argument to ensure a null pointer isn't thrown there