### PR TITLE
E2E tests and workaround for retrofit error with null payload

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
@@ -1,0 +1,165 @@
+package tests.integration.com.microsoft.azure.sdk.iot.digitaltwin;
+
+import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
+import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.RegistryManager;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinAsyncClient;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClient;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinGetHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.BasicDigitalTwin;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinCommandResponse;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandRequestOptions;
+import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.rest.ServiceResponseWithHeaders;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.*;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import tests.integration.com.microsoft.azure.sdk.iot.digitaltwin.helpers.E2ETestConstants;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.DigitalTwinTest;
+import tests.integration.com.microsoft.azure.sdk.iot.iothub.twin.TwinPnPTests;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.UUID;
+
+import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.MQTT;
+import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.MQTT_WS;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@DigitalTwinTest
+@Slf4j
+@RunWith(Parameterized.class)
+public class DigitalTwinComponentTests extends IntegrationTest
+{
+
+    private static final String IOTHUB_CONNECTION_STRING = Tools.retrieveEnvironmentVariableValue(E2ETestConstants.IOTHUB_CONNECTION_STRING_ENV_VAR_NAME);
+    private static RegistryManager registryManager;
+    private String deviceId;
+    private DeviceClient deviceClient;
+    private DigitalTwinClient digitalTwinClient = null;
+    private static final String DEVICE_ID_PREFIX = "DigitalTwinServiceClientTests_";
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5 * 60); // 5 minutes max per method tested
+
+    @Parameterized.Parameter(0)
+    public IotHubClientProtocol protocol;
+
+    @Parameterized.Parameters(name = "{index}: Digital Twin Test: protocol={0}")
+    public static Collection<Object[]> data() {
+        return asList(new Object[][] {
+                {MQTT},
+                {MQTT_WS},
+        });
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws IOException {
+        registryManager = RegistryManager.createFromConnectionString(IOTHUB_CONNECTION_STRING);
+    }
+
+    @Before
+    public void setUp() throws URISyntaxException, IOException, IotHubException {
+
+        this.deviceClient = createDeviceClient(protocol);
+        deviceClient.open();
+        digitalTwinClient = DigitalTwinClient.createFromConnectionString(IOTHUB_CONNECTION_STRING);
+    }
+
+    @After
+    public void cleanUp() {
+        try {
+            deviceClient.closeNow();
+            registryManager.removeDevice(deviceId);
+        } catch (Exception ex) {
+            log.error("An exception occurred while closing/ deleting the device {}: {}", deviceId, ex);
+        }
+    }
+
+    private DeviceClient createDeviceClient(IotHubClientProtocol protocol) throws IOException, IotHubException, URISyntaxException {
+        ClientOptions options = new ClientOptions();
+        options.setModelId(E2ETestConstants.MODEL_ID);
+
+        this.deviceId = DEVICE_ID_PREFIX.concat(UUID.randomUUID().toString());
+        Device device = Device.createDevice(deviceId, AuthenticationType.SAS);
+        Device registeredDevice = registryManager.addDevice(device);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(registeredDevice);
+        return new DeviceClient(deviceConnectionString, protocol, options);
+    }
+
+    @AfterClass
+    public static void cleanUpAfterClass()
+    {
+        registryManager.close();
+    }
+
+    @Test
+    public void getDigitalTwin() {
+        // act
+        BasicDigitalTwin response = this.digitalTwinClient.getDigitalTwin(deviceId, BasicDigitalTwin.class);
+        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders = this.digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
+
+        // assert
+        assertEquals(response.getMetadata().getModelId(), E2ETestConstants.MODEL_ID);
+        assertEquals(responseWithHeaders.body().getMetadata().getModelId(), E2ETestConstants.MODEL_ID);
+    }
+
+    @Test
+    public void updateDigitalTwin() {
+        String digitalTwinId = "";
+    }
+
+    @Test
+    public void invokeRootLevelCommand() throws IOException {
+        // arrange
+        String commandName = "getMaxMinReport";
+        String commandInput = ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(5).format(DateTimeFormatter.ISO_DATE_TIME);
+        DigitalTwinInvokeCommandRequestOptions options = new DigitalTwinInvokeCommandRequestOptions();
+        options.setConnectTimeoutInSeconds(15);
+        options.setResponseTimeoutInSeconds(15);
+
+        // setup device callback
+        Integer deviceResponseStatus = 200;
+        String deviceResponseMessage = "Success";
+        deviceClient.subscribeToDeviceMethod(
+                // Device method callback
+                (methodName, methodData, context) -> {
+                    assertEquals(methodName, commandName);
+                    return new DeviceMethodData(deviceResponseStatus, deviceResponseMessage);
+
+                },
+                commandName,
+                // IotHub event callback
+                (responseStatus, callbackContext) -> {
+                    String command = (String) callbackContext;
+                    assertEquals(command, commandName);
+                }, commandName);
+
+        // act
+        // DigitalTwinCommandResponse responseWithoutpayload = this.digitalTwinClient.invokeCommand(deviceId, commandName);
+        DigitalTwinCommandResponse response = this.digitalTwinClient.invokeCommand(deviceId, commandName, commandInput);
+        ServiceResponseWithHeaders<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> responseWithHeaders = this.digitalTwinClient.invokeCommandWithResponse(deviceId, commandName, commandInput, options);
+
+        // assert
+        String receivedDeviceResponseStatus = "\"" + deviceResponseMessage + "\"";
+        // assertEquals(responseWithoutpayload.getStatus(), deviceResponseStatus);
+        // assertEquals(responseWithoutpayload.getPayload(), deviceResponseMessage);
+        assertEquals(deviceResponseStatus, response.getStatus());
+        assertEquals(receivedDeviceResponseStatus, response.getPayload());
+        assertEquals(deviceResponseStatus, responseWithHeaders.body().getStatus());
+        assertEquals(receivedDeviceResponseStatus, responseWithHeaders.body().getPayload());
+    }
+}

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/helpers/E2ETestConstants.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/helpers/E2ETestConstants.java
@@ -2,5 +2,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.digitaltwin.helpers;
 
 public class E2ETestConstants {
     public static final String IOTHUB_CONNECTION_STRING_ENV_VAR_NAME = "IOTHUB_CONNECTION_STRING";
-    public static final String MODEL_ID = "dtmi:com:example:Thermostat;1";
+    public static final String THERMOSTAT_MODEL_ID = "dtmi:com:example:Thermostat;1";
+    public static final String TEMPERATURE_CONTROLLER_MODEL_ID = "dtmi:com:example:TemperatureController;1";
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -164,6 +164,11 @@ public class DigitalTwinAsyncClient {
      * @throws IOException can be thrown if the provided payload cannot be deserialized into a valid Json object.
      */
     public Observable<DigitalTwinCommandResponse> invokeCommand (String digitalTwinId, String commandName, String payload) throws IOException {
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
+        }
         return invokeCommandWithResponse(digitalTwinId, commandName, payload, null)
                 .map(response -> response.body());
     }
@@ -183,13 +188,13 @@ public class DigitalTwinAsyncClient {
             options = new DigitalTwinInvokeCommandRequestOptions();
         }
 
-        Object payloadAsObject = null;
-        if(payload != null)
+        // Retrofit does not work well with null in body
+        if(payload == null)
         {
-            payloadAsObject = objectMapper.readValue(payload, Object.class);
+            payload = "";
         }
 
-        return digitalTwin.invokeRootLevelCommandWithServiceResponseAsync(digitalTwinId, commandName, payloadAsObject, options.getConnectTimeoutInSeconds(), options.getResponseTimeoutInSeconds())
+        return digitalTwin.invokeRootLevelCommandWithServiceResponseAsync(digitalTwinId, commandName, payload, options.getConnectTimeoutInSeconds(), options.getResponseTimeoutInSeconds())
                 .flatMap(FUNC_TO_DIGITAL_TWIN_COMMAND_RESPONSE);
     }
 
