### PR TITLE
feat(iot-dev): Add client constructors that take sas token provider interface

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -208,6 +208,37 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
+     * Constructor that allows for the client's SAS token generation to be controlled by the user. Note that options in
+     * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
+     * the SDK no longer controls that when this constructor is used.
+     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param deviceId The Id of the device that the connection will identify as.
+     * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
+     * @param protocol The protocol that the client will connect over.
+     */
+    public DeviceClient(String hostName, String deviceId, SasTokenProvider sasTokenProvider, IotHubClientProtocol protocol)
+    {
+        this(hostName, deviceId, sasTokenProvider, protocol, null);
+    }
+
+    /**
+     * Constructor that allows for the client's SAS token generation to be controlled by the user. Note that options in
+     * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
+     * the SDK no longer controls that when this constructor is used.
+     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param deviceId The Id of the device that the connection will identify as.
+     * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
+     * @param protocol The protocol that the client will connect over.
+     * @param clientOptions The options that allow configuration of the device client instance during initialization.
+     */
+    public DeviceClient(String hostName, String deviceId, SasTokenProvider sasTokenProvider, IotHubClientProtocol protocol, ClientOptions clientOptions)
+    {
+        super(hostName, deviceId, null, sasTokenProvider, protocol, clientOptions, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
+        commonConstructorVerifications();
+        commonConstructorSetup();
+    }
+
+    /**
      * Constructor that uses x509 authentication for communicating with IotHub
      *
      * @param connString the connection string for the x509 device to connect as (format: "HostName=...;DeviceId=...;x509=true")
@@ -685,7 +716,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
+     *	      in case of MQTT and AMQP protocols, this option specifies the interval in milliseconds
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -144,6 +144,22 @@ public final class DeviceClientConfig
         this.productInfo = new ProductInfo();
     }
 
+
+    public DeviceClientConfig(String hostName, SasTokenProvider sasTokenProvider, ClientOptions clientOptions, String deviceId, String moduleId)
+    {
+        this.authenticationProvider = new IotHubSasTokenProvidedAuthenticationProvider(
+                hostName,
+                deviceId,
+                moduleId,
+                sasTokenProvider,
+                clientOptions != null ? clientOptions.sslContext : null);
+
+        this.useWebsocket = false;
+        this.productInfo = new ProductInfo();
+
+        log.debug("Device configured to use SAS token provided authentication provider");
+    }
+
     /**
      * Constructor for device configs that use x509 authentication
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -147,12 +147,9 @@ public final class DeviceClientConfig
 
     public DeviceClientConfig(String hostName, SasTokenProvider sasTokenProvider, ClientOptions clientOptions, String deviceId, String moduleId)
     {
-        this.authenticationProvider = new IotHubSasTokenProvidedAuthenticationProvider(
-                hostName,
-                deviceId,
-                moduleId,
-                sasTokenProvider,
-                clientOptions != null ? clientOptions.sslContext : null);
+        SSLContext sslContext = clientOptions != null ? clientOptions.sslContext : null;
+        this.authenticationProvider =
+                new IotHubSasTokenProvidedAuthenticationProvider(hostName, deviceId, moduleId, sasTokenProvider, sslContext);
 
         this.useWebsocket = false;
         this.productInfo = new ProductInfo();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -128,6 +128,29 @@ public class InternalClient
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
+    InternalClient(String hostName, String deviceId, String moduleId, SasTokenProvider sasTokenProvider, IotHubClientProtocol protocol, ClientOptions clientOptions, long sendPeriodMillis, long receivePeriodMillis)
+    {
+        if (hostName == null)
+        {
+            throw new IllegalArgumentException("Host name cannot be null");
+        }
+
+        if (protocol == null)
+        {
+            throw new IllegalArgumentException("Protocol cannot be null.");
+        }
+
+        this.config = new DeviceClientConfig(hostName, sasTokenProvider, clientOptions, deviceId, moduleId);
+        this.config.setProtocol(protocol);
+        if (clientOptions != null)
+        {
+            this.config.modelId = clientOptions.getModelId();
+        }
+
+        this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
+    }
+
+
     //unused
     InternalClient()
     {
@@ -415,7 +438,7 @@ public class InternalClient
      *
      *	    - <b>SetReceiveInterval</b> - this option is applicable to all protocols
      *	      in case of HTTPS protocol, this option acts the same as {@code SetMinimumPollingInterval}
-     *	      in case of MQTT and AMQP protocols, this option specifies the interval in millisecods
+     *	      in case of MQTT and AMQP protocols, this option specifies the interval in milliseconds
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -150,7 +150,6 @@ public class InternalClient
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
-
     //unused
     InternalClient()
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -161,7 +161,7 @@ public class InternalClient
 
     public void open() throws IOException
     {
-        if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN && this.config.getSasTokenAuthentication().isRenewalNecessary())
+        if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN && this.config.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary())
         {
             //Codes_SRS_INTERNALCLIENT_34_044: [If the SAS token has expired before this call, throw a Security Exception]
             throw new SecurityException("Your SasToken is expired");

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -176,6 +176,40 @@ public class ModuleClient extends InternalClient
     }
 
     /**
+     * Constructor that allows for the client's SAS token generation to be controlled by the user. Note that options in
+     * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
+     * the SDK no longer controls that when this constructor is used.
+     *
+     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param deviceId The Id of the device containing the module that the connection will identify as.
+     * @param moduleId The Id of the module that the connection will identify as.
+     * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
+     * @param protocol The protocol that the client will connect over.
+     */
+    public ModuleClient(String hostName, String deviceId, String moduleId, SasTokenProvider sasTokenProvider, IotHubClientProtocol protocol)
+    {
+        this(hostName, deviceId, moduleId, sasTokenProvider, protocol, null);
+    }
+
+    /**
+     * Constructor that allows for the client's SAS token generation to be controlled by the user. Note that options in
+     * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
+     * the SDK no longer controls that when this constructor is used.
+     *
+     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param deviceId The Id of the device containing the module that the connection will identify as.
+     * @param moduleId The Id of the module that the connection will identify as.
+     * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
+     * @param protocol The protocol that the client will connect over.
+     * @param clientOptions The options that allow configuration of the module client instance during initialization.
+     */
+    public ModuleClient(String hostName, String deviceId, String moduleId, SasTokenProvider sasTokenProvider, IotHubClientProtocol protocol, ClientOptions clientOptions)
+    {
+        super(hostName, deviceId, moduleId, sasTokenProvider, protocol, clientOptions, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
+        commonConstructorVerifications(protocol, this.getConfig());
+    }
+
+    /**
      * Create a module client instance from your environment variables
      * @return the created module client instance
      * @throws ModuleClientException if the module client cannot be created

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/SasTokenProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/SasTokenProvider.java
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.device;
+
+/**
+ * Interface for allowing users to control SAS token generation. To see an example of how SAS tokens can be generated
+ * from device connection strings, see {@link com.microsoft.azure.sdk.iot.device.auth.IotHubSasToken}.
+ * @see <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#example">This document</a> for more details on sas tokens.
+ */
+public interface SasTokenProvider
+{
+    /**
+     * Returns a SAS token to be used for authentication.
+     * <p>
+     * This function will be called each time the client library needs a SAS token. This will follow different patterns
+     * based on which protocol your client object is using.
+     * <p>
+     * For HTTPS, this function will be called for each HTTPS request made (for instance, once per telemetry send), and does not need
+     * to be a unique token each time. Because of that, users may simply cache and return the same SAS token repeatedly here.
+     * Alternatively, users can generate very short-lived SAS tokens since they will only need to be valid for a relative short period of time.
+     * The user of this API is responsible for tracking when to renew the SAS token based on how long the previous token was valid for.
+     * <p>
+     * For AMQPS/AMQPS_WS, this function will be called once when first opening the connection, and then will be called again
+     * at some point prior to the previous SAS token's expiry time in order to proactively renew the connection's authentication.
+     * This proactive renewal takes place at around 85% of the previous SAS token's lifespan.
+     * <p>
+     * For MQTT/MQTT_WS, this function will be called once when first opening the connection, and again each time the previous
+     * SAS token has expired and the client closes and re-opens the connection. MQTT/MQTT_WS does not currently support
+     * proactive token renewal.
+     * @return a SAS token to be used for authentication.
+     */
+    public char[] getSasToken();
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
@@ -56,7 +56,11 @@ public abstract class IotHubAuthenticationProvider
         this(hostname, gatewayHostname, deviceId, moduleId);
 
         this.sslContextNeedsUpdate = false;
-        this.iotHubSSLContext = new IotHubSSLContext(sslContext);
+
+        if (sslContext != null)
+        {
+            this.iotHubSSLContext = new IotHubSSLContext(sslContext);
+        }
     }
 
     public SSLContext getSSLContext() throws IOException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasToken.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasToken.java
@@ -228,10 +228,10 @@ public final class IotHubSasToken
     }
 
     /**
-     * Return the expiry time for the provided sasToken in seconds.
+     * Return the expiry time for the provided sasToken in seconds since the UNIX epoch.
      *
-     * @param sasToken the token to return the expiry time
-     * @return a long with the expiry time in seconds.
+     * @param sasToken the token to return the expiry time for.
+     * @return the expiry time for the provided sasToken in seconds since the UNIX epoch
      */
     static Long getExpiryTimeFromToken(String sasToken)
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -76,10 +76,13 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
     }
 
     /**
-     * Returns true if the saved sas token needs to be manually renewed by the user
-     * @return true if the saved sas token needs to be manually renewed by the user
+     * Returns true if the this authentication provider is no longer valid. If true, users will need to create a new
+     * DeviceClient instance to get a new authentication provider. The most common case for this is if the user
+     * provides a SAS token, but no symmetric key, and that SAS token has expired. At that point, the user's client
+     * won't be able to authenticate anymore.
+     * @return true if the this authentication provider is no longer valid. False otherwise
      */
