### PR TITLE
Add logging to both retry policies and the RetryDecision class

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
@@ -95,6 +95,6 @@ public class ExponentialBackoffWithJitter implements RetryPolicy
 
     private void logCreation()
     {
-        log.info("NOTE: An exponential backoff retry policy has been craeted with the following properties. Retry Count: {}, Min Backoff Interval: {}, Max Backoff Interval: {}, Max Time Between Retries: {}, Fast Retry Enabled: {}", this.retryCount, this.minBackoff, this.maxBackoff, this.deltaBackoff, this.firstFastRetry);
+        log.info("NOTE: A new instance of {} has been created with the following properties. Retry Count: {}, Min Backoff Interval: {}, Max Backoff Interval: {}, Max Time Between Retries: {}, Fast Retry Enabled: {}", ExponentialBackoffWithJitter.class.getName(), this.retryCount, this.minBackoff, this.maxBackoff, this.deltaBackoff, this.firstFastRetry);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
@@ -95,6 +95,6 @@ public class ExponentialBackoffWithJitter implements RetryPolicy
 
     private void logCreation()
     {
-        log.info("NOTE: A new instance of {} has been created with the following properties. Retry Count: {}, Min Backoff Interval: {}, Max Backoff Interval: {}, Max Time Between Retries: {}, Fast Retry Enabled: {}", ExponentialBackoffWithJitter.class.getName(), this.retryCount, this.minBackoff, this.maxBackoff, this.deltaBackoff, this.firstFastRetry);
+        log.info("NOTE: A new instance of ExponentialBackoffWithJitter has been created with the following properties. Retry Count: {}, Min Backoff Interval: {}, Max Backoff Interval: {}, Max Time Between Retries: {}, Fast Retry Enabled: {}", this.retryCount, this.minBackoff, this.maxBackoff, this.deltaBackoff, this.firstFastRetry);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ExponentialBackoffWithJitter.java
@@ -8,12 +8,14 @@
 package com.microsoft.azure.sdk.iot.device.transport;
 
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.security.SecureRandom;
 
 /**
  * Represents a retry policy that performs exponential backoff with jitter retries.
  */
+@Slf4j
 public class ExponentialBackoffWithJitter implements RetryPolicy
 {
     // Codes_SRS_EXPONENTIALBACKOFF_28_006: [Constructor should have default values retryCount, minBackoff, maxBackoff, deltaBackoff and firstFastRetry]
@@ -30,7 +32,8 @@ public class ExponentialBackoffWithJitter implements RetryPolicy
      */
     public ExponentialBackoffWithJitter()
     {
-
+        // Let us know when we've created a new exponential backoff
+        this.logCreation();
     }
 
     /**
@@ -56,6 +59,9 @@ public class ExponentialBackoffWithJitter implements RetryPolicy
         this.maxBackoff = maxBackoff;
         this.deltaBackoff = deltaBackoff;
         this.firstFastRetry = firstFastRetry;
+
+        // Let us know when we've created a new exponential backoff
+        this.logCreation();
     }
 
     /**
@@ -85,5 +91,10 @@ public class ExponentialBackoffWithJitter implements RetryPolicy
         }
 
         return new RetryDecision(false, 0);
+    }
+
+    private void logCreation()
+    {
+        log.info("NOTE: An exponential backoff retry policy has been craeted with the following properties. Retry Count: {}, Min Backoff Interval: {}, Max Backoff Interval: {}, Max Time Between Retries: {}, Fast Retry Enabled: {}", this.retryCount, this.minBackoff, this.maxBackoff, this.deltaBackoff, this.firstFastRetry);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NoRetry implements RetryPolicy
 {
     public NoRetry() {
-        log.info("NOTE: A new instance of {} has been created, the client will not perform any retries on disconnect.", NoRetry.class.getName());
+        log.info("NOTE: A new instance of NoRetry has been created, the client will not perform any retries on disconnect.");
     }
     /**
      * Always says to not retry.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NoRetry implements RetryPolicy
 {
     public NoRetry() {
-        log.info("NOTE: A no-retry policy has been craeted, the client will not perform any retries on disconnect.");
+        log.info("NOTE: A new instance of {} has been created, the client will not perform any retries on disconnect.", NoRetry.class.getName());
     }
     /**
      * Always says to not retry.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/NoRetry.java
@@ -8,12 +8,17 @@
 package com.microsoft.azure.sdk.iot.device.transport;
 
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
+import lombok.extern.slf4j.Slf4j;
 
 /**
   * Represents a retry policy that performs no retries.
   */
+@Slf4j
 public class NoRetry implements RetryPolicy
 {
+    public NoRetry() {
+        log.info("NOTE: A no-retry policy has been craeted, the client will not perform any retries on disconnect.");
+    }
     /**
      * Always says to not retry.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/RetryDecision.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/RetryDecision.java
@@ -32,9 +32,9 @@ public class RetryDecision
 
         // When a retry policy specifies the descision we should log what the new timing was, this will help with backoff debugging
         if (!shouldRetry){
-            log.info("NOTE: A new instance of {} has been created with retry disabled, the client will not perform any retries.", RetryDecision.class.getName());
+            log.debug("NOTE: A new instance of RetryDecision has been created with retry disabled, the client will not perform any retries.");
         } else {
-            log.info("NOTE: A new instance of {} has been created with retry enabled, the client will perform retries every {} milliseconds.", RetryDecision.class.getName(), duration);
+            log.debug("NOTE: A new instance of RetryDecision has been created with retry enabled, the client will retry after {} milliseconds", duration);
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/RetryDecision.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/RetryDecision.java
@@ -7,9 +7,12 @@
 
 package com.microsoft.azure.sdk.iot.device.transport;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Represents the retry details
  */
+@Slf4j
 public class RetryDecision
 {
     private final boolean shouldRetry;
@@ -26,6 +29,13 @@ public class RetryDecision
         // Codes_SRS_RETRYDECISION_28_001: [The constructor shall save the duration and getRetryDecision]
         this.duration = duration;
         this.shouldRetry = shouldRetry;
+
+        // When a retry policy specifies the descision we should log what the new timing was, this will help with backoff debugging
+        if (!shouldRetry){
+            log.info("NOTE: A new instance of {} has been created with retry disabled, the client will not perform any retries.", RetryDecision.class.getName());
+        } else {
+            log.info("NOTE: A new instance of {} has been created with retry enabled, the client will perform retries every {} milliseconds.", RetryDecision.class.getName(), duration);
+        }
     }
 
     /**


### PR DESCRIPTION
Mirroring the effort done in [Add a log statement to indicate a NoRetry retry policy was enabled](https://github.com/Azure/azure-iot-sdk-csharp/pull/1763) for the csharp SDK.

The ask from the CSS team is as below:
In certain situations customers raise support issues stating that the client does not recover on disconnection, only to discover on inspection of customer code that they have explicitly disabled the inbuilt retry policy in the client.
In order to avoid long delays in identifying the issue, the CSS team wants us to log a statement in case the retry policy is disabled.

This PR adds logging to the following classes `NoRetry`, `ExponentialBackoffWithJitter`, and `RetryDecision` to indicate the creation of the policy or the current decision.