### PR TITLE
release(2021-01-20): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.28.0";
+    private static final String CLIENT_VERSION = "1.29.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.28.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.0') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.28.0</iot-device-client-version>
-        <iot-service-client-version>1.26.0</iot-service-client-version>
-        <iot-deps-version>0.11.0</iot-deps-version>
-        <provisioning-device-client-version>1.8.5</provisioning-device-client-version>
-        <provisioning-service-client-version>1.7.0</provisioning-service-client-version>
+        <iot-device-client-version>1.29.0</iot-device-client-version>
+        <iot-service-client-version>1.27.0</iot-service-client-version>
+        <iot-deps-version>0.11.1</iot-deps-version>
+        <provisioning-device-client-version>1.8.6</provisioning-device-client-version>
+        <provisioning-service-client-version>1.7.1</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.5";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.6";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.0";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.26.0";
+    public static String serviceVersion = "1.27.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.27.0)
- Add support for providing custom SSLContext to service client instances (#1044)
- Increase dependency versions for commons-codec, jackson (#1039)


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.29.0)
- Add new MultiplexingClient that allows for dynamic adding and removal of devices from a multiplexed connection even after opening the connection, deprecate previous multiplexing client TransportClient (#939)

### Bug fixes
- Fix cleanup logic in AMQP layer when interrupted during open (#1015)

## Java Iot Deps (com.microsoft.azure.sdk.iot:iot-deps:0.11.1)
- Increase dependency versions for commons-codec, jackson (#1039)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.6)
- Increase dependency versions for commons-codec, jackson (#1039)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.7.1)
- Increase dependency versions for commons-codec, jackson (#1039)


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.27.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.29.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.11.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.8.6/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.7.1/jar


old
{
    "device": "1.28.0",
    "service": "1.26.0",
    "deps": "0.11.0",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.5",
    "provisioningService": "1.7.0"
}

new
{
    "device": "1.29.0",
    "service": "1.27.0",
    "deps": "0.11.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.6",
    "provisioningService": "1.7.1"
}