### PR TITLE
release(2020-10-15): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client-preview";
-    private static final String CLIENT_VERSION = "1.1.0";
+    private static final String CLIENT_VERSION = "1.27.0-preview-001";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
         <digital-twin-device-client-artifact-id>digital-twin-device-client-preview</digital-twin-device-client-artifact-id>
         <digital-twin-service-client-artifact-id>digital-twin-service-client-preview</digital-twin-service-client-artifact-id>
         
-        <iot-device-client-version>1.1.0</iot-device-client-version>
-        <iot-service-client-version>1.1.0</iot-service-client-version>
+        <iot-device-client-version>1.27.0-preview-001</iot-device-client-version>
+        <iot-service-client-version>1.27.0-preview-001</iot-service-client-version>
         <iot-deps-version>1.1.0</iot-deps-version>
         <provisioning-device-client-version>1.0.1</provisioning-device-client-version>
-        <provisioning-service-client-version>1.0.1</provisioning-service-client-version>
+        <provisioning-service-client-version>1.8.0-preview-001</provisioning-service-client-version>
         <security-provider-version>1.0.1</security-provider-version>
         <tpm-provider-emulator-version>1.0.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.0.1</tpm-provider-version>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client-preview/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.0.1";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.8.0-preview-001";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client-preview/";
-    public static String serviceVersion = "1.1.0";
+    public static String serviceVersion = "1.27.0-preview-001";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.27.0-preview-001)

- Updated API version for IoTHub service to support plug-and-play features ([#968](https://github.com/Azure/azure-iot-sdk-java/pull/968))
- Add a new client (DigitalTwinClient) to support operations against Digital Twin. Digital Twin APIs operate on high-level constructs in the Digital Twins Definition Language (DTDL) such as components, properties, and commands. The Digital Twin APIs make it easier for solution builders to create IoT Plug and Play solutions. ([#918](https://github.com/Azure/azure-iot-sdk-java/pull/918))
- Make http connect and read timeouts configurable on twin and methods clients ([#878](https://github.com/Azure/azure-iot-sdk-java/pull/878))

### Bug fixes

- Fix issue where cloud to device messages with no payload would cause NPE when sent ([#922](https://github.com/Azure/azure-iot-sdk-java/pull/922))
- Fix charset bug in IotHubServiceSasToken buildToken method ([#890](https://github.com/Azure/azure-iot-sdk-java/pull/890)). 


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.27.0-preview-001)

- Updated API version for IoTHub service to support plug-and-play features ([#968](https://github.com/Azure/azure-iot-sdk-java/pull/968))
- Added synchronous file upload completion API and deprecated asynchronous file upload completion API since it was not asynchronous ([#911](https://github.com/Azure/azure-iot-sdk-java/pull/911))
- Add support for batch event messages for HTTPS protocol ([#889](https://github.com/Azure/azure-iot-sdk-java/pull/889)).

### Bug fixes
- Fix issue where edgelet hsm requests did not support http ([#921](https://github.com/Azure/azure-iot-sdk-java/pull/921))
- Fix possible null pointer issue in amqp layer ([#915](https://github.com/Azure/azure-iot-sdk-java/pull/915), [#901](https://github.com/Azure/azure-iot-sdk-java/pull/901))
- Fix issue where amqp layer ignored delivery state of sent messages ([#888](https://github.com/Azure/azure-iot-sdk-java/pull/888))
- Fix issue where errors encountered at http message level were handled twice ([#891](https://github.com/Azure/azure-iot-sdk-java/pull/891))
- Fix device client not sending user agent string with proxy tunnel request ([#871](https://github.com/Azure/azure-iot-sdk-java/pull/871))
- Change thread scheduling pattern in deviceIO layer ([#869](https://github.com/Azure/azure-iot-sdk-java/pull/869))
- Fix issue with ordering of queue within amqp layer ([#858](https://github.com/Azure/azure-iot-sdk-java/pull/858))
- Fix issue where re-queued messages don't wake up the send thread ([#893](https://github.com/Azure/azure-iot-sdk-java/pull/893))

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.8.0-preview-001)

- Add APIs for getAttestationMechanism for individual and group enrollments ([#677](https://github.com/Azure/azure-iot-sdk-java/pull/677))
- Add a Pnp helper class for formatting the DPS device registration payload, per plug and play convention. ([#918](https://github.com/Azure/azure-iot-sdk-java/pull/918))

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.27.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.27.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.8.0-preview-001/jar