### PR TITLE
[Preview] Fix multiplexingClient not allowing re-registered clients to subscribe to twin/methods

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -1081,7 +1081,8 @@ public class InternalClient
 
     /**
      * Returns if this client is or ever was registered to a {@link MultiplexingClient} instance. Device clients that were
-     * cannot be used in non-multiplexed connections.
+     * cannot be used in non-multiplexed connections. Device clients that aren't registered to any multiplexing client
+     * will still return true.
      * @return true if this client is or ever was registered to a {@link MultiplexingClient} instance, false otherwise.
      */
     public boolean isMultiplexed()

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -649,6 +649,20 @@ public class InternalClient
         }
     }
 
+    // only used by the MultiplexingClient class to signal to this client that it needs to re-register twin
+    // callbacks
+    void markTwinAsUnsubscribed()
+    {
+        this.twin = null;
+    }
+
+    // only used by the MultiplexingClient class to signal to this client that it needs to re-register methods
+    // callbacks
+    void markMethodsAsUnsubscribed()
+    {
+        this.method = null;
+    }
+
     /**
      * Starts the device twin.
      *
@@ -1063,5 +1077,15 @@ public class InternalClient
         {
             throw new UnsupportedOperationException("Must re-register this client to a multiplexing client before using it");
         }
+    }
+
+    /**
+     * Returns if this client is or ever was registered to a {@link MultiplexingClient} instance. Device clients that were
+     * cannot be used in non-multiplexed connections.
+     * @return true if this client is or ever was registered to a {@link MultiplexingClient} instance, false otherwise.
+     */
+    public boolean isMultiplexed()
+    {
+        return this.isMultiplexed;
     }
 }

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
@@ -55,7 +55,7 @@ public class MultiplexingSample
      * Add up to 998 device connection strings from args[4] on.
      *
      * Any additional arguments will be interpreted as additional connections strings. This allows this sample to be
-     * run with more than 2 devices. At
+     * run with more than 2 devices.
      */
     public static void main(String[] args)
             throws URISyntaxException, InterruptedException, MultiplexingClientException {

--- a/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
+++ b/device/iot-device-samples/multiplexing-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/MultiplexingSample.java
@@ -178,6 +178,11 @@ public class MultiplexingSample
         }
         System.out.println("Successfully unregistered device " + deviceIdToUnregister + " from an active multiplexed connection.");
 
+        // Will always be true since this device client was registered to a multiplexing client at one point, even though
+        // it isn't right now. Clients like these cannot be used to crete non-multiplexed connections, but may
+        // be re-registered to any MultiplexingClient instance.
+        boolean isMultiplexed = multiplexedDeviceClients.get(deviceIdToUnregister).isMultiplexed();
+
         // This code demonstrates how to add a device to an active multiplexed connection without shutting down
         // the whole multiplexed connection or any of the other devices.
         System.out.println("Re-registering device " + deviceIdToUnregister + " to an active multiplexed connection...");


### PR DESCRIPTION
If a client subscribes to twin and method, then unregisters from its multiplexing client, and is later re-registered, the default behavior will be to not preserve those subscriptions. We can add an optional parameter to enable this sort of behavior later, if users are interested.