### PR TITLE
feat(javadocs): Adding links to preview APIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
           <li><a href="https://github.com/Azure/azure-iot-sdk-java/tarball/master">Download <strong>TAR ball</strong></a></li>
           <li><a href="https://github.com/Azure/azure-iot-sdk-java">View on <strong>GitHub</strong></a></li>
         </ul>
+        <ul>
+          <li><a href="https://github.com/Azure/azure-iot-sdk-java/zipball/preview">Download <strong>Preview ZIP file</strong></a></li>
+          <li><a href="https://github.com/Azure/azure-iot-sdk-java/tarball/preview">Download <strong>Preview TAR ball</strong></a></li>
+          <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview">View on <strong>Preview GitHub</strong></a></li>
+        </ul>
       </header>
       <section>
         <h1>
@@ -43,11 +48,12 @@
     <li><a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-what-is-iot-hub">What is Azure IoT Hub</a></li>
     <li><a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-java-java-getstarted">Get started with Azure IoT Hub (Java)</a></li>
     <li><a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-management-overview">Overview of device management with Azure IoT Hub</a></li>
+    <li><a href="https://docs.microsoft.com/en-us/azure/iot-pnp/quickstart-connect-device-java">Get started with Plug and Play</a></li>
   </ul>
 </p>
 
 <p>
-  These links will take you to the Azure IoT Hub SDKs for Java API reference documentation 
+  These links will take you to the latest Azure IoT Hub SDKs for Java API reference documentation 
   <ul>
     <li><a href="master/device">Azure IoT Hub Device SDK for Java API reference</a></li>
     <li><a href="master/service">Azure IoT Hub Service SDK for Java API reference</a></li>
@@ -60,7 +66,7 @@
 </p>
 
 <p>
-  The source code of the Azure IoT SDKs for Java and associated tools can be found on Github:
+  The source code of the latest Azure IoT SDKs for Java and associated tools can be found on Github:
   <ul>
     <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/master/device">Azure IoT Hub Device SDK Source Code</a></li>
     <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/master/service">Azure IoT Hub Service SDK Source Code</a></li>
@@ -69,6 +75,34 @@
     <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/master/provisioning/security/security-provider">Azure IoT Hub Security Provider SDK Source Code</a></li>
     <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/master/provisioning/security/tpm-provider">Azure IoT Hub TPM Provider SDK Source Code</a></li>
     <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/master/provisioning/security/x509-provider">Azure IoT Hub X509 Provider SDK Source Code</a></li>
+    <li><a href="https://github.com/Azure/iothub-explorer">iothub-explorer</a></li>
+    <li><a href="https://github.com/Azure/iothub-diagnostics">iothub-diagnostics</a></li>
+  </ul>
+</p>
+
+<p>
+  These links will take you to the latest <a style="color:red">(Preview)</a> Azure IoT Hub SDKs for Java API reference documentation</a>
+  <ul>
+    <li><a href="preview/device">Azure IoT Hub Device SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/service">Azure IoT Hub Service SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/provisioning/provisioning-device-client">Azure IoT Hub Provisioning Dervice SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/provisioning/provisioning-service-client">Azure IoT Hub Provisioning Service SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/provisioning/security/security-provider">Azure IoT Hub Security Provider SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/provisioning/security/tpm-provider">Azure IoT Hub TPM Provider SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="preview/provisioning/security/x509-provider">Azure IoT Hub X509 Provider SDK for Java API reference</a><a style="color:red"> (Preview)</a></li>
+  </ul>
+</p>
+
+<p>
+  The source code of the latest <a style="color:red">(Preview)</a> Azure IoT SDKs for Java and associated tools can be found on Github:
+  <ul>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/device">Azure IoT Hub Device SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/service">Azure IoT Hub Service SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+	<li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/provisioning/provisioning-device-client">Azure Provisioning Device Client SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/provisioning/provisioning-service-client">Azure Provisioning Service Client SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/provisioning/security/security-provider">Azure IoT Hub Security Provider SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/provisioning/security/tpm-provider">Azure IoT Hub TPM Provider SDK Source Code</a><a style="color:red"> (Preview)</a></li>
+    <li><a href="https://github.com/Azure/azure-iot-sdk-java/tree/preview/provisioning/security/x509-provider">Azure IoT Hub X509 Provider SDK Source Code</a><a style="color:red"> (Preview)</a></li>
     <li><a href="https://github.com/Azure/iothub-explorer">iothub-explorer</a></li>
     <li><a href="https://github.com/Azure/iothub-diagnostics">iothub-diagnostics</a></li>
   </ul>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
This update should display links to preview API versions in gh-pages website.
It will look like this - https://vinagesh.github.io/azure-iot-sdk-java/

![image](https://user-images.githubusercontent.com/14096264/97236976-7aa9f980-17a3-11eb-83b7-b805d67cad29.png)

