### PR TITLE
fix(documentation): Adding conditional docs generation

### DIFF
--- a/vsts/generate_javadocs_branch.ps1
+++ b/vsts/generate_javadocs_branch.ps1
@@ -15,7 +15,16 @@ function TestLastExitCode {
     }
 }
 
-function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources, $FolderName) {
+function CreateJavadocReleaseBranch(
+    $GitHubName,
+    $GitHubEmail,
+    $Sources,
+    $FolderName,
+    $UpdateServiceClientDocs,
+    $UpdateDeviceClientDocs,
+    $UpdateProvisioningClientDocs,
+    $UpdateDepsDocs) {
+
     if ($([string]::IsNullOrWhiteSpace($GitHubName) -eq $true)) {
         throw "GitHubName is null or empty"
     }
@@ -48,6 +57,7 @@ function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources, $Folder
 
     Write-Host "Copying generated javadocs to replace current javadocs"
     Set-Location apidocs
+
     Remove-Item ..\deps -Force -Recurse
     Copy-Item -Force -Path .\deps\* -Destination ..\deps
     Copy-Item -Recurse -Force -Path .\deps\com -Destination ..\deps
@@ -104,10 +114,26 @@ function CreateJavadocReleaseBranch($GitHubName, $GitHubEmail, $Sources, $Folder
 
     # Move the generated content to the correct folder. The folder will be different for master and preview branches.
     New-Item -Path ../$FolderName -ItemType Directory
-    Move-Item -Force -Path ..\deps -Destination ..\$FolderName\deps
-    Move-Item -Force -Path ..\device -Destination ..\$FolderName\device
-    Move-Item -Force -Path ..\service -Destination ..\$FolderName\service
-    Move-Item -Force -Path ..\provisioning -Destination ..\$FolderName\provisioning
+
+    if($UpdateDepsDocs)
+    {
+        Move-Item -Force -Path ..\deps -Destination ..\$FolderName\deps
+    }
+
+    if($UpdateDeviceClientDocs)
+    {
+        Move-Item -Force -Path ..\device -Destination ..\$FolderName\device
+    }
+
+    if($UpdateServiceClientDocs)
+    {
+        Move-Item -Force -Path ..\service -Destination ..\$FolderName\service
+    }
+
+    if($UpdateProvisioningClientDocs)
+    {
+        Move-Item -Force -Path ..\provisioning -Destination ..\$FolderName\provisioning
+    }
 
     Set-Location ..
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
As we have created a new preview branch, all packages have the same version as master and not the latest preview version. This leads to generation of incorrect docs as we have only released a new device-client preview. To ensure that the gh-pages are only updated for the corresponding package, I have added a conditional generation which can be set in the pipeline. This way, we can just generate the required documentation and keep the others ones as is.

This change will go to preview when I merge master to preview.

Pipeline now has the following options. They will be used once this PR is checked in.

![image](https://user-images.githubusercontent.com/14096264/99746259-d27c0d80-2a8e-11eb-8a32-9be2392b4eae.png)

