### PR TITLE
[Declaration redundancy] Actual method parameter is the same constant - tests

### DIFF
--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadCompletionNotificationTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadCompletionNotificationTest.java
@@ -24,6 +24,7 @@ public class FileUploadCompletionNotificationTest
     private static final Boolean VALID_IS_SUCCESS = true;
     private static final Integer VALID_STATUS_CODE = 200;
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the expected assertion param can be passed any value.
     private static void assertFileUploadStatus(FileUploadCompletionNotification fileUploadStatusParser, String expectedCorrelationId, Boolean expectedIsSuccess, Integer expectedStatusCode, String expectedStatusDescription)
     {
         assertNotNull(fileUploadStatusParser);
@@ -39,6 +40,7 @@ public class FileUploadCompletionNotificationTest
         assertEquals(expectedStatusDescription, statusDescription);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private static String createJson(String correlationId, Boolean isSuccess, Integer statusCode, String statusDescription)
     {
         return "{\n" +

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadSasUriRequestTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadSasUriRequestTest.java
@@ -20,6 +20,7 @@ public class FileUploadSasUriRequestTest
     private static final String VALID_BLOB_NAME = "test-device1/image.jpg";
     private static final String INVALID_BLOB_NAME = "\u1234 test-device1/image.jpg";
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the expected assertion param can be passed any value.
     private static void assertFileUploadRequest(FileUploadSasUriRequest fileUploadSasUriRequest, String expectedBlobName)
     {
         assertNotNull(fileUploadSasUriRequest);

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadSasUriResponseTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/FileUploadSasUriResponseTest.java
@@ -27,6 +27,7 @@ public class FileUploadSasUriResponseTest
     private static final String VALID_SAS_TOKEN = "1234asdfSAStoken";
     private static final String INVALID_SAS_TOKEN = "\u1234asdfSAStoken";
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the expected assertion param can be passed any value.
     private static void assertFileUploadResponse(FileUploadSasUriResponse fileUploadSasUriResponse, String expectedHostName, String expectedContainerName, String expectedCorrelationId, String expectedBlobName, String expectedSasToken)
     {
         assertNotNull(fileUploadSasUriResponse);
@@ -44,6 +45,7 @@ public class FileUploadSasUriResponseTest
         assertEquals(expectedSasToken, sasToken);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private static String createJson(String hostName, String containerName, String correlationId, String blobName, String sasToken)
     {
         return "{\n" +

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/MethodParserTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/serializer/MethodParserTest.java
@@ -500,7 +500,8 @@ public class MethodParserTest
         methodParser.toJsonElement();
     }
 
-    private static final TestMethod createMethodRequestWithTimeout(
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
+    private static TestMethod createMethodRequestWithTimeout(
             String methodName,
             long responseTimeOut,
             long connectTimeout,
@@ -524,7 +525,8 @@ public class MethodParserTest
         return testMethod;
     }
 
-    private static final TestMethod createMethodRequestWithOutTimeout(String methodName, String payload, boolean wrapPayloadAsString, Object expectedPayload)
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
+    private static TestMethod createMethodRequestWithOutTimeout(String methodName, String payload, boolean wrapPayloadAsString, Object expectedPayload)
     {
         TestMethod testMethod = new TestMethod();
         testMethod.name = methodName;
@@ -537,7 +539,8 @@ public class MethodParserTest
         return testMethod;
     }
 
-    private static final TestMethod createMethodRequestWithResponseTimeout(
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
+    private static TestMethod createMethodRequestWithResponseTimeout(
             String methodName,
             long responseTimeOut,
             String payload,
@@ -558,7 +561,8 @@ public class MethodParserTest
         return testMethod;
     }
 
-    private static final TestMethod createMethodRequestWithConnectTimeout(
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
+    private static TestMethod createMethodRequestWithConnectTimeout(
             String methodName,
             long connectTimeout,
             String payload,
@@ -579,7 +583,7 @@ public class MethodParserTest
         return testMethod;
     }
 
-    private static final TestMethod createMethodResponse(Integer status, String payload, boolean wrapPayloadAsString, Object expectedPayload)
+    private static TestMethod createMethodResponse(Integer status, String payload, boolean wrapPayloadAsString, Object expectedPayload)
     {
         TestMethod testMethod = new TestMethod();
         testMethod.status = status;
@@ -593,7 +597,7 @@ public class MethodParserTest
         return testMethod;
     }
 
-    private static final TestMethod createMethodResponse(String json)
+    private static TestMethod createMethodResponse(String json)
     {
         TestMethod testMethod = new TestMethod();
         testMethod.json = json;

--- a/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/ws/impl/WebSocketImplTest.java
+++ b/deps/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/deps/ws/impl/WebSocketImplTest.java
@@ -1030,6 +1030,7 @@ public class WebSocketImplTest
         assertSame(webSocketImpl.getState(), WebSocket.WebSocketState.PN_WS_FAILED);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private byte[] createMessage(int size)
     {
         byte[] data = new byte[size];

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
@@ -31,6 +31,7 @@ public class IotHubConnectionStringTest
     private static final String VALID_MODULEID = "moduleId";
     private static final String VALID_GATEWAYHOSTNAME = "edgeHubHostName";
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the expected assertion param can be passed any value.
     private void assertConnectionString(Object iotHubConnectionString, String expectedHostName,
                                         String expectedDeviceId, String expectedSharedAccessKey, String expectedSharedAccessToken)
     {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -21,6 +21,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
 {
     private class IotHubImplSasTokenWithRefreshAuthenticationProvider extends IotHubSasTokenWithRefreshAuthenticationProvider
     {
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor, the constructor params can be passed any value.
         protected IotHubImplSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)
         {
             super(hostname, gatewayHostName, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage);

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTaskTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTaskTest.java
@@ -171,6 +171,7 @@ public class FileUploadTaskTest
         };
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void failedNotificationExpectations(final String correlationId, final String notificationJson) throws IOException
     {
         new NonStrictExpectations()
@@ -188,6 +189,7 @@ public class FileUploadTaskTest
         };
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void expectSuccess(
             final String blobName, final String correlationId, final String hostName, final String containerName, final String sasToken,
             final String requestJson, final String responseJson, final String notificationJson)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
@@ -97,6 +97,7 @@ public class DeviceEmulator
      *                                    deviceMethodStatusCallback is not null.
      * @throws IOException if the client failed to subscribe on the device method.
      */
+    @SuppressWarnings("SameParameterValue") // DeviceEmulator will subscribe to default callback in case the supplied callback is null
     void subscribeToDeviceMethod(
             DeviceMethodCallback deviceMethodCallback, Object deviceMethodCallbackContext,
             IotHubEventCallback deviceMethodStatusCallback, Object deviceMethodStatusCallbackContext)
@@ -178,6 +179,7 @@ public class DeviceEmulator
      * @param mustSubscribeToDesiredProperties is a boolean to define if it should or not subscribe to the desired properties.
      * @throws IOException if failed to start the Device twin.
      */
+    @SuppressWarnings("SameParameterValue") // DeviceEmulator will subscribe to default callback in case the supplied callback is null
     void subscribeToDeviceTwin(IotHubEventCallback deviceTwinStatusCallBack, Object deviceTwinStatusCallbackContext,
                                Device deviceTwin, Object propertyCallBackContext, boolean mustSubscribeToDesiredProperties) throws IOException
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1541,6 +1541,7 @@ public class MultiplexingClientTests extends IntegrationTest
         }
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private static void assertDeviceSessionClosesGracefully(ConnectionStatusChangeTracker connectionStatusChangeTracker, int timeoutMillis) throws InterruptedException {
         long startTime = System.currentTimeMillis();
         while (connectionStatusChangeTracker.isOpen)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
@@ -624,6 +624,7 @@ public class TransportClientTests extends IntegrationTest
         return msg.getMessageId() != null && msg.getMessageId().equals(expectedMessageId);//all system properties are as expected
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void sendMessageToDevice(String deviceId, String protocolName) throws IotHubException, IOException
     {
         String messageString = "Java service e2e test message to be received over " + protocolName + " protocol";
@@ -634,6 +635,7 @@ public class TransportClientTests extends IntegrationTest
         serviceClient.send(deviceId, serviceMessage);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void waitForMessageToBeReceived(Success messageReceived, String protocolName, InternalClient client)
     {
         try
@@ -759,6 +761,7 @@ public class TransportClientTests extends IntegrationTest
 
         private Exception exception = null;
 
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor, the constructor params can be passed any value.
         RunnableInvoke(DeviceMethod methodServiceClient, String deviceId, String methodName, String methodPayload, CountDownLatch latch)
         {
             this.methodServiceClient = methodServiceClient;
@@ -1027,6 +1030,7 @@ public class TransportClientTests extends IntegrationTest
         testInstance.messageStates = null;
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private int readReportedProperties(DeviceState deviceState, String startsWithKey, String startsWithValue) throws IOException , IotHubException, InterruptedException
     {
         int totalCount = 0;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -235,6 +235,6 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
 
         waitAndVerifyTwinStatusBecomesSuccess();
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, 2);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE, 2);
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/JobClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/JobClientTests.java
@@ -83,6 +83,7 @@ public class JobClientTests extends IntegrationTest
         }
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private JobResult queryDeviceJobResult(String jobId, JobType jobType, JobStatus jobStatus) throws IOException, IotHubException
     {
         String queryContent = SqlQuery.createSqlQuery("*", SqlQuery.FromType.JOBS,
@@ -117,6 +118,7 @@ public class JobClientTests extends IntegrationTest
         throw new AssertionError("queryDeviceJob did not find the job");
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private JobResult queryJobResponseResult(String jobId, JobType jobType, JobStatus jobStatus) throws IOException, IotHubException
     {
         Query query = jobClient.queryJobResponse(jobType, jobStatus);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -295,6 +295,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method "numberOfDevices" can be passed any value.
     protected void addMultipleDevices(int numberOfDevices) throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(numberOfDevices, true);
@@ -512,7 +513,7 @@ public class DeviceTwinCommon extends IntegrationTest
         }
     }
 
-    protected void readReportedPropertiesAndVerify(DeviceState deviceState, String startsWithKey, String startsWithValue, int expectedReportedPropCount) throws IOException, IotHubException, InterruptedException
+    protected void readReportedPropertiesAndVerify(DeviceState deviceState, String startsWithValue, int expectedReportedPropCount) throws IOException, IotHubException, InterruptedException
     {
         int actualCount = 0;
 
@@ -535,7 +536,7 @@ public class DeviceTwinCommon extends IntegrationTest
             for (Pair p : repProperties)
             {
                 String val = (String) p.getValue();
-                if (p.getKey().startsWith(startsWithKey) && val.startsWith(startsWithValue))
+                if (p.getKey().startsWith(DeviceTwinCommon.PROPERTY_KEY) && val.startsWith(startsWithValue))
                 {
                     actualCount++;
                 }
@@ -604,9 +605,10 @@ public class DeviceTwinCommon extends IntegrationTest
         // Assert
         waitAndVerifyTwinStatusBecomesSuccess();
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, numOfProp);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE, numOfProp);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method "numOfProp" can be passed any value.
     protected void sendReportedArrayPropertiesAndVerify(int numOfProp) throws IOException, IotHubException, InterruptedException
     {
         // Act

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/ReportedPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/ReportedPropertiesTests.java
@@ -103,7 +103,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         }
 
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
             waitAndVerifyTwinStatusBecomesSuccess();
         }
 
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE, MAX_PROPERTIES_TO_TEST);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         waitAndVerifyTwinStatusBecomesSuccess();
 
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessage("Expected OK but twin status was " + deviceUnderTest.deviceTwinStatus, internalClient), OK, deviceUnderTest.deviceTwinStatus);
 
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
     }
 
     @Test
@@ -221,6 +221,6 @@ public class ReportedPropertiesTests extends DeviceTwinCommon
         waitAndVerifyTwinStatusBecomesSuccess();
 
         // verify if they are received by SC
-        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_KEY, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
+        readReportedPropertiesAndVerify(deviceUnderTest, PROPERTY_VALUE_UPDATE, MAX_PROPERTIES_TO_TEST);
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
@@ -263,6 +263,7 @@ public class ProvisioningTests extends ProvisioningCommon
         registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpoint, true, null, expectedHubToProvisionTo, null);
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     protected void reprovisioningFlow(EnrollmentType enrollmentType, AllocationPolicy allocationPolicy, ReprovisionPolicy reprovisionPolicy, CustomAllocationDefinition customAllocationDefinition, List<String> iothubsToStartAt, List<String> iothubsToFinishAt) throws Exception
     {
         DeviceCapabilities capabilities = new DeviceCapabilities();

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
@@ -74,6 +74,7 @@ public class EnrollmentGroupTest
         String mockedEtag;
         JsonObject mockedJsonElement;
 
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor "enrollmentGroupId" can be passed any value.
         MockEnrollmentGroup(
                 String enrollmentGroupId,
                 Attestation attestation)

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
@@ -54,6 +54,7 @@ public class IndividualEnrollmentTest
         String mockedEtag;
         JsonObject mockedJsonElement;
 
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor "registrationId" can be passed any value.
         MockIndividualEnrollment(
                 String registrationId,
                 Attestation attestation)

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/TwinCollectionTest.java
@@ -148,6 +148,8 @@ public class TwinCollectionTest
         final class MockedTwinCollection extends TwinCollection
         {
             private Map<? extends String, ?> mockedMap;
+
+            @SuppressWarnings("SameParameterValue") // Since this is a constructor "map" can be passed any value.
             private MockedTwinCollection(Map<? extends String, Object> map)
             {
                 super(map);

--- a/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
+++ b/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
@@ -64,6 +64,8 @@ public class SecurityProviderTpmTest
     class SecurityProviderTPMTestImpl extends SecurityProviderTpm
     {
         byte[] ek;
+
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor "ek" can be passed any value.
         SecurityProviderTPMTestImpl(byte[] ek)
         {
             this.ek = ek;

--- a/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderX509Test.java
+++ b/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderX509Test.java
@@ -69,6 +69,7 @@ public class SecurityProviderX509Test
         private final Key key;
         private final Collection<X509Certificate> certificates;
 
+        @SuppressWarnings("SameParameterValue") // Since this is a constructor "cn" can be passed any value.
         SecurityProviderX509TestImpl(String cn, X509Certificate x509Certificate, Key key, Collection<X509Certificate> certificates)
         {
             this.cn = cn;

--- a/provisioning/security/tpm-provider-emulator/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMEmulator.java
+++ b/provisioning/security/tpm-provider-emulator/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMEmulator.java
@@ -249,6 +249,7 @@ public class SecurityProviderTPMEmulator extends SecurityProviderTpm
         }
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private TPMT_PUBLIC createPersistentPrimary(Tpm tpm, TPM_HANDLE hPersistent, TPM_RH hierarchy, TPMT_PUBLIC inPub, String primaryRole) throws SecurityProviderException
     {
         ReadPublicResponse rpResp = tpm._allowErrors().ReadPublic(hPersistent);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
@@ -51,6 +51,7 @@ public class JobResultTest
     final static String DATEFORMAT_JSON = "MMM d, yyyy h:mm:ss a";
 
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void JobsResponseParserExpectations(String json, TwinState twinState, MethodParser methodParser, Date date, MethodParser methodParserResponse, String jobTypeStr)
     {
         new NonStrictExpectations()
@@ -100,6 +101,7 @@ public class JobResultTest
         };
     }
 
+    @SuppressWarnings("SameParameterValue") // Since this is a helper method, the params can be passed any value.
     private void jobsResponseParserWithNullDeviceIdExpectations(String json, TwinState twinState, MethodParser methodParser, Date date, MethodParser methodParserResponse, String jobTypeStr)
     {
         new NonStrictExpectations()


### PR DESCRIPTION
The warning has been suppressed in test classes, since the flagged params were being referenced in helper methods