### PR TITLE
fix(iot-dev): Fix multiplexing client so that it unwinds previous bulk registrations if one client isn't supported

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -416,6 +416,13 @@ public class MultiplexingClient
         synchronized (this.operationLock)
         {
             List<DeviceClientConfig> deviceClientConfigsToRegister = new ArrayList<>();
+
+            // When registering in bulk, some clients may cause this method to throw (for example if the client uses MQTT),
+            // so it is important to be able to unwind the bulk operation when this happens. This list
+            // contains the Ids of the clients that were ready to be registered before encountering an error like that
+            // so that they can be removed from the local state.
+            List<String> partiallyRegisteredClientIds = new ArrayList<>();
+
             for (DeviceClient deviceClientToRegister : deviceClients)
             {
                 DeviceClientConfig configToAdd = deviceClientToRegister.getConfig();
@@ -432,16 +439,19 @@ public class MultiplexingClient
 
                 if (configToAdd.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN)
                 {
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
                     throw new UnsupportedOperationException("Can only register to multiplex a device client that uses SAS token based authentication");
                 }
 
                 if (configToAdd.getProtocol() != this.protocol)
                 {
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
                     throw new UnsupportedOperationException("A device client cannot be registered to a multiplexing client that specifies a different transport protocol.");
                 }
 
                 if (this.protocol == IotHubClientProtocol.AMQPS && this.multiplexedDeviceClients.size() > MAX_MULTIPLEX_DEVICE_COUNT_AMQPS)
                 {
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
                     throw new UnsupportedOperationException(String.format("Multiplexed connections over AMQPS only support up to %d devices", MAX_MULTIPLEX_DEVICE_COUNT_AMQPS));
                 }
 
@@ -449,17 +459,20 @@ public class MultiplexingClient
                 // AMQPS_WS connection so this is the only way that users will know about this limit
                 if (this.protocol == IotHubClientProtocol.AMQPS_WS && this.multiplexedDeviceClients.size() > MAX_MULTIPLEX_DEVICE_COUNT_AMQPS_WS)
                 {
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
                     throw new UnsupportedOperationException(String.format("Multiplexed connections over AMQPS_WS only support up to %d devices", MAX_MULTIPLEX_DEVICE_COUNT_AMQPS_WS));
                 }
 
                 if (!this.hostName.equalsIgnoreCase(configToAdd.getIotHubHostname()))
                 {
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
                     throw new UnsupportedOperationException("A device client cannot be registered to a multiplexing client that specifies a different host name.");
                 }
 
                 if (deviceClientToRegister.getDeviceIO() != null && deviceClientToRegister.getDeviceIO().isOpen() && !deviceClientToRegister.isMultiplexed)
                 {
-                    throw new IllegalStateException("Cannot register a device client to a multiplexed connection when the device client was already opened.");
+                    unwindPreviousRegistrations(partiallyRegisteredClientIds);
+                    throw new UnsupportedOperationException("Cannot register a device client to a multiplexed connection when the device client was already opened.");
                 }
 
                 deviceClientToRegister.setAsMultiplexed();
@@ -475,7 +488,9 @@ public class MultiplexingClient
                 }
                 else
                 {
-                    this.multiplexedDeviceClients.put(deviceClientToRegister.getConfig().getDeviceId(), deviceClientToRegister);
+                    String deviceIdToRegister = deviceClientToRegister.getConfig().getDeviceId();
+                    this.multiplexedDeviceClients.put(deviceIdToRegister, deviceClientToRegister);
+                    partiallyRegisteredClientIds.add(deviceIdToRegister);
                     deviceClientConfigsToRegister.add(configToAdd);
                 }
             }
