### PR TITLE
fix(iot-dev): Fix possible NPE in AMQP layer

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -740,35 +740,13 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
     }
 
-    private void executorServicesCleanup() throws TransportException
+    private void executorServicesCleanup()
     {
         if (this.executorService != null)
         {
             log.trace("Shutdown of executor service has started");
-            this.executorService.shutdown();
-            try
-            {
-                // Wait a while for existing tasks to terminate
-                if (!this.executorService.awaitTermination(MAX_WAIT_TO_TERMINATE_EXECUTOR, TimeUnit.SECONDS))
-                {
-                    this.executorService.shutdownNow(); // Cancel currently executing tasks
-                    // Wait a while for tasks to respond to being cancelled
-                    if (!this.executorService.awaitTermination(MAX_WAIT_TO_TERMINATE_EXECUTOR, TimeUnit.SECONDS))
-                    {
-                        log.trace("Pool did not terminate");
-                    }
-                }
-
-                this.executorService = null;
-            }
-            catch (InterruptedException e)
-            {
-                log.warn("Interrupted while cleaning up executor services", e);
-                // (Re-)Cancel if current thread also interrupted
-                this.executorService.shutdownNow();
-                this.executorService = null;
-                throw new TransportException("Waited too long for the connection to close.", e);
-            }
+            this.executorService.shutdownNow();
+            this.executorService = null;
             log.trace("Shutdown of executor service completed");
         }
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -72,6 +72,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private IotHubListener listener;
     private TransportException savedException;
     private boolean reconnectionScheduled = false;
+    private final Object executorServiceLock = new Object();
     private ExecutorService executorService;
 
     // State latches are used for asynchronous open and close operations
@@ -694,10 +695,13 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     {
         log.trace("OpenAsnyc called for amqp connection");
 
-        if (executorService == null)
+        synchronized (this.executorServiceLock)
         {
-            log.trace("Creating new executor service");
-            executorService = Executors.newFixedThreadPool(1);
+            if (executorService == null)
+            {
+                log.trace("Creating new executor service");
+                executorService = Executors.newFixedThreadPool(1);
+            }
         }
 
         this.reactor = createReactor();
@@ -742,12 +746,15 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
     private void executorServicesCleanup()
     {
-        if (this.executorService != null)
+        synchronized (this.executorServiceLock)
         {
-            log.trace("Shutdown of executor service has started");
-            this.executorService.shutdownNow();
-            this.executorService = null;
-            log.trace("Shutdown of executor service completed");
+            if (this.executorService != null)
+            {
+                log.trace("Shutdown of executor service has started");
+                this.executorService.shutdownNow();
+                this.executorService = null;
+                log.trace("Shutdown of executor service completed");
+            }
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -355,6 +355,26 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
                         || senderLinkHandler instanceof AmqpsTwinSenderLinkHandler && messageType == DEVICE_TWIN
                         || senderLinkHandler instanceof AmqpsMethodsSenderLinkHandler && messageType == DEVICE_METHODS)
                 {
+                    if (messageType == DEVICE_TWIN)
+                    {
+                        if (explicitInProgressTwinSubscriptionMessage != null)
+                        {
+                            // Don't send any twin messages while a twin subscription is in progress. Wait until the subscription
+                            // has been acknowledged by the service before sending it.
+                            return false;
+                        }
+
+                        for (SubscriptionType subscriptionType : this.implicitInProgressSubscriptionMessages.values())
+                        {
+                            if (subscriptionType == SubscriptionType.DESIRED_PROPERTIES_SUBSCRIPTION)
+                            {
+                                // Don't send any twin messages while a twin subscription is in progress. Wait until the subscription
+                                // has been acknowledged by the service before sending it.
+                                return false;
+                            }
+                        }
+                    }
+                    
                     AmqpsSendResult amqpsSendResult = senderLinkHandler.sendMessageAndGetDeliveryTag(message);
 
                     if (amqpsSendResult.isDeliverySuccessful())

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -548,7 +548,7 @@ public class AmqpsIotHubConnectionTest {
         {
             {
                 mockReactorFuture.cancel(true);
-                mockExecutorService.shutdown();
+                mockExecutorService.shutdownNow();
             }
         };
 
@@ -567,7 +567,7 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                mockExecutorService.shutdown();
+                mockExecutorService.shutdownNow();
                 times = 1;
             }
         };


### PR DESCRIPTION
Sending a get twin request while the subscribe to desired properties request was in progress seemed to cause reliable NPE in transport clients that start twin for each of their devices. By waiting for the in progress subscriptions to finish before sending actual messages over these links, the NPE goes away. The NPE itself comes from within the AMQP library, so my best guess is that there is a race condition of some sort that we would hit previously

Also simplify some code in our executor service cleanup logic to match what we checked into preview earlier.