### PR TITLE
refactor(e2e): Add longer amqp open timeouts to device clients in e2e tests

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -745,6 +745,8 @@ public final class DeviceClient extends InternalClient implements Closeable
             case SET_RECEIVE_INTERVAL:
             case SET_HTTPS_CONNECT_TIMEOUT:
             case SET_HTTPS_READ_TIMEOUT:
+            case SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT:
+            case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
             {
                 break;
             }
@@ -812,16 +814,6 @@ public final class DeviceClient extends InternalClient implements Closeable
                     setOption_SetSASTokenExpiryTime(value);
                     return;
                 }
-            }
-            case SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT:
-            {
-                setOption_SetAmqpOpenAuthenticationSessionTimeout(value);
-                return;
-            }
-            case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
-            {
-                setOption_SetAmqpOpenDeviceSessionsTimeout(value);
-                return;
             }
             default:
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -440,6 +440,16 @@ public class InternalClient
      *         made by this client. By default, this value is 0 (no connect timeout).
      *         The value is expected to be of type {@code int}.
      *
+     *      - <b>SetAmqpOpenAuthenticationSessionTimeout</b> - this option is applicable for AMQP with SAS token authentication.
+     *         This option specifies the timeout in seconds to wait to open the authentication session.
+     *         By default, this value is 20 seconds.
+     *         The value is expected to be of type {@code int}.
+     *
+     *      - <b>SetAmqpOpenDeviceSessionsTimeout</b> - this option is applicable for AMQP.
+     *         This option specifies the timeout in seconds to open the device sessions.
+     *         By default, this value is 60 seconds.
+     *         The value is expected to be of type {@code int}.
+     *
      * @param optionName the option name to modify
      * @param value an object of the appropriate type for the option's value
      * @throws IllegalArgumentException if the provided optionName is null

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -543,6 +543,16 @@ public class InternalClient
                     setOption_SetHttpsReadTimeout(value);
                     break;
                 }
+                case SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT:
+                {
+                    setOption_SetAmqpOpenAuthenticationSessionTimeout(value);
+                    return;
+                }
+                case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
+                {
+                    setOption_SetAmqpOpenDeviceSessionsTimeout(value);
+                    return;
+                }
                 default:
                 {
                     throw new IllegalArgumentException("optionName is unknown = " + optionName);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IntegrationTest.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/IntegrationTest.java
@@ -76,4 +76,8 @@ public abstract class IntegrationTest
 
     // Infinite read timeout for all http operations
     public static int HTTP_READ_TIMEOUT = 0;
+
+    // Amqp specific timeout values for waiting on authentication/device sessions to open
+    public static int AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS = 4 * 60;
+    public static int AMQP_DEVICE_SESSION_TIMEOUT_SECONDS = 4 * 60;
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -222,8 +222,11 @@ public class DeviceMethodCommon extends IntegrationTest
                 }
             }
 
-            this.deviceTestManager.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
-            this.deviceTestManager.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+            if ((this.protocol == AMQPS || this.protocol == AMQPS_WS) && this.authenticationType == SAS)
+            {
+                this.deviceTestManager.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+                this.deviceTestManager.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+            }
 
             Thread.sleep(2000);
         }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -222,6 +222,9 @@ public class DeviceMethodCommon extends IntegrationTest
                 }
             }
 
+            this.deviceTestManager.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+            this.deviceTestManager.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+
             Thread.sleep(2000);
         }
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -340,6 +340,9 @@ public class DeviceTwinCommon extends IntegrationTest
                 }
             }
 
+            internalClient.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+            internalClient.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+
             if (openDeviceClient)
             {
                 internalClient.open();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -340,9 +340,11 @@ public class DeviceTwinCommon extends IntegrationTest
                 }
             }
 
-            internalClient.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
-            internalClient.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
-
+            if ((this.testInstance.protocol == AMQPS || this.testInstance.protocol == AMQPS_WS) && this.testInstance.authenticationType == SAS)
+            {
+                internalClient.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+                internalClient.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+            }
             if (openDeviceClient)
             {
                 internalClient.open();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
@@ -204,6 +204,9 @@ public class ReceiveMessagesCommon extends IntegrationTest
                 {
                     throw new Exception("Test code has not been written for this path yet");
                 }
+
+                this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+                this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
             }
 
             testInstance.serviceClient.open();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
@@ -205,8 +205,11 @@ public class ReceiveMessagesCommon extends IntegrationTest
                     throw new Exception("Test code has not been written for this path yet");
                 }
 
-                this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
-                this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+                if ((this.protocol == AMQPS || this.protocol == AMQPS_WS) && this.authenticationType == SAS)
+                {
+                    this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+                    this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+                }
             }
 
             testInstance.serviceClient.open();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -378,6 +378,10 @@ public class SendMessagesCommon extends IntegrationTest
         public void openConnection() throws IOException, URISyntaxException, InterruptedException
         {
             client = new DeviceClient(connString, protocol);
+
+            this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+            this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+
             client.open();
         }
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -295,6 +295,12 @@ public class SendMessagesCommon extends IntegrationTest
                 }
             }
 
+            if ((this.protocol == AMQPS || this.protocol == AMQPS_WS) && this.authenticationType == SAS)
+            {
+                this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
+                this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
+            }
+
             if (this.useHttpProxy)
             {
                 Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
@@ -378,10 +384,6 @@ public class SendMessagesCommon extends IntegrationTest
         public void openConnection() throws IOException, URISyntaxException, InterruptedException
         {
             client = new DeviceClient(connString, protocol);
-
-            this.client.setOption("SetAmqpOpenAuthenticationSessionTimeout", AMQP_AUTHENTICATION_SESSION_TIMEOUT_SECONDS);
-            this.client.setOption("SetAmqpOpenDeviceSessionsTimeout", AMQP_DEVICE_SESSION_TIMEOUT_SECONDS);
-
             client.open();
         }
 


### PR DESCRIPTION
Opening a device client can sometimes fail due to the client taking too long to get a device session or authentication session established. This PR lengthens these timeouts from the restrictive default values.