@@ -697,5 +712,13 @@ public class MultiplexingClient
     public void setRetryPolicy(RetryPolicy retryPolicy)
     {
         this.deviceIO.setMultiplexingRetryPolicy(retryPolicy);
+    }
+
+    private void unwindPreviousRegistrations(List<String> partiallyRegisteredClientIds)
+    {
+        for (String partiallyRegisteredClientId : partiallyRegisteredClientIds)
+        {
+            this.multiplexedDeviceClients.remove(partiallyRegisteredClientId);
+        }
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -491,8 +491,8 @@ public class MultiplexingClient
             for (DeviceClient successfullyRegisteredClient : deviceClients)
             {
                 // Only update the local state map once the register call has succeeded
-                String deviceIdToRegister = successfullyRegisteredClient.getConfig().getDeviceId();
-                this.multiplexedDeviceClients.put(deviceIdToRegister, successfullyRegisteredClient);
+                String registeredDeviceId = successfullyRegisteredClient.getConfig().getDeviceId();
+                this.multiplexedDeviceClients.put(registeredDeviceId, successfullyRegisteredClient);
             }
         }
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1491,7 +1491,7 @@ public class MultiplexingClientTests extends IntegrationTest
 
         assertTrue("Expected bulk registration to throw an UnsupportedOperationException", expectedExceptionThrown);
 
-        // Because one of the devices in the bulk registration was MQTT, and therefore unsupported, none of the other clients
+        // Because one of the devices in the bulk registration has some unsupported feature (MQTT protocol, X509 auth, etc.), none of the other clients
         // should have been registered.
         for (int i = 0; i < this.testInstance.deviceClientArray.size(); i++)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -6,6 +6,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.iothub;
 
 
+import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
@@ -32,6 +33,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
 import com.microsoft.azure.sdk.iot.service.ServiceClient;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.auth.SymmetricKey;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethod;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
@@ -1396,6 +1398,107 @@ public class MultiplexingClientTests extends IntegrationTest
 
         assertTrue("Expected exception was not thrown", expectedExceptionThrown);
     }
