### PR TITLE
release(2021-02-04): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.29.0";
+    private static final String CLIENT_VERSION = "1.29.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.1') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.29.0</iot-device-client-version>
-        <iot-service-client-version>1.27.0</iot-service-client-version>
+        <iot-device-client-version>1.29.1</iot-device-client-version>
+        <iot-service-client-version>1.27.1</iot-service-client-version>
         <iot-deps-version>0.11.1</iot-deps-version>
         <provisioning-device-client-version>1.8.6</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.1</provisioning-service-client-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.27.0";
+    public static String serviceVersion = "1.27.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.27.1)
- Fix service client's cloud to device message sender not using custom SSLContext when set (#1090)


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.29.1)
- Add additional logging to retry logic (#1103)
- Fix some log statemnts within transport layer (#1091)



https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.29.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.27.1/jar


old
{
    "device": "1.29.0",
    "service": "1.27.0",
    "deps": "0.11.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.6",
    "provisioningService": "1.7.1"
}

new
{
    "device": "1.29.1",
    "service": "1.27.1",
    "deps": "0.11.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.6",
    "provisioningService": "1.7.1"
}