@@ -216,6 +221,12 @@ public class DigitalTwinAsyncClient {
      * @throws IOException can be thrown if the provided payload cannot be deserialized into a valid Json object.
      */
     public Observable<DigitalTwinCommandResponse> invokeComponentCommand(String digitalTwinId, String componentName, String commandName, String payload) throws IOException {
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
+        }
+
         return invokeComponentCommandWithResponse(digitalTwinId, componentName, commandName, payload, null)
                 .map(response -> response.body());
     }
@@ -236,13 +247,13 @@ public class DigitalTwinAsyncClient {
             options = new DigitalTwinInvokeCommandRequestOptions();
         }
 
-        Object payloadAsObject = null;
-        if(payload != null)
+        // Retrofit does not work well with null in body
+        if(payload == null)
         {
-            payloadAsObject = objectMapper.readValue(payload, Object.class);
+            payload = "";
         }
 
-        return digitalTwin.invokeComponentCommandWithServiceResponseAsync(digitalTwinId, componentName, commandName, payloadAsObject, options.getConnectTimeoutInSeconds(), options.getResponseTimeoutInSeconds())
+        return digitalTwin.invokeComponentCommandWithServiceResponseAsync(digitalTwinId, componentName, commandName, payload, options.getConnectTimeoutInSeconds(), options.getResponseTimeoutInSeconds())
                 .flatMap(FUNC_TO_DIGITAL_TWIN_COMPONENT_COMMAND_RESPONSE);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -129,6 +129,12 @@ public class DigitalTwinClient {
      * @throws IOException can be thrown if the provided payload cannot be deserialized into a valid Json object.
      */
     public DigitalTwinCommandResponse invokeCommand(String digitalTwinId, String commandName, String payload) throws IOException {
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
+        }
+
         return invokeCommandWithResponse(digitalTwinId, commandName, payload, null).body();
     }
 
