### PR TITLE
fix(iot-dev): fix issue where edgelet hsm requests did not support http

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
@@ -199,9 +199,13 @@ public class HttpsHsmClient
         }
 
         HttpsResponse response;
-        if (this.scheme.equalsIgnoreCase(HTTPS_SCHEME) || this.scheme.equalsIgnoreCase(HTTP_SCHEME))
+        if (this.scheme.equalsIgnoreCase(HTTPS_SCHEME))
         {
             response = httpsRequest.send();
+        }
+        else if (this.scheme.equalsIgnoreCase(HTTP_SCHEME))
+        {
+            response = httpsRequest.sendAsHttpRequest();
         }
         else if (this.scheme.equalsIgnoreCase(UNIX_SCHEME))
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnection.java
@@ -68,12 +68,34 @@ public class HttpsConnection
      */
     public HttpsConnection(URL url, HttpsMethod method, final ProxySettings proxySettings) throws TransportException
     {
-        // Codes_SRS_HTTPSCONNECTION_11_022: [If the URI given does not use the HTTPS or HTTP protocol, the constructor shall throw an IllegalArgumentException.]
+        this(url, method, proxySettings, true);
+    }
+    /**
+     * Constructor. Opens a connection to the given URL. Can be HTTPS or HTTP
+     *
+     * @param url the URL for the HTTP/HTTPS connection.
+     * @param method the HTTP method (i.e. GET).
+     * @param proxySettings The proxy settings to use when connecting. If null, then no proxy will be used
+     * @param isHttps if true, then this request is an https request as opposed to an http request
+     * @throws TransportException if the connection could not be opened.
+     */
+    public HttpsConnection(URL url, HttpsMethod method, final ProxySettings proxySettings, boolean isHttps) throws TransportException
+    {
         final String protocol = url.getProtocol();
-        if (!protocol.equalsIgnoreCase("HTTPS"))
+        if (isHttps && !protocol.equalsIgnoreCase("HTTPS"))
         {
             String errMsg = String.format("Expected URL that uses protocol "
                             + "HTTPS but received one that uses "
+                            + "protocol '%s'.%n",
+                    protocol);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+
+        if (!isHttps && !protocol.equalsIgnoreCase("HTTP"))
+        {
+            String errMsg = String.format("Expected URL that uses protocol "
+                            + "HTTP but received one that uses "
                             + "protocol '%s'.%n",
                     protocol);
             throw new IllegalArgumentException(errMsg);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
@@ -115,6 +115,7 @@ public class HttpsRequest
     /**
      * Executes the HTTPS request.
      *
+     * @param isHttps if true, the request will be sent as an HTTPS request. Otherwise it will be sent as an Http request
      * @return an HTTPS response.
      *
      * @throws TransportException if the connection could not be established, or the

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequest.java
@@ -94,12 +94,40 @@ public class HttpsRequest
      */
     public HttpsResponse send() throws TransportException
     {
+        return send(true);
+    }
+
+    /**
+     * Executes the HTTPS request as an HTTP request. This method should only be called when a user supplied
+     * url contains HTTP rather than HTTPS. Currently, this only happens from the {@link com.microsoft.azure.sdk.iot.device.hsm.HttpsHsmClient}
+     * for some edge workload urls.
+     *
+     * @return an HTTPS response.
+     *
+     * @throws TransportException if the connection could not be established, or the
+     * input/output streams could not be accessed.
+     */
+    public HttpsResponse sendAsHttpRequest() throws TransportException
+    {
+        return send(false);
+    }
+
+    /**
+     * Executes the HTTPS request.
+     *
+     * @return an HTTPS response.
+     *
+     * @throws TransportException if the connection could not be established, or the
+     * input/output streams could not be accessed.
+     */
+    private HttpsResponse send(boolean isHttps) throws TransportException
+    {
         if (this.url == null)
         {
             throw new IllegalArgumentException("url cannot be null");
         }
 
-        HttpsConnection connection = new HttpsConnection(url, method, this.proxySettings);
+        HttpsConnection connection = new HttpsConnection(url, method, this.proxySettings, isHttps);
 
         for (String headerKey : headers.keySet())
         {
@@ -111,7 +139,7 @@ public class HttpsRequest
 
         connection.writeOutput(this.body);
 
-        if (this.sslContext != null)
+        if (this.sslContext != null && isHttps)
         {
             connection.setSSLContext(this.sslContext);
         }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
@@ -43,7 +43,7 @@ public class HttpsConnectionTest
 
     // Tests_SRS_HTTPSCONNECTION_11_001: [The constructor shall open a connection to the given URL.]
     @Test
-    public void constructorOpensConnection() throws IOException, TransportException
+    public void constructorOpensHttpsConnection() throws IOException, TransportException
     {
         final HttpsMethod httpsMethod = HttpsMethod.PUT;
         new NonStrictExpectations()
@@ -64,6 +64,64 @@ public class HttpsConnectionTest
                 mockUrl.openConnection();
             }
         };
+    }
+
+    @Test
+    public void constructorOpensHttpConnection() throws IOException, TransportException
+    {
+        final HttpsMethod httpsMethod = HttpsMethod.PUT;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "http";
+                mockUrl.openConnection();
+                result = mockUrlConn;
+            }
+        };
+
+        new HttpsConnection(mockUrl, httpsMethod, null, false);
+
+        new Verifications()
+        {
+            {
+                mockUrl.openConnection();
+            }
+        };
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsIfHttpsProtocolIsNotExpected() throws IOException, TransportException
+    {
+        final HttpsMethod httpsMethod = HttpsMethod.PUT;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "https";
+                mockUrl.openConnection();
+                result = mockUrlConn;
+            }
+        };
+
+        new HttpsConnection(mockUrl, httpsMethod, null, false);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void constructorThrowsIfHttpProtocolIsNotExpected() throws IOException, TransportException
+    {
+        final HttpsMethod httpsMethod = HttpsMethod.PUT;
+        new NonStrictExpectations()
+        {
+            {
+                mockUrl.getProtocol();
+                result = "http";
+                mockUrl.openConnection();
+                result = mockUrlConn;
+            }
+        };
+
+        new HttpsConnection(mockUrl, httpsMethod, null, true);
     }
 
     // Tests_SRS_HTTPSCONNECTION_11_002: [The constructor shall throw a TransportException if the connection was unable to be opened.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
@@ -30,41 +30,26 @@ public class HttpsRequestTest
 {
     // Tests_SRS_HTTPSREQUEST_11_001: [The function shall open a connection with the given URL as the endpoint.]
     @Test
-    public void constructorOpensConnection(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void constructorOpensConnection(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = new byte[0];
-        new NonStrictExpectations()
-        {
-            {
-                mockUrl.getProtocol();
-                result = "https";
-            }
-        };
-
+        final URL mockUrl = new URL("https://www.microsoft.com");
         HttpsRequest request = new HttpsRequest(mockUrl, httpsMethod, body, "");
 
         request.send();
         new Verifications()
         {
             {
-                new HttpsConnection(mockUrl, (HttpsMethod) any, null);
+                new HttpsConnection(mockUrl, (HttpsMethod) any, null, true);
             }
         };
     }
 
     @Test
-    public void sendRequestWithProxyUsesProxyFromConstructor(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl, @Mocked final ProxySettings mockProxySettings) throws TransportException
-    {
+    public void sendRequestWithProxyUsesProxyFromConstructor(@Mocked final HttpsConnection mockConn, @Mocked final ProxySettings mockProxySettings) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = new byte[0];
-        new NonStrictExpectations()
-        {
-            {
-                mockUrl.getProtocol();
-                result = "https";
-            }
-        };
+        final URL mockUrl = new URL("https://www.microsoft.com");
 
         HttpsRequest request = new HttpsRequest(mockUrl, httpsMethod, body, "", mockProxySettings);
 
@@ -72,24 +57,17 @@ public class HttpsRequestTest
         new Verifications()
         {
             {
-                new HttpsConnection(mockUrl, (HttpsMethod) any, mockProxySettings);
+                new HttpsConnection(mockUrl, (HttpsMethod) any, mockProxySettings, true);
             }
         };
     }
 
     // Tests_SRS_HTTPSREQUEST_11_002: [The function shall write the body to the connection.]
     @Test
-    public void constructorWritesBodyToConnection(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void constructorWritesBodyToConnection(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = { 1, 2, 3 };
-        new NonStrictExpectations()
-        {
-            {
-                mockUrl.getProtocol();
-                result = "https";
-            }
-        };
+        final URL mockUrl = new URL("https://www.microsoft.com");
 
         HttpsRequest request = new HttpsRequest(mockUrl, httpsMethod, body, "");
 
@@ -99,7 +77,7 @@ public class HttpsRequestTest
         new Verifications()
         {
             {
-                new HttpsConnection(mockUrl, (HttpsMethod) any, null)
+                new HttpsConnection(mockUrl, (HttpsMethod) any, null, true)
                         .writeOutput(expectedBody);
             }
         };
@@ -107,17 +85,10 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_004: [The function shall use the given HTTPS method (i.e. GET) as the request method.]
     @Test
-    public void constructorSetsHttpsMethodCorrectly(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void constructorSetsHttpsMethodCorrectly(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = new byte[0];
-        new NonStrictExpectations()
-        {
-            {
-                mockUrl.getProtocol();
-                result = "https";
-            }
-        };
+        final URL mockUrl = new URL("https://www.microsoft.com");
 
         HttpsRequest request = new HttpsRequest(mockUrl, httpsMethod, body, "");
         request.send();
@@ -125,7 +96,7 @@ public class HttpsRequestTest
         new Verifications()
         {
             {
-                new HttpsConnection((URL) any, httpsMethod, null);
+                new HttpsConnection((URL) any, httpsMethod, null, true);
             }
         };
     }
@@ -136,65 +107,6 @@ public class HttpsRequestTest
     {
         final HttpsMethod expectedMethod = HttpsMethod.GET;
         final byte[] body = new byte[0];
-        new MockUp<HttpsConnection>()
-        {
-            HttpsMethod testMethod;
-
-            @Mock
-            public void $init(URL url, HttpsMethod method, ProxySettings proxySettings)
-            {
-                this.testMethod = method;
-            }
-
-            @Mock
-            public void connect()
-            {
-                assertThat(testMethod, is(expectedMethod));
-            }
-
-            @Mock
-            public void setRequestMethod(HttpsMethod method)
-            {
-                this.testMethod = method;
-            }
-
-            // every method that is used must be manually mocked.
-            @Mock
-            public void setRequestHeader(String field, String value)
-            {
-
-            }
-
-            @Mock
-            public void writeOutput(byte[] body)
-            {
-
-            }
-
-            @Mock
-            public byte[] readInput()
-            {
-                return new byte[0];
-            }
-
-            @Mock
-            public byte[] readError()
-            {
-                return new byte[0];
-            }
-
-            @Mock
-            public int getResponseStatus()
-            {
-                return 0;
-            }
-
-            @Mock
-            public Map<String, List<String>> getResponseHeaders()
-            {
-                return new HashMap<>();
-            }
-        };
 
         URL mockUrl = new URL("https://www.microsoft.com");
 
@@ -279,7 +191,7 @@ public class HttpsRequestTest
         };
 
 
-        URL mockUrl = new URL("Http://www.microsoft.com");
+        URL mockUrl = new URL("Https://www.microsoft.com");
 
         HttpsRequest request = new HttpsRequest(mockUrl, expectedMethod, body, userAgentValue);
         request.setHeaderField(field0, value0);
@@ -360,16 +272,14 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_009: [The function shall return the HTTPS response received, including the status code, body, header fields, and error reason (if any).]
     @Test
-    public void sendReadsStatusCode(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void sendReadsStatusCode(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] body = new byte[0];
         final int status = 204;
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                mockUrl.getProtocol();
-                result = "https";
                 mockConn.getResponseStatus();
                 result = status;
             }
@@ -386,16 +296,14 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_009: [The function shall return the HTTPS response received, including the status code, body (if 200 status code), header fields, and error reason (if any).]
     @Test
-    public void sendReturnsBody(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void sendReturnsBody(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.GET;
         final byte[] requestBody = new byte[0];
         final byte[] responseBody = { 1, 2, 3, 0, 4 };
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                mockUrl.getProtocol();
-                result = "https";
                 mockConn.readInput();
                 result = responseBody;
                 mockConn.getResponseStatus();
@@ -414,8 +322,7 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_009: [The function shall return the HTTPS response received, including the status code, body, header fields, and error reason (if any).]
     @Test
-    public void sendReturnsHeaderFields(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void sendReturnsHeaderFields(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final Map<String, List<String>> headerFields = new HashMap<>();
         final String field = "test-field";
         final List<String> values = new LinkedList<>();
@@ -426,11 +333,10 @@ public class HttpsRequestTest
         headerFields.put(field, values);
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final byte[] body = new byte[0];
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                mockUrl.getProtocol();
-                result = "https";
                 mockConn.getResponseHeaders();
                 result = headerFields;
             }
@@ -447,20 +353,17 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_013: [The function shall set the header field with the given name to the given value.]
     @Test
-    public void setHeaderFieldSetsHeaderField(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void setHeaderFieldSetsHeaderField(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final byte[] body = new byte[0];
         final String field = "test-field";
         final String value = "test-value";
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                new HttpsConnection((URL) any, httpsMethod, null);
+                new HttpsConnection((URL) any, httpsMethod, null, true);
                 result = mockConn;
-
-                mockUrl.getProtocol();
-                result = "https";
             }
         };
 
@@ -478,19 +381,16 @@ public class HttpsRequestTest
 
     // Tests_SRS_HTTPSREQUEST_11_014: [The function shall set the read timeout for the request to the given value.]
     @Test
-    public void setReadTimeoutSetsReadTimeout(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void setReadTimeoutSetsReadTimeout(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final byte[] body = new byte[0];
         final int readTimeout = 1;
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                new HttpsConnection(mockUrl, httpsMethod, null);
+                new HttpsConnection(mockUrl, httpsMethod, null, true);
                 result = mockConn;
-
-                mockUrl.getProtocol();
-                result = "https";
             }
         };
 
@@ -510,19 +410,16 @@ public class HttpsRequestTest
     }
 
     @Test
-    public void setConnectTimeoutSetsConnectTimeout(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void setConnectTimeoutSetsConnectTimeout(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final byte[] body = new byte[0];
         final int readTimeout = 1;
+        final URL mockUrl = new URL("https://www.microsoft.com");
         new NonStrictExpectations()
         {
             {
-                new HttpsConnection(mockUrl, httpsMethod, null);
+                new HttpsConnection(mockUrl, httpsMethod, null, true);
                 result = mockConn;
-
-                mockUrl.getProtocol();
-                result = "https";
             }
         };
 
@@ -573,17 +470,10 @@ public class HttpsRequestTest
 
     //Tests_SRS_HTTPSREQUEST_25_015: [The function shall throw IllegalArgumentException if argument is null.]
     @Test (expected = IllegalArgumentException.class)
-    public void setSSLContextThrowsOnNull(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void setSSLContextThrowsOnNull(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         final byte[] body = new byte[0];
-        new NonStrictExpectations()
-        {
-            {
-                mockUrl.getProtocol();
-                result = "https";
-            }
-        };
+        final URL mockUrl = new URL("https://www.microsoft.com");
 
         HttpsRequest request =
                 new HttpsRequest(mockUrl, httpsMethod, body, "");
@@ -593,18 +483,18 @@ public class HttpsRequestTest
     // Tests_SRS_HTTPSREQUEST_34_020: [The function shall return the request headers saved in this object's connection instance.]
     // Tests_SRS_HTTPSREQUEST_34_017: [The function shall return the body saved in this object's connection instance.]
     @Test
-    public void gettersWork(@Mocked final HttpsConnection mockConn, final @Mocked URL mockUrl) throws TransportException
-    {
+    public void gettersWork(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         //arrange
+        final URL mockUrl = new URL("https://www.microsoft.com");
         HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.POST, "some body".getBytes(), "some user agent string");
 
-        final String expectedRequestHeaders = "User-Agent: some user agent string\r\n";
+        final String expectedRequestHeaders = "User-Agent: some user agent string\r\nHost: www.microsoft.com\r\n";
         final String expectedMethod = "POST";
         final byte[] expectedBody = "some body".getBytes();
         new NonStrictExpectations()
         {
             {
-                new HttpsConnection((URL) any, HttpsMethod.POST, null);
+                new HttpsConnection(mockUrl, HttpsMethod.POST, null, true);
                 result = mockConn;
 
                 Deencapsulation.invoke(mockConn, "getBody");
@@ -624,6 +514,34 @@ public class HttpsRequestTest
         assertEquals(expectedRequestHeaders, actualRequestHeaders);
         assertEquals(mockUrl, actualURL);
         Assert.assertArrayEquals(expectedBody, actualBody);
+    }
+
+    @Test
+    public void sendAsHttpRequestWorks(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
+        //arrange
+        final URL mockUrl = new URL("http://www.microsoft.com");
+        HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.GET, "some body".getBytes(), "some user agent string");
+
+        final String expectedRequestHeaders = "User-Agent: some user agent string\r\nHost: www.microsoft.com\r\n";
+        final String expectedMethod = "GET";
+        new Expectations()
+        {
+            {
+                new HttpsConnection(mockUrl, HttpsMethod.GET, null, false);
+                result = mockConn;
+            }
+        };
+
+        //act
+        String actualRequestHeaders = request.getRequestHeaders();
+        String actualMethod = request.getHttpMethod();
+        URL actualURL = request.getRequestUrl();
+        request.sendAsHttpRequest();
+
+        //assert
+        assertEquals(expectedMethod, actualMethod);
+        assertEquals(expectedRequestHeaders, actualRequestHeaders);
+        assertEquals(mockUrl, actualURL);
     }
 
     // Tests_SRS_HTTPSREQUEST_34_031: [The function shall save the provided arguments to be used when the http connection is built during the call to send().]


### PR DESCRIPTION
Some edgelet uris are http requests to localhosts, so the SDK needs to support that.

issue #914