### PR TITLE
Fix(e2e) fix e2e test

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
@@ -107,10 +107,11 @@ public class TokenRenewalTests extends IntegrationTest
     public void tokenRenewalWorks() throws Exception
     {
         List<InternalClient> clients = createClientsToTest();
+        String hostname = clients.get(0).getConfig().getIotHubHostname();
         ArrayList<DeviceClient> amqpMultiplexedClients = new ArrayList<>();
-        MultiplexingClient amqpMultiplexingClient = createMultiplexedClientToTest(AMQPS, amqpMultiplexedClients);
+        MultiplexingClient amqpMultiplexingClient = createMultiplexedClientToTest(AMQPS, amqpMultiplexedClients, hostname);
         ArrayList<DeviceClient> amqpwsMultiplexedClients = new ArrayList<>();
-        MultiplexingClient amqpWsMultiplexingClient = createMultiplexedClientToTest(AMQPS_WS, amqpwsMultiplexedClients);
+        MultiplexingClient amqpWsMultiplexingClient = createMultiplexedClientToTest(AMQPS_WS, amqpwsMultiplexedClients, hostname);
 
         // Allow registry operations some buffer time before attempting to open connections for them
         Thread.sleep(2000);
@@ -253,17 +254,16 @@ public class TokenRenewalTests extends IntegrationTest
         return clients;
     }
 
-    private MultiplexingClient createMultiplexedClientToTest(IotHubClientProtocol protocol, List<DeviceClient> createdClients) throws IotHubException, IOException, URISyntaxException, MultiplexingClientException, InterruptedException {
-        String hostName = createdClients.get(0).getConfig().getIotHubHostname();
-        MultiplexingClient multiplexingClient = new MultiplexingClient(hostName, protocol);
+    private MultiplexingClient createMultiplexedClientToTest(IotHubClientProtocol protocol, List<DeviceClient> clientsToCreate, String hostname) throws IotHubException, IOException, URISyntaxException, MultiplexingClientException, InterruptedException {
+        MultiplexingClient multiplexingClient = new MultiplexingClient(hostname, protocol);
 
         for (int i = 0; i < MULTIPLEX_COUNT; i++)
         {
             DeviceClient deviceClientToMultiplex = (DeviceClient) createDeviceClient(protocol, true);
-            createdClients.add(deviceClientToMultiplex);
+            clientsToCreate.add(deviceClientToMultiplex);
         }
 
-        multiplexingClient.registerDeviceClients(createdClients);
+        multiplexingClient.registerDeviceClients(clientsToCreate);
 
         return multiplexingClient;
     }


### PR DESCRIPTION
Test threw an indexOutOfBounds exception because the list that it tried to get the hostname from was always empty, so the test has been refactored to get the hostname from a different list of clients that is never empty instead

Without this change, the test always fails. The only reason it got like this was because we don't run this test at the gate since it is a 15 minute test