+
+    @Test
+    public void registrationsUnwindForMqttClient() throws Exception
+    {
+        Device newDevice = Device.createDevice(UUID.randomUUID().toString(), AuthenticationType.SAS);
+        registryManager.addDevice(newDevice);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(newDevice);
+
+        // MQTT clients should throw unsupportedoperationexception when registered
+        DeviceClient mqttDeviceClient = new DeviceClient(deviceConnectionString, IotHubClientProtocol.MQTT);
+        registrationsUnwindForUnsupportedOperationExceptions(mqttDeviceClient);
+    }
+
+    @Test
+    public void registrationsUnwindForX509Client() throws Exception
+    {
+        // Create a new device client that uses x509 auth, which should throw an UnsupportedOperationException
+        // since x509 auth isn't supported while multiplexing
+        Device x509Device = Device.createDevice(UUID.randomUUID().toString(), AuthenticationType.SELF_SIGNED);
+        registryManager.addDevice(x509Device);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(x509Device);
+        DeviceClient x509DeviceClient = new DeviceClient(deviceConnectionString, testInstance.protocol, new IotHubSSLContext().getSSLContext());
+        registrationsUnwindForUnsupportedOperationExceptions(x509DeviceClient);
+    }
+
+    @Test
+    public void registrationsUnwindForAlreadyOpenClient() throws Exception
+    {
+        Device nonMultiplexedDevice = Device.createDevice(UUID.randomUUID().toString(), AuthenticationType.SAS);
+        registryManager.addDevice(nonMultiplexedDevice);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(nonMultiplexedDevice);
+        DeviceClient nonMultiplexedDeviceClient = new DeviceClient(deviceConnectionString, testInstance.protocol);
+
+        //By opening the client once, this client can no longer be registered to a multiplexing client
+        nonMultiplexedDeviceClient.open();
+        registrationsUnwindForUnsupportedOperationExceptions(nonMultiplexedDeviceClient);
+        nonMultiplexedDeviceClient.closeNow();
+    }
+
+    @Test
+    public void registrationsUnwindForClientOfDifferentHostName() throws Exception
+    {
+        Device nonMultiplexedDevice = Device.createDevice(UUID.randomUUID().toString(), AuthenticationType.SAS);
+        registryManager.addDevice(nonMultiplexedDevice);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(nonMultiplexedDevice);
+
+        // intentionally change the hostname of the device to simulate registering a device with a different hostname
+        // to a multiplexing client. It shouldn't matter that the hostname itself isn't tied to an actual IoT Hub since
+        // no network requests should be made before this hostname validation.
+
+        String actualHostName = IotHubConnectionString.createConnectionString(iotHubConnectionString).getHostName();
+        deviceConnectionString = deviceConnectionString.replace(actualHostName, "some-fake-host-name.azure-devices.net");
+
+        DeviceClient deviceClientWithDifferentHostName = new DeviceClient(deviceConnectionString, testInstance.protocol);
+
+        registrationsUnwindForUnsupportedOperationExceptions(deviceClientWithDifferentHostName);
+    }
+
+    @Test
+    public void registrationsUnwindForDifferentProtocolClient() throws Exception
+    {
+        Device newDevice = Device.createDevice(UUID.randomUUID().toString(), AuthenticationType.SAS);
+        registryManager.addDevice(newDevice);
+        String deviceConnectionString = registryManager.getDeviceConnectionString(newDevice);
+
+        // Protocol for the new client is AMQPS if the test parameters are for AMQPS_WS, and vice versa. MultiplexingClient
+        // should throw an exception since this new client's protocol doesn't match, even though both AMQPS and AMQPS_WS are valid
+        // protocols
+        IotHubClientProtocol protocol = testInstance.protocol == IotHubClientProtocol.AMQPS ? IotHubClientProtocol.AMQPS_WS : IotHubClientProtocol.AMQPS;
+
+        DeviceClient differentProtocolDeviceClient = new DeviceClient(deviceConnectionString, protocol);
+        registrationsUnwindForUnsupportedOperationExceptions(differentProtocolDeviceClient);
+    }
+
+    public void registrationsUnwindForUnsupportedOperationExceptions(DeviceClient unsupportedDeviceClient) throws Exception
+    {
+        testInstance.setup(DEVICE_MULTIPLEX_COUNT);
+        this.testInstance.multiplexingClient.unregisterDeviceClients(this.testInstance.deviceClientArray);
+
+        this.testInstance.deviceClientArray.add(unsupportedDeviceClient);
+
+        boolean expectedExceptionThrown = false;
+        try
+        {
+            this.testInstance.multiplexingClient.registerDeviceClients(this.testInstance.deviceClientArray);
+        }
+        catch (UnsupportedOperationException e)
+        {
+            expectedExceptionThrown = true;
+        }
+
+        assertTrue("Expected bulk registration to throw an UnsupportedOperationException", expectedExceptionThrown);
+
+        // Because one of the devices in the bulk registration was MQTT, and therefore unsupported, none of the other clients
+        // should have been registered.
+        for (int i = 0; i < this.testInstance.deviceClientArray.size(); i++)
+        {
+            assertFalse(this.testInstance.multiplexingClient.isDeviceRegistered(this.testInstance.deviceClientArray.get(i).getConfig().getDeviceId()));
+        }
+    }
+
 
     private static void assertMultiplexedDevicesClosedGracefully(ConnectionStatusChangeTracker[] connectionStatusChangeTrackers)
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1406,7 +1406,7 @@ public class MultiplexingClientTests extends IntegrationTest
         registryManager.addDevice(newDevice);
         String deviceConnectionString = registryManager.getDeviceConnectionString(newDevice);
 
-        // MQTT clients should throw unsupportedoperationexception when registered
+        // MQTT clients should throw UnsupportedOperationException when registered
         DeviceClient mqttDeviceClient = new DeviceClient(deviceConnectionString, IotHubClientProtocol.MQTT);
         registrationsUnwindForUnsupportedOperationExceptions(mqttDeviceClient);
     }


### PR DESCRIPTION
Previously, the local state of which devices were registered already would be incorrect upon encountering an error like this if the error wasn't triggered by the first device client in the list to register.