-    public boolean isRenewalNecessary()
+    public boolean isAuthenticationProviderRenewalNecessary()
     {
         //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_017: [If the saved sas token has expired, this function shall return true.]
         return (this.sasToken != null && this.sasToken.isExpired());

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -34,7 +34,7 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
     protected IotHubSasToken sasToken;
 
     public abstract boolean canRefreshToken();
-    public abstract String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException;
+    public abstract char[] getSasToken() throws IOException, TransportException;
 
     public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
@@ -120,7 +120,7 @@ public class IotHubSasTokenHardwareAuthenticationProvider extends IotHubSasToken
      * @return always returns false as the hardware authentication mechanism will never need to be updated with a new key or token
      */
     @Override
-    public boolean isRenewalNecessary()
+    public boolean isAuthenticationProviderRenewalNecessary()
     {
         //Hardware will always be able to generate new sas tokens
         //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_012: [This function shall return false.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
@@ -65,25 +65,14 @@ public class IotHubSasTokenHardwareAuthenticationProvider extends IotHubSasToken
     /**
      * Getter for SasToken. If the saved token has expired, this method shall renew it if possible
      *
-     * @param proactivelyRenew if true, this method will generate a fresh sas token even if the previously saved token
-     *                                 has not expired yet as long as the current token has lived beyond its buffer.
-     *                                 Use this for pre-emptively renewing sas tokens.
-
      * @throws IOException if generating the sas token from the TPM fails
      * @return The value of SasToken
      */
-    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException
+    public char[] getSasToken() throws IOException
     {
-        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
-        {
-            //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_035: [If the saved sas token has expired and there is a security provider, the saved sas token shall be refreshed with a new token from the security provider.]
-            //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_036: [If the saved sas token has not expired and there is a security provider, but the sas token should be proactively renewed, the saved sas token shall be refreshed with a new token from the security provider.]
-            String sasTokenString = this.generateSasTokenSignatureFromSecurityProvider(this.tokenValidSecs);
-            this.sasToken = new IotHubSasToken(this.hostname, this.deviceId, null, sasTokenString, this.moduleId, 0);
-        }
-
-        //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_005: [This function shall return the saved sas token.]
-        return this.sasToken.toString();
+        String sasTokenString = this.generateSasTokenSignatureFromSecurityProvider(this.tokenValidSecs);
+        this.sasToken = new IotHubSasToken(this.hostname, this.deviceId, null, sasTokenString, this.moduleId, 0);
+        return this.sasToken.toString().toCharArray();
     }
 
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -66,7 +66,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
 
         // Assuming that the token's life "starts" now for the sake of figuring out when it needs to be renewed. Users
         // could theoretically give us a SAS token that started a while ago, but since we have no way of figuring that out,
-        // we will conservatively just renew at 85% of the remaining time on the token, rather than 85% of the time the token
+        // we will conservatively just renew at timeBufferPercentage% of the remaining time on the token, rather than timeBufferPercentage% of the time the token
         // has existed for.
         long tokenValidSeconds = expiryTimeSeconds - (System.currentTimeMillis() / 1000);
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -48,6 +48,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
     @Override
     public boolean canRefreshToken()
     {
+        // User is always capable of providing a new SAS token when using this authentication provider.
         return true;
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -5,10 +5,16 @@
 
 package com.microsoft.azure.sdk.iot.device.auth;
 
+import com.microsoft.azure.sdk.iot.device.ClientOptions;
+import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.SasTokenProvider;
 
 import javax.net.ssl.SSLContext;
 
+/**
+ * {@link IotHubSasTokenAuthenticationProvider} implementation where the tokens are provided by an instance of {@link SasTokenProvider}.
+ * This is used in cases like when the user creates a device client with {@link com.microsoft.azure.sdk.iot.device.DeviceClient#DeviceClient(String, String, SasTokenProvider, IotHubClientProtocol, ClientOptions)}
+ */
 public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasTokenAuthenticationProvider
 {
     SasTokenProvider sasTokenProvider;
@@ -19,7 +25,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
 
         if (sasTokenProvider == null)
         {
-            throw new IllegalArgumentException("sas token provider cannot be null");
+            throw new IllegalArgumentException("SAS token provider cannot be null");
         }
 
         this.sasTokenProvider = sasTokenProvider;
@@ -34,7 +40,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
     @Override
     public void setTokenValidSecs(long tokenValidSecs)
     {
-        throw new UnsupportedOperationException("Cannot configure sas token time to live when custom sas token provider is in use");
+        throw new UnsupportedOperationException("Cannot configure SAS token time to live when custom sas token provider is in use");
     }
 
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -32,7 +32,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
     }
 
     @Override
-    public boolean isRenewalNecessary()
+    public boolean isAuthenticationProviderRenewalNecessary()
     {
         // Renewal of the authentication provider itself is never needed since the SAS token provider is responsible
         // for providing SAS tokens indefinitely.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -1,0 +1,68 @@
+/*
+*  Copyright (c) Microsoft. All rights reserved.
+*  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+package com.microsoft.azure.sdk.iot.device.auth;
+
+import com.microsoft.azure.sdk.iot.device.SasTokenProvider;
+
+import javax.net.ssl.SSLContext;
+
+public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasTokenAuthenticationProvider
+{
+    SasTokenProvider sasTokenProvider;
+    char[] lastSasToken;
+
+    public IotHubSasTokenProvidedAuthenticationProvider(String hostName, String deviceId, String moduleId, SasTokenProvider sasTokenProvider, SSLContext sslContext) {
+        super(hostName, null, deviceId, moduleId, sslContext);
+
+        if (sasTokenProvider == null)
+        {
+            throw new IllegalArgumentException("sas token provider cannot be null");
+        }
+
+        this.sasTokenProvider = sasTokenProvider;
+    }
+
+    @Override
+    public boolean isRenewalNecessary()
+    {
+        return false;
+    }
+
+    @Override
+    public void setTokenValidSecs(long tokenValidSecs)
+    {
+        throw new UnsupportedOperationException("Cannot configure sas token time to live when custom sas token provider is in use");
+    }
+
+    @Override
+    public boolean canRefreshToken()
+    {
+        return true;
+    }
+
+    @Override
+    public char[] getSasToken()
+    {
+        lastSasToken = sasTokenProvider.getSasToken();
+        return lastSasToken;
+    }
+
+    @Override
+    public int getMillisecondsBeforeProactiveRenewal()
+    {
+        // Seconds since UNIX epoch when this sas token will expire
+        long expiryTimeSeconds = IotHubSasToken.getExpiryTimeFromToken(new String(lastSasToken));
+
+        // Assuming that the token's life "starts" now for the sake of figuring out when it needs to be renewed. Users
+        // could theoretically give us a SAS token that started a while ago, but since we have no way of figuring that out,
+        // we will conservatively just renew at 85% of the remaining time on the token, rather than 85% of the time the token
+        // has existed for.
+        long tokenValidSeconds = expiryTimeSeconds - (System.currentTimeMillis() / 1000);
+
+        double timeBufferMultiplier = this.timeBufferPercentage / 100.0; //Convert 85 to .85, for example. Percentage multipliers are in decimal
+        return (int) (tokenValidSeconds * 1000 * timeBufferMultiplier);
+    }
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -34,13 +34,15 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
     @Override
     public boolean isRenewalNecessary()
     {
+        // Renewal of the authentication provider itself is never needed since the SAS token provider is responsible
+        // for providing SAS tokens indefinitely.
         return false;
     }
 
     @Override
     public void setTokenValidSecs(long tokenValidSecs)
     {
-        throw new UnsupportedOperationException("Cannot configure SAS token time to live when custom sas token provider is in use");
+        throw new UnsupportedOperationException("Cannot configure SAS token time to live when custom SAS token provider is in use");
     }
 
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -5,15 +5,10 @@
 
 package com.microsoft.azure.sdk.iot.device.auth;
 
-import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 
 public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasTokenAuthenticationProvider
 {
@@ -91,10 +86,10 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      * @return if the sas token needs manual renewal
      */
     @Override
-    public boolean isRenewalNecessary()
+    public boolean isAuthenticationProviderRenewalNecessary()
     {
-        // Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_018: [This function shall return true if a deviceKey is present and if super.isRenewalNecessary returns true.]
-        return (super.isRenewalNecessary() && this.deviceKey == null);
+        // Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_018: [This function shall return true if a deviceKey is present and if super.isAuthenticationProviderRenewalNecessary returns true.]
+        return (super.isAuthenticationProviderRenewalNecessary() && this.deviceKey == null);
     }
 
     @Override

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -118,26 +118,19 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
     /**
      * Getter for SasToken. If the saved token has expired, this method shall renew it if possible
      *
-     * @param proactivelyRenew if true, this method will generate a fresh sas token even if the previously saved token
-     *                                 has not expired yet as long as the current token has lived beyond its buffer.
-     *                                 Use this for pre-emptively renewing sas tokens.
-     *
      * @return The value of SasToken
      */
     @Override
-    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException
+    public char[] getSasToken() throws IOException, TransportException
     {
-        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
+        if (this.deviceKey != null)
         {
-            if (this.deviceKey != null)
-            {
-                //Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_004: [If the saved sas token has expired and there is a device key present, the saved sas token shall be renewed.]
-                //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_006: [If the saved sas token has not expired and there is a device key present, but this method is called to proactively renew and the token should renew, the saved sas token shall be renewed.]
-                this.sasToken = new IotHubSasToken(this.hostname, this.deviceId, this.deviceKey, null, this.moduleId, getExpiryTimeInSeconds());
-            }
+            //Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_004: [If the saved sas token has expired and there is a device key present, the saved sas token shall be renewed.]
+            //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_006: [If the saved sas token has not expired and there is a device key present, but this method is called to proactively renew and the token should renew, the saved sas token shall be renewed.]
+            this.sasToken = new IotHubSasToken(this.hostname, this.deviceId, this.deviceKey, null, this.moduleId, getExpiryTimeInSeconds());
         }
 
         //Codes_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_005: [This function shall return the saved sas token.]
-        return this.sasToken.toString();
+        return this.sasToken.toString().toCharArray();
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
@@ -61,7 +61,7 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * @return false
      */
     @Override
-    public boolean isRenewalNecessary()
+    public boolean isAuthenticationProviderRenewalNecessary()
     {
         // Codes_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_003: [This function shall always return false.]
         return false;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
@@ -81,16 +81,11 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * @throws TransportException If a TransportException is encountered while refreshing the sas token
      */
     @Override
-    public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException, TransportException
+    public char[] getSasToken() throws IOException, TransportException
     {
-        if (this.shouldRefreshToken(proactivelyRenew) || forceRenewal)
-        {
-            log.debug("Renewing the internal sas token");
-            // Codes_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_004: [This function shall invoke shouldRefreshSasToken, and if it should refresh, this function shall refresh the sas token.]
-            this.refreshSasToken();
-        }
+        log.debug("Renewing the internal sas token");
+        this.refreshSasToken();
 
-        // Codes_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_005: [This function shall return the saved sas token's string representation.]
-        return this.sasToken.toString();
+        return this.sasToken.toString().toCharArray();
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1200,7 +1200,7 @@ public class IotHubTransport implements IotHubListener
     {
         //Codes_SRS_IOTHUBTRANSPORT_28_003: [This function shall indicate if the device's sas token is expired.]
         return this.defaultConfig.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN
-                && this.defaultConfig.getSasTokenAuthentication().isRenewalNecessary();
+                && this.defaultConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsCbsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsCbsSenderLinkHandler.java
@@ -107,7 +107,7 @@ public final class AmqpsCbsSenderLinkHandler extends AmqpsSenderLinkHandler
         Section section;
         try
         {
-            section = new AmqpValue(deviceClientConfig.getSasTokenAuthentication().getRenewedSasToken(true, true));
+            section = new AmqpValue(String.valueOf(deviceClientConfig.getSasTokenAuthentication().getSasToken()));
             outgoingMessage.setBody(section);
         }
         catch (IOException e)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnection.java
@@ -490,7 +490,7 @@ public class HttpsIotHubConnection implements IotHubTransportConnection
     {
         try
         {
-            return this.config.getSasTokenAuthentication().getRenewedSasToken(false, false);
+            return String.valueOf(this.config.getSasTokenAuthentication().getSasToken());
         }
         catch (IOException e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnection.java
@@ -45,7 +45,7 @@ public class MqttConnection
      * @throws IllegalArgumentException is thrown if any of the parameters are null or empty
      * @throws TransportException when Mqtt async client cannot be instantiated
      */
-    MqttConnection(String serverURI, String clientId, String userName, String password, SSLContext sslContext, ProxySettings proxySettings) throws TransportException, IllegalArgumentException, UnknownHostException
+    MqttConnection(String serverURI, String clientId, String userName, char[] password, SSLContext sslContext, ProxySettings proxySettings) throws TransportException, IllegalArgumentException, UnknownHostException
     {
         if (serverURI == null || clientId == null || userName == null || sslContext == null)
         {
@@ -86,7 +86,7 @@ public class MqttConnection
      * @param userName the user name for the mqtt broker connection.
      * @param userPassword the user password for the mqtt broker connection.
      */
-    private void updateConnectionOptions(String userName, String userPassword, SSLContext iotHubSSLContext, ProxySettings proxySettings) throws UnknownHostException
+    private void updateConnectionOptions(String userName, char[] userPassword, SSLContext iotHubSSLContext, ProxySettings proxySettings) throws UnknownHostException
     {
         this.connectionOptions.setKeepAliveInterval(KEEP_ALIVE_INTERVAL);
         this.connectionOptions.setCleanSession(SET_CLEAN_SESSION);
@@ -112,9 +112,9 @@ public class MqttConnection
             this.connectionOptions.setSocketFactory(iotHubSSLContext.getSocketFactory());
         }
 
-        if (userPassword != null && !userPassword.isEmpty())
+        if (userPassword != null && userPassword.length > 0)
         {
-            this.connectionOptions.setPassword(userPassword.toCharArray());
+            this.connectionOptions.setPassword(userPassword);
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
@@ -30,7 +29,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
     private IotHubConnectionStatus state = IotHubConnectionStatus.DISCONNECTED;
 
     private String iotHubUserName;
-    private String iotHubUserPassword;
+    private char[] iotHubUserPassword;
     private MqttConnection mqttConnection;
 
     //string constants
@@ -129,7 +128,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
                 if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN)
                 {
                     this.log.trace("MQTT connection will use sas token based auth");
-                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                    this.iotHubUserPassword = this.config.getSasTokenAuthentication().getSasToken();
                     this.webSocketQueryString = NO_CLIENT_CERT_QUERY_STRING;
                 }
                 else if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.X509_CERTIFICATE)

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -1405,7 +1405,7 @@ public class InternalClientTest
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
 
-                mockConfig.getSasTokenAuthentication().isRenewalNecessary();
+                mockConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
                 result = true;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
@@ -165,7 +165,7 @@ public class TransportClientTest
                 result = mockDeviceClientConfig;
                 mockDeviceClientConfig.getSasTokenAuthentication();
                 result = mockIotHubSasTokenAuthenticationProvider;
-                mockIotHubSasTokenAuthenticationProvider.isRenewalNecessary();
+                mockIotHubSasTokenAuthenticationProvider.isAuthenticationProviderRenewalNecessary();
                 result = true;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
@@ -78,7 +78,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         }
 
         @Override
-        public String getRenewedSasToken(boolean proactivelyRenew, boolean forceRenewal) throws IOException
+        public char[] getSasToken() throws IOException
         {
             return null;
         }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
@@ -139,7 +139,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         Deencapsulation.setField(sasAuth, "sasToken", mockSasToken);
 
         //act
-        boolean isRenewalNecessary = Deencapsulation.invoke(sasAuth, "isRenewalNecessary");
+        boolean isRenewalNecessary = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
 
         //assert
         assertTrue(isRenewalNecessary);
@@ -162,7 +162,7 @@ public class IotHubSasTokenAuthenticationProviderTest
         Deencapsulation.setField(sasAuth, "sasToken", mockSasToken);
 
         //act
-        boolean isRenewalNecessary = Deencapsulation.invoke(sasAuth, "isRenewalNecessary");
+        boolean isRenewalNecessary = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
 
         //assert
         assertFalse(isRenewalNecessary);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
@@ -502,7 +502,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
-        boolean result = sasTokenAuthentication.isRenewalNecessary();
+        boolean result = sasTokenAuthentication.isAuthenticationProviderRenewalNecessary();
 
         //assert
         assertFalse(result);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
@@ -162,16 +162,13 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
 
                 URLEncoder.encode(anyString, encodingName);
                 result = someToken;
-                
-                Deencapsulation.invoke(mockSasToken, "isExpired");
-                result = true;
             }
         };
 
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
-        sasAuth.getRenewedSasToken(false, false);
+        sasAuth.getSasToken();
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_036: [If the saved sas token has not expired and there is a security provider, but the sas token should be proactively renewed, the saved sas token shall be refreshed with a new token from the security provider.]
@@ -201,16 +198,13 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
 
                 URLEncoder.encode(anyString, encodingName);
                 result = someToken;
-
-                Deencapsulation.invoke(mockSasToken, "isExpired");
-                result = false;
             }
         };
 
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
-        sasAuth.getRenewedSasToken(true, false);
+        sasAuth.getSasToken();
     }
 
     @Test
@@ -240,19 +234,16 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
                 URLEncoder.encode(anyString, encodingName);
                 result = someToken;
 
-                Deencapsulation.invoke(mockSasToken, "isExpired");
-                result = false;
-
                 new IotHubSasToken(anyString, anyString, anyString, null, anyString, anyLong);
                 result = mockSasToken;
-                times = 2; //initial creation during constructor, then again during getRenewedSasToken
+                times = 2; //initial creation during constructor, then again during getSasToken
             }
         };
 
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
-        sasAuth.getRenewedSasToken(true, true);
+        sasAuth.getSasToken();
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_005: [This function shall return the saved sas token.]
@@ -283,10 +274,10 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
-        String actualSasToken = sasAuth.getRenewedSasToken(true, false);
+        char[] actualSasToken = sasAuth.getSasToken();
 
         //assert
-        assertEquals(mockSasToken.toString(), actualSasToken);
+        assertEquals(mockSasToken.toString(), String.valueOf(actualSasToken));
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_001: [This function shall throw an UnsupportedOperationException.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
@@ -302,7 +302,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, null, expectedSasToken);
 
         //act
-        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isRenewalNecessary");
+        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
 
         //assert
         assertTrue(needsToRenew);
@@ -326,7 +326,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isRenewalNecessary");
+        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
 
         //assert
         assertFalse(needsToRenew);
@@ -348,13 +348,13 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isRenewalNecessary");
+        boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
 
         //assert
         assertFalse(needsToRenew);
     }
 
-    // Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_018: [This function shall return true if a deviceKey is present and if super.isRenewalNecessary returns true.]
+    // Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_018: [This function shall return true if a deviceKey is present and if super.isAuthenticationProviderRenewalNecessary returns true.]
     @Test
     public void isRenewalNecessaryReturnsTrueIfDeviceKeyPresent()
     {
@@ -362,7 +362,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        boolean result = sasAuth.isRenewalNecessary();
+        boolean result = sasAuth.isAuthenticationProviderRenewalNecessary();
 
         //assert
         assertFalse(result);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
@@ -155,8 +155,6 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
             {
                 System.currentTimeMillis();
                 result = 0;
-                Deencapsulation.invoke(mockSasToken, "isExpired");
-                result = true;
                 System.currentTimeMillis();
                 result = 0;
                 Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, expectedHostname, expectedDeviceId, expectedDeviceKey, null, expectedModuleId, expectedExpiryTime);
@@ -168,7 +166,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(false, false);
+        sasAuth.getSasToken();
 
     }
 
@@ -201,7 +199,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(true, false);
+        sasAuth.getSasToken();
     }
 
     @Test
@@ -232,7 +230,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(true, true);
+        sasAuth.getSasToken();
     }
 
     //Tests_SRS_IOTHUBSASTOKENAUTHENTICATION_34_006: [If the saved sas token has not expired and there is a device key present, but this method is called to proactively renew and the token should renew, the saved sas token shall be renewed.]
