### PR TITLE
[Memory] Inner class may be 'static'

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinProperty.java
@@ -33,7 +33,7 @@ public class TwinProperty
 
     private final Object lock = new Object();
 
-    private class Property
+    private static class Property
     {
         private final Object value;
         private final TwinMetadata metadata;

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -518,7 +518,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     /**
      * Class which runs the reactor.
      */
-    private class ReactorRunner implements Callable
+    private static class ReactorRunner implements Callable
     {
         private final static String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
         private final AmqpReactor amqpReactor;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
@@ -27,7 +27,7 @@ public final class FileUpload
     private final HttpsTransportManager httpsTransportManager;
     private final ScheduledExecutorService taskScheduler;
     private final FileUploadStatusCallBack fileUploadStatusCallBack;
-    private static Queue<FileUploadInProgress> fileUploadInProgressesSet;
+    static Queue<FileUploadInProgress> fileUploadInProgressesSet;
 
     /**
      * CONSTRUCTOR
@@ -112,31 +112,6 @@ public final class FileUpload
         FileUploadTask fileUploadTask = new FileUploadTask(blobName, inputStream, streamLength, httpsTransportManager, fileUploadStatusCallBack, newUpload);
 
         newUpload.setTask(taskScheduler.submit(fileUploadTask));
-    }
-
-    private static final class FileUploadStatusCallBack implements IotHubEventCallback
-    {
-        @Override
-        public synchronized void execute(IotHubStatusCode status, Object context)
-        {
-            if(context instanceof FileUploadInProgress)
-            {
-                FileUploadInProgress uploadInProgress = (FileUploadInProgress) context;
-                uploadInProgress.triggerCallback(status);
-                try
-                {
-                    fileUploadInProgressesSet.remove(context);
-                }
-                catch (ClassCastException | NullPointerException | UnsupportedOperationException e)
-                {
-                    log.error("FileUploadStatusCallBack received callback for unknown FileUpload", e);
-                }
-            }
-            else
-            {
-                log.error("FileUploadStatusCallBack received callback for unknown FileUpload");
-            }
-        }
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
@@ -130,7 +130,7 @@ public final class FileUpload
         newUpload.setTask(taskScheduler.submit(fileUploadTask));
     }
 
-    private final class FileUploadStatusCallBack implements IotHubEventCallback
+    private static final class FileUploadStatusCallBack implements IotHubEventCallback
     {
         @Override
         public synchronized void execute(IotHubStatusCode status, Object context)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUpload.java
@@ -27,7 +27,7 @@ public final class FileUpload
     private final HttpsTransportManager httpsTransportManager;
     private final ScheduledExecutorService taskScheduler;
     private final FileUploadStatusCallBack fileUploadStatusCallBack;
-    private static Queue<FileUploadInProgress> fileUploadInProgressesSet;
+    private final Queue<FileUploadInProgress> fileUploadInProgressesSet;
 
     /**
      * CONSTRUCTOR
@@ -130,7 +130,7 @@ public final class FileUpload
         newUpload.setTask(taskScheduler.submit(fileUploadTask));
     }
 
-    private static final class FileUploadStatusCallBack implements IotHubEventCallback
+    private final class FileUploadStatusCallBack implements IotHubEventCallback
     {
         @Override
         public synchronized void execute(IotHubStatusCode status, Object context)
@@ -144,7 +144,7 @@ public final class FileUpload
                 /* Codes_SRS_FILEUPLOAD_21_021: [The FileUploadStatusCallBack shall delete the `FileUploadInProgress` that store this file upload context.] */
                 try
                 {
-                    fileUploadInProgressesSet.remove(context);
+                    FileUpload.this.fileUploadInProgressesSet.remove(context);
                 }
                 catch (ClassCastException | NullPointerException | UnsupportedOperationException e)
                 {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadStatusCallBack.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadStatusCallBack.java
@@ -1,0 +1,33 @@
+package com.microsoft.azure.sdk.iot.device.fileupload;
+
+import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.microsoft.azure.sdk.iot.device.fileupload.FileUpload.fileUploadInProgressesSet;
+
+@Slf4j
+public final class FileUploadStatusCallBack implements IotHubEventCallback
+{
+    @Override
+    public synchronized void execute(IotHubStatusCode status, Object context)
+    {
+        if(context instanceof FileUploadInProgress)
+        {
+            FileUploadInProgress uploadInProgress = (FileUploadInProgress) context;
+            uploadInProgress.triggerCallback(status);
+            try
+            {
+                fileUploadInProgressesSet.remove(context);
+            }
+            catch (ClassCastException | NullPointerException | UnsupportedOperationException e)
+            {
+                log.error("FileUploadStatusCallBack received callback for unknown FileUpload", e);
+            }
+        }
+        else
+        {
+            log.error("FileUploadStatusCallBack received callback for unknown FileUpload");
+        }
+    }
+}

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1234,7 +1234,7 @@ public class IotHubTransport implements IotHubListener
     /**
      * Task for adding a packet back to the waiting queue. Used for delaying message retry
      */
-    public class MessageRetryRunnable implements Runnable
+    public static class MessageRetryRunnable implements Runnable
     {
         final IotHubTransportPacket transportPacket;
         final Queue<IotHubTransportPacket> waitingPacketsQueue;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
@@ -162,6 +162,7 @@ public class ProxiedSSLSocket extends SSLSocket
     }
 
     @RequiredArgsConstructor
+    static
     class HttpConnectResponseReader
     {
         private boolean alreadyRead = false;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
@@ -162,8 +162,7 @@ public class ProxiedSSLSocket extends SSLSocket
     }
 
     @RequiredArgsConstructor
-    static
-    class HttpConnectResponseReader
+    static class HttpConnectResponseReader
     {
         private boolean alreadyRead = false;
         @NonNull private final InputStream inputStream;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -1092,7 +1092,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
     }
 
-    private class ReactorRunner implements Callable
+    private static class ReactorRunner implements Callable
     {
         private static final String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
         private final IotHubReactor iotHubReactor;

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
@@ -31,7 +31,7 @@ public class IotHubAuthenticationProviderTest
     private static final String expectedDeviceId = "deviceId";
     private static final String expectedModuleId = "moduleId";
     
-    private class IotHubAuthenticationProviderMock extends IotHubAuthenticationProvider
+    private static class IotHubAuthenticationProviderMock extends IotHubAuthenticationProvider
     {
         public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String deviceId, String moduleId)
         {

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -19,7 +19,7 @@ import static junit.framework.TestCase.assertFalse;
 
 public class IotHubSasTokenWithRefreshAuthenticationProviderTest
 {
-    private class IotHubImplSasTokenWithRefreshAuthenticationProvider extends IotHubSasTokenWithRefreshAuthenticationProvider
+    private static class IotHubImplSasTokenWithRefreshAuthenticationProvider extends IotHubSasTokenWithRefreshAuthenticationProvider
     {
         @SuppressWarnings("SameParameterValue") // Since this is a constructor, the constructor params can be passed any value.
         protected IotHubImplSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTest.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUpload;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUploadInProgress;
+import com.microsoft.azure.sdk.iot.device.fileupload.FileUploadStatusCallBack;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUploadTask;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 import mockit.*;
@@ -358,7 +359,7 @@ public class FileUploadTest
         final Map<String, Object> context = new HashMap<>();
         constructorExpectations();
         FileUpload fileUpload = new FileUpload(mockConfig);
-        IotHubEventCallback testFileUploadStatusCallBack = Deencapsulation.newInnerInstance("FileUploadStatusCallBack", fileUpload);
+        IotHubEventCallback testFileUploadStatusCallBack = new FileUploadStatusCallBack();
 
         //act
         testFileUploadStatusCallBack.execute(IotHubStatusCode.OK_EMPTY, mockFileUploadInProgress);
@@ -393,7 +394,7 @@ public class FileUploadTest
             }
         };
         FileUpload fileUpload = new FileUpload(mockConfig);
-        IotHubEventCallback testFileUploadStatusCallBack = Deencapsulation.newInnerInstance("FileUploadStatusCallBack", fileUpload);
+        IotHubEventCallback testFileUploadStatusCallBack = new FileUploadStatusCallBack();
 
         //act
         testFileUploadStatusCallBack.execute(IotHubStatusCode.OK_EMPTY, mockFileUploadInProgress);
@@ -424,7 +425,7 @@ public class FileUploadTest
             }
         };
         FileUpload fileUpload = new FileUpload(mockConfig);
-        IotHubEventCallback testFileUploadStatusCallBack = Deencapsulation.newInnerInstance("FileUploadStatusCallBack", fileUpload);
+        IotHubEventCallback testFileUploadStatusCallBack = new FileUploadStatusCallBack();
 
         //act
         testFileUploadStatusCallBack.execute(IotHubStatusCode.OK_EMPTY, mockFileUploadInProgress);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
@@ -233,7 +233,7 @@ public class DeviceEmulator
 
     InternalClient getClient() {return client;}
 
-    private class DeviceStatus
+    private static class DeviceStatus
     {
         int statusOk;
         int statusError;
@@ -258,7 +258,7 @@ public class DeviceEmulator
         }
     }
 
-    protected class DeviceTwinProperty extends Device
+    protected static class DeviceTwinProperty extends Device
     {
         @Override
         public synchronized void PropertyCall(String propertyKey, Object propertyValue, Object context)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/BasicTierHubOnlyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/BasicTierHubOnlyTestRule.java
@@ -14,7 +14,7 @@ public class BasicTierHubOnlyTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ContinuousIntegrationTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ContinuousIntegrationTestRule.java
@@ -14,7 +14,7 @@ public class ContinuousIntegrationTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DeviceProvisioningServiceTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DeviceProvisioningServiceTestRule.java
@@ -14,7 +14,7 @@ public class DeviceProvisioningServiceTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
@@ -16,7 +16,7 @@ public class DigitalTwinTestRule implements TestRule {
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/FlakeyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/FlakeyTestRule.java
@@ -14,7 +14,7 @@ public class FlakeyTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/IotHubTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/IotHubTestRule.java
@@ -14,7 +14,7 @@ public class IotHubTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/StandardTierHubOnlyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/StandardTierHubOnlyTestRule.java
@@ -14,7 +14,7 @@ public class StandardTierHubOnlyTestRule implements TestRule
         return new IgnorableStatement(base, description);
     }
 
-    private class IgnorableStatement extends Statement {
+    private static class IgnorableStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ThrottleResistantTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ThrottleResistantTestRule.java
@@ -22,7 +22,7 @@ public class ThrottleResistantTestRule implements TestRule
         return new ThrottleResistantStatement(base, description);
     }
 
-    private class ThrottleResistantStatement extends Statement {
+    private static class ThrottleResistantStatement extends Statement {
 
         private final Statement base;
         private final Description description;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -119,7 +119,7 @@ public class FileUploadTests extends IntegrationTest
 
     public FileUploadTestInstance testInstance;
 
-    public class FileUploadTestInstance
+    public static class FileUploadTestInstance
     {
         public IotHubClientProtocol protocol;
         public AuthenticationType authenticationType;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
@@ -147,7 +147,7 @@ public class HubTierConnectionTests extends IntegrationTest
         }
     }
 
-    public class HubTierConnectionTestInstance
+    public static class HubTierConnectionTestInstance
     {
         public DeviceClient client;
         public IotHubClientProtocol protocol;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -136,7 +136,7 @@ public class MultiplexingClientTests extends IntegrationTest
 
     public MultiplexingClientTestInstance testInstance;
 
-    public class MultiplexingClientTestInstance
+    public static class MultiplexingClientTestInstance
     {
         public IotHubClientProtocol protocol;
         public List<Device> deviceIdentityArray;
@@ -610,7 +610,7 @@ public class MultiplexingClientTests extends IntegrationTest
         assertTrue("Message callback fired, but unexpected message was received", messageCallback.expectedMessageReceived);
     }
 
-    private class MessageCallback implements com.microsoft.azure.sdk.iot.device.MessageCallback
+    private static class MessageCallback implements com.microsoft.azure.sdk.iot.device.MessageCallback
     {
         public boolean messageCallbackFired = false;
         public boolean expectedMessageReceived = false;
@@ -736,7 +736,7 @@ public class MultiplexingClientTests extends IntegrationTest
         }
     }
 
-    private class DeviceMethodCallback implements com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback
+    private static class DeviceMethodCallback implements com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback
     {
         public boolean deviceMethodCallbackFired = false;
         public boolean expectedMethodReceived = false;
@@ -766,7 +766,7 @@ public class MultiplexingClientTests extends IntegrationTest
         }
     }
 
-    class TwinPropertyCallBackImpl implements TwinPropertyCallBack
+    static class TwinPropertyCallBackImpl implements TwinPropertyCallBack
     {
         String expectedKey;
         String expectedValue;
@@ -960,7 +960,7 @@ public class MultiplexingClientTests extends IntegrationTest
         assertEquals(expectedReportedPropertyValue, actualReportedPropertyValue);
     }
 
-    class ConnectionStatusChangeTracker implements IotHubConnectionStatusChangeCallback
+    static class ConnectionStatusChangeTracker implements IotHubConnectionStatusChangeCallback
     {
         public boolean isOpen = false;
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TransportClientTests.java
@@ -862,7 +862,7 @@ public class TransportClientTests extends IntegrationTest
         DeviceTwinDevice sCDeviceForTwin;
     }
 
-    class PropertyState
+    static class PropertyState
     {
         boolean callBackTriggered;
         Property property;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
@@ -66,7 +66,7 @@ public class RegistryManagerTests extends IntegrationTest
 
     public RegistryManagerTests.RegistryManagerTestInstance testInstance;
 
-    public class RegistryManagerTestInstance
+    public static class RegistryManagerTestInstance
     {
         public String deviceId;
         public String moduleId;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
@@ -55,7 +55,7 @@ public class ServiceClientTests extends IntegrationTest
         this.testInstance = new ServiceClientITRunner(protocol);
     }
 
-    private class ServiceClientITRunner
+    private static class ServiceClientITRunner
     {
         private final IotHubServiceClientProtocol protocol;
         private final String deviceId;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -122,7 +122,7 @@ public class DeviceMethodCommon extends IntegrationTest
         this.testInstance = new DeviceMethodTestInstance(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-    public class DeviceMethodTestInstance
+    public static class DeviceMethodTestInstance
     {
         public DeviceTestManager deviceTestManager;
         public IotHubClientProtocol protocol;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -202,7 +202,7 @@ public class DeviceTwinCommon extends IntegrationTest
         public IotHubStatusCode deviceTwinStatus;
     }
 
-    public class PropertyState
+    public static class PropertyState
     {
         public boolean callBackTriggered;
         public Property property;
@@ -433,7 +433,7 @@ public class DeviceTwinCommon extends IntegrationTest
         this.testInstance = new DeviceTwinTestInstance(protocol, authenticationType, clientType, publicKeyCert, privateKey, x509Thumbprint);
     }
 
-    public class DeviceTwinTestInstance
+    public static class DeviceTwinTestInstance
     {
         public IotHubClientProtocol protocol;
         public AuthenticationType authenticationType;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/ReceiveMessagesCommon.java
@@ -273,7 +273,7 @@ public class ReceiveMessagesCommon extends IntegrationTest
         }
     }
 
-    public class MessageCallbackMqtt implements com.microsoft.azure.sdk.iot.device.MessageCallback
+    public static class MessageCallbackMqtt implements com.microsoft.azure.sdk.iot.device.MessageCallback
     {
         public IotHubMessageResult execute(com.microsoft.azure.sdk.iot.device.Message msg, Object context)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
@@ -341,6 +341,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     }
 
     @AllArgsConstructor
+    static
     class TwinPropertiesCallbackImpl implements TwinPropertiesCallback
     {
         TwinCollection expectedProperties;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
@@ -341,8 +341,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
     }
 
     @AllArgsConstructor
-    static
-    class TwinPropertiesCallbackImpl implements TwinPropertiesCallback
+    static class TwinPropertiesCallbackImpl implements TwinPropertiesCallback
     {
         TwinCollection expectedProperties;
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
@@ -159,7 +159,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         }
     }
 
-    protected class DeviceTwinStatusCallBack implements IotHubEventCallback
+    protected static class DeviceTwinStatusCallBack implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -184,7 +184,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         this.testInstance = new DeviceTwinWithVersionTestInstance(protocol);
     }
 
-    public class DeviceTwinWithVersionTestInstance
+    public static class DeviceTwinWithVersionTestInstance
     {
         public IotHubClientProtocol protocol;
         private com.microsoft.azure.sdk.iot.service.Device deviceForRegistryManager;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
@@ -299,7 +299,7 @@ public class ProvisioningTests extends ProvisioningCommon
         assertTwinIsCorrect(reprovisionPolicy, expectedReportedPropertyName, expectedReportedPropertyValue, !reprovisionPolicy.getUpdateHubAssignment());
     }
 
-    private class StubTwinCallback implements IotHubEventCallback, PropertyCallBack
+    private static class StubTwinCallback implements IotHubEventCallback, PropertyCallBack
     {
         private final CountDownLatch twinLock;
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -195,7 +195,7 @@ public class ProvisioningCommon extends IntegrationTest
 
     public ProvisioningTestInstance testInstance;
 
-    public class ProvisioningTestInstance
+    public static class ProvisioningTestInstance
     {
         public ProvisioningDeviceClientTransportProtocol protocol;
         public AttestationType attestationType;
@@ -272,7 +272,7 @@ public class ProvisioningCommon extends IntegrationTest
         }
     }
 
-    public class ProvisioningStatus
+    public static class ProvisioningStatus
     {
         public ProvisioningDeviceClientRegistrationResult provisioningDeviceClientRegistrationInfoClient = new ProvisioningDeviceClientRegistrationResult();
         public Exception exception;

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/DeviceRegistrationParser.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/DeviceRegistrationParser.java
@@ -28,7 +28,7 @@ public class DeviceRegistrationParser
     /**
      * Inner class describing TPM Attestation i.e it holds EndorsementKey and StorageRootKey
      */
-    class TpmAttestation
+    static class TpmAttestation
     {
         private final String endorsementKey;
         private final String storageRootKey;

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/X509RegistrationResultParser.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/X509RegistrationResultParser.java
@@ -24,7 +24,7 @@ public class X509RegistrationResultParser
      * Class representing X509CertificateInfo
      * https://docs.microsoft.com/en-us/rest/api/iot-dps/RuntimeRegistration/RegisterDevice#definitions_x509certificateinfo
      */
-    public class X509CertificateInfo
+    public static class X509CertificateInfo
     {
         private static final String SUBJECT_NAME = "subjectName";
         @SerializedName(SUBJECT_NAME)

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
@@ -48,7 +48,7 @@ public class RegisterTask implements Callable<RegistrationOperationStatusParser>
     private final SecurityProvider securityProvider;
     private final ProvisioningDeviceClientConfig provisioningDeviceClientConfig;
 
-    private class ResponseCallbackImpl implements ResponseCallback
+    private static class ResponseCallbackImpl implements ResponseCallback
     {
         @Override
         public void run(ResponseData responseData, Object context) throws ProvisioningDeviceClientException

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/StatusTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/StatusTask.java
@@ -28,7 +28,7 @@ public class StatusTask implements Callable<RegistrationOperationStatusParser>
     private final String operationId;
     private final Authorization authorization;
 
-    private class ResponseCallbackImpl implements ResponseCallback
+    private static class ResponseCallbackImpl implements ResponseCallback
     {
         @Override
         public void run(ResponseData responseData, Object context) throws ProvisioningDeviceClientException

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
@@ -61,7 +61,7 @@ public class EnrollmentGroupTest
     private static final Date VALID_DATE = new Date(System.currentTimeMillis()/1000 * 1000);
     private static final String VALID_DATE_AS_STRING = ParserUtility.dateTimeUtcToString(VALID_DATE);
 
-    private final class MockEnrollmentGroup extends EnrollmentGroup
+    private static final class MockEnrollmentGroup extends EnrollmentGroup
     {
         String mockedEnrollmentGroupId;
         AttestationMechanism mockedAttestationMechanism;

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
@@ -39,7 +39,7 @@ public class IndividualEnrollmentTest
     private static final Date VALID_DATE = new Date();
     private static final String VALID_DATE_AS_STRING = ParserUtility.dateTimeUtcToString(VALID_DATE);
 
-    private final class MockIndividualEnrollment extends IndividualEnrollment
+    private static final class MockIndividualEnrollment extends IndividualEnrollment
     {
         String mockedRegistrationId;
         String mockedDeviceId;

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/SerializableTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/SerializableTest.java
@@ -22,7 +22,7 @@ public class SerializableTest
             "    \"prop3\":\"val3\"" +
             "}";
 
-    final class mockedChild extends Serializable
+    static final class mockedChild extends Serializable
     {
         protected JsonElement toJsonElement()
         {

--- a/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
+++ b/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
@@ -61,7 +61,7 @@ public class SecurityProviderTpmTest
     @Mocked
     UUID mockedUUID;
 
-    class SecurityProviderTPMTestImpl extends SecurityProviderTpm
+    static class SecurityProviderTPMTestImpl extends SecurityProviderTpm
     {
         byte[] ek;
 

--- a/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderX509Test.java
+++ b/provisioning/security/security-provider/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderX509Test.java
@@ -62,7 +62,7 @@ public class SecurityProviderX509Test
     @Mocked
     X509KeyManager mockedX509KeyManager;
 
-    class SecurityProviderX509TestImpl extends SecurityProviderX509
+    static class SecurityProviderX509TestImpl extends SecurityProviderX509
     {
         private final String cn;
         private final X509Certificate x509Certificate;


### PR DESCRIPTION
Code inspection details:
An inner class may be static if it doesn't reference its enclosing instance.
A static inner class does not keep an implicit reference to its enclosing instance. This prevents a common cause of memory leaks and uses less memory per instance of the class.