### PR TITLE
release(2020-11-16): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.27.0";
+    private static final String CLIENT_VERSION = "1.28.0-preview-001";
 
     private static String JAVA_RUNTIME = System.getProperty("java.version");
     private static String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.27.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.28.0-preview-001') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.27.0</iot-device-client-version>
+        <iot-device-client-version>1.28.0-preview-001</iot-device-client-version>
         <iot-service-client-version>1.26.0</iot-service-client-version>
         <iot-deps-version>0.11.0</iot-deps-version>
         <provisioning-device-client-version>1.8.5</provisioning-device-client-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.27.0)

- Added `MultiplexingClient` that allows for adding and removing of devices from active multiplexed connection ([#939](https://github.com/Azure/azure-iot-sdk-java/pull/939))

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.28.0-preview-001/jar


old
{
    "device": "1.27.0",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.5",
    "provisioningService": "1.7.0"
}

new
{
    "device": "1.28.0-preview-001",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.3.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.5",
    "provisioningService": "1.7.0"
}