@@ -262,13 +260,12 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        sasAuth.getRenewedSasToken(true, false);
+        sasAuth.getSasToken();
     }
 
     //Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_005: [This function shall return the saved sas token.]
     @Test
-    public void getSasTokenReturnsSavedValue() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, IOException
-    {
+    public void getSasTokenReturnsSavedValue() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, IOException, TransportException {
         //arrange
         new Expectations()
         {
@@ -277,18 +274,16 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
                 result = mockSasToken;
                 mockSasToken.toString();
                 result = "some token";
-                Deencapsulation.invoke(mockSasToken, "isExpired");
-                result = false;
             }
         };
 
         IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
-        String actualSasToken = Deencapsulation.invoke(sasAuth, "getRenewedSasToken", false, false);
+        char[] actualSasToken = sasAuth.getSasToken();
 
         //assert
-        assertEquals(mockSasToken.toString(), actualSasToken);
+        assertEquals(mockSasToken.toString(), String.valueOf(actualSasToken));
     }
 
     //Tests_SRS_IOTHUBSASTOKENAUTHENTICATION_34_017: [If the saved sas token has expired and cannot be renewed, this function shall return true.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -109,7 +109,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         IotHubSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
 
         //act, assert
-        assertFalse(moduleAuthenticationWithTokenRefresh.isRenewalNecessary());
+        assertFalse(moduleAuthenticationWithTokenRefresh.isAuthenticationProviderRenewalNecessary());
     }
 
     // Tests_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_004: [This function shall invoke shouldRefreshSasToken, and if it should refresh, this function shall refresh the sas token.]

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -126,10 +126,10 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true, false);
+        char[] actual = moduleAuthenticationWithTokenRefresh.getSasToken();
 
         //assert
