### PR TITLE
Fixing script to generate gh-pages in correct folder

### DIFF
--- a/vsts/generate_javadocs_branch.ps1
+++ b/vsts/generate_javadocs_branch.ps1
@@ -15,7 +15,7 @@ function TestLastExitCode {
     }
 }
 
-function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources) {
+function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources, $FolderName) {
     if ($([string]::IsNullOrWhiteSpace($GitHubName) -eq $true)) {
         throw "GitHubName is null or empty"
     }
@@ -95,6 +95,19 @@ function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources) {
 
     Copy-Item -Force -Path .\provisioning\security\x509-provider\* -Destination ..\provisioning\security\x509-provider
     Copy-Item -Recurse -Force -Path .\provisioning\security\x509-provider\com -Destination ..\provisioning\security\x509-provider
+
+    # Create the folder to place content in if it does not exist.
+    if (Test-Path ..\$FolderName)
+    {
+        Remove-Item ../$FolderName -Recurse
+    }
+
+    # Move the generated content to the correct folder. The folder will be different for master and preview branches.
+    New-Item -Path ../$FolderName -ItemType Directory
+    Move-Item -Force -Path ..\deps -Destination ..\$FolderName\deps
+    Move-Item -Force -Path ..\device -Destination ..\$FolderName\device
+    Move-Item -Force -Path ..\service -Destination ..\$FolderName\provisioning
+    Move-Item -Force -Path ..\provisioning -Destination ..\$FolderName\service
 
     Set-Location ..
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
This script is use in a pipeline to autogenerate the content for java docs. They will not be placed in corresponding master/preview folders. The pipeline will be updated after the change is checked in.