### PR TITLE
Multiplexing samples: Device Client Manager and Multiplexing client manager

### DIFF
--- a/device/iot-device-samples/multiplexing-sample/pom.xml
+++ b/device/iot-device-samples/multiplexing-sample/pom.xml
@@ -9,21 +9,42 @@
     <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
     <artifactId>multiplexing-sample</artifactId>
     <name>Multiplexing Client Sample</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j-version>1.7.25</slf4j-version>
+        <lombok-version>1.18.8</lombok-version>
+        <maven-jar-plugin-version>3.1.0</maven-jar-plugin-version>
+    </properties>
     <developers>
         <developer>
             <id>microsoft</id>
             <name>Microsoft</name>
         </developer>
     </developers>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j-version}</version>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven-jar-plugin-version}</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -1,6 +1,5 @@
 package samples.com.microsoft.azure.sdk.iot;
 
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
 import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason;
 import com.microsoft.azure.sdk.iot.device.exceptions.DeviceOperationTimeoutException;
@@ -10,100 +9,83 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
-import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.NO_NETWORK;
 import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.RETRY_EXPIRED;
 import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.DISCONNECTED;
-import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.DISCONNECTED_RETRYING;
 
 /**
  * This is the base class for DeviceClientManager and MultiplexingClientManager
- * The shared logic for reconnection and handling status change call back exists here.
+ * The shared logic for reconnection and handling status change callback exists here.
  */
 @Slf4j