-        assertEquals(newSasToken.toString(), actual);
+        assertEquals(newSasToken.toString(), String.valueOf(actual));
     }
 
     @Test
@@ -144,29 +144,9 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
 
         //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(true, true);
+        char[] actual = moduleAuthenticationWithTokenRefresh.getSasToken();
 
         //assert
-        assertEquals(newSasToken.toString(), actual);
-    }
-
-    // Tests_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_004: [This function shall invoke shouldRefreshSasToken, and if it should refresh, this function shall refresh the sas token.]
-    // Tests_SRS_MODULEAUTHENTICATIONWITHTOKENREFRESH_34_005: [This function shall return the saved sas token's string representation.]
-    @Test
-    public void getRenewedSasTokenDoesNotRefreshIfNotNeeded() throws IOException, TransportException
-    {
-        //arrange
-        final IotHubSasToken oldSasToken = Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, "", "", "", "", "", 1);
-        final IotHubSasToken newSasToken = mockedIotHubSasToken;
-        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
-        Deencapsulation.setField(moduleAuthenticationWithTokenRefresh, "sasToken", oldSasToken);
-        moduleAuthenticationWithTokenRefresh.shouldRefresh = false;
-        moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
-
-        //act
-        String actual = moduleAuthenticationWithTokenRefresh.getRenewedSasToken(false, false);
-
-        //assert
-        assertEquals(oldSasToken.toString(), actual);
+        assertEquals(newSasToken.toString(), String.valueOf(actual));
     }
 }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -2310,7 +2310,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockedConfig.getSasTokenAuthentication().isRenewalNecessary();
+                mockedConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
                 result = true;
             }
         };
@@ -2333,7 +2333,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockedConfig.getSasTokenAuthentication().isRenewalNecessary();
+                mockedConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
                 result = false;
             }
         };
@@ -2356,7 +2356,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.X509_CERTIFICATE;
-                mockedConfig.getSasTokenAuthentication().isRenewalNecessary();
+                mockedConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
                 result = true;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/https/HttpsIotHubConnectionTest.java
@@ -60,7 +60,7 @@ public class HttpsIotHubConnectionTest
     @Mocked
     ProxySettings mockProxySettings;
 
-    private static final String testSasToken = "SharedAccessSignature sr=test&sig=test&se=0";
+    private static final char[] testSasToken = "SharedAccessSignature sr=test&sig=test&se=0".toCharArray();
 
     @Before
     public void setup() throws IOException, TransportException
@@ -68,7 +68,7 @@ public class HttpsIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result=testSasToken;
             }
         };
@@ -283,7 +283,7 @@ public class HttpsIotHubConnectionTest
         final String iotHubHostname = "test-iothubname";
         final String deviceId = "test-device-key";
         final String deviceKey = "test-device-key";
-        final String tokenStr = "test-token-str";
+        final char[] tokenStr = "test-token-str".toCharArray();
         new NonStrictExpectations()
         {
             {
@@ -293,7 +293,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = tokenStr;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
@@ -304,12 +304,12 @@ public class HttpsIotHubConnectionTest
         conn.setListener(mockedListener);
         conn.sendMessage(mockedMessage);
 
-        final String expectedTokenStr = tokenStr;
+        final char[] expectedTokenStr = tokenStr;
         new Verifications()
         {
             {
                 mockRequest.setHeaderField(withMatch("(?i)authorization"),
-                        expectedTokenStr);
+                        String.valueOf(expectedTokenStr));
             }
         };
     }
@@ -733,8 +733,7 @@ public class HttpsIotHubConnectionTest
     {
         final String iotHubHostname = "test-iothubname";
         final String deviceId = "test-device-key";
-        final String deviceKey = "test-device-key";
-        final String tokenStr = "test-token-str";
+        final char[] tokenStr = "test-token-str".toCharArray();
         final String uriPath = "/files";
         final HttpsMethod httpsMethod = HttpsMethod.POST;
         new NonStrictExpectations()
@@ -746,7 +745,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = tokenStr;
             }
         };
@@ -754,12 +753,12 @@ public class HttpsIotHubConnectionTest
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
         conn.sendHttpsMessage(mockMsg, httpsMethod, uriPath, new HashMap<String, String>());
 
-        final String expectedTokenStr = tokenStr;
+        final char[] expectedTokenStr = tokenStr;
         new Verifications()
         {
             {
                 mockRequest.setHeaderField(withMatch("(?i)authorization"),
-                        expectedTokenStr);
+                        String.valueOf(expectedTokenStr));
             }
         };
     }
@@ -1013,7 +1012,7 @@ public class HttpsIotHubConnectionTest
         final String iotHubHostname = "test-iothubname";
         final String deviceId = "test-device-key";
         final String deviceKey = "test-device-key";
-        final String tokenStr = "test-token-str";
+        final char[] tokenStr = "test-token-str".toCharArray();
         new NonStrictExpectations()
         {
             {
@@ -1023,7 +1022,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = tokenStr;
             }
         };
@@ -1031,12 +1030,12 @@ public class HttpsIotHubConnectionTest
         HttpsIotHubConnection conn = new HttpsIotHubConnection(mockConfig);
         conn.receiveMessage();
 
