### PR TITLE
release(2020-11-16): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.26.0";
+    private static final String CLIENT_VERSION = "1.27.0";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.26.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.27.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.26.0</iot-device-client-version>
+        <iot-device-client-version>1.27.0</iot-device-client-version>
         <iot-service-client-version>1.26.0</iot-service-client-version>
         <iot-deps-version>0.11.0</iot-deps-version>
-        <provisioning-device-client-version>1.8.4</provisioning-device-client-version>
+        <provisioning-device-client-version>1.8.5</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.0</provisioning-service-client-version>
         <security-provider-version>1.3.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.4";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.5";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.27.0)

- Added support for configuring amqp layer timeout values ([#908](https://github.com/Azure/azure-iot-sdk-java/pull/908))

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.5)

### Bug fixes
- Fixed bug where provisioning device client URL encoded SAS token URL before signing and after signing ([#990](https://github.com/Azure/azure-iot-sdk-java/pull/990))


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.27.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.8.5/jar



old
{
    "device": "1.26.0",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.4",
    "provisioningService": "1.7.0"
}

new
{
    "device": "1.27.0",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.5",
    "provisioningService": "1.7.0"
}
