### PR TITLE
fix(iot-dev): Fix issue where unregistering a multiplexed device that isn't registered loops infinitely

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -977,17 +977,15 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
                 log.debug("Closing device session for multiplexed device {}", configToUnregister.getDeviceId());
                 amqpsSessionHandler.closeSession();
-
-                configsUnregisteredSuccessfully.add(configToUnregister);
-
-                configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
             }
             else
             {
                 log.warn("Attempted to remove device session for device {} from multiplexed connection, but device was not currently registered.", configToUnregister.getDeviceId());
-                configsUnregisteredSuccessfully.add(configToUnregister);
-                configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
             }
+
+            configsUnregisteredSuccessfully.add(configToUnregister);
+            configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
+
         }
 
         this.multiplexingClientsToUnregister.removeAll(configsUnregisteredSuccessfully);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -947,8 +947,12 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 }
             }
 
-            // If a device session currently exists for this device identity, then remove it
-            if (amqpsSessionHandler != null)
+            // If a device session doesn't currently exist for this device identity
+            if (amqpsSessionHandler == null)
+            {
+                log.warn("Attempted to remove device session for device {} from multiplexed connection, but device was not currently registered.", configToUnregister.getDeviceId());
+            }
+            else
             {
                 log.trace("Removing session handler for device {}", amqpsSessionHandler.getDeviceId());
                 this.sessionHandlers.remove(amqpsSessionHandler);
@@ -978,14 +982,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 log.debug("Closing device session for multiplexed device {}", configToUnregister.getDeviceId());
                 amqpsSessionHandler.closeSession();
             }
-            else
-            {
-                log.warn("Attempted to remove device session for device {} from multiplexed connection, but device was not currently registered.", configToUnregister.getDeviceId());
-            }
 
             configsUnregisteredSuccessfully.add(configToUnregister);
             configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
-
         }
 
         this.multiplexingClientsToUnregister.removeAll(configsUnregisteredSuccessfully);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -986,6 +986,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             {
                 log.warn("Attempted to remove device session for device {} from multiplexed connection, but device was not currently registered.", configToUnregister.getDeviceId());
                 configsUnregisteredSuccessfully.add(configToUnregister);
+                configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
             }
         }
 


### PR DESCRIPTION
This loop happens in the AMQP worker thread, so users wouldn't notice this, but it is still a bug.