-        final String expectedTokenStr = tokenStr;
+        final char[] expectedTokenStr = tokenStr;
         new Verifications()
         {
             {
                 mockRequest.setHeaderField(withMatch("(?i)authorization"),
-                        expectedTokenStr);
+                        String.valueOf(expectedTokenStr));
             }
         };
     }
@@ -1680,7 +1679,7 @@ public class HttpsIotHubConnectionTest
         final String iotHubHostname = "test-iothubname";
         final String deviceId = "test-device-key";
         final String deviceKey = "test-device-key";
-        final String tokenStr = "test-token-str";
+        final char[] tokenStr = "test-token-str".toCharArray();
         new NonStrictExpectations()
         {
             {
@@ -1698,7 +1697,7 @@ public class HttpsIotHubConnectionTest
                 result = iotHubHostname;
                 mockConfig.getDeviceId();
                 result = deviceId;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = tokenStr;
             }
         };
@@ -1708,12 +1707,12 @@ public class HttpsIotHubConnectionTest
         eTagMap.put(mockedTransportMessage, eTag);
         conn.sendMessageResult(mockedTransportMessage, IotHubMessageResult.REJECT);
 
-        final String expectedTokenStr = tokenStr;
+        final char[] expectedTokenStr = tokenStr;
         new Verifications()
         {
             {
                 mockRequest.setHeaderField(withMatch("(?i)authorization"),
-                        expectedTokenStr);
+                        String.valueOf(expectedTokenStr));
             }
         };
     }
@@ -1887,7 +1886,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 times = 1;
             }
         };
@@ -1914,7 +1913,7 @@ public class HttpsIotHubConnectionTest
         new Verifications()
         {
             {
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 times = 1;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttConnectionTest.java
@@ -28,7 +28,7 @@ public class MqttConnectionTest
     private static final String SERVER_URI = "test.host.name";
     private static final String CLIENT_ID = "test.iothub";
     private static final String USER_NAME = "test-deviceId";
-    private static final String PWORD = "this is not a secret";
+    private static final char[] PWORD = "this is not a secret".toCharArray();
 
     @Mocked
     SSLContext mockSSLContext;
@@ -76,7 +76,7 @@ public class MqttConnectionTest
                 times = 1;
                 mockMqttConnectionOptions.setUserName(USER_NAME);
                 times = 1;
-                mockMqttConnectionOptions.setPassword(PWORD.toCharArray());
+                mockMqttConnectionOptions.setPassword(PWORD);
                 times = 1;
                 mockMqttConnectionOptions.setSocketFactory(mockSSLContext.getSocketFactory());
                 times = 1;
@@ -96,7 +96,7 @@ public class MqttConnectionTest
         //arrange
         baseConstructorExpectations();
         //act
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, (ProxySettings) null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, (ProxySettings) null);
 
         //assert
         baseConstructorVerifications();
@@ -251,7 +251,7 @@ public class MqttConnectionTest
     public void getAsyncClientSucceeds() throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
 
         //act
         MqttAsyncClient mqttAsyncClient = Deencapsulation.invoke(mqttConnection, "getMqttAsyncClient");
@@ -265,7 +265,7 @@ public class MqttConnectionTest
     public void getAllReceivedMessagesSucceeds() throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
 
         //act
         ConcurrentLinkedQueue concurrentLinkedQueue = Deencapsulation.invoke(mqttConnection, "getAllReceivedMessages");
@@ -279,7 +279,7 @@ public class MqttConnectionTest
     public void getMqttLockSucceeds() throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
 
         //act
         Object mqttLock = Deencapsulation.invoke(mqttConnection, "getMqttLock");
@@ -293,7 +293,7 @@ public class MqttConnectionTest
     public void getConnectionOptionsSucceeds() throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
 
         //act
         MqttConnectOptions mqttConnectOptions = Deencapsulation.invoke(mqttConnection, "getConnectionOptions");
@@ -307,7 +307,7 @@ public class MqttConnectionTest
     public void setMqttAsyncClientSucceeds() throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         MqttAsyncClient testMqttAsyncClient = null;
 
         //act
@@ -323,7 +323,7 @@ public class MqttConnectionTest
     public void setMqttCallbackSucceeds(@Mocked MqttCallback mockedMqttCallback) throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         final MqttCallback testMqttCallback = mockedMqttCallback;
 
         //act
@@ -344,7 +344,7 @@ public class MqttConnectionTest
     public void setMqttCallbackThrowsOnNull(@Mocked MqttCallback mockedMqttCallback) throws Exception
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         MqttCallback testMqttCallback = null;
 
         //act
@@ -362,7 +362,7 @@ public class MqttConnectionTest
     {
         //arrange
         final int expectedMessageId = 13;
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
 
         //act
         boolean returnedValue = Deencapsulation.invoke(mqttConnection, "sendMessageAcknowledgement", expectedMessageId);
@@ -386,7 +386,7 @@ public class MqttConnectionTest
     {
         //arrange
         final int expectedMessageId = 13;
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         final MqttException mqttException = new MqttException(new Throwable());
         new NonStrictExpectations()
         {
@@ -407,7 +407,7 @@ public class MqttConnectionTest
     public void isConnectedChecksMqttAsyncClientFalse()
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", mockMqttAsyncClient);
 
         new NonStrictExpectations()
@@ -438,7 +438,7 @@ public class MqttConnectionTest
     public void isConnectedChecksMqttAsyncClientTrue()
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", mockMqttAsyncClient);
 
         new NonStrictExpectations()
@@ -468,7 +468,7 @@ public class MqttConnectionTest
     public void isConnectedReturnsFalseIfMqttAsyncClientIsNull()
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", null);
 
         //act
@@ -484,7 +484,7 @@ public class MqttConnectionTest
     public void disconnectInvokesDisconnectOnAsyncClient() throws MqttException
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", mockMqttAsyncClient);
         new NonStrictExpectations()
         {
@@ -513,7 +513,7 @@ public class MqttConnectionTest
     public void disconnectReturnsNullIfNullAsyncClient() throws MqttException
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", null);
 
         //act
@@ -529,7 +529,7 @@ public class MqttConnectionTest
     public void closeInvokesCloseOnAsyncClient() throws MqttException
     {
         //arrange
-        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
+        final MqttConnection mqttConnection = Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, SERVER_URI, CLIENT_ID, USER_NAME, PWORD, mockSSLContext, null);
         Deencapsulation.setField(mqttConnection, "mqttAsyncClient", mockMqttAsyncClient);
 
         //act

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
@@ -45,7 +45,7 @@ public class MqttIotHubConnectionTest
     final String modelId = "dtmi:my:company:namespace;1";
     final String apiVersionPrefix = "?api-version=";
     final String API_VERSION = apiVersionPrefix + TransportUtils.IOTHUB_API_VERSION;
-    final String expectedToken = "someToken";
+    final char[] expectedToken = "someToken".toCharArray();
     final byte[] expectedMessageBody = { 0x61, 0x62, 0x63 };
     final String userAgentString = "some user agent string";
 
@@ -263,7 +263,7 @@ public class MqttIotHubConnectionTest
     @Test
     public void openEstablishesConnectionUsingCorrectConfig() throws IOException, TransportException
     {
-        final String expectedSasToken = "someToken";
+        final char[] expectedSasToken = "someToken".toCharArray();
         final String serverUri = SSL_PREFIX + iotHubHostName + SSL_PORT_SUFFIX;
         baseExpectations();
 
@@ -272,7 +272,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -288,7 +288,7 @@ public class MqttIotHubConnectionTest
         String clientIdentifier = "DeviceClientType=" + URLEncoder.encode(TransportUtils.USER_AGENT_STRING, "UTF-8").replaceAll("\\+", "%20");
         assertTrue(actualIotHubUserName.contains(iotHubHostName + "/" + deviceId + "/" + API_VERSION));
 
-        final String actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
+        final char[] actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
 
         assertEquals(expectedSasToken, actualUserPassword);
 
@@ -299,7 +299,7 @@ public class MqttIotHubConnectionTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, null);
                 times = 1;
             }
         };
@@ -308,7 +308,7 @@ public class MqttIotHubConnectionTest
     @Test
     public void openEstablishesConnectionUsingModelId() throws IOException, TransportException
     {
-        final String expectedSasToken = "someToken";
+        final char[] expectedSasToken = "someToken".toCharArray();
         final String serverUri = SSL_PREFIX + iotHubHostName + SSL_PORT_SUFFIX;
         baseExpectations();
 
@@ -317,7 +317,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -335,7 +335,7 @@ public class MqttIotHubConnectionTest
         String clientIdentifier = "DeviceClientType=" + URLEncoder.encode(TransportUtils.USER_AGENT_STRING, "UTF-8").replaceAll("\\+", "%20");
         assertTrue(actualIotHubUserName.contains(iotHubHostName + "/" + deviceId + "/" + API_VERSION + "&model-id=" + modelId));
 
-        final String actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
+        final char[] actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
 
         assertEquals(expectedSasToken, actualUserPassword);
 
@@ -346,7 +346,7 @@ public class MqttIotHubConnectionTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, null);
                 times = 1;
             }
         };
@@ -369,7 +369,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = true;
@@ -386,7 +386,7 @@ public class MqttIotHubConnectionTest
 
         assertTrue(actualIotHubUserName.contains(iotHubHostName + "/" + deviceId + "/" + API_VERSION + "&"));
 
-        String actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
+        char[] actualUserPassword = Deencapsulation.getField(connection, "iotHubUserPassword");
 
         assertEquals(expectedToken, actualUserPassword);
 
@@ -397,7 +397,7 @@ public class MqttIotHubConnectionTest
         new Verifications()
         {
             {
-               Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, mockedProxySettings);
+               Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, any, mockedProxySettings);
                times = 1;
             }
         };
