### PR TITLE
feat(iot-service): Add custom SSLContext option to service client construction

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.service;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpReceive;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -89,6 +90,23 @@ public class FeedbackReceiver extends Receiver
      */
     public FeedbackReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to verify initialization parameters
+     * Create instance of AmqpReceive
+     *
+     * @param hostName The iot hub host name
+     * @param userName The iot hub user name
+     * @param sasToken The iot hub SAS token for the given device
+     * @param iotHubServiceClientProtocol protocol to be used
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    public FeedbackReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
         if (Tools.isNullOrEmpty(hostName))
         {
             throw new IllegalArgumentException("hostName cannot be null or empty");
@@ -101,14 +119,14 @@ public class FeedbackReceiver extends Receiver
         {
             throw new IllegalArgumentException("sasToken cannot be null or empty");
         }
-        
+
         if (iotHubServiceClientProtocol  == null)
         {
             throw new IllegalArgumentException("iotHubServiceClientProtocol cannot be null");
         }
-                
+
         // Codes_SRS_SERVICE_SDK_JAVA_FEEDBACKRECEIVER_12_003: [The constructor shall create a new instance of AmqpReceive object]
-        this.amqpReceive = new AmqpReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        this.amqpReceive = new AmqpReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, sslContext);
     }
         
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
@@ -103,7 +103,7 @@ public class FeedbackReceiver extends Receiver
      * @param iotHubServiceClientProtocol protocol to be used
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     public FeedbackReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
@@ -57,7 +57,7 @@ public class FileUploadNotificationReceiver extends Receiver
      * @param iotHubServiceClientProtocol The iot hub protocol name
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     FileUploadNotificationReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.sdk.iot.service;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpFileUploadNotificationReceive;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -44,6 +45,22 @@ public class FileUploadNotificationReceiver extends Receiver
      */
     FileUploadNotificationReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to verify initialization parameters
+     * Create instance of AmqpReceive
+     * @param hostName The iot hub host name
+     * @param userName The iot hub user name
+     * @param sasToken The iot hub SAS token for the given device
+     * @param iotHubServiceClientProtocol The iot hub protocol name
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    FileUploadNotificationReceiver(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
         if (Tools.isNullOrEmpty(hostName))
         {
             throw new IllegalArgumentException("hostName cannot be null or empty");
@@ -61,8 +78,7 @@ public class FileUploadNotificationReceiver extends Receiver
             throw new IllegalArgumentException("iotHubServiceClientProtocol cannot be null");
         }
 
-        // Codes_SRS_SERVICE_SDK_JAVA_FILEUPLOADNOTIFICATIONRECEIVER_25_002: [** The constructor shall create a new instance of AmqpFileUploadNotificationReceive object **]**
-        this.amqpFileUploadNotificationReceive = new AmqpFileUploadNotificationReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        this.amqpFileUploadNotificationReceive = new AmqpFileUploadNotificationReceive(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, sslContext);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -286,7 +286,7 @@ public class ServiceClient
      */
      public FeedbackReceiver getFeedbackReceiver()
      {
-        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions());
+        return new FeedbackReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions(), options.getSslContext());
      }
 
     /**
@@ -296,7 +296,7 @@ public class ServiceClient
      */
     public FileUploadNotificationReceiver getFileUploadNotificationReceiver()
     {
-        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions());
+        return new FileUploadNotificationReceiver(hostName, userName, sasToken, iotHubServiceClientProtocol, options.getProxyOptions(), options.getSslContext());
     }
     
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -3,6 +3,8 @@ package com.microsoft.azure.sdk.iot.service;
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * Configurable options for all service client operations
  */
@@ -14,4 +16,12 @@ public class ServiceClientOptions
      */
     @Getter
     private ProxyOptions proxyOptions;
+
+
+    /**
+     * The SSL context to use when opening the AMQPS/AMQPS_WS connections. If not set, this library will generate the default
+     * SSL context that trusts the IoT Hub public certificates.
+     */
+    @Getter
+    private SSLContext sslContext;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
@@ -18,6 +18,7 @@ import org.apache.qpid.proton.engine.*;
 import org.apache.qpid.proton.reactor.FlowController;
 import org.apache.qpid.proton.reactor.Handshaker;
 
+import javax.net.ssl.SSLContext;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,16 +65,31 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
      */
     public AmqpFeedbackReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize
+     * handshaker and flow controller for transport
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    public AmqpFeedbackReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, sslContext);
 
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
 
         // Add a child handler that performs some default handshaking
         // behaviour.
 
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPFEEDBACKRECEIVEDHANDLER_12_002: [The constructor shall initialize a new Handshaker (Proton) object to handle communication handshake]
         add(new Handshaker());
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPFEEDBACKRECEIVEDHANDLER_12_003: [The constructor shall initialize a new FlowController (Proton) object to handle communication handshake]
         add(new FlowController());
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
@@ -78,7 +78,7 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
      * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     public AmqpFeedbackReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
@@ -64,7 +64,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
      * @param iotHubServiceClientProtocol protocol to use
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     public AmqpFileUploadNotificationReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 
 /**
@@ -28,6 +29,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
     private FileUploadNotification fileUploadNotification;
     private ProxyOptions proxyOptions;
+    private final SSLContext sslContext;
 
     /**
      * Constructor to set up connection parameters
@@ -51,12 +53,27 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
      */
     public AmqpFileUploadNotificationReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVE_25_001: [The constructor shall copy all input parameters to private member variables for event processing]
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    public AmqpFileUploadNotificationReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
         this.hostName = hostName;
         this.userName = userName;
         this.sasToken = sasToken;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.proxyOptions = proxyOptions;