@@ -145,6 +151,12 @@ public class DigitalTwinClient {
         if(options == null)
         {
             options = new DigitalTwinInvokeCommandRequestOptions();
+        }
+
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
         }
 
         return digitalTwinAsyncClient.invokeCommandWithResponse(digitalTwinId, commandName, payload, options)
@@ -173,6 +185,12 @@ public class DigitalTwinClient {
      * @throws IOException can be thrown if the provided payload cannot be deserialized into a valid Json object.
      */
     public DigitalTwinCommandResponse invokeComponentCommand(String digitalTwinId, String componentName, String commandName, String payload) throws IOException {
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
+        }
+
         return invokeComponentCommandWithResponse(digitalTwinId, componentName, commandName, payload, null).body();
     }
 
@@ -190,6 +208,12 @@ public class DigitalTwinClient {
         if(options == null)
         {
             options = new DigitalTwinInvokeCommandRequestOptions();
+        }
+
+        // Retrofit does not work well with null in body
+        if(payload == null)
+        {
+            payload = "";
         }
 
         return digitalTwinAsyncClient.invokeComponentCommandWithResponse(digitalTwinId, componentName, commandName, payload, options)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/models/DigitalTwinMetadata.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/models/DigitalTwinMetadata.java
@@ -18,7 +18,7 @@ public final class DigitalTwinMetadata {
 
     /* Model-defined writable properties' request state. */
     @JsonIgnore
-    private final Map<String, Object> writeableProperties = new HashMap<>();
+    private final Map<String, WritableProperty> writeableProperties = new HashMap<>();
 
     /**
      * Creates an instance of digital twin metadata.
@@ -50,7 +50,7 @@ public final class DigitalTwinMetadata {
      * @return The model-defined writable properties' request state.
      */
     @JsonAnyGetter
-    public Map<String, Object> getWriteableProperties() {
+    public Map<String, WritableProperty> getWriteableProperties() {
         return writeableProperties;
     }
 
@@ -59,7 +59,7 @@ public final class DigitalTwinMetadata {
      * @return The DigitalTwinMetadata object itself.
      */
     @JsonAnySetter
-    DigitalTwinMetadata setWritableProperties(String key, Object value) {
+    DigitalTwinMetadata setWritableProperties(String key, WritableProperty value) {
         this.writeableProperties.put(key, value);
         return this;
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
Add E2E tests other than update
Fixed retrofit error for null payloads