@@ -421,7 +421,7 @@ public class MqttIotHubConnectionTest
                 result = true;
                 mockConfig.getProxySettings();
                 result = mockedProxySettings;
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, null, any, mockedProxySettings);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, null, any, mockedProxySettings);
             }
         };
 
@@ -451,7 +451,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -461,7 +461,7 @@ public class MqttIotHubConnectionTest
         new StrictExpectations()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, mockSslContext, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, serverUri, deviceId, any, any, mockSslContext, null);
                 result = new IOException();
             }
         };
@@ -509,7 +509,7 @@ public class MqttIotHubConnectionTest
         new StrictExpectations()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, any, any, any, any, mockSslContext, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, any, any, any, any, mockSslContext, null);
                 result = mockedMqttConnection;
             }
         };
@@ -519,7 +519,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean, (Map) any);
                 result = mockDeviceMessaging;
@@ -565,7 +565,7 @@ public class MqttIotHubConnectionTest
         new StrictExpectations()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, any, any, any, any, mockSslContext, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, any, any, any, any, mockSslContext, null);
                 result = mockedMqttConnection;
             }
         };
@@ -575,7 +575,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedToken;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean, (Map) any);
                 result = mockDeviceMessaging;
@@ -623,7 +623,7 @@ public class MqttIotHubConnectionTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, any, any, any, any, any, (ProxySettings) any);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, any, any, any, any, any, (ProxySettings) any);
                 maxTimes = 1;
             }
         };
@@ -1128,7 +1128,7 @@ public class MqttIotHubConnectionTest
     public void openSavesListenerToMessagingClient() throws IOException, TransportException
     {
         //arrange
-        final String expectedSasToken = "someToken";
+        final char[] expectedSasToken = "someToken".toCharArray();
         baseExpectations();
 
         new Expectations()
@@ -1136,7 +1136,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1164,7 +1164,7 @@ public class MqttIotHubConnectionTest
     public void openWithModuleId() throws IOException, TransportException
     {
         //arrange
-        final String expectedSasToken = "someToken";
+        final char[] expectedSasToken = "someToken".toCharArray();
         final String expectedModuleId = "someModule";
         final String expectedClientId = deviceId + "/" + expectedModuleId;
         final String expectedUserName = "hostname.com/" + expectedClientId + "/" + API_VERSION + "&" + "DeviceClientType=someUserAgentString";
@@ -1173,7 +1173,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1202,7 +1202,7 @@ public class MqttIotHubConnectionTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, anyString, anyString, expectedUserName, anyString, any, null);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, anyString, anyString, expectedUserName, (char[]) any, any, null);
                 times = 1;
             }
         };