-public abstract class ClientManagerBase implements IotHubConnectionStatusChangeCallback {
-
-    protected enum ConnectionStatus {
-        DISCONNECTED, CONNECTING, CONNECTED
-    }
-    
-    protected static final Object lock = new Object();
+public abstract class ClientManagerBase implements IotHubConnectionStatusChangeCallback, ConnectionStatusTracker
+{
     protected static final int SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS = 2;
-    protected ConnectionStatus connectionStatus;
-    protected Pair<IotHubConnectionStatusChangeCallback, Object> suppliedConnectionStatusChangeCallback;
+
+    // Initialize the connection status as DISCONNECTED
+    protected ConnectionStatus lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
+
+    protected ConnectionStatusTracker dependencyConnectionStatusTracker;
 
     public abstract void openClient() throws IOException;
     public abstract void closeClient() throws IOException;
     public abstract String getClientId();
 
-    public void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext) {
-        if (callback != null) {
-            this.suppliedConnectionStatusChangeCallback = new Pair<>(callback, callbackContext);
-        } else {
-            this.suppliedConnectionStatusChangeCallback = null;
-        }
+    // Since the client manager is in charge of handling the connection status callback, this method is a no-op
+    public void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext)
+    {
+        return;
     }
 
-    public void doConnect() throws IOException {
-        // Device client does not have retry on the initial open() call. Will need to be re-opened by the calling application
-        while (connectionStatus == ConnectionStatus.CONNECTING) {
-            synchronized (lock) {
-                if(connectionStatus == ConnectionStatus.CONNECTING) {
-                    try {
-                        log.debug("Opening the device client instance " + getClientId() + " ...");
-                        openClient();
-                        connectionStatus = ConnectionStatus.CONNECTED;
-                        break;
-                    }
-                    catch (Exception ex) {
-                        if (ex.getCause() instanceof TransportException && ((TransportException) ex.getCause()).isRetryable()) {
-                            log.warn("Transport exception thrown while opening DeviceClient instance " + getClientId() + ", retrying: ", ex);
-                        } else {
-                            log.error("Non-retryable exception thrown while opening DeviceClient instance " + getClientId() + ": ", ex);
-                            connectionStatus = ConnectionStatus.DISCONNECTED;
-                            throw ex;
-                        }
-                    }
-                }
-            }
-
-            try {
-                log.debug("Sleeping for " + SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS + " secs before attempting another open()");
-                Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
-            }
-            catch (InterruptedException ex) {
-                throw new RuntimeException("Interrupted while waiting between attempting to open the client: ", ex);
-            }
-        }
-    }
-
-    public void closeNow() {
-        synchronized (lock) {
-            try {
+    public void closeNow()
+    {
+        synchronized (lastKnownConnectionStatus)
+        {
+            try
+            {
                 log.debug("Closing the client instance " + getClientId() + " ...");
                 closeClient();
             }
-            catch (IOException e) {
-                log.error("Exception thrown while closing client instance " + getClientId() + " : ", e);
-            } finally {
-                connectionStatus = ConnectionStatus.DISCONNECTED;
+            catch (IOException ex)
+            {
+                log.error("Exception thrown while closing client instance " + getClientId() + " : ", ex);
+            }
+            finally
+            {
+                // Once the connection is closed, set the Status to DISCONNECTED
+                lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
             }
         }
     }
 
-    public void open() throws IOException {
-        synchronized (lock) {
-            if(connectionStatus == ConnectionStatus.DISCONNECTED) {
-                connectionStatus = ConnectionStatus.CONNECTING;
-            } else {
+    // When client manager is being opened it first makes sure the client is in a DISCONNECTED state
+    // If the client is in CONNECTING or CONNECTED state, Open will be no-op.
+    public void open() throws IOException
+    {
+        synchronized (lastKnownConnectionStatus)
+        {
+            // Do not attempt to CONNECT if the connection status is not DISCONNECTED. This ensure that only one process is going to attempt to connect
+            if (lastKnownConnectionStatus != ConnectionStatus.DISCONNECTED)
+            {
                 return;
             }
+            else
+            {
+                // Set the connection status to CONNECTING
+                lastKnownConnectionStatus = ConnectionStatus.CONNECTING;
+            }
         }
-        doConnect();
+
+        establishConnection();
     }
 
     @Override
-    public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext) {
-        Pair<IotHubConnectionStatusChangeCallback, Object> suppliedCallbackPair = this.suppliedConnectionStatusChangeCallback;
+    public ConnectionStatus getConnectionStatus(){
+        return this.lastKnownConnectionStatus;
+    }
+
+    @Override
+    public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
+    {
         if (throwable == null)
         {
             log.info("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason);
@@ -114,52 +96,122 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
             throwable.printStackTrace();
         }
 
-        if (shouldDeviceReconnect(status, statusChangeReason, throwable)) {
-            if (suppliedCallbackPair != null) {
-                suppliedCallbackPair.getKey().execute(DISCONNECTED_RETRYING, NO_NETWORK, throwable, suppliedCallbackPair.getValue());
-            }
-
+        if (shouldDeviceReconnect(status, statusChangeReason, throwable))
+        {
             handleRecoverableDisconnection();
-        } else if (suppliedCallbackPair != null) {
-            suppliedCallbackPair.getKey().execute(status, statusChangeReason, throwable, suppliedCallbackPair.getValue());
         }
     }
 
-    // This handles the state where the DeviceClient reports that OperationTimeout has expired, and stops retrying; even though the applied RetryPolicy is still valid.
-    protected boolean shouldDeviceReconnect(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable) {
+    // This detects the state where the DeviceClient reports that OperationTimeout has expired, and stops retrying; even though the applied RetryPolicy is still valid.
+    // The logic to identify whether or not the connection should be established lives in this method.
+    // The client will automatically retry to establish the connection if the error is retryable
+    protected boolean shouldDeviceReconnect(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable)
+    {
         return (status == DISCONNECTED && statusChangeReason == RETRY_EXPIRED && throwable instanceof DeviceOperationTimeoutException);
     }
 
+    // We only expect the connection status to be CONNECTED by the time we enter this state.
     public void handleRecoverableDisconnection() {
-        synchronized (lock) {
-            if (connectionStatus == ConnectionStatus.CONNECTED) {
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        log.debug("Attempting reconnect for client: " + getClientId() + " ...");
-                        synchronized (lock) {
-                            if (connectionStatus == ConnectionStatus.CONNECTED) {
-                                try {
-                                    closeClient();
-                                } catch (Exception e) {
-                                    log.warn("Client " + getClientId() + " closeNow failed.", e);
-                                } finally {
-                                    connectionStatus = ConnectionStatus.CONNECTING;
-                                }
-                            } else {
-                                log.debug("Client `" + getClientId() + "` is currently connecting, or already connected; skipping...");
-                                return;
+        // If the lastKnownConnectionStatus is not in a CONNECTED state it can mean two things:
+        // 1: the status is CONNECTING, in which case there is nothing to be done.
+        // 2: the status is DISCONNECTED, in which case connection cannot be re-established.
+        if (lastKnownConnectionStatus == ConnectionStatus.CONNECTED)
+        {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    log.debug("Attempting reconnect for client: " + getClientId() + " ...");
+                    synchronized (lastKnownConnectionStatus)
+                    {
+                        if (lastKnownConnectionStatus == ConnectionStatus.CONNECTED)
+                        {
+                            try
+                            {
+                                closeClient();
+                            }
+                            catch (Exception ex)
+                            {
+                                log.warn("Client " + getClientId() + " closeNow failed.", ex);
+                            }
+                            finally
+                            {
+                                lastKnownConnectionStatus = ConnectionStatus.CONNECTING;
                             }
                         }
-                        try {
-                            doConnect();
-                        } catch (IOException e) {
-                            log.error("Exception thrown while opening client instance: " + getClientId(), e);
+                        else
+                        {
+                            log.debug("Client `" + getClientId() + "` is currently connecting; skipping...");
+                            return;
                         }
                     }
-                }).start();
-            } else {
-                connectionStatus = ConnectionStatus.DISCONNECTED;
+
+                    // The client is now closed and the connection status is CONNECTING. Connection can be established now.
+                    try
+                    {
+                        establishConnection();
+                    }
+                    catch (IOException ex)
+                    {
+                        log.error("Exception thrown while opening client instance: " + getClientId(), ex);
+                    }
+                }
+            }).start();
+        }
+    }
+
+    public void establishConnection() throws IOException
+    {
+        // Device client does not have retry on the initial open() call. Will need to be re-opened by the calling application
+        // Lock the lastKnownConnectionStus so no other process will be able to change it while the client manager is attempting to open the connection.
+        synchronized (lastKnownConnectionStatus)
+        {
+            while (lastKnownConnectionStatus == ConnectionStatus.CONNECTING)
+            {
+                // If the client has dependencies to another client (in this case it could be the multiplexing client) we have to wait to make sure the
+                // dependent connection is established first.
+                if (dependencyConnectionStatusTracker != null && dependencyConnectionStatusTracker.getConnectionStatus() != ConnectionStatus.CONNECTED)
+                {
+                    try
+                    {
+                        log.info("Waiting for the dependent connection to be established before attempting to open the connection");
+                        Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
+                    }
+                    catch (InterruptedException ex)
+                    {
+                        throw new RuntimeException("Interrupted while waiting between attempting to open the client: ", ex);
+                    }
+                }
+
+                try
+                {
+                    log.debug("Opening the client instance " + getClientId() + " ...");
+                    openClient();
+                    lastKnownConnectionStatus = ConnectionStatus.CONNECTED;
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (ex.getCause() instanceof TransportException && ((TransportException) ex.getCause()).isRetryable())
+                    {
+                        log.warn("Transport exception thrown while opening client instance " + getClientId() + ", retrying: ", ex);
+                    }
+                    else
+                    {
+                        log.error("Non-retryable exception thrown while opening client instance " + getClientId() + ": ", ex);
+                        lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
+                        throw ex;
+                    }
+                }
+
+                try
+                {
+                    log.debug("Sleeping for " + SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS + " secs before attempting another open()");
+                    Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
+                }
+                catch (InterruptedException ex)
+                {
+                    throw new RuntimeException("Interrupted while waiting between attempting to open the client: ", ex);
+                }
             }
         }
     }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -24,6 +24,7 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
     // Initialize the connection status as DISCONNECTED
     protected ConnectionStatus lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
 
+    // Tracks connection status of the dependency connection (multiplexing client connection status for example in this case for DeviceClientManager)
     protected ConnectionStatusTracker dependencyConnectionStatusTracker;
 
     public abstract void openClient() throws IOException;

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -1,0 +1,166 @@
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeCallback;
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason;
+import com.microsoft.azure.sdk.iot.device.exceptions.DeviceOperationTimeoutException;
+import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.NO_NETWORK;
+import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.RETRY_EXPIRED;
+import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.DISCONNECTED;
+import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.DISCONNECTED_RETRYING;
+
+/**
+ * This is the base class for DeviceClientManager and MultiplexingClientManager
+ * The shared logic for reconnection and handling status change call back exists here.
+ */
+@Slf4j
+public abstract class ClientManagerBase implements IotHubConnectionStatusChangeCallback {
+
+    protected enum ConnectionStatus {
+        DISCONNECTED, CONNECTING, CONNECTED
+    }
+
+    protected static final Object lock = new Object();
+    protected static final int SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS = 2;
+    protected ConnectionStatus connectionStatus;
+    protected Pair<IotHubConnectionStatusChangeCallback, Object> suppliedConnectionStatusChangeCallback;
+
+    public abstract void openClient() throws IOException;
+    public abstract void closeClient() throws IOException;
+    public abstract String getClientId();
+
+    public void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext) {
+        if (callback != null) {
+            this.suppliedConnectionStatusChangeCallback = new Pair<>(callback, callbackContext);
+        } else {
+            this.suppliedConnectionStatusChangeCallback = null;
+        }
+    }
+
+    public void doConnect() throws IOException {
+        // Device client does not have retry on the initial open() call. Will need to be re-opened by the calling application
+        while (connectionStatus == ConnectionStatus.CONNECTING) {
+            synchronized (lock) {
+                if(connectionStatus == ConnectionStatus.CONNECTING) {
+                    try {
+                        log.debug("Opening the device client instance " + getClientId() + " ...");
+                        openClient();
+                        connectionStatus = ConnectionStatus.CONNECTED;
+                        break;
+                    }
+                    catch (Exception ex) {
+                        if (ex.getCause() instanceof TransportException && ((TransportException) ex.getCause()).isRetryable()) {
+                            log.warn("Transport exception thrown while opening DeviceClient instance " + getClientId() + ", retrying: ", ex);
+                        } else {
+                            log.error("Non-retryable exception thrown while opening DeviceClient instance " + getClientId() + ": ", ex);
+                            connectionStatus = ConnectionStatus.DISCONNECTED;
+                            throw ex;
+                        }
+                    }
+                }
+            }
+
+            try {
+                log.debug("Sleeping for 10 secs before attempting another open()");
+                Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
+            }
+            catch (InterruptedException ex) {
+                throw new RuntimeException("Interrupted while waiting between attempting to open the client: ", ex);
+            }
+        }
+    }
+
+    public void closeNow() {
+        synchronized (lock) {
+            try {
+                log.debug("Closing the client instance " + getClientId() + " ...");
+                closeClient();
+            }
+            catch (IOException e) {
+                log.error("Exception thrown while closing client instance " + getClientId() + " : ", e);
+            } finally {
+                connectionStatus = ConnectionStatus.DISCONNECTED;
+            }
+        }
+    }
+
+    public void open() throws IOException {
+        synchronized (lock) {
+            if(connectionStatus == ConnectionStatus.DISCONNECTED) {
+                connectionStatus = ConnectionStatus.CONNECTING;
+            } else {
+                return;
+            }
+        }
+        doConnect();
+    }
+
+    @Override
+    public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext) {
+        Pair<IotHubConnectionStatusChangeCallback, Object> suppliedCallbackPair = this.suppliedConnectionStatusChangeCallback;
+        if (throwable == null)
+        {
+            System.out.println("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason);
+        }
+        else
+        {
+            System.out.println("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason + ", " + throwable.getMessage());
+            throwable.printStackTrace();
+        }
+
+        if (shouldDeviceReconnect(status, statusChangeReason, throwable)) {
+            if (suppliedCallbackPair != null) {
+                suppliedCallbackPair.getKey().execute(DISCONNECTED_RETRYING, NO_NETWORK, throwable, suppliedCallbackPair.getValue());
+            }
+
+            handleRecoverableDisconnection();
+        } else if (suppliedCallbackPair != null) {
+            suppliedCallbackPair.getKey().execute(status, statusChangeReason, throwable, suppliedCallbackPair.getValue());
+        }
+    }
+
+    // This handles the state where the DeviceClient reports that OperationTimeout has expired, and stops retrying; even though the applied RetryPolicy is still valid.
+    protected boolean shouldDeviceReconnect(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable) {
+        return (status == DISCONNECTED && statusChangeReason == RETRY_EXPIRED && throwable instanceof DeviceOperationTimeoutException);
+    }
+
+    public void handleRecoverableDisconnection() {
+        synchronized (lock) {
+            if (connectionStatus == ConnectionStatus.CONNECTED) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        log.debug("Attempting reconnect for client: " + getClientId() + " ...");
+                        synchronized (lock) {
+                            if (connectionStatus == ConnectionStatus.CONNECTED) {
+                                try {
+                                    closeClient();
+                                } catch (Exception e) {
+                                    log.warn("Client " + getClientId() + " closeNow failed.", e);
+                                } finally {
+                                    connectionStatus = ConnectionStatus.CONNECTING;
+                                }
+                            } else {
+                                log.debug("Client `" + getClientId() + "` is currently connecting, or already connected; skipping...");
+                                return;
+                            }
+                        }
+                        try {
+                            doConnect();
+                        } catch (IOException e) {
+                            log.error("Exception thrown while opening client instance: " + getClientId(), e);
+                        }
+                    }
+                }).start();
+            } else {
+                connectionStatus = ConnectionStatus.DISCONNECTED;
+            }
+        }
+    }
+}

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -25,7 +25,7 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
     protected enum ConnectionStatus {
         DISCONNECTED, CONNECTING, CONNECTED
     }
-
+    
     protected static final Object lock = new Object();
     protected static final int SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS = 2;
     protected ConnectionStatus connectionStatus;
@@ -67,7 +67,7 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
             }
 
             try {
-                log.debug("Sleeping for 10 secs before attempting another open()");
+                log.debug("Sleeping for " + SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS + " secs before attempting another open()");
                 Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
             }
             catch (InterruptedException ex) {
@@ -106,11 +106,11 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
         Pair<IotHubConnectionStatusChangeCallback, Object> suppliedCallbackPair = this.suppliedConnectionStatusChangeCallback;
         if (throwable == null)
         {
-            System.out.println("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason);
+            log.info("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason);
         }
         else
         {
-            System.out.println("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason + ", " + throwable.getMessage());
+            log.info("CONNECTION STATUS UPDATE FOR CLIENT: " + getClientId() + " - " + status + ", " + statusChangeReason + ", " + throwable.getMessage());
             throwable.printStackTrace();
         }
 

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -135,8 +135,8 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
     protected boolean shouldClientReconnect(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable)
     {
         return status == DISCONNECTED
-                && statusChangeReason == RETRY_EXPIRED
-                && throwable instanceof DeviceOperationTimeoutException;
+            && statusChangeReason == RETRY_EXPIRED
+            && throwable instanceof DeviceOperationTimeoutException;
     }
 
     /**

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ClientManagerBase.java
@@ -113,7 +113,7 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
     // We only expect the connection status to be CONNECTED by the time we enter this state.
     public void handleRecoverableDisconnection() {
         // If the lastKnownConnectionStatus is not in a CONNECTED state it can mean two things:
-        // 1: the status is CONNECTING, in which case there is nothing to be done.
+        // 1: the status is CONNECTING, in which case there is nothing to be done at this time.
         // 2: the status is DISCONNECTED, in which case connection cannot be re-established.
         if (lastKnownConnectionStatus == ConnectionStatus.CONNECTED)
         {
@@ -169,12 +169,13 @@ public abstract class ClientManagerBase implements IotHubConnectionStatusChangeC
             {
                 // If the client has dependencies to another client (in this case it could be the multiplexing client) we have to wait to make sure the
                 // dependent connection is established first.
-                if (dependencyConnectionStatusTracker != null && dependencyConnectionStatusTracker.getConnectionStatus() != ConnectionStatus.CONNECTED)
+                if (dependencyConnectionStatusTracker != null && dependencyConnectionStatusTracker.getConnectionStatus() == ConnectionStatus.CONNECTING)
                 {
                     try
                     {
                         log.info("Waiting for the dependent connection to be established before attempting to open the connection");
                         Thread.sleep(SLEEP_TIME_BEFORE_RECONNECTING_IN_SECONDS * 1000);
+                        continue;
                     }
                     catch (InterruptedException ex)
                     {

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatus.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatus.java
@@ -1,0 +1,11 @@
+package samples.com.microsoft.azure.sdk.iot;
+
+public enum ConnectionStatus
+{
+    // Either the connection is closed or is in a state where the ClientManager will not attempt to reconnect.
+    DISCONNECTED,
+    // The client manager is attempting to reconnect.
+    CONNECTING,
+    // The connection is established successfully.
+    CONNECTED
+}

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatus.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatus.java
@@ -4,8 +4,10 @@ public enum ConnectionStatus
 {
     // Either the connection is closed or is in a state where the ClientManager will not attempt to reconnect.
     DISCONNECTED,
+
     // The client manager is attempting to reconnect.
     CONNECTING,
+
     // The connection is established successfully.
     CONNECTED
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatusTracker.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatusTracker.java
@@ -1,0 +1,6 @@
+package samples.com.microsoft.azure.sdk.iot;
+
+public interface ConnectionStatusTracker
+{
+    ConnectionStatus getConnectionStatus();
+}

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatusTracker.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ConnectionStatusTracker.java
@@ -1,6 +1,12 @@
 package samples.com.microsoft.azure.sdk.iot;
 
+/**
+ * Allows for getting a connection status from implementing classes.
+ */
 public interface ConnectionStatusTracker
 {
+    /**
+     * Gets connection status {@link ConnectionStatus} of the implementing object
+     */
     ConnectionStatus getConnectionStatus();
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -34,7 +34,6 @@ public class DeviceClientManager extends ClientManagerBase
     DeviceClientManager(DeviceClient deviceClient, ConnectionStatusTracker dependencyConnectionStatusTracker)
     {
         this.dependencyConnectionStatusTracker = dependencyConnectionStatusTracker;
-        lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
         client = deviceClient;
         client.registerConnectionStatusChangeCallback(this, this);
     }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -1,0 +1,52 @@
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.device.DeviceClient;
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeCallback;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * This class is in charge of handling reconnection logic and registering callbacks for connection status changes.
+ * It will delegate all other calls other than `Open`, `Close` and registerConnectionStatusChangeCallbaack to the inner client (DeviceClient)
+ */
+@Slf4j
+public class DeviceClientManager extends ClientManagerBase {
+
+    // Define method calls that will not be delegated to the inner client.
+    private interface DeviceClientNonDelegatedFunction {
+        void open();
+        void closeNow();
+        void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
+    }
+
+    // The methods defined in the interface DeviceClientNonDelegatedFunction will be called on DeviceClientManager, and not on DeviceClient.
+    @Delegate(excludes = DeviceClientNonDelegatedFunction.class)
+    private final DeviceClient client;
+
+    DeviceClientManager(DeviceClient deviceClient) {
+        connectionStatus = ConnectionStatus.DISCONNECTED;
+        client = deviceClient;
+        client.registerConnectionStatusChangeCallback(this, this);
+    }
+
+    @Override
+    public void openClient() throws IOException {
+        client.open();
+    }
+
+    @Override
+    public void closeClient() throws IOException {
+        client.closeNow();
+    }
+
+    @Override
+    public String getClientId() {
+        return  client.getConfig().getDeviceId();
+    }
+
+    public DeviceClient getClient(){
+        return client;
+    }
+}

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -12,10 +12,11 @@ import java.io.IOException;
  * It will delegate all other calls other than `Open`, `Close` and registerConnectionStatusChangeCallbaack to the inner client (DeviceClient)
  */
 @Slf4j
-public class DeviceClientManager extends ClientManagerBase {
-
+public class DeviceClientManager extends ClientManagerBase
+{
     // Define method calls that will not be delegated to the inner client.
-    private interface DeviceClientNonDelegatedFunction {
+    private interface DeviceClientNonDelegatedFunction
+    {
         void open();
         void closeNow();
         void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
@@ -25,28 +26,34 @@ public class DeviceClientManager extends ClientManagerBase {
     @Delegate(excludes = DeviceClientNonDelegatedFunction.class)
     private final DeviceClient client;
 
-    DeviceClientManager(DeviceClient deviceClient) {
-        connectionStatus = ConnectionStatus.DISCONNECTED;
+    /**
+     * Creates an instance of DeviceClientManager
+     * @param deviceClient the DeviceClient to manage
+     * @param dependencyConnectionStatusTracker the dependency connection status tracker (it may be the MultiplexClientManager object)
+     */
+    DeviceClientManager(DeviceClient deviceClient, ConnectionStatusTracker dependencyConnectionStatusTracker)
+    {
+        this.dependencyConnectionStatusTracker = dependencyConnectionStatusTracker;
+        lastKnownConnectionStatus = ConnectionStatus.DISCONNECTED;
         client = deviceClient;
         client.registerConnectionStatusChangeCallback(this, this);
     }
 
     @Override
-    public void openClient() throws IOException {
+    public void openClient() throws IOException
+    {
         client.open();
     }
 
     @Override
-    public void closeClient() throws IOException {
+    public void closeClient() throws IOException
+    {
         client.closeNow();
     }
 
     @Override
-    public String getClientId() {
+    public String getClientId()
+    {
         return  client.getConfig().getDeviceId();
-    }
-
-    public DeviceClient getClient(){
-        return client;
     }
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -49,7 +49,6 @@ public class DeviceClientManager extends ClientManagerBase
 
     /**
      * All classes that extend ClientManagerBase should implement how their inner client can be opened.
-     * @throws IOException
      */
     @Override
     protected void openClient() throws IOException
@@ -59,7 +58,6 @@ public class DeviceClientManager extends ClientManagerBase
 
     /**
      * All classes that extend ClientManagerBase should implement how their inner client can be closed.
-     * @throws IOException
      */
     @Override
     protected void closeClient() throws IOException
@@ -69,7 +67,6 @@ public class DeviceClientManager extends ClientManagerBase
 
     /**
      * All classes that extend ClientManagerBase should implement how their inner client can be identified for logging purposes.
-     * @throws IOException
      */
     @Override
     public String getClientId()

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
@@ -12,10 +12,11 @@ import java.io.IOException;
  * It will delegate all other calls other than `Open`, `Close` and registerConnectionStatusChangeCallbaack to the inner client (MultiplexingClient)
  */
 @Slf4j
-public class MultiplexClientManager extends ClientManagerBase {
-
+public class MultiplexClientManager extends ClientManagerBase
+{
     // Define method calls that will not be delegated to the inner client.
-    private interface DeviceClientNonDelegatedFunction {
+    private interface DeviceClientNonDelegatedFunction
+    {
         void open();
         void close();
         void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
@@ -32,29 +33,28 @@ public class MultiplexClientManager extends ClientManagerBase {
      * @param multiplexingClient the multiplexing client
      * @param multiplexClientId user defined Id for the multiplexing client.
      */
-    MultiplexClientManager(MultiplexingClient multiplexingClient, String multiplexClientId) {
-        this.connectionStatus = ConnectionStatus.DISCONNECTED;
+    MultiplexClientManager(MultiplexingClient multiplexingClient, String multiplexClientId)
+    {
         this.client = multiplexingClient;
         this.multiplexClientId = multiplexClientId;
         this.client.registerConnectionStatusChangeCallback(this, this);
     }
 
     @Override
-    public void openClient() throws IOException {
+    public void openClient() throws IOException
+    {
         this.client.open();
     }
 
     @Override
-    public void closeClient() throws IOException {
+    public void closeClient() throws IOException
+    {
         this.client.close();
     }
 
     @Override
-    public String getClientId() {
-        return  multiplexClientId;
-    }
-
-    public MultiplexingClient getMultiplexClient(){
-        return client;
+    public String getClientId()
+    {
+        return multiplexClientId;
     }
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
@@ -26,6 +26,12 @@ public class MultiplexClientManager extends ClientManagerBase {
     private final MultiplexingClient client;
     private final String multiplexClientId;
 
+    /**
+     * Creates an instance of the MultiplexClientManager
+     *
+     * @param multiplexingClient the multiplexing client
+     * @param multiplexClientId user defined Id for the multiplexing client.
+     */
     MultiplexClientManager(MultiplexingClient multiplexingClient, String multiplexClientId) {
         this.connectionStatus = ConnectionStatus.DISCONNECTED;
         this.client = multiplexingClient;

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
@@ -1,0 +1,54 @@
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeCallback;
+import com.microsoft.azure.sdk.iot.device.MultiplexingClient;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * This class is in charge of handling reconnection logic and registering callbacks for connection status changes.
+ * It will delegate all other calls other than `Open`, `Close` and registerConnectionStatusChangeCallbaack to the inner client (MultiplexingClient)
+ */
+@Slf4j
+public class MultiplexClientManager extends ClientManagerBase {
+
+    // Define method calls that will not be delegated to the inner client.
+    private interface DeviceClientNonDelegatedFunction {
+        void open();
+        void close();
+        void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
+    }
+
+    // The methods defined in the interface DeviceClientNonDelegatedFunction will be called on MultiplexingClientManager, and not on MultiplexingClient.
+    @Delegate(excludes = DeviceClientNonDelegatedFunction.class)
+    private final MultiplexingClient client;
+    private final String multiplexClientId;
+
+    MultiplexClientManager(MultiplexingClient multiplexingClient, String multiplexClientId) {
+        this.connectionStatus = ConnectionStatus.DISCONNECTED;
+        this.client = multiplexingClient;
+        this.multiplexClientId = multiplexClientId;
+        this.client.registerConnectionStatusChangeCallback(this, this);
+    }
+
+    @Override
+    public void openClient() throws IOException {
+        this.client.open();
+    }
+
+    @Override
+    public void closeClient() throws IOException {
+        this.client.close();
+    }
+
+    @Override
+    public String getClientId() {
+        return  multiplexClientId;
+    }
+
+    public MultiplexingClient getMultiplexClient(){
+        return client;
+    }
+}

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
@@ -19,12 +19,13 @@ public class MultiplexClientManager extends ClientManagerBase
     {
         void open();
         void close();
+        void closeNow();
         void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
     }
 
     // The methods defined in the interface DeviceClientNonDelegatedFunction will be called on MultiplexingClientManager, and not on MultiplexingClient.
     @Delegate(excludes = DeviceClientNonDelegatedFunction.class)
-    private final MultiplexingClient client;
+    private final MultiplexingClient multiplexingClient;
     private final String multiplexClientId;
 
     /**
@@ -35,21 +36,21 @@ public class MultiplexClientManager extends ClientManagerBase
      */
     MultiplexClientManager(MultiplexingClient multiplexingClient, String multiplexClientId)
     {
-        this.client = multiplexingClient;
+        this.multiplexingClient = multiplexingClient;
         this.multiplexClientId = multiplexClientId;
-        this.client.registerConnectionStatusChangeCallback(this, this);
+        this.multiplexingClient.registerConnectionStatusChangeCallback(this, this);
     }
 
     @Override
-    public void openClient() throws IOException
+    protected void openClient() throws IOException
     {
-        this.client.open();
+        this.multiplexingClient.open();
     }
 
     @Override
-    public void closeClient() throws IOException
+    protected void closeClient() throws IOException
     {
-        this.client.close();
+        this.multiplexingClient.close();
     }
 
     @Override

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexClientManager.java
@@ -14,16 +14,19 @@ import java.io.IOException;
 @Slf4j
 public class MultiplexClientManager extends ClientManagerBase
 {
-    // Define method calls that will not be delegated to the inner client.
+    /**
+     * Define method calls that will not be delegated to the inner client.
+     */
     private interface DeviceClientNonDelegatedFunction
     {
         void open();
         void close();
-        void closeNow();
         void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext);
     }
 
-    // The methods defined in the interface DeviceClientNonDelegatedFunction will be called on MultiplexingClientManager, and not on MultiplexingClient.
+    /**
+     * The methods defined in the interface DeviceClientNonDelegatedFunction will be called on MultiplexingClientManager, and not on MultiplexingClient.
+     */
     @Delegate(excludes = DeviceClientNonDelegatedFunction.class)
     private final MultiplexingClient multiplexingClient;
     private final String multiplexClientId;
@@ -41,18 +44,27 @@ public class MultiplexClientManager extends ClientManagerBase
         this.multiplexingClient.registerConnectionStatusChangeCallback(this, this);
     }
 
+    /**
+     * All classes that extend ClientManagerBase should implement how their inner client can be opened.
+     */
     @Override
     protected void openClient() throws IOException
     {
         this.multiplexingClient.open();
     }
 
+    /**
+     * All classes that extend ClientManagerBase should implement how their inner client can be closed.
+     */
     @Override
     protected void closeClient() throws IOException
     {
         this.multiplexingClient.close();
     }
 
+    /**
+     * All classes that extend ClientManagerBase should implement how their inner client can be identified for logging purposes.
+     */
     @Override
     public String getClientId()
     {

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
@@ -81,7 +81,7 @@ public class MultiplexingSample
 
             multiplexedDeviceClients.put(deviceId, clientToMultiplex);
 
-            deviceManagers.put(deviceId, new DeviceClientManager(clientToMultiplex));
+            deviceManagers.put(deviceId, new DeviceClientManager(clientToMultiplex, multiplexClientManager));
         }
 
         System.out.println("Opening multiplexed connection");
@@ -97,6 +97,7 @@ public class MultiplexingSample
         multiplexClientManager.registerDeviceClients(multiplexedDeviceClients.values());
 
         System.out.println("Successfully registered " + multiplexedDeviceCount + " clients to the multiplexing client");
+
 
         for (String deviceId : deviceIds)
         {

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
@@ -4,98 +4,18 @@
 package samples.com.microsoft.azure.sdk.iot;
 
 import com.microsoft.azure.sdk.iot.device.*;
-import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import java.util.*;
 /**
  * Sample that demonstrates creating a multiplexed connection to IoT Hub using AMQPS / AMQPS_WS. It also demonstrates
  * removing and adding device clients from the multiplexed connection while it is open.
  */
 public class MultiplexingSample
 {
-    // Every multiplexed device will maintain its own connection status callback. Because of that, you can monitor
-    // if a particular device session goes offline unexpectedly. This connection status callback is also how you
-    // confirm when a device client is connected after registering it to an active multiplexed connection since the .registerDeviceClients(...)
-    // call behaves asynchronously when the multiplexing client is already open. Similarly, this callback is used to track
-    // when a device client is closed when unregistering it from an active connection.
-    public static class MultiplexedDeviceConnectionStatusChangeTracker implements IotHubConnectionStatusChangeCallback
-    {
-        private boolean isOpen = false;
-        private boolean isDisconnectedRetrying = false;
-
-        public boolean isOpen() {
-            return isOpen;
-        }
-
-        public boolean isDisconnectedRetrying() {
-            return isDisconnectedRetrying;
-        }
-
-        @Override
-        public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
-        {
-            // In this sample, both the device clients and the multiplexing client use this class to track their respective connection statuses.
-            // If the context is not null, it has the device id that the status belongs to. If the context is null, the status
-            // update belongs to the multiplexed connection itself.
-            String deviceId = (String) callbackContext;
-
-            if (throwable == null)
-            {
-                if (deviceId == null)
-                {
-                    System.out.println("CONNECTION STATUS UPDATE FOR MULTIPLEXED CONNECTION - " + status + ", " + statusChangeReason);
-                }
-                else
-                {
-                    System.out.println("CONNECTION STATUS UPDATE FOR DEVICE " + deviceId + " - " + status + ", " + statusChangeReason);
-                }
-            }
-            else
-            {
-                if (deviceId == null)
-                {
-                    System.out.println("CONNECTION STATUS UPDATE FOR MULTIPLEXED CONNECTION - " + status + ", " + statusChangeReason + ", " + throwable.getMessage());
-                }
-                else
-                {
-                    System.out.println("CONNECTION STATUS UPDATE FOR DEVICE " + deviceId + " - " + status + ", " + statusChangeReason + ", " + throwable.getMessage());
-                }
-            }
-
-            if (status == IotHubConnectionStatus.CONNECTED)
-            {
-                isOpen = true;
-                isDisconnectedRetrying = false;
-            }
-            else if (status == IotHubConnectionStatus.DISCONNECTED)
-            {
-                isOpen = false;
-                isDisconnectedRetrying = false;
-            }
-            else if (status == IotHubConnectionStatus.DISCONNECTED_RETRYING)
-            {
-                isDisconnectedRetrying = true;
-                isOpen = false;
-            }
-        }
-    }
-
-    public static int acknowledgedSentMessages = 0;
-    protected static class TelemetryAcknowledgedEventCallback implements IotHubEventCallback
-    {
-        public void execute(IotHubStatusCode status, Object context)
-        {
-            String messageId = (String) context;
-            System.out.println("IoT Hub responded to message "+ messageId  + " with status " + status.name());
-            acknowledgedSentMessages++;
-        }
-    }
+    // In this sample we are using MultiplexClientManager to implement the reconnection
+    // logic for the MultiplexingClient and DeviceClientManager to implement and track DeviceClient
 
     /**
      * Multiplex devices an IoT Hub using AMQPS / AMQPS_WS
@@ -105,6 +25,7 @@ public class MultiplexingSample
      * args[1] = host name to connect to (for instance, "my-iot-hub.azure-devices.net")
      * args[2] = IoT Hub connection string - Device Client 1
      * args[3] = IoT Hub connection string - Device Client 2
+     * Add up to 998 device connection strings from args[4] on.
      *
      * Any additional arguments will be interpreted as additional connections strings. This allows this sample to be
      * run with more than 2 devices. At
@@ -122,7 +43,10 @@ public class MultiplexingSample
                             + "1. [Protocol]                   - amqps | amqps_ws\n"
                             + "2. [HostName]                   - my-iot-hub.azure-devices.net\n"
                             + "3. [Device 1 connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>\n"
-                            + "4. [Device 2 connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>\n",
+                            + "4. [Device 2 connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>\n"
+                            + ".\n"
+                            + ".\n"
+                            + ".\n",
                     args.length);
             return;
         }
@@ -135,33 +59,34 @@ public class MultiplexingSample
 
         String hostName = args[1];
 
-        // This sample allows for users to pass in 2 to many device connection strings, so this sample may multiplex
-        // 2 to many devices
-        int multiplexedDeviceCount = args.length - 2;
+        // This sample requires users for pass in at least 2 device connection strings, so this sample may multiplex
+        final int multiplexedDeviceCount = args.length - 2;
 
         // Options include setting a custom SSLContext to use for the SSL handshake, configuring proxy support, and setting threading strategies
         MultiplexingClientOptions options = MultiplexingClientOptions.builder().build();
-        MultiplexingClient multiplexingClient = new MultiplexingClient(hostName, protocol, options);
-        MultiplexedDeviceConnectionStatusChangeTracker multiplexedConnectionStatusTracker = new MultiplexedDeviceConnectionStatusChangeTracker();
-        multiplexingClient.registerConnectionStatusChangeCallback(multiplexedConnectionStatusTracker, null);
+        final MultiplexingClient multiplexingClient = new MultiplexingClient(hostName, protocol, options);
+
+        MultiplexClientManager multiplexClientManager = new MultiplexClientManager(multiplexingClient, "MultiplexingClient");
 
         System.out.println("Creating device clients that will be multiplexed");
-        List<String> deviceIds = new ArrayList<>();
-        Map<String, DeviceClient> multiplexedDeviceClients = new HashMap<>(multiplexedDeviceCount);
-        List<MultiplexedDeviceConnectionStatusChangeTracker> deviceConnectionStatusTrackers = new ArrayList<>(multiplexedDeviceCount);
+        final List<String> deviceIds = new ArrayList<>();
+        final Map<String, DeviceClient> multiplexedDeviceClients = new HashMap<>(multiplexedDeviceCount);
+        final Map<String, DeviceClientManager> deviceManagers = new HashMap<>(multiplexedDeviceCount);
+
         for (int i = 0; i < multiplexedDeviceCount; i++)
         {
             DeviceClient clientToMultiplex = new DeviceClient(args[i+2], protocol);
             String deviceId = clientToMultiplex.getConfig().getDeviceId();
             deviceIds.add(deviceId);
+
             multiplexedDeviceClients.put(deviceId, clientToMultiplex);
-            deviceConnectionStatusTrackers.add(new MultiplexedDeviceConnectionStatusChangeTracker());
-            multiplexedDeviceClients.get(deviceId).registerConnectionStatusChangeCallback(deviceConnectionStatusTrackers.get(i), deviceId);
+
+            deviceManagers.put(deviceId, new DeviceClientManager(clientToMultiplex));
         }
 
         System.out.println("Opening multiplexed connection");
         // All previously registered device clients will be opened alongside this multiplexing client
-        multiplexingClient.open();
+        multiplexClientManager.open();
         System.out.println("Multiplexed connection opened successfully");
 
         // Note that all the clients are registered at once. This method will asynchronously start the registration
@@ -169,7 +94,8 @@ public class MultiplexingSample
         // If instead each client was registered separately through multiplexingClient.registerDeviceClient(), it would
         // take a longer time since it would block on each registration completing, rather than block on all registrations completing
         System.out.println("Registering " + multiplexedDeviceCount + " clients to the multiplexing client...");
-        multiplexingClient.registerDeviceClients(multiplexedDeviceClients.values());
+        multiplexClientManager.registerDeviceClients(multiplexedDeviceClients.values());
+
         System.out.println("Successfully registered " + multiplexedDeviceCount + " clients to the multiplexing client");
 
         for (String deviceId : deviceIds)
@@ -196,22 +122,34 @@ public class MultiplexingSample
         String deviceIdToUnregister = deviceIds.get(0);
 
         System.out.println("Unregistering device " + deviceIdToUnregister + " from multiplexed connection...");
-        multiplexingClient.unregisterDeviceClient(multiplexedDeviceClients.get(deviceIdToUnregister));
+        multiplexClientManager.unregisterDeviceClient(multiplexedDeviceClients.get(deviceIdToUnregister));
         System.out.println("Successfully unregistered device " + deviceIdToUnregister + " from an active multiplexed connection.");
 
         // This code demonstrates how to add a device to an active multiplexed connection without shutting down
         // the whole multiplexed connection or any of the other devices.
         System.out.println("Re-registering device " + deviceIdToUnregister + " to an active multiplexed connection...");
-        multiplexingClient.registerDeviceClient(multiplexedDeviceClients.get(deviceIdToUnregister));
+        multiplexClientManager.registerDeviceClient(multiplexedDeviceClients.get(deviceIdToUnregister));
         System.out.println("Successfully registered " + deviceIdToUnregister + " to an active multiplexed connection");
 
         // Before closing a multiplexing client, you do not need to unregister all of the registered clients.
         // If they are not unregistered, then you can re-open the multiplexing client later and it will still
         // have all of your registered devices
-
         System.out.println("Closing entire multiplexed connection...");
         // This call will close all multiplexed device client instances as well
-        multiplexingClient.close();
+        multiplexClientManager.closeClient();
         System.out.println("Successfully closed the multiplexed connection");
+
+        System.out.println("Shutting down...");
+    }
+
+    private static int acknowledgedSentMessages = 0;
+    private static class TelemetryAcknowledgedEventCallback implements IotHubEventCallback
+    {
+        public void execute(IotHubStatusCode status, Object context)
+        {
+            String messageId = (String) context;
+            System.out.println("IoT Hub responded to message "+ messageId  + " with status " + status.name());
+            acknowledgedSentMessages++;
+        }
     }
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
@@ -8,15 +8,31 @@ import com.microsoft.azure.sdk.iot.device.*;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
+
 /**
  * Sample that demonstrates creating a multiplexed connection to IoT Hub using AMQPS / AMQPS_WS. It also demonstrates
  * removing and adding device clients from the multiplexed connection while it is open.
+ *
+ * This sample also demonstrates how reconnection can be handled by introducing {@link MultiplexClientManager} and {@link DeviceClientManager}
+ * both of which extend {@link ClientManagerBase}.
+ *
+ * ClientManagerBase class implements two separate interfaces
+ *
+ * 1. {@link IotHubConnectionStatusChangeCallback} which is an SDK type for handling a connection status change callback
+ * 2. {@link ConnectionStatusTracker} which allows for a dependent connection check the underlying connection status before attempting a reconnection.
+ *
+ * Both {@link DeviceClientManager} and {@link MultiplexClientManager} classes delegate all but 3 API calls to their underlying SDK client (MultiplexingClient or DeviceClient) they are wrapping around.
+ * open(), close(), registerConnectionStatusChangeCallback() are the 3 APIs that are handled by the ClientManager instance to allow for dynamic reconnection logic.
+ *
+ * These client managers are in charge of handling the reconnection logic since they are the connection status callback handler.
+ *
+ * DeviceClientManager also takes an instance of {@link ConnectionStatusTracker} to identify whether or not the underlying
+ * Multiplexing connection is established or not before they attempt a re-connection in an event of a disconnection.
+ * This will avoid unnecessary reconnection attempts by DeviceClient since it cannot be connected unless the Multiplexing connection is established.
+ *
  */
 public class MultiplexingSample
 {
-    // In this sample we are using MultiplexClientManager to implement the reconnection
-    // logic for the MultiplexingClient and DeviceClientManager to implement and track DeviceClient
-
     /**
      * Multiplex devices an IoT Hub using AMQPS / AMQPS_WS
      *

--- a/device/iot-device-samples/multiplexing-sample/src/main/resources/log4j.properties
+++ b/device/iot-device-samples/multiplexing-sample/src/main/resources/log4j.properties
@@ -5,4 +5,5 @@ log4j.rootLogger=ERROR, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.logger.com.microsoft.azure.sdk.iot.device = INFO 
+log4j.logger.com.microsoft.azure.sdk.iot.device = DEBUG 
+log4j.logger.samples.com.microsoft.azure.sdk.iot = DEBUG


### PR DESCRIPTION
With this change, `DeviceClientManager `objects will be wrapped around device clients to manage the reconnection logic. 
`DeviceClientManager `and `MultiplexingClientManager `both extend `ClientManagerBase `that hold the core reconnection logic.
All API calls to the `DeviceClientManager `and `MultiplexingClientManager `will be delegated to the client they are wrapping. 