+        this.sslContext = sslContext;
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
@@ -75,7 +75,7 @@ public class AmqpFileUploadNotificationReceivedHandler extends AmqpConnectionHan
      * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     AmqpFileUploadNotificationReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
@@ -19,6 +19,7 @@ import org.apache.qpid.proton.engine.*;
 import org.apache.qpid.proton.reactor.FlowController;
 import org.apache.qpid.proton.reactor.Handshaker;
 
+import javax.net.ssl.SSLContext;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,16 +63,30 @@ public class AmqpFileUploadNotificationReceivedHandler extends AmqpConnectionHan
      */
     AmqpFileUploadNotificationReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, amqpFeedbackReceivedEvent, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize
+     * handshaker and flow controller for transport
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param amqpFeedbackReceivedEvent callback to delegate the received message to the user API
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    AmqpFileUploadNotificationReceivedHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, sslContext);
 
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
 
         // Add a child handler that performs some default handshaking
         // behaviour.
 
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVEDHANDLER_25_002: [The constructor shall initialize a new Handshaker (Proton) object to handle communication handshake]
         add(new Handshaker());
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPFILEUPLOADNOTIFICATIONRECEIVEDHANDLER_25_003: [The constructor shall initialize a new FlowController (Proton) object to handle communication handshake]
         add(new FlowController());
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
@@ -64,7 +64,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      * @param iotHubServiceClientProtocol protocol to use
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     public AmqpReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 
 /**
@@ -28,6 +29,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
     private IotHubServiceClientProtocol iotHubServiceClientProtocol;
     private FeedbackBatch feedbackBatch;
     private ProxyOptions proxyOptions;
+    private final SSLContext sslContext;
 
     /**
      * Constructor to set up connection parameters
@@ -51,12 +53,27 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      */
     public AmqpReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
-        // Codes_SRS_SERVICE_SDK_JAVA_AMQPRECEIVE_12_001: [The constructor shall copy all input parameters to private member variables for event processing]
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    public AmqpReceive(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
         this.hostName = hostName;
         this.userName = userName;
         this.sasToken = sasToken;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.proxyOptions = proxyOptions;
+        this.sslContext = sslContext;
     }
 
     /**
@@ -64,7 +81,14 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      */
     public void open()
     {
-        amqpReceiveHandler = new AmqpFeedbackReceivedHandler(this.hostName, this.userName, this.sasToken, this.iotHubServiceClientProtocol, this, this.proxyOptions);
+        amqpReceiveHandler = new AmqpFeedbackReceivedHandler(
+                this.hostName,
+                this.userName,
+                this.sasToken,
+                this.iotHubServiceClientProtocol,
+                this,
+                this.proxyOptions,
+                this.sslContext);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -82,7 +82,7 @@ public class AmqpSendHandler extends AmqpConnectionHandler
      * @param iotHubServiceClientProtocol protocol to use
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
      * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
-     *                   SSL context will be generated.
+     *                   SSL context will be generated. This default SSLContext trusts the IoT Hub public certificates.
      */
     public AmqpSendHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -18,6 +18,7 @@ import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.engine.*;
 import org.apache.qpid.proton.reactor.Handshaker;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.util.HashMap;
@@ -69,7 +70,23 @@ public class AmqpSendHandler extends AmqpConnectionHandler
      */
     public AmqpSendHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions)
     {
-        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions);
+        this(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, null);
+    }
+
+    /**
+     * Constructor to set up connection parameters and initialize handshaker for transport
+     *
+     * @param hostName The address string of the service (example: AAA.BBB.CCC)
+     * @param userName The username string to use SASL authentication (example: user@sas.service)
+     * @param sasToken The SAS token string
+     * @param iotHubServiceClientProtocol protocol to use
+     * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the SSL context to use during the TLS handshake when opening the connection. If null, a default
+     *                   SSL context will be generated.
+     */
+    public AmqpSendHandler(String hostName, String userName, String sasToken, IotHubServiceClientProtocol iotHubServiceClientProtocol, ProxyOptions proxyOptions, SSLContext sslContext)
+    {
+        super(hostName, userName, sasToken, iotHubServiceClientProtocol, proxyOptions, sslContext);
         add(new Handshaker());
     }
 

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiverTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiverTest.java
@@ -15,6 +15,7 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
@@ -135,7 +136,7 @@ public class FileUploadNotificationReceiverTest
         new Verifications()
         {
             {
-                new AmqpFileUploadNotificationReceive(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
+                new AmqpFileUploadNotificationReceive(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any, (SSLContext) any);
                 times = 1;
 
             }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpSend;
 import mockit.*;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
@@ -522,7 +523,7 @@ public class ServiceClientTest
         new Expectations()
         {
             {
-                feedbackReceiver = new FeedbackReceiver(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any);
+                feedbackReceiver = new FeedbackReceiver(anyString, anyString, anyString, iotHubServiceClientProtocol, (ProxyOptions) any, (SSLContext) any);
             }
         };
         // Act


### PR DESCRIPTION
This enables users to load their preferred public certificates which is necessary for supporting private Hub environments

 #1027 for reference