### PR TITLE
release(2020-10-01): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.25.0";
+    private static final String CLIENT_VERSION = "1.26.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.25.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.26.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.25.0</iot-device-client-version>
-        <iot-service-client-version>1.25.0</iot-service-client-version>
-        <iot-deps-version>0.10.0</iot-deps-version>
-        <provisioning-device-client-version>1.8.3</provisioning-device-client-version>
-        <provisioning-service-client-version>1.6.2</provisioning-service-client-version>
+        <iot-device-client-version>1.26.0</iot-device-client-version>
+        <iot-service-client-version>1.26.0</iot-service-client-version>
+        <iot-deps-version>0.11.0</iot-deps-version>
+        <provisioning-device-client-version>1.8.4</provisioning-device-client-version>
+        <provisioning-service-client-version>1.7.0</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.3";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.4";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.6.2";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.25.0";
+    public static String serviceVersion = "1.26.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
release(2020-10-01): bump package versions

old:
{
    "device": "1.25.0",
    "service": "1.25.0",
    "deps": "0.10.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.3",
    "provisioningService": "1.6.2"
}
new:
{
    "device": "1.26.0",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.4",
    "provisioningService": "1.7.0"
}

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.26.0)

- Add a new client (DigitalTwinClient) to support operations against Digital Twin. Digital Twin APIs operate on high-level constructs in the Digital Twins Definition Language (DTDL) such as components, properties, and commands. The Digital Twin APIs make it easier for solution builders to create IoT Plug and Play solutions. ([#918](https://github.com/Azure/azure-iot-sdk-java/pull/918))
- Add model Id support for Twins ([#822](https://github.com/Azure/azure-iot-sdk-java/pull/822))
- Make http connect and read timeouts configurable on twin and methods clients ([#878](https://github.com/Azure/azure-iot-sdk-java/pull/878))

### Bug fixes

- Fix issue where cloud to device messages with no payload would cause NPE when sent ([#922](https://github.com/Azure/azure-iot-sdk-java/pull/922))

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.26.0)

- Added synchronous file upload completion API and deprecated asynchronous file upload completion API since it was not asynchronous ([#911](https://github.com/Azure/azure-iot-sdk-java/pull/911))

### Bug fixes
- Fix issue where edgelet hsm requests did not support http ([#921](https://github.com/Azure/azure-iot-sdk-java/pull/921))
- Fix possible null pointer issue in amqp layer ([#915](https://github.com/Azure/azure-iot-sdk-java/pull/915), [#901](https://github.com/Azure/azure-iot-sdk-java/pull/901))

## Java Iot Deps (com.microsoft.azure.sdk.iot:iot-deps:1.11.0)

- Add model Id support for Twins ([#822](https://github.com/Azure/azure-iot-sdk-java/pull/822))

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.4)

- Updated reference to com.microsoft.azure.sdk.iot:iot-deps:1.11.0.

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.7.0)

- Add APIs for getAttestationMechanism for individual and group enrollments ([#677](https://github.com/Azure/azure-iot-sdk-java/pull/677))
- Add a Pnp helper class for formatting the DPS device registration payload, per plug and play convention. ([#918](https://github.com/Azure/azure-iot-sdk-java/pull/918))