@@ -1213,7 +1213,7 @@ public class MqttIotHubConnectionTest
     public void openNotifiesListenerIfConnectionOpenedSuccessfully() throws IOException, TransportException
     {
         //arrange
-        final String expectedSasToken = "someToken";
+        final char[] expectedSasToken = "someToken".toCharArray();
         baseExpectations();
 
         new Expectations()
@@ -1221,7 +1221,7 @@ public class MqttIotHubConnectionTest
             {
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockConfig.getSasTokenAuthentication().getRenewedSasToken(false, false);
+                mockConfig.getSasTokenAuthentication().getSasToken();
                 result = expectedSasToken;
                 mockConfig.isUseWebsocket();
                 result = false;
@@ -1674,7 +1674,7 @@ public class MqttIotHubConnectionTest
         new NonStrictExpectations()
         {
             {
-                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, String.class, SSLContext.class, ProxySettings.class}, anyString, anyString, anyString, anyString, any, proxySettings);
+                Deencapsulation.newInstance(MqttConnection.class, new Class[] {String.class, String.class, String.class, char[].class, SSLContext.class, ProxySettings.class}, anyString, anyString, anyString, (char[]) any, any, proxySettings);
                 result = mockedMqttConnection;
                 new MqttMessaging(mockedMqttConnection, anyString, (IotHubListener) any, null, null, anyString, anyBoolean, (Map) any);
                 result = mockDeviceMessaging;

--- a/device/iot-device-samples/custom-sas-token-provider-sample/pom.xml
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/pom.xml
@@ -1,0 +1,37 @@
+<!-- Copyright (c) Microsoft. All rights reserved. --><!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<project>
+    <parent>
+        <groupId>com.microsoft.azure.sdk.iot.samples</groupId>
+        <artifactId>iot-device-samples</artifactId>
+        <version>1.18.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.microsoft.azure.sdk.iot.samples.device</groupId>
+    <artifactId>custom-sas-token-provider-sample</artifactId>
+    <developers>
+        <developer>
+            <id>microsoft</id>
+            <name>Microsoft</name>
+        </developer>
+    </developers>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>samples.com.microsoft.azure.sdk.iot.CustomSasTokenProviderSample</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
@@ -1,0 +1,364 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.device.*;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * This sample demonstrates how to configure your device client to use a custom SAS token provider instead of
+ * directly providing it the device's symmetric key.
+ */
+public class CustomSasTokenProviderSample
+{
+    private static final int D2C_MESSAGE_TIMEOUT = 2000; // 2 seconds
+    private static List failedMessageListOnClose = new ArrayList(); // List of messages that failed on close
+
+    /**
+     * Helper class for turning symmetric keys into SAS tokens. It also provides some helpful functions around
+     * if this token should be renewed.
+     */
+    protected static class SasToken
+    {
+        private static final String RAW_SIGNATURE_FORMAT = "%s\n%s";
+        private static final String SHARED_ACCESS_SIGNATURE_FORMAT = "SharedAccessSignature %s=%s&%s=%s&%s=%d";
+        private static final Charset SIGNATURE_CHARSET = StandardCharsets.UTF_8;
+        private static final String ExpiryTimeFieldKey = "se";
+        private static final String SignatureFieldKey = "sig";
+        private static final String ResourceURIFieldKey = "sr";
+
+        // When deciding whether to renew SAS tokens or not, it is wise to renew proactively to avoid clock skew issues
+        // between client and server.
+        private int renewalBufferSeconds;
+        private long expiryTimeSeconds;
+        private final char[] sasToken;
+
+        /**
+         * Generate a new SAS token from your host name, device Id, and device Key.
+         * @param hostName the host name of your IoT Hub (for instance, "my-iot-hub.azure-devices.net").
+         * @param deviceId the Id of your device.
+         * @param deviceKey the primary or secondary key of your device.
+         * @param secondsToLive the number of seconds that the token will live for.
+         * @param renewalBufferSeconds the number of seconds before the token expires when this instance will recommend renewal via {{@link #shouldRenewSasToken()}}
+         */
+        public SasToken(String hostName, String deviceId, String deviceKey, int secondsToLive, int renewalBufferSeconds)
+        {
+            this.renewalBufferSeconds = renewalBufferSeconds;
+
+            try
+            {
+                // expiry time is represented by seconds since the UNIX epoch.
+                this.expiryTimeSeconds = (System.currentTimeMillis() / 1000) + secondsToLive;
+
+                String scope = buildScope(hostName, deviceId);
+
+                byte[] signature = String.format(RAW_SIGNATURE_FORMAT, scope, this.expiryTimeSeconds).getBytes(SIGNATURE_CHARSET);
+                byte[] decodedDeviceKey = Base64.decodeBase64(deviceKey);
+
+                // HMAC encrypt the signature
+                byte[] hmacEncryptedSignature = encryptSignatureHmacSha256(signature, decodedDeviceKey);
+
+                // Base64 encode the HMAC encrypted byte[]
+                byte[] base64EncodedHmacEncryptedSignature = Base64.encodeBase64(hmacEncryptedSignature);
+
+                // Convert byte[] of base64 encoded and HMAC encrypted bits to a UTF-8 String
+                String utf8Sig = new String(base64EncodedHmacEncryptedSignature, SIGNATURE_CHARSET);
+
+                // URL encode the string
+                String urlEncodedSignature = URLEncoder.encode(utf8Sig, SIGNATURE_CHARSET.name());
+
+                this.sasToken = String.format(SHARED_ACCESS_SIGNATURE_FORMAT,
+                        ResourceURIFieldKey,
+                        scope,
+                        SignatureFieldKey,
+                        urlEncodedSignature,
+                        ExpiryTimeFieldKey,
+                        this.expiryTimeSeconds).toCharArray();
+            }
+            catch (UnsupportedEncodingException | InvalidKeyException | NoSuchAlgorithmException e)
+            {
+                // The exceptions here should never be thrown since the algorithm, encoding, and key are all hardcoded
+                throw new IllegalStateException("Failed to generate a new SAS token", e);
+            }
+        }
+
+        /**
+         * Get the SAS token char array.
+         * @return The SAS token char array.
+         */
+        public char[] getValue()
+        {
+            return this.sasToken;
+        }
+
+        /**
+         * Returns if this SAS token should be renewed.
+         * @return true if this SAS token has expired, or will expire soon (depending on the provided renewal buffer). False, otherwise.
+         */
+        public boolean shouldRenewSasToken()
+        {
+            long currentTimeSeconds = (System.currentTimeMillis() / 1000);
+
+            // It will recommend renewing the token if it is expired, or if it will expire in the next few seconds
+            return this.expiryTimeSeconds + this.renewalBufferSeconds >= currentTimeSeconds;
+        }
+
+        private byte[] encryptSignatureHmacSha256(byte[] signature, byte[] deviceKey) throws NoSuchAlgorithmException, InvalidKeyException
+        {
+            String hmacSha256 = "HmacSHA256";
+
+            SecretKeySpec secretKey = new SecretKeySpec(deviceKey, hmacSha256);
+
+            byte[] encryptedSig = null;
+            Mac hMacSha256 = Mac.getInstance(hmacSha256);
+            hMacSha256.init(secretKey);
+            encryptedSig = hMacSha256.doFinal(signature);
+
+            return encryptedSig;
+        }
+
+        private String buildScope(String hostName, String deviceId)
+        {
+            return String.format("%s/devices/%s", hostName, deviceId);
+        }
+    }
+
+    /**
+     * A sample implementation of the {@link SasTokenProvider} interface. It demonstrates how to generate your own SAS
+     * tokens from your device key, device Id, and host name. It also demonstrates how to choose how long your SAS tokens
+     * will live for.
+     *
+     * The purpose of the {@link SasTokenProvider} interface is to allow users to generate these tokens in separate
+     * processes from the SDK for security purposes, if they wish. This sample does not demonstrate that scenario.
+     */
+    protected static class SasTokenProviderImpl implements SasTokenProvider
+    {
+        private String deviceKey;
+        private String hostName;
+        private String deviceId;
+        private int secondsToLivePerToken;
+        private int renewalBufferSeconds;
+
+        private SasToken cachedSasToken;
+
+        public SasTokenProviderImpl(String hostName, String deviceId, String deviceKey, int secondsToLivePerToken, int renewalBufferSeconds)
+        {
+            this.hostName = hostName;
+            this.deviceId = deviceId;
+            this.deviceKey = deviceKey;
+            this.secondsToLivePerToken = secondsToLivePerToken;
+            this.renewalBufferSeconds = renewalBufferSeconds;
+        }
+
+        @Override
+        public char[] getSasToken()
+        {
+            if (this.cachedSasToken == null || this.cachedSasToken.shouldRenewSasToken())
+            {
+                // if no SAS token is cached, or if the cached token is expired/about to expire, create a new one
+                this.cachedSasToken = new SasToken(this.hostName, this.deviceId, this.deviceKey, this.secondsToLivePerToken, this.renewalBufferSeconds);
+                return this.cachedSasToken.getValue();
+            }
+            else
+            {
+                return this.cachedSasToken.getValue();
+            }
+        }
+    }
+
+    protected static class EventCallback implements IotHubEventCallback
+    {
+        public void execute(IotHubStatusCode status, Object context)
+        {
+            Message msg = (Message) context;
+
+            System.out.println("IoT Hub responded to message "+ msg.getMessageId()  + " with status " + status.name());
+
+            if (status==IotHubStatusCode.MESSAGE_CANCELLED_ONCLOSE)
+            {
+                failedMessageListOnClose.add(msg.getMessageId());
+            }
+        }
+    }
+
+    protected static class IotHubConnectionStatusChangeCallbackLogger implements IotHubConnectionStatusChangeCallback
+    {
+        @Override
+        public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
+        {
+            System.out.println();
+            System.out.println("CONNECTION STATUS UPDATE: " + status);
+            System.out.println("CONNECTION STATUS REASON: " + statusChangeReason);
+            System.out.println("CONNECTION STATUS THROWABLE: " + (throwable == null ? "null" : throwable.getMessage()));
+            System.out.println();
+
+            if (throwable != null)
+            {
+                throwable.printStackTrace();
+            }
+
+            if (status == IotHubConnectionStatus.DISCONNECTED)
+            {
+                //connection was lost, and is not being re-established. Look at provided exception for
+                // how to resolve this issue. Cannot send messages until this issue is resolved, and you manually
+                // re-open the device client
+            }
+            else if (status == IotHubConnectionStatus.DISCONNECTED_RETRYING)
+            {
+                //connection was lost, but is being re-established. Can still send messages, but they won't
+                // be sent until the connection is re-established
+            }
+            else if (status == IotHubConnectionStatus.CONNECTED)
+            {
+                //Connection was successfully re-established. Can send messages.
+            }
+        }
+    }
+
+    /**
+     * This sample demonstrates how to configure your device client to use a custom SAS token provider instead of
+     * directly providing it the device's symmetric key.
+     *
+     * @param args
+     * args[0] = IoT Hub or Edge Hub connection string
+     * args[1] = number of messages to send
+     * args[2] = protocol (optional, one of 'mqtt' or 'amqps' or 'https' or 'amqps_ws')
+     * args[3] = path to certificate to enable one-way authentication over ssl. (Not necessary when connecting directly to Iot Hub, but required if connecting to an Edge device using a non public root CA certificate).
+     */
+    public static void main(String[] args) throws IOException
+    {
+        System.out.println("Starting...");
+        System.out.println("Beginning setup.");
+
+        if (args.length != 4)
+        {
+            System.out.format(
+                    "Expected 4 arguments but received: %d.\n"
+                            + "The program should be called with the following args: \n"
+                            + "1. Host Name of your IoT Hub, for instance my-iot-hub.azure-devices.net \n"
+                            + "2. Id of your device\n"
+                            + "3. The device key of your device\n"
+                            + "4. (https | amqps | amqps_ws | mqtt | mqtt_ws)\n",
+                    args.length);
+            return;
+        }
+
+        String hostName = args[0];
+        String deviceId = args[1];
+        String deviceKey = args[2];
+
+        IotHubClientProtocol protocol;
+        String protocolStr = args[3];
+        if (protocolStr.equals("https"))
+        {
+            protocol = IotHubClientProtocol.HTTPS;
+        }
+        else if (protocolStr.equals("amqps"))
+        {
+            protocol = IotHubClientProtocol.AMQPS;
+        }
+        else if (protocolStr.equals("mqtt"))
+        {
+            protocol = IotHubClientProtocol.MQTT;
+        }
+        else if (protocolStr.equals("amqps_ws"))
+        {
+            protocol = IotHubClientProtocol.AMQPS_WS;
+        }
+        else if (protocolStr.equals("mqtt_ws"))
+        {
+            protocol = IotHubClientProtocol.MQTT_WS;
+        }
+        else
+        {
+            System.out.format(
+                    "Expected argument 4 to be one of 'mqtt', 'https', 'amqps' or 'amqps_ws' but received %s\n"
+                            + "The program should be called with the following args: \n"
+                            + "1. Host Name of your IoT Hub, for instance my-iot-hub.azure-devices.net \n"
+                            + "2. Id of your device\n"
+                            + "3. The device key of your device\n"
+                            + "4. (https | amqps | amqps_ws | mqtt | mqtt_ws)\n",
+                    protocolStr);
+            return;
+        }
+
+        System.out.println("Successfully read input parameters.");
+        System.out.format("Using communication protocol %s.\n", protocol.name());
+
+        System.out.println("Constructing SAS token provider");
+        int tokenTimeToLiveSeconds = 60 * 60; // 1 hour
+        int tokenRenewalBufferSeconds = 60; // token will recommend renewal after it reaches 1 minute before it expires
+        SasTokenProvider sasTokenProvider = new SasTokenProviderImpl(hostName, deviceId, deviceKey, tokenTimeToLiveSeconds, tokenRenewalBufferSeconds);
+
+        System.out.println("Constructing Device Client that will use the SAS token provider");
+        DeviceClient client = new DeviceClient(hostName, deviceId, sasTokenProvider, protocol);
+
+        System.out.println("Successfully created an IoT Hub client.");
+
+        client.registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeCallbackLogger(), new Object());
+
+        client.open();
+
+        System.out.println("Opened connection to IoT Hub.");
+        System.out.println("Sending telemetry...");
+
+        double temperature = 20 + Math.random() * 10;
+        double humidity = 30 + Math.random() * 20;
+        String msgStr = "{\"temperature\":"+ temperature +",\"humidity\":"+ humidity +"}";
+
+        try
+        {
+            Message msg = new Message(msgStr);
+            msg.setContentTypeFinal("application/json");
+            msg.setProperty("temperatureAlert", temperature > 28 ? "true" : "false");
+            msg.setMessageId(java.util.UUID.randomUUID().toString());
+            msg.setExpiryTime(D2C_MESSAGE_TIMEOUT);
+            System.out.println(msgStr);
+
+            EventCallback callback = new EventCallback();
+            client.sendEventAsync(msg, callback, msg);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace(); // Trace the exception
+        }
+
+        System.out.println("Wait for " + D2C_MESSAGE_TIMEOUT / 1000 + " second(s) for response from the IoT Hub...");
+
+        // Wait for IoT Hub to respond.
+        try
+        {
+            Thread.sleep(D2C_MESSAGE_TIMEOUT);
+        }
+        catch (InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+
+        // close the connection
+        System.out.println("Closing");
+        client.closeNow();
+
+        if (!failedMessageListOnClose.isEmpty())
+        {
+            System.out.println("List of messages that were cancelled on close:" + failedMessageListOnClose.toString());
+        }
+
+        System.out.println("Shutting down...");
+    }
+}

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
@@ -33,7 +33,7 @@ public class CustomSasTokenProviderSample
      * Helper class for turning symmetric keys into SAS tokens. It also provides some helpful functions around
      * if this token should be renewed.
      */
-    protected static class SasToken
+    protected static class SasTokenHelper
     {
         private static final String RAW_SIGNATURE_FORMAT = "%s\n%s";
         private static final String SHARED_ACCESS_SIGNATURE_FORMAT = "SharedAccessSignature %s=%s&%s=%s&%s=%d";
@@ -58,7 +58,7 @@ public class CustomSasTokenProviderSample
          * @param secondsToLive the number of seconds that the token will live for.
          * @param renewalBufferSeconds the number of seconds before the token expires when this instance will recommend renewal via {{@link #shouldRenewSasToken()}}
          */
-        public SasToken(String hostName, String deviceId, String deviceKey, int secondsToLive, int renewalBufferSeconds)
+        public SasTokenHelper(String hostName, String deviceId, String deviceKey, int secondsToLive, int renewalBufferSeconds)
         {
             this.renewalBufferSeconds = renewalBufferSeconds;
 
@@ -155,7 +155,7 @@ public class CustomSasTokenProviderSample
         private int secondsToLivePerToken;
         private int renewalBufferSeconds;
 
-        private SasToken cachedSasToken;
+        private SasTokenHelper cachedSasToken;
 
         public SasTokenProviderImpl(String hostName, String deviceId, String deviceKey, int secondsToLivePerToken, int renewalBufferSeconds)
         {
@@ -172,7 +172,7 @@ public class CustomSasTokenProviderSample
             if (this.cachedSasToken == null || this.cachedSasToken.shouldRenewSasToken())
             {
                 // if no SAS token is cached, or if the cached token is expired/about to expire, create a new one
-                this.cachedSasToken = new SasToken(this.hostName, this.deviceId, this.deviceKey, this.secondsToLivePerToken, this.renewalBufferSeconds);
+                this.cachedSasToken = new SasTokenHelper(this.hostName, this.deviceId, this.deviceKey, this.secondsToLivePerToken, this.renewalBufferSeconds);
                 return this.cachedSasToken.getValue();
             }
             //else if (...)

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
@@ -174,6 +174,12 @@ public class CustomSasTokenProviderSample
                 this.cachedSasToken = new SasToken(this.hostName, this.deviceId, this.deviceKey, this.secondsToLivePerToken, this.renewalBufferSeconds);
                 return this.cachedSasToken.getValue();
             }
+            //else if (...)
+            //{
+                // It is recommended to have some logic in here that checks to make sure that the device key in use itself
+                // is still valid. A given device may have it's keys cycled by its owner, and this would be an appropriate
+                // time to update the device key if a new one was cycled in.
+            //}
             else
             {
                 return this.cachedSasToken.getValue();

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class CustomSasTokenProviderSample
 {
     private static final int D2C_MESSAGE_TIMEOUT = 2000; // 2 seconds
-    private static List failedMessageListOnClose = new ArrayList(); // List of messages that failed on close
+    private static List<String> failedMessageListOnClose = new ArrayList(); // List of messages that failed on close
 
     /**
      * Helper class for turning symmetric keys into SAS tokens. It also provides some helpful functions around

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/CustomSasTokenProviderSample.java
@@ -86,11 +86,11 @@ public class CustomSasTokenProviderSample
 
                 this.sasToken = String.format(
                     SHARED_ACCESS_SIGNATURE_FORMAT,
-                        RESOURCE_URI_FIELD_KEY,
+                    RESOURCE_URI_FIELD_KEY,
                     scope,
-                        SIGNATURE_FIELD_KEY,
+                    SIGNATURE_FIELD_KEY,
                     urlEncodedSignature,
-                        EXPIRY_TIME_FIELD_KEY,
+                    EXPIRY_TIME_FIELD_KEY,
                     this.expiryTimeSeconds).toCharArray();
             }
             catch (UnsupportedEncodingException | InvalidKeyException | NoSuchAlgorithmException e)

--- a/device/iot-device-samples/custom-sas-token-provider-sample/src/main/resources/log4j.properties
+++ b/device/iot-device-samples/custom-sas-token-provider-sample/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=ERROR, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.logger.com.microsoft.azure.sdk.iot.device = DEBUG

--- a/device/iot-device-samples/pom.xml
+++ b/device/iot-device-samples/pom.xml
@@ -36,6 +36,7 @@
         <module>send-event-with-proxy</module>
         <module>device-reconnection-sample</module>
         <module>pnp-device-sample</module>
+        <module>custom-sas-token-provider-sample</module>
     </modules>
     <dependencies>
         <dependency>

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SasTokenProviderImpl.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SasTokenProviderImpl.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tests.integration.com.microsoft.azure.sdk.iot.helpers;
+
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.device.SasTokenProvider;
+import com.microsoft.azure.sdk.iot.device.auth.IotHubSasToken;
+
+import java.net.URISyntaxException;
+
+/**
+ * Basic implementation of the SasTokenProvider interface, for test purposes.
+ */
+public class SasTokenProviderImpl implements SasTokenProvider
+{
+    IotHubConnectionString deviceConnectionString;
+    int expiryLengthSeconds;
+
+    // Same value as the default SAS token timespan when using SDK defaults.
+    private static final int DEFAULT_EXPIRY_LENGTH_SECONDS =  60 * 60; // 1 hour
+
+    public SasTokenProviderImpl(String deviceConnectionString) throws URISyntaxException {
+        this(deviceConnectionString, DEFAULT_EXPIRY_LENGTH_SECONDS);
+    }
+
+    // expiryLengthSeconds is useful to configure in tests like the token renewal tests where we want shorter
+    // lived SAS tokens
+    public SasTokenProviderImpl(String deviceConnectionString, int expiryLengthSeconds) throws URISyntaxException {
+        this.deviceConnectionString = new IotHubConnectionString(deviceConnectionString);
+        this.expiryLengthSeconds = expiryLengthSeconds;
+    }
+
+    @Override
+    public char[] getSasToken() {
+        long expiryTimeSeconds = expiryLengthSeconds + (System.currentTimeMillis() / 1000);
+        return new IotHubSasToken(
+                deviceConnectionString.getHostName(),
+                deviceConnectionString.getDeviceId(),
+                deviceConnectionString.getSharedAccessKey(),
+                null,
+                deviceConnectionString.getModuleId(),
+                expiryTimeSeconds).toString().toCharArray();
+    }
+}

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -227,7 +227,16 @@ public class SendMessagesCommon extends IntegrationTest
             setup(sslContext);
         }
 
-        public void setup(SSLContext customSSLContext) throws Exception
+        public void setup(SSLContext customSSLContext) throws Exception {
+            setup(customSSLContext, false);
+        }
+
+        public void setup(boolean useCustomSasTokenProvider) throws Exception {
+            SSLContext sslContext = SSLContextBuilder.buildSSLContext(publicKeyCert, privateKey);
+            setup(sslContext, useCustomSasTokenProvider);
+        }
+
+        public void setup(SSLContext customSSLContext, boolean useCustomSasTokenProvider) throws Exception
         {
             String TEST_UUID = UUID.randomUUID().toString();
 
@@ -239,8 +248,17 @@ public class SendMessagesCommon extends IntegrationTest
                     String deviceId = "java-send-message-e2e-test-device".concat("-" + TEST_UUID);
                     Device device = Device.createFromId(deviceId, null, null);
                     device = Tools.addDeviceWithRetry(registryManager, device);
-                    this.client = new DeviceClient(registryManager.getDeviceConnectionString(device), protocol);
                     this.identity = device;
+
+                    if (useCustomSasTokenProvider)
+                    {
+                        SasTokenProvider sasTokenProvider = new SasTokenProviderImpl(registryManager.getDeviceConnectionString(device));
+                        this.client = new DeviceClient(hostName, deviceId, sasTokenProvider, protocol, null);
+                    }
+                    else
+                    {
+                        this.client = new DeviceClient(registryManager.getDeviceConnectionString(device), protocol);
+                    }
                 }
                 else if (authenticationType == SELF_SIGNED)
                 {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -70,6 +70,14 @@ public class SendMessagesTests extends SendMessagesCommon
     }
 
     @Test
+    public void sendMessagesWithCustomSasTokenProvider() throws Exception
+    {
+        this.testInstance.setup(true);
+
+        IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, NORMAL_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
+    }
+
+    @Test
     public void sendBulkMessages() throws Exception
     {
         this.testInstance.setup();

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/pom.xml
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/pom.xml
@@ -50,7 +50,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>samples.com.microsoft.azure.sdk.iot.ProvisioningSymmetricKeyIndividualEnrollmentSample</mainClass>
+                            <mainClass>samples.com.microsoft.azure.sdk.iot.ProvisioningSymmetricKeyEnrollmentGroupSample</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Currently, users who have symmetric key authenticated devices have to provide the whole symmetric key to our SDK. Some customers have asked for the ability to just provide the SAS tokens instead so that they can store the symmetric key somewhere else, which is a reasonable ask. This PR add support for that scenario.