### PR TITLE
fix(iot-dev): Add missing checks for multiplexing state before client methods

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -368,7 +368,7 @@ public class InternalClient
             throw new IllegalArgumentException("Reported properties set cannot be null or empty.");
         }
 
-        if(version < 0)
+        if (version < 0)
         {
             throw new IllegalArgumentException("Version cannot be null.");
         }
@@ -724,6 +724,8 @@ public class InternalClient
                            TwinPropertiesCallback genericPropertiesCallBack, Object genericPropertyCallBackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
+        verifyRegisteredIfMultiplexing();
+
         if (!this.deviceIO.isOpen())
         {
             throw new IOException("Open the client connection before using it.");
@@ -929,6 +931,7 @@ public class InternalClient
             {
                 try
                 {
+                    verifyRegisteredIfMultiplexing();
                     this.deviceIO.setSendPeriodInMilliseconds((long) value);
                 }
                 catch (IOException e)
@@ -952,6 +955,7 @@ public class InternalClient
             {
                 try
                 {
+                    verifyRegisteredIfMultiplexing();
                     this.deviceIO.setReceivePeriodInMilliseconds((long) value);
                 }
                 catch (IOException e)


### PR DESCRIPTION
Cannot start twin after unregistering from a multiplexing client, for example. Some methods like that were just missing the check that verifyRegisteredIfMultiplexing() runs and were throwing NPE when they tried to access the device IO instance