### PR TITLE
feat(iot-service): Add TokenCredential and AzureSasCredential support to Query and Twin clients

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/GetTwinTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/GetTwinTests.java
@@ -5,10 +5,15 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 
+import com.azure.core.credential.AzureSasCredential;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.ServiceClient;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinClientOptions;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
@@ -42,9 +47,26 @@ public class GetTwinTests extends DeviceTwinCommon
 
     @Test
     @StandardTierHubOnlyTest
-    public void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
+    public void testGetDeviceTwinWithConnectionString() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
     {
         super.setUpNewDeviceAndModule();
+        super.testGetDeviceTwin();
+    }
+
+    @Test
+    @StandardTierHubOnlyTest
+    public void testGetDeviceTwinWithAzureSasCredential() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
+    {
+        super.setUpNewDeviceAndModule();
+
+        IotHubConnectionString iotHubConnectionStringObj =
+                IotHubConnectionStringBuilder.createIotHubConnectionString(iotHubConnectionString);
+
+        IotHubServiceSasToken serviceSasToken = new IotHubServiceSasToken(iotHubConnectionStringObj);
+        AzureSasCredential sasCredential = new AzureSasCredential(serviceSasToken.toString());
+
+        testInstance.twinServiceClient = new DeviceTwin(iotHubConnectionStringObj.getHostName(), sasCredential);
+
         super.testGetDeviceTwin();
     }
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/QueryTwinTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/QueryTwinTests.java
@@ -5,12 +5,17 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 
+import com.azure.core.credential.AzureSasCredential;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinConnectionState;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
+import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.ServiceClient;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.devicetwin.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import lombok.extern.slf4j.Slf4j;
@@ -70,6 +75,26 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @StandardTierHubOnlyTest
+    public void testRawQueryTwinWithConnectionString() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    {
+        testInstance.twinServiceClient = new DeviceTwin(iotHubConnectionString);
+        testRawQueryTwin();
+    }
+
+    @Test
+    @StandardTierHubOnlyTest
+    public void testRawQueryTwinWithAzureSasCredential() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    {
+        IotHubConnectionString iotHubConnectionStringObj =
+                IotHubConnectionStringBuilder.createIotHubConnectionString(iotHubConnectionString);
+
+        IotHubServiceSasToken serviceSasToken = new IotHubServiceSasToken(iotHubConnectionStringObj);
+        AzureSasCredential sasCredential = new AzureSasCredential(serviceSasToken.toString());
+        testInstance.twinServiceClient = new DeviceTwin(iotHubConnectionStringObj.getHostName(), sasCredential);
+
+        testRawQueryTwin();
+    }
+
     public void testRawQueryTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
     {
         addMultipleDevices(MAX_DEVICES, false);
@@ -271,7 +296,27 @@ public class QueryTwinTests extends DeviceTwinCommon
 
     @Test
     @StandardTierHubOnlyTest
-    public void testQueryTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    public void testQueryTwinWithConnectionString() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    {
+        testInstance.twinServiceClient = new DeviceTwin(iotHubConnectionString);
+        testQueryTwin();
+    }
+
+    @Test
+    @StandardTierHubOnlyTest
+    public void testQueryTwinWithAzureSasCredential() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, URISyntaxException, ModuleClientException
+    {
+        IotHubConnectionString iotHubConnectionStringObj =
+                IotHubConnectionStringBuilder.createIotHubConnectionString(iotHubConnectionString);
+
+        IotHubServiceSasToken serviceSasToken = new IotHubServiceSasToken(iotHubConnectionStringObj);
+        AzureSasCredential sasCredential = new AzureSasCredential(serviceSasToken.toString());
+        testInstance.twinServiceClient = new DeviceTwin(iotHubConnectionStringObj.getHostName(), sasCredential);
+
+        testQueryTwin();
+    }
+
+    public void testQueryTwin() throws InterruptedException, ModuleClientException, IOException, GeneralSecurityException, IotHubException, URISyntaxException
     {
         addMultipleDevices(MAX_DEVICES, false);
 
@@ -402,7 +447,7 @@ public class QueryTwinTests extends DeviceTwinCommon
     public void queryCollectionCanReturnEmptyQueryResults() throws IOException, IotHubException
     {
         String fullQuery = "select * from devices where deviceId='nonexistantdevice'";
-        DeviceTwin twinClient = DeviceTwin.createFromConnectionString(iotHubConnectionString, DeviceTwinClientOptions.builder().httpReadTimeout(HTTP_READ_TIMEOUT).build());
+        DeviceTwin twinClient = new DeviceTwin(iotHubConnectionString, DeviceTwinClientOptions.builder().httpReadTimeout(HTTP_READ_TIMEOUT).build());
         QueryCollection twinQuery = twinClient.queryTwinCollection(fullQuery);
         QueryOptions options = new QueryOptions();
         QueryCollectionResponse<DeviceTwinDevice> response = twinClient.next(twinQuery, options);

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/Query.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/Query.java
@@ -12,7 +12,6 @@ import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningS
 
 import java.util.*;
 
-
 /**
  * The query iterator.
  *
@@ -103,44 +102,31 @@ public class Query implements Iterator
      */
     protected Query(ContractApiHttp contractApiHttp, String targetPath, QuerySpecification querySpecification, int pageSize)
     {
-        /* SRS_QUERY_21_001: [The constructor shall throw IllegalArgumentException if the provided contractApiHttp is null.] */
-        if(contractApiHttp == null)
+        if (contractApiHttp == null)
         {
             throw new IllegalArgumentException("contractApiHttp cannot be null.");
         }
 
-        /* SRS_QUERY_21_002: [The constructor shall throw IllegalArgumentException if the provided targetPath is null or empty.] */
-        if(Tools.isNullOrEmpty(targetPath))
+        if (Tools.isNullOrEmpty(targetPath))
         {
             throw new IllegalArgumentException("targetPath cannot be null.");
         }
 
-        /* SRS_QUERY_21_003: [The constructor shall throw IllegalArgumentException if the provided querySpecification is null.] */
-        if(querySpecification == null)
+        if (querySpecification == null)
         {
             throw new IllegalArgumentException("querySpecification cannot be null.");
         }
 
-        /* SRS_QUERY_21_004: [The constructor shall throw IllegalArgumentException if the provided pageSize is negative.] */
-        if(pageSize < 0)
+        if (pageSize < 0)
         {
             throw new IllegalArgumentException("pageSize cannot be negative.");
         }
 
-        /* SRS_QUERY_21_005: [The constructor shall store the provided `contractApiHttp` and `pageSize`.] */
         this.contractApiHttp = contractApiHttp;
         this.pageSize = pageSize;
-
-        /* SRS_QUERY_21_006: [The constructor shall create and store a JSON from the provided querySpecification.] */
         this.querySpecificationJson = querySpecification.toJson();
-
-        /* SRS_QUERY_21_007: [The constructor shall create and store a queryPath adding `/query` to the provided `targetPath`.] */
         this.queryPath = targetPath + PATH_SEPARATOR + PATH_QUERY;
-
-        /* SRS_QUERY_21_008: [The constructor shall set continuationToken as null.] */
         this.continuationToken = null;
-
-        /* SRS_QUERY_21_009: [The constructor shall set hasNext as true.] */
         this.hasNext = true;
     }
 
@@ -157,7 +143,6 @@ public class Query implements Iterator
     @Override
     public boolean hasNext()
     {
-        /* SRS_QUERY_21_010: [The hasNext shall return the store hasNext.] */
         return hasNext;
     }
 
@@ -170,25 +155,21 @@ public class Query implements Iterator
     @Override
     public QueryResult next()
     {
-        /* SRS_QUERY_21_011: [The next shall throw NoSuchElementException if the hasNext is false.] */
-        if(!hasNext)
+        if (!hasNext)
         {
             throw new NoSuchElementException("There are no more pending elements");
         }
 
-        /* SRS_QUERY_21_012: [If the pageSize is not 0, the next shall send the Http request with `x-ms-max-item-count=[pageSize]` in the header.] */
         Map<String, String> headerParameters = new HashMap<>();
-        if(pageSize != 0)
+        if (pageSize != 0)
         {
             headerParameters.put(PAGE_SIZE_KEY, Integer.toString(pageSize));
         }
-        /* SRS_QUERY_21_013: [If the continuationToken is not null or empty, the next shall send the Http request with `x-ms-continuation=[continuationToken]` in the header.] */
-        if(!Tools.isNullOrEmpty(this.continuationToken))
+        if (!Tools.isNullOrEmpty(this.continuationToken))
         {
             headerParameters.put(CONTINUATION_TOKEN_KEY, this.continuationToken);
         }
 
-        /* SRS_QUERY_21_014: [The next shall send a Http request with a Http verb `POST`.] */
         HttpResponse httpResponse;
         try
         {
@@ -201,24 +182,21 @@ public class Query implements Iterator
         }
         catch (ProvisioningServiceClientException e)
         {
-            /* SRS_QUERY_21_015: [The next shall throw IllegalArgumentException if the Http request throws any ProvisioningServiceClientException.] */
             // Because Query implements the iterator interface, the next cannot throws ProvisioningServiceClientException.
             throw new IllegalArgumentException(e);
         }
 
-        /* SRS_QUERY_21_024: [The next shall throw IllegalArgumentException if the heepResponse contains a null body.] */
         byte[] body = httpResponse.getBody();
-        if(body == null)
+        if (body == null)
         {
             throw new IllegalArgumentException("Http response for next cannot contains a null body");
         }
-        /* SRS_QUERY_21_016: [The next shall create and return a new instance of the QueryResult using the `x-ms-item-type` as type, `x-ms-continuation` as the next continuationToken, and the message body.] */
+
         String bodyStr = new String(body);
         Map<String, String> headers = httpResponse.getHeaderFields();
         String type = headers.get(ITEM_TYPE_KEY);
         this.continuationToken = headers.get(CONTINUATION_TOKEN_KEY);
 
-        /* SRS_QUERY_21_017: [The next shall set hasNext as true if the continuationToken is not null, or false if it is null.] */
         hasNext = (this.continuationToken != null);
 
         return new QueryResult(type, bodyStr, this.continuationToken);
@@ -233,16 +211,12 @@ public class Query implements Iterator
      */
     public QueryResult next(String continuationToken)
     {
-        /* SRS_QUERY_21_018: [The next shall throw NoSuchElementException if the provided continuationToken is null or empty.] */
-        if(Tools.isNullOrEmpty(continuationToken))
+        if (Tools.isNullOrEmpty(continuationToken))
         {
             throw new NoSuchElementException("There is no Continuation Token to get pending elements,");
         }
 
-        /* SRS_QUERY_21_019: [The next shall store the provided continuationToken.] */
         this.continuationToken = continuationToken;
-
-        /* SRS_QUERY_21_020: [The next shall return the next page of results by calling the next().] */
         return next();
     }
 
@@ -255,7 +229,6 @@ public class Query implements Iterator
      */
     public int getPageSize()
     {
-        /* SRS_QUERY_21_021: [The getPageSize shall return the stored pageSize.] */
         return pageSize;
     }
 
@@ -270,12 +243,11 @@ public class Query implements Iterator
      */
     public void setPageSize(int pageSize)
     {
-        /* SRS_QUERY_21_022: [The setPageSize shall throw IllegalArgumentException if the provided pageSize is negative.] */
-        if(pageSize < 0)
+        if (pageSize < 0)
         {
             throw new IllegalArgumentException("pageSize cannot be null");
         }
-        /* SRS_QUERY_21_023: [The setPageSize shall store the new pageSize value.] */
+
         this.pageSize = pageSize;
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
@@ -91,7 +91,7 @@ public class DeviceOperations
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
          if (Tools.isNullOrEmpty(sasTokenString))
         {
-            throw new IOException("Illegal sasToken null or empty");
+            throw new IllegalArgumentException("Illegal sasToken null or empty");
         }
 
         HttpRequest request = new HttpRequest(url, method, payload);
@@ -171,7 +171,7 @@ public class DeviceOperations
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
         if (Tools.isNullOrEmpty(sasTokenString))
         {
-            throw new IOException("Illegal sasToken null or empty");
+            throw new IllegalArgumentException("Illegal sasToken null or empty");
         }
 
         HttpRequest request;

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperations.java
@@ -4,6 +4,7 @@
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubExceptionManager;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Set of common operations for Twin and Method.
@@ -31,6 +33,7 @@ public class DeviceOperations
     private static final String ACCEPT = "Accept";
     private static final String ACCEPT_VALUE = "application/json";
     private static final String ACCEPT_CHARSET = "charset=utf-8";
+    private static final String CONTENT_LENGTH = "Content-Length";
     private static final String CONTENT_TYPE = "Content-Type";
     private static final Integer DEFAULT_HTTP_TIMEOUT_MS = 24000;
     private static Map<String, String> headers = null;
@@ -59,74 +62,59 @@ public class DeviceOperations
             long timeoutInMs) 
             throws IOException, IotHubException, IllegalArgumentException
     {
-        /* Codes_SRS_DEVICE_OPERATIONS_21_001: [The request shall throw IllegalArgumentException if the provided `iotHubConnectionString` is null.] */
-        if(iotHubConnectionString == null)
+        if (iotHubConnectionString == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null connection string");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_002: [The request shall throw IllegalArgumentException if the provided `url` is null.] */
-        if(url == null)
+        if (url == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_003: [The request shall throw IllegalArgumentException if the provided `method` is null.] */
-        if(method == null)
+        if (method == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null http method");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_004: [The request shall throw IllegalArgumentException if the provided `payload` is null.] */
-        if(payload == null)
+        if (payload == null)
         {
             // This is an odd requirement, but since we won't use this API since its deprecation, it will stay.
             throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_99_018: [The request shall throw IllegalArgumentException if the provided `timeoutInMs` exceed Integer.MAX_VALUE.] */
-        if((timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS) > Integer.MAX_VALUE) 
+        if ((timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS) > Integer.MAX_VALUE)
         {
             throw new IllegalArgumentException("HTTP Request timeout shouldn't not exceed " + timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS + " milliseconds");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_006: [The request shall create a new SASToken with the ServiceConnect rights.] */
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
-        /* Codes_SRS_DEVICE_OPERATIONS_21_007: [If the SASToken is null or empty, the request shall throw IOException.] */
-         if((sasTokenString == null) || sasTokenString.isEmpty())
+         if (Tools.isNullOrEmpty(sasTokenString))
         {
             throw new IOException("Illegal sasToken null or empty");
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_008: [The request shall create a new HttpRequest with the provided `url`, http `method`, and `payload`.] */
         HttpRequest request = new HttpRequest(url, method, payload);
-
-        /* Codes_SRS_DEVICE_OPERATIONS_21_009: [The request shall add to the HTTP header the sum of timeout and default timeout in milliseconds.] */
         request.setReadTimeoutMillis((int)(timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS));
-        
-        /* Codes_SRS_DEVICE_OPERATIONS_21_010: [The request shall add to the HTTP header an `authorization` key with the SASToken.] */
         request.setHeaderField(AUTHORIZATION, sasTokenString);
 
-        //Codes_SRS_DEVICE_OPERATIONS_21_011: [If the requestId is not null or empty, the request shall add to the HTTP header a Request-Id key with a new unique string value for every request.]
-        if((requestId != null) && !requestId.isEmpty())
+        if (!Tools.isNullOrEmpty(requestId))
         {
-            /* Codes_SRS_DEVICE_OPERATIONS_21_011: [The request shall add to the HTTP header a `Request-Id` key with a new unique string value for every request.] */
             request.setHeaderField(REQUEST_ID, requestId);
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_012: [The request shall add to the HTTP header a `User-Agent` key with the client Id and service version.] */
         request.setHeaderField(USER_AGENT, TransportUtils.javaServiceClientIdentifier + TransportUtils.serviceVersion);
-
-        /* Codes_SRS_DEVICE_OPERATIONS_21_013: [The request shall add to the HTTP header a `Accept` key with `application/json`.] */
         request.setHeaderField(ACCEPT, ACCEPT_VALUE);
-
-        /* Codes_SRS_DEVICE_OPERATIONS_21_014: [The request shall add to the HTTP header a `Content-Type` key with `application/json; charset=utf-8`.] */
         request.setHeaderField(CONTENT_TYPE, ACCEPT_VALUE + "; " + ACCEPT_CHARSET);
+
+        if (payload != null)
+        {
+            request.setHeaderField(CONTENT_LENGTH, String.valueOf(payload.length));
+        }
 
         if (headers != null)
         {
-            //SRS_DEVICE_OPERATIONS_25_019: [The request shall add to the HTTP header all the additional custom headers set for this request.]
-            for(Map.Entry<String, String> header : headers.entrySet())
+            for (Map.Entry<String, String> header : headers.entrySet())
             {
                 request.setHeaderField(header.getKey(), header.getValue());
             }
@@ -134,13 +122,8 @@ public class DeviceOperations
             headers = null;
         }
 
-        /* Codes_SRS_DEVICE_OPERATIONS_21_015: [The request shall send the created request and get the response.] */
         HttpResponse response = request.send();
-
-        /* Codes_SRS_DEVICE_OPERATIONS_21_016: [If the resulted HttpResponseStatus represents fail, the request shall throw proper Exception by calling httpResponseVerification.] */
         IotHubExceptionManager.httpResponseVerification(response);
-        
-        /* Codes_SRS_DEVICE_OPERATIONS_21_017: [If the resulted status represents success, the request shall return the http response.] */
         return response;
     }
 
@@ -170,23 +153,23 @@ public class DeviceOperations
             Proxy proxy)
             throws IOException, IotHubException, IllegalArgumentException
     {
-        if(iotHubConnectionString == null)
+        if (iotHubConnectionString == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null connection string");
         }
 
-        if(url == null)
+        if (url == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null URL");
         }
 
-        if(method == null)
+        if (method == null)
         {
             throw new IllegalArgumentException("Http requests must provide a non-null http method");
         }
 
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
-        if((sasTokenString == null) || sasTokenString.isEmpty())
+        if (Tools.isNullOrEmpty(sasTokenString))
         {
             throw new IOException("Illegal sasToken null or empty");
         }
@@ -204,7 +187,7 @@ public class DeviceOperations
         request.setReadTimeoutMillis(readTimeout);
         request.setConnectTimeoutMillis(connectTimeout);
 
-        if((requestId != null) && !requestId.isEmpty())
+        if (!Tools.isNullOrEmpty(requestId))
         {
             request.setHeaderField(REQUEST_ID, requestId);
         }
@@ -214,9 +197,95 @@ public class DeviceOperations
         request.setHeaderField(ACCEPT, ACCEPT_VALUE);
         request.setHeaderField(CONTENT_TYPE, ACCEPT_VALUE + "; " + ACCEPT_CHARSET);
 
+        if (payload != null)
+        {
+            request.setHeaderField(CONTENT_LENGTH, String.valueOf(payload.length));
+        }
+
         if (headers != null)
         {
-            for(Map.Entry<String, String> header : headers.entrySet())
+            for (Map.Entry<String, String> header : headers.entrySet())
+            {
+                request.setHeaderField(header.getKey(), header.getValue());
+            }
+
+            headers = null;
+        }
+
+        HttpResponse response = request.send();
+        IotHubExceptionManager.httpResponseVerification(response);
+        return response;
+    }
+
+    /**
+     * Send a http request to the IoTHub using the Twin/Method standard, and return its response.
+     *
+     * @param credentialToken The authentication token that will be used to authorize the request
+     * @param url is the Twin URL for the device ID.
+     * @param method is the HTTP method (GET, POST, DELETE, PATCH, PUT).
+     * @param payload is the array of bytes that contains the payload.
+     * @param requestId is an unique number that identify the request.
+     * @param connectTimeout the http connect timeout to use, in milliseconds.
+     * @param readTimeout the http read timeout to use, in milliseconds.
+     * @param proxy the proxy to use, or null if no proxy will be used.
+     * @return the result of the request.
+     * @throws IotHubException This exception is thrown if the response verification failed.
+     * @throws IOException This exception is thrown if the IO operation failed.
+     */
+    public static HttpResponse request(
+            String credentialToken,
+            URL url,
+            HttpMethod method,
+            byte[] payload,
+            String requestId,
+            int connectTimeout,
+            int readTimeout,
+            Proxy proxy)
+            throws IOException, IotHubException, IllegalArgumentException
+    {
+        Objects.requireNonNull(credentialToken);
+
+        if (url == null)
+        {
+            throw new IllegalArgumentException("Http requests must provide a non-null URL");
+        }
+
+        if (method == null)
+        {
+            throw new IllegalArgumentException("Http requests must provide a non-null http method");
+        }
+
+        HttpRequest request;
+        if (proxy != null)
+        {
+            request = new HttpRequest(url, method, payload, proxy);
+        }
+        else
+        {
+            request = new HttpRequest(url, method, payload);
+        }
+
+        request.setReadTimeoutMillis(readTimeout);
+        request.setConnectTimeoutMillis(connectTimeout);
+
+        if (!Tools.isNullOrEmpty(requestId))
+        {
+            request.setHeaderField(REQUEST_ID, requestId);
+        }
+
+        request.setHeaderField(AUTHORIZATION, credentialToken);
+        request.setHeaderField(USER_AGENT, TransportUtils.javaServiceClientIdentifier + TransportUtils.serviceVersion);
+        request.setHeaderField(ACCEPT, ACCEPT_VALUE);
+        request.setHeaderField(CONTENT_TYPE, ACCEPT_VALUE + "; " + ACCEPT_CHARSET);
+
+        if (payload != null)
+        {
+            request.setHeaderField(CONTENT_LENGTH, String.valueOf(payload.length));
+        }
+
+        if (headers != null)
+        {
+            for (Map.Entry<String, String> header : headers.entrySet())
             {
                 request.setHeaderField(header.getKey(), header.getValue());
             }
@@ -238,11 +307,9 @@ public class DeviceOperations
     {
         if (httpHeaders == null || httpHeaders.size() == 0)
         {
-            //SRS_DEVICE_OPERATIONS_25_021: [If the headers map is null or empty then this method shall throw IllegalArgumentException.]
             throw new IllegalArgumentException("Null or Empty headers can't be set");
         }
 
-        //SRS_DEVICE_OPERATIONS_25_020: [This method shall set the headers map to be used for next request only.]
         headers = httpHeaders;
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -5,9 +5,15 @@
 
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
-import com.microsoft.azure.sdk.iot.deps.twin.*;
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.Tools;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
@@ -17,22 +23,35 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 
 public class DeviceTwin
 {
-    private IotHubConnectionString iotHubConnectionString = null;
-    private Integer requestId = 0;
+    private int requestId = 0;
     private final int DEFAULT_PAGE_SIZE = 100;
+
     private DeviceTwinClientOptions options;
+    private String hostName;
+    private TokenCredential credential;
+    private AzureSasCredential azureSasCredential;
+    private IotHubConnectionString iotHubConnectionString;
 
     /**
      * Static constructor to create instance from connection string.
      *
      * @param connectionString The iot hub connection string.
      * @return The instance of DeviceTwin.
-     * @throws IOException This exception is thrown if the object creation failed.
+     * @throws IOException This exception is never thrown.
+     * @deprecated because this method declares a thrown IOException even though it never throws an IOException. Users
+     * are recommended to use {@link #DeviceTwin(String, DeviceTwinClientOptions)} instead
+     * since it does not declare this exception even though it constructs the same DeviceTwin.
      */
+    @Deprecated
     public static DeviceTwin createFromConnectionString(String connectionString) throws IOException
     {
         return createFromConnectionString(
@@ -49,24 +68,121 @@ public class DeviceTwin
      * @param connectionString The iot hub connection string.
      * @param options the configurable options for each operation on this client. May not be null.
      * @return The instance of DeviceTwin.
-     * @throws IOException This exception is thrown if the object creation failed.
+     * @throws IOException This exception is never thrown.
+     * @deprecated because this method declares a thrown IOException even though it never throws an IOException. Users
+     * are recommended to use {@link #DeviceTwin(String, DeviceTwinClientOptions)} instead
+     * since it does not declare this exception even though it constructs the same DeviceTwin.
      */
-    public static DeviceTwin createFromConnectionString(String connectionString, DeviceTwinClientOptions options) throws IOException
+    @Deprecated
+    public static DeviceTwin createFromConnectionString(
+            String connectionString,
+            DeviceTwinClientOptions options) throws IOException
     {
-        if (connectionString == null || connectionString.length() == 0)
+        return new DeviceTwin(connectionString, options);
+    }
+
+    /**
+     * Constructor to create instance from connection string.
+     *
+     * @param connectionString The iot hub connection string.
+     * @return The instance of DeviceTwin.
+     */
+    public DeviceTwin(String connectionString)
+    {
+        this(connectionString,
+             DeviceTwinClientOptions.builder()
+                     .httpConnectTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                     .httpReadTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
+                     .build());
+    }
+
+    /**
+     * Constructor to create instance from connection string.
+     *
+     * @param connectionString The iot hub connection string.
+     * @param options the configurable options for each operation on this client. May not be null.
+     * @return The instance of DeviceTwin.
+     */
+    public DeviceTwin(String connectionString, DeviceTwinClientOptions options)
+    {
+        if (Tools.isNullOrEmpty(connectionString))
         {
             throw new IllegalArgumentException("Connection string cannot be null or empty");
         }
 
-        if (options == null)
+        this.options = options;
+        this.iotHubConnectionString = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
+        this.hostName = this.iotHubConnectionString.getHostName();
+    }
+
+    /**
+     * Create a new DeviceTwin instance.
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
+     * @return the new DeviceTwin instance.
+     */
+    public DeviceTwin(String hostName, TokenCredential credential)
+    {
+        this(hostName, credential, DeviceTwinClientOptions.builder().build());
+    }
+
+    /**
+     * Create a new DeviceTwin instance.
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
+     * @param options The connection options to use when connecting to the service.
+     * @return the new DeviceTwin instance.
+     */
+    public DeviceTwin(String hostName, TokenCredential credential, DeviceTwinClientOptions options)
+    {
+        Objects.requireNonNull(credential, "TokenCredential cannot be null");
+        Objects.requireNonNull(options, "options cannot be null");
+        if (Tools.isNullOrEmpty(hostName))
         {
-            throw new IllegalArgumentException("options cannot be null");
+            throw new IllegalArgumentException("hostName cannot be null or empty");
         }
 
-        DeviceTwin deviceTwin = new DeviceTwin();
-        deviceTwin.iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
-        deviceTwin.options = options;
-        return deviceTwin;
+        this.options = options;
+        this.credential = credential;
+        this.hostName = hostName;
+    }
+
+    /**
+     * Create a new DeviceTwin instance.
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param azureSasCredential The SAS token provider that will be used for authentication.
+     * @return the new DeviceTwin instance.
+     */
+    public DeviceTwin(String hostName, AzureSasCredential azureSasCredential)
+    {
+        this(hostName, azureSasCredential, DeviceTwinClientOptions.builder().build());
+    }
+
+    /**
+     * Create a new DeviceTwin instance.
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param azureSasCredential The SAS token provider that will be used for authentication.
+     * @param options The connection options to use when connecting to the service.
+     * @return the new DeviceTwin instance.
+     */
+    public DeviceTwin(String hostName, AzureSasCredential azureSasCredential, DeviceTwinClientOptions options)
+    {
+        Objects.requireNonNull(azureSasCredential, "azureSasCredential cannot be null");
+        Objects.requireNonNull(options, "options cannot be null");
+        if (Tools.isNullOrEmpty(hostName))
+        {
+            throw new IllegalArgumentException("hostName cannot be null or empty");
+        }
+
+        this.options = options;
+        this.azureSasCredential = azureSasCredential;
+        this.hostName = hostName;
     }
 
     /**
@@ -80,26 +196,17 @@ public class DeviceTwin
     {
         if (device == null || device.getDeviceId() == null || device.getDeviceId().length() == 0)
         {
-            /*
-             **Codes_SRS_DEVICETWIN_25_004: [** The function shall throw IllegalArgumentException if the input device is null or if deviceId is null or empty **]**
-             */
             throw new IllegalArgumentException("Instantiate a device and set device id to be used");
         }
 
         URL url;
         if ((device.getModuleId() == null) || device.getModuleId().length() ==0)
         {
-            /*
-             **Codes_SRS_DEVICETWIN_25_005: [** The function shall build the URL for this operation by calling getUrlTwin **]**
-             */
-            url = this.iotHubConnectionString.getUrlTwin(device.getDeviceId());
+            url = IotHubConnectionString.getUrlTwin(this.hostName, device.getDeviceId());
         }
         else
         {
-            /*
-             **Codes_SRS_DEVICETWIN_28_001: [** The function shall build the URL for this operation by calling getUrlModuleTwin if moduleId is not null **]**
-             */
-            url = this.iotHubConnectionString.getUrlModuleTwin(device.getDeviceId(), device.getModuleId());
+            url = IotHubConnectionString.getUrlModuleTwin(this.hostName, device.getDeviceId(), device.getModuleId());
         }
 
         getTwinOperation(url, device);
@@ -107,32 +214,22 @@ public class DeviceTwin
 
     private void getTwinOperation(URL url, DeviceTwinDevice device) throws IotHubException, IOException
     {
-        /*
-        **Codes_SRS_DEVICETWIN_25_006: [** The function shall create a new SAS token **]**
-        **Codes_SRS_DEVICETWIN_25_007: [** The function shall create a new HttpRequest with http method as Get **]**
-        **Codes_SRS_DEVICETWIN_25_008: [** The function shall set the following HTTP headers specified in the IotHub DeviceTwin doc.
-                                                1. Key as authorization with value as sastoken
-                                                2. Key as request id with a new string value for every request
-                                                3. Key as User-Agent with value specified by the clientIdentifier and its version
-                                                4. Key as Accept with value as application/json
-                                                5. Key as Content-Type and value as application/json
-                                                6. Key as charset and value as utf-8
-                                                7. Key as If-Match and value as '*'  **]**
-         **Codes_SRS_DEVICETWIN_25_009: [** The function shall send the created request and get the response **]**
-         **Codes_SRS_DEVICETWIN_25_010: [** The function shall verify the response status and throw proper Exception **]**
-         */
-        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.GET, new byte[0], String.valueOf(requestId++), options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
+        HttpResponse response = DeviceOperations.request(
+                this.getAuthenticationToken(),
+                url,
+                HttpMethod.GET,
+                new byte[0],
+                String.valueOf(requestId++),
+                options.getHttpConnectTimeout(),
+                options.getHttpReadTimeout(),
+                proxy);
+
         String twin = new String(response.getBody(), StandardCharsets.UTF_8);
 
-        /*
-        **Codes_SRS_DEVICETWIN_25_011: [** The function shall deserialize the payload by calling updateTwin Api on the twin object **]**
-         */
         TwinState twinState = TwinState.createFromTwinJson(twin);
 
-        /*
-        **Codes_SRS_DEVICETWIN_25_012: [** The function shall set eTag, tags, desired property map, reported property map on the user device **]**
-         */
         device.setModelId(twinState.getModelId());
         device.setETag(twinState.getETag());
         device.setTags(twinState.getTags());
@@ -160,63 +257,39 @@ public class DeviceTwin
     {
         if (device == null || device.getDeviceId() == null || device.getDeviceId().length() == 0)
         {
-            /*
-            **Codes_SRS_DEVICETWIN_25_013: [** The function shall throw IllegalArgumentException if the input device is null or if deviceId is null or empty **]**
-             */
             throw new IllegalArgumentException("Instantiate a device and set device id to be used");
         }
 
         if ((device.getDesiredMap() == null || device.getDesiredMap().isEmpty()) &&
                 (device.getTagsMap() == null || device.getTagsMap().isEmpty()))
         {
-            /*
-            **Codes_SRS_DEVICETWIN_25_045: [** The function shall throw IllegalArgumentException if the both desired and tags maps are either empty or null **]**
-             */
             throw new IllegalArgumentException("Set either desired properties or tags for the device to be updated with");
         }
 
         URL url;
         if ((device.getModuleId() == null) || device.getModuleId().length() ==0)
         {
-            /*
-             **Codes_SRS_DEVICETWIN_25_005: [** The function shall build the URL for this operation by calling getUrlTwin**]**
-             */
-            url = this.iotHubConnectionString.getUrlTwin(device.getDeviceId());
+            url = IotHubConnectionString.getUrlTwin(this.hostName, device.getDeviceId());
         }
         else
         {
-            /*
-             **Codes_SRS_DEVICETWIN_28_002: [** The function shall build the URL for this operation by calling getUrlModuleTwin if moduleId is not null **]**
-             */
-            url = this.iotHubConnectionString.getUrlModuleTwin(device.getDeviceId(), device.getModuleId());
+            url = IotHubConnectionString.getUrlModuleTwin(this.hostName, device.getDeviceId(), device.getModuleId());
         }
 
-        /*
-        **Codes_SRS_DEVICETWIN_25_015: [** The function shall serialize the twin map by calling updateTwin Api on the twin object for the device provided by the user**]**
-         */
         TwinState twinState = new TwinState(device.getTagsMap(), device.getDesiredMap(), null);
         String twinJson = twinState.toJsonElement().toString();
 
-        /*
-        **Codes_SRS_DEVICETWIN_25_016: [** The function shall create a new SAS token **]**
-
-        **Codes_SRS_DEVICETWIN_25_017: [** The function shall create a new HttpRequest with http method as Patch **]**
-
-        **Codes_SRS_DEVICETWIN_25_018: [** The function shall set the following HTTP headers specified in the IotHub DeviceTwin doc.
-                                                1. Key as authorization with value as sastoken
-                                                2. Key as request id with a new string value for every request
-                                                3. Key as User-Agent with value specified by the clientIdentifier and its version
-                                                4. Key as Accept with value as application/json
-                                                5. Key as Content-Type and value as application/json
-                                                6. Key as charset and value as utf-8
-                                                7. Key as If-Match and value as '*'  **]**
-
-        **Codes_SRS_DEVICETWIN_25_019: [** The function shall send the created request and get the response **]**
-
-        **Codes_SRS_DEVICETWIN_25_020: [** The function shall verify the response status and throw proper Exception **]**
-         */
-        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
-        HttpResponse response = DeviceOperations.request(this.iotHubConnectionString, url, HttpMethod.PATCH, twinJson.getBytes(StandardCharsets.UTF_8), String.valueOf(requestId++),options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
+        DeviceOperations.request(
+                this.getAuthenticationToken(),
+                url,
+                HttpMethod.PATCH,
+                twinJson.getBytes(StandardCharsets.UTF_8),
+                String.valueOf(requestId++),
+                options.getHttpConnectTimeout(),
+                options.getHttpReadTimeout(),
+                proxy);
     }
 
     /**
@@ -272,23 +345,50 @@ public class DeviceTwin
     {
         if (sqlQuery == null || sqlQuery.length() == 0)
         {
-            //Codes_SRS_DEVICETWIN_25_047: [ The method shall throw IllegalArgumentException if the query is null or empty.]
             throw new IllegalArgumentException("Query cannot be null or empty");
         }
 
         if (pageSize <= 0)
         {
-            //Codes_SRS_DEVICETWIN_25_048: [ The method shall throw IllegalArgumentException if the page size is zero or negative.]
             throw new IllegalArgumentException("pagesize cannot be negative or zero");
         }
 
-        //Codes_SRS_DEVICETWIN_25_050: [ The method shall create a new Query Object of Type TWIN. ]
         Query deviceTwinQuery = new Query(sqlQuery, pageSize, QueryType.TWIN);
 
-        //Codes_SRS_DEVICETWIN_25_049: [ The method shall build the URL for this operation by calling getUrlTwinQuery ]
-        //Codes_SRS_DEVICETWIN_25_051: [ The method shall send a Query Request to IotHub as HTTP Method Post on the query Object by calling sendQueryRequest.]
-        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
-        deviceTwinQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
+
+        if (this.credential != null)
+        {
+            deviceTwinQuery.sendQueryRequest(
+                    this.credential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
+        else if (this.azureSasCredential != null)
+        {
+            deviceTwinQuery.sendQueryRequest(
+                    this.azureSasCredential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
+        else
+        {
+            deviceTwinQuery.sendQueryRequest(
+                    this.iotHubConnectionString,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
+
         return deviceTwinQuery;
     }
 
@@ -302,7 +402,6 @@ public class DeviceTwin
      */
     public synchronized Query queryTwin(String sqlQuery) throws IotHubException, IOException
     {
-        //Codes_SRS_DEVICETWIN_25_052: [ If the pageSize if not provided then a default pageSize of 100 is used for the query.]
         return this.queryTwin(sqlQuery, DEFAULT_PAGE_SIZE);
     }
 
@@ -316,7 +415,6 @@ public class DeviceTwin
      */
     public synchronized QueryCollection queryTwinCollection(String sqlQuery) throws MalformedURLException
     {
-        //Codes_SRS_DEVICETWIN_34_069: [This function shall return the results of calling queryTwinCollection(sqlQuery, DEFAULT_PAGE_SIZE).]
         return this.queryTwinCollection(sqlQuery, DEFAULT_PAGE_SIZE);
     }
 
@@ -331,9 +429,48 @@ public class DeviceTwin
      */
     public synchronized QueryCollection queryTwinCollection(String sqlQuery, Integer pageSize) throws MalformedURLException
     {
-        //Codes_SRS_DEVICETWIN_34_070: [This function shall return a new QueryCollection object of type TWIN with the provided sql query and page size.]
-        Proxy proxy = options.getProxyOptions() != null ? options.getProxyOptions().getProxy() : null;
-        return new QueryCollection(sqlQuery, pageSize, QueryType.TWIN, this.iotHubConnectionString, this.iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, options.getHttpConnectTimeout(), options.getHttpReadTimeout(), proxy);
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
+
+        if (this.credential != null)
+        {
+            return new QueryCollection(
+                    sqlQuery,
+                    pageSize,
+                    QueryType.TWIN,
+                    this.credential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
+        else if (this.azureSasCredential != null)
+        {
+            return new QueryCollection(
+                    sqlQuery,
+                    pageSize,
+                    QueryType.TWIN,
+                    this.azureSasCredential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
+        else
+        {
+            return new QueryCollection(
+                    sqlQuery,
+                    pageSize,
+                    QueryType.TWIN,
+                    this.iotHubConnectionString,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    options.getHttpConnectTimeout(),
+                    options.getHttpReadTimeout(),
+                    proxy);
+        }
     }
 
     /**
@@ -350,11 +487,9 @@ public class DeviceTwin
     {
         if (deviceTwinQuery == null)
         {
-            //Codes_SRS_DEVICETWIN_25_053: [ The method shall throw IllegalArgumentException if query is null ]
             throw new IllegalArgumentException("Query cannot be null");
         }
 
-        //Codes_SRS_DEVICETWIN_25_055: [ If a queryResponse is available, this method shall return true as is to the user, and false otherwise.. ]
         return deviceTwinQuery.hasNext();
     }
 
@@ -371,7 +506,6 @@ public class DeviceTwin
     {
         if (deviceTwinQuery == null)
         {
-            //Codes_SRS_DEVICETWIN_25_054: [ The method shall throw IllegalArgumentException if query is null ]
             throw new IllegalArgumentException("Query cannot be null");
         }
 
@@ -379,13 +513,11 @@ public class DeviceTwin
 
         if (nextObject instanceof String)
         {
-            //Codes_SRS_DEVICETWIN_25_059: [ The method shall parse the next element from the query response as Twin Document using TwinState and provide the response on DeviceTwinDevice.]
             String twinJson = (String) nextObject;
             return jsonToDeviceTwinDevice(twinJson);
         }
         else
         {
-            //Codes_SRS_DEVICETWIN_25_060: [ If the next element from the query response is an object other than String, then this method shall throw IOException ]
             throw new IOException("Received a response that could not be parsed");
         }
     }
@@ -400,11 +532,9 @@ public class DeviceTwin
     {
         if (deviceTwinQueryCollection == null)
         {
-            //Codes_SRS_DEVICETWIN_34_080: [If the provided deviceTwinQueryCollection is null, an IllegalArgumentException shall be thrown.]
             throw new IllegalArgumentException("deviceTwinQueryCollection cannot be null");
         }
 
-        //Codes_SRS_DEVICETWIN_34_071: [This function shall return if the provided deviceTwinQueryCollection has next.]
         return deviceTwinQueryCollection.hasNext();
     }
 
@@ -419,9 +549,9 @@ public class DeviceTwin
      * @throws IotHubException If an IotHubException occurs when querying the service.
      * @throws IOException If an IotHubException occurs when querying the service or if the results of that query don't match expectations.
      */
-    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(QueryCollection deviceTwinQueryCollection) throws IOException, IotHubException
+    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(
+            QueryCollection deviceTwinQueryCollection) throws IOException, IotHubException
     {
-        //Codes_SRS_DEVICETWIN_34_075: [This function shall call next(deviceTwinQueryCollection, queryOptions) where queryOptions has the deviceTwinQueryCollection's current page size.]
         QueryOptions options = new QueryOptions();
         options.setPageSize(deviceTwinQueryCollection.getPageSize());
         return this.next(deviceTwinQueryCollection, options);
@@ -442,17 +572,17 @@ public class DeviceTwin
      * @throws IotHubException If an IotHubException occurs when querying the service.
      * @throws IOException If an IotHubException occurs when querying the service or if the results of that query don't match expectations.
      */
-    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(QueryCollection deviceTwinQueryCollection, QueryOptions options) throws IOException, IotHubException
+    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(
+            QueryCollection deviceTwinQueryCollection,
+            QueryOptions options) throws IOException, IotHubException
     {
         if (deviceTwinQueryCollection == null)
         {
-            //Codes_SRS_DEVICETWIN_34_076: [If the provided deviceTwinQueryCollection is null, an IllegalArgumentException shall be thrown.]
             throw new IllegalArgumentException("Query cannot be null");
         }
 
         if (!this.hasNext(deviceTwinQueryCollection))
         {
-            //Codes_SRS_DEVICETWIN_34_077: [If the provided deviceTwinQueryCollection has no next set to give, this function shall return null.]
             return null;
         }
 
@@ -460,13 +590,11 @@ public class DeviceTwin
         Iterator<String> jsonCollectionIterator = queryResults.getCollection().iterator();
         Collection<DeviceTwinDevice> deviceTwinDeviceList = new ArrayList<>();
 
-        //Codes_SRS_DEVICETWIN_34_078: [If the provided deviceTwinQueryCollection has a next set to give, this function shall retrieve that set from deviceTwinQueryCollection, cast its contents to DeviceTwinDevice objects, and return it in a QueryCollectionResponse object.]
         while (jsonCollectionIterator.hasNext())
         {
             deviceTwinDeviceList.add(jsonToDeviceTwinDevice(jsonCollectionIterator.next()));
         }
 
-        //Codes_SRS_DEVICETWIN_34_079: [The returned QueryCollectionResponse object shall contain the continuation token needed to retrieve the next set with.]
         return new QueryCollectionResponse<>(deviceTwinDeviceList, queryResults.getContinuationToken());
     }
 
@@ -481,42 +609,35 @@ public class DeviceTwin
      * @throws IOException if the function contains invalid parameters.
      * @throws IotHubException if the http request failed.
      */
-    public Job scheduleUpdateTwin(String queryCondition,
-                                  DeviceTwinDevice updateTwin,
-                                  Date startTimeUtc,
-                                  long maxExecutionTimeInSeconds) throws IOException, IotHubException
+    public Job scheduleUpdateTwin(
+            String queryCondition,
+            DeviceTwinDevice updateTwin,
+            Date startTimeUtc,
+            long maxExecutionTimeInSeconds) throws IOException, IotHubException
     {
-        // Codes_SRS_DEVICETWIN_21_061: [If the updateTwin is null, the scheduleUpdateTwin shall throws IllegalArgumentException ]
-        if(updateTwin == null)
+        if (updateTwin == null)
         {
             throw new IllegalArgumentException("null updateTwin");
         }
 
-        // Codes_SRS_DEVICETWIN_21_062: [If the startTimeUtc is null, the scheduleUpdateTwin shall throws IllegalArgumentException ]
-        if(startTimeUtc == null)
+        if (startTimeUtc == null)
         {
             throw new IllegalArgumentException("null startTimeUtc");
         }
 
-        // Codes_SRS_DEVICETWIN_21_063: [If the maxExecutionTimeInSeconds is negative, the scheduleUpdateTwin shall throws IllegalArgumentException ]
-        if(maxExecutionTimeInSeconds < 0)
+        if (maxExecutionTimeInSeconds < 0)
         {
             throw new IllegalArgumentException("negative maxExecutionTimeInSeconds");
         }
 
-        // Codes_SRS_DEVICETWIN_21_064: [The scheduleUpdateTwin shall create a new instance of the Job class ]
-        // Codes_SRS_DEVICETWIN_21_065: [If the scheduleUpdateTwin failed to create a new instance of the Job class, it shall throws IOException. Threw by the Jobs constructor ]
-        Job job = new Job(iotHubConnectionString.toString());
+        Job job = new Job(this.hostName, this.credential);
 
-        // Codes_SRS_DEVICETWIN_21_066: [The scheduleUpdateTwin shall invoke the scheduleUpdateTwin in the Job class with the received parameters ]
-        // Codes_SRS_DEVICETWIN_21_067: [If scheduleUpdateTwin failed, the scheduleUpdateTwin shall throws IotHubException. Threw by the scheduleUpdateTwin ]
         job.scheduleUpdateTwin(queryCondition, updateTwin, startTimeUtc, maxExecutionTimeInSeconds);
 
-        // Codes_SRS_DEVICETWIN_21_068: [The scheduleUpdateTwin shall return the created instance of the Job class ]
         return job;
     }
 
-    private DeviceTwinDevice jsonToDeviceTwinDevice(String json) throws IOException
+    private DeviceTwinDevice jsonToDeviceTwinDevice(String json)
     {
         TwinState twinState = TwinState.createFromTwinJson(json);
 
@@ -537,5 +658,22 @@ public class DeviceTwin
         }
 
         return deviceTwinDevice;
+    }
+
+    private String getAuthenticationToken()
+    {
+        // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
+        // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
+        // one of the three options.
+        if (this.credential != null)
+        {
+            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+        }
+        else if (this.azureSasCredential != null)
+        {
+            return this.azureSasCredential.getSignature();
+        }
+
+        return new IotHubServiceSasToken(iotHubConnectionString).toString();
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Job.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Job.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.jobs.JobClient;
 import com.microsoft.azure.sdk.iot.service.jobs.JobResult;
@@ -17,8 +19,8 @@ import java.util.UUID;
  */
 public class Job
 {
-    private final String jobId;
-    private final JobClient jobClient;
+    private String jobId;
+    private JobClient jobClient;
 
     /**
      * CONSTRUCTOR
@@ -63,6 +65,16 @@ public class Job
         /* Codes_SRS_JOB_21_004: [The constructor shall create a new instance of JobClient to manage the Job.] */
         /* Codes_SRS_JOB_21_005: [The constructor shall throw IOException if it failed to create a new instance of the JobClient. Threw by the JobClient constructor.] */
         this.jobClient = JobClient.createFromConnectionString(connectionString);
+    }
+
+    Job(String hostName, TokenCredential tokenCredential)
+    {
+        //TODO empty implementation for now since this PR is for twin/query, not jobs
+    }
+
+    Job(String hostName, AzureSasCredential azureSasCredential)
+    {
+        //TODO empty implementation for now since this PR is for twin/query, not jobs
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
@@ -5,6 +5,9 @@
 
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.serializer.QueryRequestParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
@@ -19,8 +22,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-/*
-    Sql style query IotHub for twin, jobs, device jobs or raw data
+/**
+ * Sql style query IotHub for twin, jobs, device jobs or raw data
  */
 public class Query
 {
@@ -41,6 +44,8 @@ public class Query
     private QueryResponse queryResponse;
 
     private IotHubConnectionString iotHubConnectionString;
+    private AzureSasCredential azureSasCredential;
+    private TokenCredential credential;
     private URL url;
     private HttpMethod httpMethod;
 
@@ -59,19 +64,15 @@ public class Query
      */
     public Query(String query, int pageSize, QueryType requestQueryType) throws IllegalArgumentException
     {
-        //Codes_SRS_QUERY_25_001: [The constructor shall validate query and save query, pagesize and request type]
-        //Codes_SRS_QUERY_25_002: [If the query is null or empty or is not a valid sql query (containing select and from), the constructor shall throw an IllegalArgumentException.]
         ParserUtility.validateQuery(query);
 
         if (pageSize <= 0)
         {
-            //Codes_SRS_QUERY_25_003: [If the pagesize is zero or negative the constructor shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Page Size cannot be zero or negative");
         }
 
         if (requestQueryType == null || requestQueryType == QueryType.UNKNOWN)
         {
-            //Codes_SRS_QUERY_25_004: [If the QueryType is null or unknown then the constructor shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Cannot process a unknown type query");
         }
 
@@ -82,7 +83,6 @@ public class Query
         this.requestQueryType = requestQueryType;
         this.responseQueryType = QueryType.UNKNOWN;
         this.queryResponse = null;
-        //Codes_SRS_QUERY_25_017: [If the query is avaliable then isSqlQuery shall be set to true, and false otherwise.]
         this.isSqlQuery = true;
     }
 
@@ -97,13 +97,11 @@ public class Query
     {
         if (pageSize <= 0)
         {
-            //Codes_SRS_QUERY_25_003: [If the pagesize is zero or negative the constructor shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Page Size cannot be zero or negative");
         }
 
         if (requestQueryType == null || requestQueryType == QueryType.UNKNOWN)
         {
-            //Codes_SRS_QUERY_25_004: [If the QueryType is null or unknown then the constructor shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Cannot process a unknown type query");
         }
 
@@ -126,31 +124,38 @@ public class Query
      */
     private void continueQuery(String continuationToken) throws IOException, IotHubException
     {
-        //Codes_SRS_QUERY_25_005: [The method shall update the request continuation token and request pagesize which shall be used for processing subsequent query request.]
         this.requestContinuationToken = continuationToken;
-        //Codes_SRS_QUERY_25_018: [The method shall send the query request again.]
-        sendQueryRequest(this.iotHubConnectionString, this.url, this.httpMethod, this.httpConnectTimeout, this.httpReadTimeout, this.proxy);
-    }
 
-    /**
-     * Continuation token and page size to be used for next query request.
-     * @param continuationToken token to be used for next query request. Can be {@code null}.
-     * @param pageSize size batch for this query.
-     * @throws IOException if sending the request is unsuccessful because of input parameters.
-     * @throws IotHubException if sending the request is unsuccessful at the Hub.
-     */
-    private void continueQuery(String continuationToken, int pageSize) throws IOException, IotHubException
-    {
-        if (pageSize <= 0)
+        if (this.credential != null)
         {
-            //Codes_SRS_QUERY_25_006: [If the pagesize is zero or negative the constructor shall throw an IllegalArgumentException.]
-            throw new IllegalArgumentException("Page Size cannot be zero or negative");
+            sendQueryRequest(
+                    this.credential,
+                    this.url,
+                    this.httpMethod,
+                    this.httpConnectTimeout,
+                    this.httpReadTimeout,
+                    this.proxy);
         }
-
-        this.pageSize = pageSize;
-        this.requestContinuationToken = continuationToken;
-        //Codes_SRS_QUERY_25_018: [The method shall send the query request again.]
-        sendQueryRequest(this.iotHubConnectionString, this.url, this.httpMethod, this.httpConnectTimeout, this.httpReadTimeout, this.proxy);
+        else if (this.azureSasCredential != null)
+        {
+            sendQueryRequest(
+                    this.azureSasCredential,
+                    this.url,
+                    this.httpMethod,
+                    this.httpConnectTimeout,
+                    this.httpReadTimeout,
+                    this.proxy);
+        }
+        else
+        {
+            sendQueryRequest(
+                    this.iotHubConnectionString,
+                    this.url,
+                    this.httpMethod,
+                    this.httpConnectTimeout,
+                    this.httpReadTimeout,
+                    this.proxy);
+        }
     }
 
     /**
@@ -167,18 +172,18 @@ public class Query
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
-    public QueryResponse sendQueryRequest(IotHubConnectionString iotHubConnectionString,
-                                   URL url,
-                                   HttpMethod method,
-                                   Long timeoutInMs) throws IOException, IotHubException
+    public QueryResponse sendQueryRequest(
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod method,
+            Long timeoutInMs)
+            throws IOException, IotHubException
     {
         if (iotHubConnectionString == null || url == null || method == null)
         {
-            //Codes_SRS_QUERY_25_019: [This method shall throw IllegalArgumentException if any of the parameters are null or empty.]
             throw new IllegalArgumentException("Input parameters cannot be null");
         }
 
-        //Codes_SRS_QUERY_25_020: [This method shall save all the parameters for future use.]
         this.iotHubConnectionString = iotHubConnectionString;
         this.url = url;
         this.httpMethod = method;
@@ -193,14 +198,12 @@ public class Query
         {
             queryHeaders.put(CONTINUATION_TOKEN_KEY, requestContinuationToken);
         }
-        //Codes_SRS_QUERY_25_007: [The method shall set the http headers x-ms-continuation and x-ms-max-item-count with request continuation token and page size if they were not null.]
         queryHeaders.put(PAGE_SIZE_KEY, String.valueOf(pageSize));
 
         DeviceOperations.setHeaders(queryHeaders);
 
         if (isSqlQuery)
         {
-            //Codes_SRS_QUERY_25_008: [The method shall obtain the serilaized query by using QueryRequestParser.]
             QueryRequestParser requestParser = new QueryRequestParser(this.query);
             payload = requestParser.toJson().getBytes();
         }
@@ -209,12 +212,10 @@ public class Query
             payload = new byte[0];
         }
 
-        //Codes_SRS_QUERY_25_009: [The method shall use the provided HTTP Method and send request to IotHub with the serialized body over the provided URL.]
         HttpResponse httpResponse = DeviceOperations.request(iotHubConnectionString, url, method, payload, null, this.httpConnectTimeout, this.httpReadTimeout, null);
 
         this.responseContinuationToken = null;
         Map<String, String> headers = httpResponse.getHeaderFields();
-        //Codes_SRS_QUERY_25_010: [The method shall read the continuation token (x-ms-continuation) and response type (x-ms-item-type) from the HTTP Headers and save it.]
         for (Map.Entry<String, String> header : headers.entrySet())
         {
             switch (header.getKey())
@@ -232,17 +233,14 @@ public class Query
 
         if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
         {
-            //Codes_SRS_QUERY_25_012: [If the response type is Unknown or not found then this method shall throw IOException.]
             throw new IOException("Query response type is not defined by IotHub");
         }
 
         if (this.requestQueryType != this.responseQueryType)
         {
-            //Codes_SRS_QUERY_25_011: [If the request type and response does not match then the method shall throw IOException.]
             throw new IOException("Query response does not match query request");
         }
 
-        //Codes_SRS_QUERY_25_013: [The method shall create a QueryResponse object with the contents from the response body and save it.]
         this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
         return this.queryResponse;
     }
@@ -260,12 +258,14 @@ public class Query
      * @throws IOException If any of the input parameters are not valid.
      * @throws IotHubException If HTTP response other then status ok is received.
      */
-    public QueryResponse sendQueryRequest(IotHubConnectionString iotHubConnectionString,
-                                          URL url,
-                                          HttpMethod method,
-                                          int httpConnectTimeout,
-                                          int httpReadTimeout,
-                                          Proxy proxy) throws IOException, IotHubException
+    public QueryResponse sendQueryRequest(
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod method,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
+            throws IOException, IotHubException
     {
         if (iotHubConnectionString == null || url == null || method == null)
         {
@@ -336,12 +336,191 @@ public class Query
     }
 
     /**
+     * Sends request for the query to the IotHub.
+     *
+     * @param azureSasCredential The SAS authorization token provider.
+     * @param url URL to Query on.
+     * @param method HTTP Method for the requesting a query.
+     * @param httpConnectTimeout the http connect timeout to use for this request.
+     * @param httpReadTimeout the http read timeout to use for this request.
+     * @param proxy the proxy to use, or null if no proxy should be used.
+     * @return QueryResponse object which holds the response Iterator.
+     * @throws IOException If any of the input parameters are not valid.
+     * @throws IotHubException If HTTP response other then status ok is received.
+     */
+    public QueryResponse sendQueryRequest(
+            AzureSasCredential azureSasCredential,
+            URL url,
+            HttpMethod method,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
+            throws IOException, IotHubException
+    {
+        this.url = url;
+        this.httpMethod = method;
+        this.azureSasCredential = azureSasCredential;
+
+        this.httpConnectTimeout = httpConnectTimeout;
+        this.httpReadTimeout = httpReadTimeout;
+
+        this.proxy = proxy;
+
+        byte[] payload;
+        Map<String, String> queryHeaders = new HashMap<>();
+
+        if (this.requestContinuationToken != null)
+        {
+            queryHeaders.put(CONTINUATION_TOKEN_KEY, requestContinuationToken);
+        }
+        queryHeaders.put(PAGE_SIZE_KEY, String.valueOf(pageSize));
+
+        DeviceOperations.setHeaders(queryHeaders);
+
+        if (isSqlQuery)
+        {
+            QueryRequestParser requestParser = new QueryRequestParser(this.query);
+            payload = requestParser.toJson().getBytes();
+        }
+        else
+        {
+            payload = new byte[0];
+        }
+
+        HttpResponse httpResponse = DeviceOperations.request(azureSasCredential.getSignature(), url, method, payload, null, httpConnectTimeout, httpReadTimeout, proxy);
+
+        this.responseContinuationToken = null;
+        Map<String, String> headers = httpResponse.getHeaderFields();
+        for (Map.Entry<String, String> header : headers.entrySet())
+        {
+            switch (header.getKey())
+            {
+                case CONTINUATION_TOKEN_KEY:
+                    this.responseContinuationToken = header.getValue();
+                    break;
+                case ITEM_TYPE_KEY:
+                    this.responseQueryType = QueryType.fromString(header.getValue());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
+        {
+            throw new IOException("Query response type is not defined by IotHub");
+        }
+
+        if (this.requestQueryType != this.responseQueryType)
+        {
+            throw new IOException("Query response does not match query request");
+        }
+
+        this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
+        return this.queryResponse;
+    }
+
+    /**
+     * Sends request for the query to the IotHub.
+     *
+     * @param credential The authorization token provider.
+     * @param url URL to Query on.
+     * @param method HTTP Method for the requesting a query.
+     * @param httpConnectTimeout the http connect timeout to use for this request.
+     * @param httpReadTimeout the http read timeout to use for this request.
+     * @param proxy the proxy to use, or null if no proxy should be used.
+     * @return QueryResponse object which holds the response Iterator.
+     * @throws IOException If any of the input parameters are not valid.
+     * @throws IotHubException If HTTP response other then status ok is received.
+     */
+    public QueryResponse sendQueryRequest(
+            TokenCredential credential,
+            URL url,
+            HttpMethod method,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
+            throws IOException, IotHubException
+    {
+        this.url = url;
+        this.httpMethod = method;
+
+        this.credential = credential;
+        this.httpConnectTimeout = httpConnectTimeout;
+        this.httpReadTimeout = httpReadTimeout;
+
+        this.proxy = proxy;
+
+        byte[] payload;
+        Map<String, String> queryHeaders = new HashMap<>();
+
+        if (this.requestContinuationToken != null)
+        {
+            queryHeaders.put(CONTINUATION_TOKEN_KEY, requestContinuationToken);
+        }
+        queryHeaders.put(PAGE_SIZE_KEY, String.valueOf(pageSize));
+
+        DeviceOperations.setHeaders(queryHeaders);
+
+        if (isSqlQuery)
+        {
+            QueryRequestParser requestParser = new QueryRequestParser(this.query);
+            payload = requestParser.toJson().getBytes();
+        }
+        else
+        {
+            payload = new byte[0];
+        }
+
+        HttpResponse httpResponse =
+                DeviceOperations.request(
+                        credential.getToken(new TokenRequestContext()).block().getToken(),
+                        url,
+                        method,
+                        payload,
+                        null,
+                        httpConnectTimeout,
+                        httpReadTimeout,
+                        proxy);
+
+        this.responseContinuationToken = null;
+        Map<String, String> headers = httpResponse.getHeaderFields();
+        for (Map.Entry<String, String> header : headers.entrySet())
+        {
+            switch (header.getKey())
+            {
+                case CONTINUATION_TOKEN_KEY:
+                    this.responseContinuationToken = header.getValue();
+                    break;
+                case ITEM_TYPE_KEY:
+                    this.responseQueryType = QueryType.fromString(header.getValue());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
+        {
+            throw new IOException("Query response type is not defined by IotHub");
+        }
+
+        if (this.requestQueryType != this.responseQueryType)
+        {
+            throw new IOException("Query response does not match query request");
+        }
+
+        this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
+        return this.queryResponse;
+    }
+
+
+    /**
      * Getter for the continuation token received on response
      * @return continuation token. Can be {@code null}.
      */
     private String getContinuationToken()
     {
-        //Codes_SRS_QUERY_25_014: [The method shall return the continuation token found in response to a query (which can be null).]
         return this.responseContinuationToken;
     }
 
@@ -354,17 +533,14 @@ public class Query
      */
     public boolean hasNext() throws IOException, IotHubException
     {
-        //Codes_SRS_QUERY_25_015: [The method shall return true if next element from QueryResponse is available and false otherwise.]
         boolean isNextAvailable = this.queryResponse.hasNext();
         if (!isNextAvailable && this.getContinuationToken() != null)
         {
-            //Codes_SRS_QUERY_25_021: [If no further query response is available, then this method shall continue to request query to IotHub if continuation token is available.]
             this.continueQuery(this.getContinuationToken());
             return this.queryResponse.hasNext();
         }
         else
         {
-            //Codes_SRS_QUERY_25_015: [The method shall return true if next element from QueryResponse is available and false otherwise.]
             return isNextAvailable;
         }
     }
@@ -379,14 +555,12 @@ public class Query
      */
     public Object next() throws IOException, IotHubException, NoSuchElementException
     {
-        //Codes_SRS_QUERY_25_016: [The method shall return the next element for this QueryResponse.]
        if (this.hasNext())
        {
            return queryResponse.next();
        }
        else
        {
-           //Codes_SRS_QUERY_25_022: [The method shall check if any further elements are available by calling hasNext and if none is available then it shall throw NoSuchElementException.]
            throw new NoSuchElementException();
        }
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
@@ -212,7 +212,16 @@ public class Query
             payload = new byte[0];
         }
 
-        HttpResponse httpResponse = DeviceOperations.request(iotHubConnectionString, url, method, payload, null, this.httpConnectTimeout, this.httpReadTimeout, null);
+        HttpResponse httpResponse =
+                DeviceOperations.request(
+                        iotHubConnectionString,
+                        url,
+                        method,
+                        payload,
+                        null,
+                        this.httpConnectTimeout,
+                        this.httpReadTimeout,
+                        null);
 
         this.responseContinuationToken = null;
         Map<String, String> headers = httpResponse.getHeaderFields();
@@ -233,12 +242,12 @@ public class Query
 
         if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
         {
-            throw new IOException("Query response type is not defined by IotHub");
+            throw new IotHubException("Query response type is not defined by IotHub");
         }
 
         if (this.requestQueryType != this.responseQueryType)
         {
-            throw new IOException("Query response does not match query request");
+            throw new IotHubException("Query response does not match query request");
         }
 
         this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
@@ -302,7 +311,16 @@ public class Query
             payload = new byte[0];
         }
 
-        HttpResponse httpResponse = DeviceOperations.request(iotHubConnectionString, url, method, payload, null, httpConnectTimeout, httpReadTimeout, proxy);
+        HttpResponse httpResponse =
+                DeviceOperations.request(
+                        iotHubConnectionString,
+                        url,
+                        method,
+                        payload,
+                        null,
+                        httpConnectTimeout,
+                        httpReadTimeout,
+                        proxy);
 
         this.responseContinuationToken = null;
         Map<String, String> headers = httpResponse.getHeaderFields();
@@ -323,12 +341,12 @@ public class Query
 
         if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
         {
-            throw new IOException("Query response type is not defined by IotHub");
+            throw new IotHubException("Query response type is not defined by IotHub");
         }
 
         if (this.requestQueryType != this.responseQueryType)
         {
-            throw new IOException("Query response does not match query request");
+            throw new IotHubException("Query response does not match query request");
         }
 
         this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
@@ -387,7 +405,16 @@ public class Query
             payload = new byte[0];
         }
 
-        HttpResponse httpResponse = DeviceOperations.request(azureSasCredential.getSignature(), url, method, payload, null, httpConnectTimeout, httpReadTimeout, proxy);
+        HttpResponse httpResponse =
+                DeviceOperations.request(
+                        azureSasCredential.getSignature(),
+                        url,
+                        method,
+                        payload,
+                        null,
+                        httpConnectTimeout,
+                        httpReadTimeout,
+                        proxy);
 
         this.responseContinuationToken = null;
         Map<String, String> headers = httpResponse.getHeaderFields();
@@ -408,12 +435,12 @@ public class Query
 
         if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
         {
-            throw new IOException("Query response type is not defined by IotHub");
+            throw new IotHubException("Query response type is not defined by IotHub");
         }
 
         if (this.requestQueryType != this.responseQueryType)
         {
-            throw new IOException("Query response does not match query request");
+            throw new IotHubException("Query response does not match query request");
         }
 
         this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));
@@ -502,12 +529,12 @@ public class Query
 
         if (this.responseQueryType == null || this.responseQueryType == QueryType.UNKNOWN)
         {
-            throw new IOException("Query response type is not defined by IotHub");
+            throw new IotHubException("Query response type is not defined by IotHub");
         }
 
         if (this.requestQueryType != this.responseQueryType)
         {
-            throw new IOException("Query response does not match query request");
+            throw new IotHubException("Query response does not match query request");
         }
 
         this.queryResponse = new QueryResponse(new String(httpResponse.getBody()));

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
@@ -5,11 +5,16 @@
 
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.serializer.QueryRequestParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
+import com.microsoft.azure.sdk.iot.service.transport.http.HttpRequest;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
 
 import java.io.IOException;
@@ -34,12 +39,15 @@ public class QueryCollection
 
     private String responseContinuationToken;
 
-    private final IotHubConnectionString iotHubConnectionString;
     private final URL url;
     private final HttpMethod httpMethod;
 
     private final int httpConnectTimeout;
     private final int httpReadTimeout;
+
+    private IotHubConnectionString iotHubConnectionString;
+    private AzureSasCredential azureSasCredential;
+    private TokenCredential credential;
 
     private Proxy proxy;
 
@@ -60,32 +68,31 @@ public class QueryCollection
      * @deprecated use {@link #QueryCollection(String, int, QueryType, IotHubConnectionString, URL, HttpMethod, int, int, Proxy)} instead.
      */
     @Deprecated
-    protected QueryCollection(String query, int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long timeout)
+    protected QueryCollection(
+            String query,
+            int pageSize,
+            QueryType requestQueryType,
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod httpMethod,
+            long timeout)
     {
-        //Codes_SRS_QUERYCOLLECTION_34_037: [If the provided connection string, url, or http method is null, this function shall throw an IllegalArgumentException.]
-        //Codes_SRS_QUERYCOLLECTION_34_004: [If the provided QueryType is null or UNKNOWN, an IllegalArgumentException shall be thrown.]
-        //Codes_SRS_QUERYCOLLECTION_34_002: [If the provided page size is not a positive integer, an IllegalArgumentException shall be thrown.]
         this.validateQueryRequestArguments(iotHubConnectionString, url, httpMethod, pageSize, requestQueryType);
 
-        //Codes_SRS_QUERYCOLLECTION_34_001: [If the provided query string is invalid or does not contain both SELECT and FROM, an IllegalArgumentException shall be thrown.]
         ParserUtility.validateQuery(query);
 
-        //Codes_SRS_QUERYCOLLECTION_34_006: [This function shall save the provided query, pageSize, requestQueryType, iotHubConnectionString, url, httpMethod and timeout.]
         this.pageSize = pageSize;
         this.query = query;
         this.requestQueryType = requestQueryType;
-        this.iotHubConnectionString = iotHubConnectionString;
         this.responseContinuationToken = null;
         this.httpMethod = httpMethod;
         this.httpConnectTimeout = DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
         this.httpReadTimeout = DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
         this.url = url;
         this.responseQueryType = QueryType.UNKNOWN;
-
-        //Codes_SRS_QUERYCOLLECTION_34_008: [The constructed QueryCollection shall be a sql query type.]
         this.isSqlQuery = true;
-
         this.isInitialQuery = true;
+        this.iotHubConnectionString = iotHubConnectionString;
     }
 
     /**
@@ -102,30 +109,28 @@ public class QueryCollection
      * @deprecated use {@link #QueryCollection(int, QueryType, IotHubConnectionString, URL, HttpMethod, int, int, Proxy)} instead.
      */
     @Deprecated
-    protected QueryCollection(int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, long timeout)
+    protected QueryCollection(
+            int pageSize,
+            QueryType requestQueryType,
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod httpMethod,
+            long timeout)
     {
-        //Codes_SRS_QUERYCOLLECTION_34_038: [If the provided connection string, url, or http method is null, this function shall throw an IllegalArgumentException.]
-        //Codes_SRS_QUERYCOLLECTION_34_003: [If the provided page size is not a positive integer, an IllegalArgumentException shall be thrown.]
-        //Codes_SRS_QUERYCOLLECTION_34_005: [If the provided QueryType is null or UNKNOWN, an IllegalArgumentException shall be thrown.]
         this.validateQueryRequestArguments(iotHubConnectionString, url, httpMethod, pageSize, requestQueryType);
 
-        //Codes_SRS_QUERYCOLLECTION_34_007: [This function shall save the provided pageSize, requestQueryType, iotHubConnectionString, url, httpMethod and timeout.]
         this.pageSize = pageSize;
         this.requestQueryType = requestQueryType;
-
         this.query = null;
         this.responseQueryType = QueryType.UNKNOWN;
         this.responseContinuationToken = null;
-        this.iotHubConnectionString = iotHubConnectionString;
         this.httpMethod = httpMethod;
         this.httpConnectTimeout = DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
         this.httpReadTimeout = DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
         this.url = url;
-
-        //Codes_SRS_QUERYCOLLECTION_34_009: [The constructed QueryCollection shall not be a sql query type.]
         this.isSqlQuery = false;
-
         this.isInitialQuery = true;
+        this.iotHubConnectionString = iotHubConnectionString;
     }
 
     /**
@@ -144,7 +149,16 @@ public class QueryCollection
      *  or if the provided connection string is null, or if the provided url is null, or if the provided http method is null.
      */
     @SuppressWarnings("SameParameterValue") // Generic method for executing queries, "requestQueryType" and "httpMethod" can have any service-allowed value.
-    protected QueryCollection(String query, int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, int httpConnectTimeout, int httpReadTimeout, Proxy proxy)
+    protected QueryCollection(
+            String query,
+            int pageSize,
+            QueryType requestQueryType,
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod httpMethod,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
     {
         this.validateQueryRequestArguments(iotHubConnectionString, url, httpMethod, pageSize, requestQueryType);
 
@@ -153,7 +167,6 @@ public class QueryCollection
         this.pageSize = pageSize;
         this.query = query;
         this.requestQueryType = requestQueryType;
-        this.iotHubConnectionString = iotHubConnectionString;
         this.responseContinuationToken = null;
         this.httpMethod = httpMethod;
         this.httpConnectTimeout = httpConnectTimeout;
@@ -161,10 +174,9 @@ public class QueryCollection
         this.proxy = proxy;
         this.url = url;
         this.responseQueryType = QueryType.UNKNOWN;
-
         this.isSqlQuery = true;
-
         this.isInitialQuery = true;
+        this.iotHubConnectionString = iotHubConnectionString;
     }
 
     /**
@@ -181,26 +193,83 @@ public class QueryCollection
      * @throws IllegalArgumentException if page size is 0 or negative, or if the query type is null or unknown,
      *  or if the provided connection string is null, or if the provided url is null, or if the provided http method is null.
      */
-    protected QueryCollection(int pageSize, QueryType requestQueryType, IotHubConnectionString iotHubConnectionString, URL url, HttpMethod httpMethod, int httpConnectTimeout, int httpReadTimeout, Proxy proxy)
+    protected QueryCollection(
+            int pageSize,
+            QueryType requestQueryType,
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod httpMethod,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
     {
         this.validateQueryRequestArguments(iotHubConnectionString, url, httpMethod, pageSize, requestQueryType);
 
         this.pageSize = pageSize;
         this.requestQueryType = requestQueryType;
-
         this.query = null;
         this.responseQueryType = QueryType.UNKNOWN;
         this.responseContinuationToken = null;
-        this.iotHubConnectionString = iotHubConnectionString;
         this.httpMethod = httpMethod;
         this.httpConnectTimeout = httpConnectTimeout;
         this.httpReadTimeout = httpReadTimeout;
         this.proxy = proxy;
         this.url = url;
-
         this.isSqlQuery = false;
-
         this.isInitialQuery = true;
+        this.iotHubConnectionString = iotHubConnectionString;
+    }
+
+    QueryCollection(
+            String query,
+            int pageSize,
+            QueryType requestQueryType,
+            TokenCredential credential,
+            URL url,
+            HttpMethod httpMethod,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
+    {
+        this.pageSize = pageSize;
+        this.requestQueryType = requestQueryType;
+        this.query = query;
+        this.responseQueryType = QueryType.UNKNOWN;
+        this.responseContinuationToken = null;
+        this.httpMethod = httpMethod;
+        this.httpConnectTimeout = httpConnectTimeout;
+        this.httpReadTimeout = httpReadTimeout;
+        this.proxy = proxy;
+        this.url = url;
+        this.isSqlQuery = false;
+        this.isInitialQuery = true;
+        this.credential = credential;
+    }
+
+    QueryCollection(
+            String query,
+            int pageSize,
+            QueryType requestQueryType,
+            AzureSasCredential azureSasCredential,
+            URL url,
+            HttpMethod httpMethod,
+            int httpConnectTimeout,
+            int httpReadTimeout,
+            Proxy proxy)
+    {
+        this.pageSize = pageSize;
+        this.requestQueryType = requestQueryType;
+        this.query = query;
+        this.responseQueryType = QueryType.UNKNOWN;
+        this.responseContinuationToken = null;
+        this.httpMethod = httpMethod;
+        this.httpConnectTimeout = httpConnectTimeout;
+        this.httpReadTimeout = httpReadTimeout;
+        this.proxy = proxy;
+        this.url = url;
+        this.isSqlQuery = false;
+        this.isInitialQuery = true;
+        this.azureSasCredential = azureSasCredential;
     }
 
     /**
@@ -214,14 +283,8 @@ public class QueryCollection
      */
     private QueryCollectionResponse<String> sendQueryRequest(QueryOptions options) throws IOException, IotHubException
     {
-        //Codes_SRS_QUERYCOLLECTION_34_011: [If the provided query options is not null and contains a continuation token, it shall be put in the query headers to continue the query.]
-        //Codes_SRS_QUERYCOLLECTION_34_012: [If a continuation token is not provided from the passed in query options, but there is a continuation token saved in the latest queryCollectionResponse, that token shall be put in the query headers to continue the query.]
-        //Codes_SRS_QUERYCOLLECTION_34_013: [If the provided query options is not null, the query option's page size shall be included in the query headers.]
-        //Codes_SRS_QUERYCOLLECTION_34_014: [If the provided query options is null, this object's page size shall be included in the query headers.]
         DeviceOperations.setHeaders(buildQueryHeaders(options));
 
-        //Codes_SRS_QUERYCOLLECTION_34_015: [If this is a sql query, the payload of the query message shall be set to the json bytes representation of this object's query string.]
-        //Codes_SRS_QUERYCOLLECTION_34_016: [If this is not a sql query, the payload of the query message shall be set to empty bytes.]
         byte[] payload;
         if (isSqlQuery)
         {
@@ -233,13 +296,32 @@ public class QueryCollection
             payload = new byte[0];
         }
 
-        //Codes_SRS_QUERYCOLLECTION_34_017: [This function shall send an HTTPS request using DeviceOperations.]
-        HttpResponse httpResponse = DeviceOperations.request(this.iotHubConnectionString, this.url, this.httpMethod, payload, null, this.httpConnectTimeout, this.httpReadTimeout, this.proxy);
+        String authorizationToken;
+        if (this.credential != null)
+        {
+            authorizationToken = this.credential.getToken(new TokenRequestContext()).block().getToken();
+        }
+        else if (this.azureSasCredential != null)
+        {
+            authorizationToken = this.azureSasCredential.getSignature();
+        }
+        else
+        {
+            authorizationToken = new IotHubServiceSasToken(iotHubConnectionString).toString();
+        }
 
-        //Codes_SRS_QUERYCOLLECTION_34_018: [The method shall read the continuation token (x-ms-continuation) and response type (x-ms-item-type) from the HTTP Headers and save it.]
+        HttpResponse httpResponse = DeviceOperations.request(
+                authorizationToken,
+                this.url,
+                this.httpMethod,
+                payload,
+                null,
+                this.httpConnectTimeout,
+                this.httpReadTimeout,
+                this.proxy);
+
         handleQueryResponse(httpResponse);
 
-        //Codes_SRS_QUERYCOLLECTION_34_021: [The method shall create a QueryResponse object with the contents from the response body and its continuation token and return it.]
         this.isInitialQuery = false;
         return new QueryCollectionResponse<>(
                 new String(httpResponse.getBody(), StandardCharsets.UTF_8), this.responseContinuationToken);
@@ -254,12 +336,10 @@ public class QueryCollection
     {
         if (this.isInitialQuery)
         {
-            //Codes_SRS_QUERYCOLLECTION_34_025: [If this query is the initial query, this function shall return true.]
             return true;
         }
         else
         {
-            //Codes_SRS_QUERYCOLLECTION_34_026: [If this query is not the initial query, this function shall return true if there is a continuation token and false otherwise.]
             return (this.responseContinuationToken != null);
         }
     }
@@ -272,8 +352,6 @@ public class QueryCollection
      */
     protected QueryCollectionResponse<String> next() throws IOException, IotHubException
     {
-        //Codes_SRS_QUERYCOLLECTION_34_032: [If this object has a next set to return, this function shall return it.]
-        //Codes_SRS_QUERYCOLLECTION_34_033: [If this object does not have a next set to return, this function shall return null.]
         QueryOptions options = new QueryOptions();
         options.setPageSize(this.pageSize);
         return this.next(options);
@@ -292,12 +370,10 @@ public class QueryCollection
     {
         if (this.hasNext())
         {
-            //Codes_SRS_QUERYCOLLECTION_34_034: [If this object has a next set to return using the provided query options, this function shall return it.]
             return this.sendQueryRequest(options);
         }
         else
         {
-            //Codes_SRS_QUERYCOLLECTION_34_035: [If this object does not have a next set to return, this function shall return null.]
             return null;
         }
     }
@@ -308,11 +384,15 @@ public class QueryCollection
      */
     protected Integer getPageSize()
     {
-        //Codes_SRS_QUERYCOLLECTION_34_036: [This function shall return the saved page size.]
         return this.pageSize;
     }
 
-    private void validateQueryRequestArguments(IotHubConnectionString iotHubConnectionString, URL url, HttpMethod method, int pageSize, QueryType requestQueryType)
+    private void validateQueryRequestArguments(
+            IotHubConnectionString iotHubConnectionString,
+            URL url,
+            HttpMethod method,
+            int pageSize,
+            QueryType requestQueryType)
     {
         if (iotHubConnectionString == null || url == null || method == null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -5,19 +5,31 @@
 
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.Tools;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 public class RawTwinQuery
 {
-    private IotHubConnectionString iotHubConnectionString = null;
-    private static final long USE_DEFAULT_TIMEOUT = 0;
     private static final int DEFAULT_PAGE_SIZE = 100;
+
+    private static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
+    private static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
+
+    private String hostName;
+    private TokenCredential credential;
+    private AzureSasCredential azureSasCredential;
+    private IotHubConnectionString iotHubConnectionString;
 
     private RawTwinQuery()
     {
@@ -29,23 +41,72 @@ public class RawTwinQuery
      *
      * @param connectionString The iot hub connection string
      * @return The instance of RawTwinQuery
-     * @throws IOException This exception is thrown if the object creation failed
+     * @throws IOException This exception is never thrown.
+     * @deprecated because this method declares a thrown IOException even though it never throws an IOException. Users
+     * are recommended to use {@link #RawTwinQuery(String)} instead
+     * since it does not declare this exception even though it constructs the same RawTwinQuery.
      */
+    @Deprecated
     public static RawTwinQuery createFromConnectionString(String connectionString) throws IOException
     {
-        if (connectionString == null || connectionString.length() == 0)
-        {
+        return new RawTwinQuery(connectionString);
+    }
 
-            //Codes_SRS_RAW_QUERY_25_001: [ The constructor shall throw IllegalArgumentException if the input string is null or empty ]
+    /**
+     * Constructor to create instance from connection string
+     *
+     * @param connectionString The iot hub connection string
+     * @return The instance of RawTwinQuery
+     */
+    public RawTwinQuery(String connectionString)
+    {
+        if (Tools.isNullOrEmpty(connectionString))
+        {
             throw new IllegalArgumentException("Connection string cannot be null or empty");
         }
 
-        //Codes_SRS_RAW_QUERY_25_003: [ The constructor shall create a new RawTwinQuery instance and return it ]
-        RawTwinQuery rawTwinQuery = new RawTwinQuery();
+        this.iotHubConnectionString = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
+        this.hostName = this.iotHubConnectionString.getHostName();
+    }
 
-        //Codes_SRS_RAW_QUERY_25_001: [ The constructor shall throw IllegalArgumentException if the input string is null or empty ]
-        rawTwinQuery.iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
-        return rawTwinQuery;
+    /**
+     * Constructor to create instance from connection string
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
+     */
+    public RawTwinQuery(String hostName, TokenCredential credential)
+    {
+        if (Tools.isNullOrEmpty(hostName))
+        {
+            throw new IllegalArgumentException("hostName cannot be null or empty");
+        }
+
+        Objects.requireNonNull(credential);
+
+        this.hostName = hostName;
+        this.credential = credential;
+    }
+
+    /**
+     * Constructor to create instance from connection string
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param azureSasCredential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed.
+     */
+    public RawTwinQuery(String hostName, AzureSasCredential azureSasCredential)
+    {
+        if (Tools.isNullOrEmpty(hostName))
+        {
+            throw new IllegalArgumentException("hostName cannot be null or empty");
+        }
+
+        Objects.requireNonNull(azureSasCredential);
+
+        this.hostName = hostName;
+        this.azureSasCredential = azureSasCredential;
     }
 
     /**
@@ -60,21 +121,47 @@ public class RawTwinQuery
     {
         if (sqlQuery == null || sqlQuery.length() == 0)
         {
-            //Codes_SRS_RAW_QUERY_25_004: [ The method shall throw IllegalArgumentException if the query is null or empty.]
             throw new IllegalArgumentException("Query cannot be null or empty");
         }
 
         if (pageSize <= 0)
         {
-            //Codes_SRS_RAW_QUERY_25_005: [ The method shall throw IllegalArgumentException if the page size is zero or negative.]
             throw new IllegalArgumentException("pagesize cannot be negative or zero");
         }
 
-        //Codes_SRS_RAW_QUERY_25_007: [ The method shall create a new Query Object of Type Raw. ]
         Query rawQuery = new Query(sqlQuery, pageSize, QueryType.RAW);
-        //Codes_SRS_RAW_QUERY_25_006: [ The method shall build the URL for this operation by calling getUrlTwinQuery ]
-        //Codes_SRS_RAW_QUERY_25_008: [ The method shall send a Query Request to IotHub as HTTP Method Post on the query Object by calling sendQueryRequest.]
-        rawQuery.sendQueryRequest(iotHubConnectionString, iotHubConnectionString.getUrlTwinQuery(), HttpMethod.POST, USE_DEFAULT_TIMEOUT);
+
+        if (this.credential != null)
+        {
+            rawQuery.sendQueryRequest(
+                    this.credential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    DEFAULT_HTTP_CONNECT_TIMEOUT_MS,
+                    DEFAULT_HTTP_READ_TIMEOUT_MS,
+                    null);
+        }
+        else if (this.azureSasCredential != null)
+        {
+            rawQuery.sendQueryRequest(
+                    this.azureSasCredential,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    DEFAULT_HTTP_CONNECT_TIMEOUT_MS,
+                    DEFAULT_HTTP_READ_TIMEOUT_MS,
+                    null);
+        }
+        else
+        {
+            rawQuery.sendQueryRequest(
+                    this.iotHubConnectionString,
+                    IotHubConnectionString.getUrlTwinQuery(this.hostName),
+                    HttpMethod.POST,
+                    DEFAULT_HTTP_CONNECT_TIMEOUT_MS,
+                    DEFAULT_HTTP_READ_TIMEOUT_MS,
+                    null);
+        }
+
         return rawQuery;
     }
 
@@ -87,7 +174,6 @@ public class RawTwinQuery
      */
     public synchronized Query query(String sqlQuery) throws IotHubException, IOException
     {
-        //Codes_SRS_RAW_QUERY_25_009: [ If the pageSize if not provided then a default pageSize of 100 is used for the query.]
         return this.query(sqlQuery, DEFAULT_PAGE_SIZE);
     }
 
@@ -103,11 +189,9 @@ public class RawTwinQuery
     {
         if (query == null)
         {
-            //Codes_SRS_RAW_QUERY_25_010: [ The method shall throw IllegalArgumentException if query is null ]
             throw new IllegalArgumentException("Query cannot be null");
         }
 
-        //Codes_SRS_RAW_QUERY_25_011: [ The method shall check if a response to query is avaliable by calling hasNext on the query object.]
         return query.hasNext();
     }
 
@@ -121,9 +205,6 @@ public class RawTwinQuery
      */
     public synchronized String next(Query query) throws IOException, IotHubException, NoSuchElementException
     {
-        //Codes_SRS_RAW_QUERY_25_015: [ The method shall check if hasNext returns true and throw NoSuchElementException otherwise ]
-        //Codes_SRS_RAW_QUERY_25_018: [ If the input query is null, then this method shall throw IllegalArgumentException ]
-
         if (query == null)
         {
             throw new IllegalArgumentException();
@@ -137,9 +218,24 @@ public class RawTwinQuery
         }
         else
         {
-            //Codes_SRS_RAW_QUERY_25_017: [ If the next element from the query response is an object other than String, then this method shall throw IOException ]
             throw new IOException("Received a response that could not be parsed");
         }
+    }
 
+    private String getAuthenticationToken()
+    {
+        // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
+        // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
+        // one of the three options.
+        if (this.credential != null)
+        {
+            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+        }
+        else if (this.azureSasCredential != null)
+        {
+            return this.azureSasCredential.getSignature();
+        }
+
+        return new IotHubServiceSasToken(iotHubConnectionString).toString();
     }
 }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
@@ -367,38 +367,6 @@ public class DeviceOperationsTest
                 0);
     }
 
-    /* Tests_SRS_DEVICE_OPERATIONS_21_011: [The request shall add to the HTTP header a `Request-Id` key with a new unique string value for every request.] */
-    @Test (expected = IllegalArgumentException.class)
-    public void invokeThrowOnRequestIDFailed(
-            @Mocked IotHubServiceSasToken iotHubServiceSasToken,
-            @Mocked HttpRequest httpRequest)
-            throws Exception
-    {
-        //arrange
-        new NonStrictExpectations()
-        {
-            {
-                iotHubServiceSasToken.toString();
-                result = STANDARD_SASTOKEN_STRING;
-                httpRequest.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
-                result = httpRequest;
-                httpRequest.setHeaderField(AUTHORIZATION, STANDARD_SASTOKEN_STRING);
-                result = httpRequest;
-                httpRequest.setHeaderField(REQUEST_ID, STANDARD_REQUEST_ID);
-                result = new IllegalArgumentException();
-            }
-        };
-
-        //act
-        HttpResponse response = DeviceOperations.request(
-                IOT_HUB_CONNECTION_STRING,
-                new URL(STANDARD_URL),
-                HttpMethod.POST,
-                STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
-    }
-
     /* Tests_SRS_DEVICE_OPERATIONS_21_012: [The request shall add to the HTTP header a `User-Agent` key with the client Id and service version.] */
     @Test (expected = IllegalArgumentException.class)
     public void invokeThrowOnUserAgentFailed(
@@ -651,7 +619,7 @@ public class DeviceOperationsTest
                 httpRequest.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
                 times = 1;
                 httpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 httpRequest.send();
                 times = 1;
                 IotHubExceptionManager.httpResponseVerification(sendResponse);
@@ -722,7 +690,7 @@ public class DeviceOperationsTest
                 httpRequest.setReadTimeoutMillis(timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS);
                 times = 1;
                 httpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 httpRequest.send();
                 times = 1;
                 IotHubExceptionManager.httpResponseVerification(sendResponse);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -5,6 +5,7 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
+import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.deps.twin.*;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
@@ -20,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.*;
 
@@ -79,6 +79,14 @@ public class DeviceTwinTest
 
     static String VALID_SQL_QUERY = null;
 
+    private static final String STANDARD_HOSTNAME = "testHostName.azure.net";
+    private static final String STANDARD_SHAREDACCESSKEYNAME = "testKeyName";
+    private static final String STANDARD_SHAREDACCESSKEY = "1234567890ABCDEFGHIJKLMNOPQRESTUVWXYZ=";
+    private static final String STANDARD_CONNECTIONSTRING =
+            "HostName=" + STANDARD_HOSTNAME +
+                    ";SharedAccessKeyName=" + STANDARD_SHAREDACCESSKEYNAME +
+                    ";SharedAccessKey=" + STANDARD_SHAREDACCESSKEY;
+
     @Before
     public void setUp() throws IOException
     {
@@ -109,6 +117,7 @@ public class DeviceTwinTest
         final String connectionString = "testString";
 
         //act
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         //assert
@@ -140,24 +149,6 @@ public class DeviceTwinTest
 
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsOnImproperCS() throws Exception
-    {
-        //arrange
-        final String connectionString = "ImproperCSFormat";
-
-        new NonStrictExpectations()
-        {
-            {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
-                result = new IllegalArgumentException();
-            }
-        };
-
-        //act
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
-    }
-
     /*
     **Tests_SRS_DEVICETWIN_25_006: [** The function shall create a new SAS token **]**
     **Tests_SRS_DEVICETWIN_25_007: [** The function shall create a new HttpRequest with http method as Get **]**
@@ -178,6 +169,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         String expectedConnectionState = TwinConnectionState.CONNECTED.toString();
@@ -208,7 +200,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 mockedHttpRequest.send();
                 times = 1;
                 TwinState.createFromTwinJson((String)any);
@@ -244,6 +236,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         new NonStrictExpectations()
@@ -272,7 +265,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 mockedHttpRequest.send();
                 times = 1;
                 TwinState.createFromTwinJson((String)any);
@@ -365,6 +358,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         new NonStrictExpectations()
         {
@@ -383,7 +377,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlTwin(anyString);
+                IotHubConnectionString.getUrlTwin(anyString, anyString);
                 times = 1;
             }
         };
@@ -397,6 +391,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         new NonStrictExpectations()
         {
@@ -415,7 +410,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlTwin(anyString);
+                IotHubConnectionString.getUrlTwin(anyString, anyString);
                 times = 1;
             }
         };
@@ -429,6 +424,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         new NonStrictExpectations()
         {
@@ -447,7 +443,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlModuleTwin(anyString, anyString);
+                IotHubConnectionString.getUrlModuleTwin(anyString, anyString, anyString);
                 times = 1;
             }
         };
@@ -461,6 +457,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         new NonStrictExpectations()
         {
@@ -481,6 +478,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         //act
@@ -492,6 +490,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         //act
@@ -526,6 +525,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         testMap.putFinal("TestKey", "TestValue");
@@ -552,12 +552,12 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlTwin(anyString);
+                IotHubConnectionString.getUrlTwin(anyString, anyString);
                 times = 1;
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -645,6 +645,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         testMap.putFinal("TestKey", "TestValue");
@@ -671,12 +672,12 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlTwin(anyString);
+                IotHubConnectionString.getUrlTwin(anyString, anyString);
                 times = 1;
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -689,6 +690,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         testMap.putFinal("TestKey", "TestValue");
@@ -715,12 +717,12 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedConnectionString.getUrlTwin(anyString);
+                IotHubConnectionString.getUrlTwin(anyString, anyString);
                 times = 1;
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 5;
+                times = 4;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -732,6 +734,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
         TwinCollection testMap = new TwinCollection();
         testMap.putFinal("TestKey", "TestValue");
@@ -768,6 +771,7 @@ public class DeviceTwinTest
         final String connectionString = "testString";
         final int connectTimeout = 1234;
         final int readTimeout = 5678;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
 
 
@@ -781,15 +785,6 @@ public class DeviceTwinTest
 
         //act
         testTwin.queryTwin(VALID_SQL_QUERY);
-
-        //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
-                times = 1;
-            }
-        };
     }
 
     //Tests_SRS_DEVICETWIN_25_047: [ The method shall throw IllegalArgumentException if the query is null or empty.]
@@ -838,30 +833,6 @@ public class DeviceTwinTest
         testTwin.queryTwin(VALID_SQL_QUERY, 0);
     }
 
-    @Test (expected = IotHubException.class)
-    public void twinQueryThrowsOnNewQueryThrows(@Mocked DeviceTwinDevice mockedDevice) throws IotHubException, IOException
-    {
-        //arrange
-        final String connectionString = "testString";
-        final int connectTimeout = 1234;
-        final int readTimeout = 5678;
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
-
-
-        new NonStrictExpectations()
-        {
-            {
-                Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.TWIN);
-                result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
-                result = new IotHubException();
-            }
-        };
-
-        //act
-        testTwin.queryTwin(VALID_SQL_QUERY);
-    }
-
     //Tests_SRS_DEVICETWIN_25_055: [ If a queryResponse is available, this method shall return true as is to the user. ]
     //Tests_SRS_DEVICETWIN_25_054: [ The method shall check if a response to query is avaliable by calling hasNext on the query object.]
     @Test
@@ -871,6 +842,7 @@ public class DeviceTwinTest
         final String connectionString = "testString";
         final int connectTimeout = 1234;
         final int readTimeout = 5678;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
 
         new NonStrictExpectations()
@@ -887,16 +859,6 @@ public class DeviceTwinTest
 
         //act
         boolean result = testTwin.hasNextDeviceTwin(testQuery);
-
-        //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
-                times = 1;
-            }
-        };
-
         assertTrue(result);
     }
 
@@ -927,6 +889,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -955,6 +918,7 @@ public class DeviceTwinTest
         final String connectionString = "testString";
         final int connectTimeout = 1234;
         final int readTimeout = 5678;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
         final String expectedString = "testJsonAsNext";
         final String modelId = "testModelId";
@@ -999,14 +963,6 @@ public class DeviceTwinTest
         DeviceTwinDevice result = testTwin.getNextDeviceTwin(testQuery);
 
         //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
-                times = 1;
-            }
-        };
-
         assertNotNull(result.getTags());
         assertNotNull(result.getReportedProperties());
         assertNotNull(result.getDesiredProperties());
@@ -1030,6 +986,7 @@ public class DeviceTwinTest
         final int connectTimeout = 1234;
         final int readTimeout = 5678;
         final String connectionString = "someConnectionString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
         final String expectedString = "testJsonAsNext";
         final String moduleId = "testModuleId";
@@ -1073,15 +1030,6 @@ public class DeviceTwinTest
         //act
         DeviceTwinDevice result = testTwin.getNextDeviceTwin(testQuery);
 
-        //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, any, any, HttpMethod.POST, connectTimeout, readTimeout, any);
-                times = 1;
-            }
-        };
-
         assertNotNull(result.getTags());
         assertNotNull(result.getReportedProperties());
         assertNotNull(result.getDesiredProperties());
@@ -1122,6 +1070,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1146,6 +1095,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1170,6 +1120,7 @@ public class DeviceTwinTest
     {
         //arrange
         final String connectionString = "testString";
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1255,6 +1206,7 @@ public class DeviceTwinTest
         final String queryCondition = "validQueryCondition";
         final Date now = new Date();
         final long maxExecutionTimeInSeconds = 100;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1262,7 +1214,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, connectionString);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
                 result = mockedJob;
                 times = 1;
             }
@@ -1284,6 +1236,7 @@ public class DeviceTwinTest
         final String queryCondition = "validQueryCondition";
         final Date now = new Date();
         final long maxExecutionTimeInSeconds = 100;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1291,7 +1244,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, connectionString);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
                 result = new IOException();
             }
         };
@@ -1309,6 +1262,7 @@ public class DeviceTwinTest
         final String queryCondition = "validQueryCondition";
         final Date now = new Date();
         final long maxExecutionTimeInSeconds = 100;
+        constructorExpectations(connectionString);
         DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
 
         new NonStrictExpectations()
@@ -1316,7 +1270,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, connectionString);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
                 result = mockedJob;
             }
         };
@@ -1334,32 +1288,17 @@ public class DeviceTwinTest
         };
     }
 
-    // Tests_SRS_DEVICETWIN_21_067: [If scheduleUpdateTwin failed, the scheduleUpdateTwin shall throws IotHubException. Threw by the scheduleUpdateTwin ]
-    @Test (expected = IotHubException.class)
-    public void scheduleUpdateTwinScheduleUpdateTwinFailed(@Mocked Job mockedJob, @Mocked DeviceTwinDevice mockedDevice) throws IOException, IotHubException
+    private void constructorExpectations(String connectionString)
     {
-        //arrange
-        final String connectionString = "testString";
-        final String queryCondition = "validQueryCondition";
-        final Date now = new Date();
-        final long maxExecutionTimeInSeconds = 100;
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString);
-
-        new NonStrictExpectations()
+        new Expectations()
         {
             {
-                mockedConnectionString.toString();
-                result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, connectionString);
-                result = mockedJob;
-                Deencapsulation.invoke(mockedJob, "scheduleUpdateTwin", queryCondition, mockedDevice, now, maxExecutionTimeInSeconds);
-                result = new IotHubException();
-                times = 1;
+                IotHubConnectionString.createIotHubConnectionString(connectionString);
+                result = mockedConnectionString;
+                mockedConnectionString.getHostName();
+                result = "someHostName";
             }
         };
-
-        //act
-        testTwin.scheduleUpdateTwin(queryCondition, mockedDevice, now, maxExecutionTimeInSeconds);
     }
 
     //Tests_SRS_DEVICETWIN_34_069: [This function shall return the results of calling queryTwinCollection(sqlQuery, DEFAULT_PAGE_SIZE).]
@@ -1367,7 +1306,7 @@ public class DeviceTwinTest
     public void queryTwinCollectionWithoutPageSizeUsesDefaultPageSize() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
         String expectedQuery = "someQuery";
         Integer expectedPageSize = Deencapsulation.getField(deviceTwin, "DEFAULT_PAGE_SIZE");
         new StrictExpectations(deviceTwin)
@@ -1383,76 +1322,12 @@ public class DeviceTwinTest
         deviceTwin.queryTwinCollection(expectedQuery);
     }
 
-    //Tests_SRS_DEVICETWIN_34_070: [This function shall return a new QueryCollection object of type TWIN with the provided sql query and page size.]
-    @Test
-    public void queryTwinCollectionWithPageSizeSuccess() throws IOException, IotHubException
-    {
-        //arrange
-        String expectedSqlQuery = "some query";
-        int expectedPageSize = 23;
-        final int connectTimeout = 1234;
-        final int readTimeout = 5678;
-        final String connectionString = "someConnectionString";
-        DeviceTwin testTwin = DeviceTwin.createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().httpConnectTimeout(connectTimeout).httpReadTimeout(readTimeout).build());
-
-        new StrictExpectations()
-        {
-            {
-                //returning mock URL seems to break this test for some reason
-                mockedConnectionString.getUrlTwinQuery();
-                result = null;
-                Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, int.class, int.class, Proxy.class}, expectedSqlQuery, expectedPageSize, QueryType.TWIN, mockedConnectionString, null, HttpMethod.POST, connectTimeout, readTimeout, null);
-                result = mockQueryCollection;
-            }
-        };
-
-        Deencapsulation.setField(testTwin, "iotHubConnectionString", mockedConnectionString);
-
-        //act
-        testTwin.queryTwinCollection(expectedSqlQuery, expectedPageSize);
-    }
-
-    //Tests_SRS_DEVICETWIN_34_075: [This function shall call next(deviceTwinQueryCollection, queryOptions) where queryOptions has the deviceTwinQueryCollection's current page size.]
-    @Test
-    public void getNextDeviceTwinCollectionWithoutOptionsCallsGetNextDeviceTwinCollectionWithOptions() throws IOException, IotHubException
-    {
-        //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
-        Integer expectedPageSize = 33;
-
-        new NonStrictExpectations(deviceTwin)
-        {
-            {
-                new QueryOptions();
-                result = mockQueryOptions;
-                mockQueryOptions.getPageSize();
-                result = expectedPageSize;
-                deviceTwin.next(mockQueryCollection, mockQueryOptions);
-                result = mockQueryCollectionResponse;
-            }
-        };
-
-        //act
-        deviceTwin.next(mockQueryCollection);
-
-        //assert
-        new Verifications()
-        {
-            {
-                mockQueryOptions.setPageSize(anyInt);
-                times = 1;
-                deviceTwin.next(mockQueryCollection, mockQueryOptions);
-                times = 1;
-            }
-        };
-    }
-
     //Tests_SRS_DEVICETWIN_34_076: [If the provided deviceTwinQueryCollection is null, an IllegalArgumentException shall be thrown.]
     @Test (expected = IllegalArgumentException.class)
     public void getNextDeviceTwinCollectionWithOptionsThrowsForNullQueryCollection() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
 
         //act
         deviceTwin.next(null, new QueryOptions());
@@ -1463,7 +1338,7 @@ public class DeviceTwinTest
     public void getNextDeviceTwinCollectionWithOptionsReturnsNullIfDoesNotHaveNext() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
 
         new NonStrictExpectations(deviceTwin)
         {
@@ -1486,7 +1361,7 @@ public class DeviceTwinTest
     public void getNextDeviceTwinCollectionWithOptionsSuccess() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
         String expectedContinuationToken = "some continuation token";
 
         String expectedJsonString = "some json string";
@@ -1548,7 +1423,7 @@ public class DeviceTwinTest
     public void hasNextDeviceTwinQueryCollectionSuccess() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
 
         new StrictExpectations()
         {
@@ -1570,7 +1445,7 @@ public class DeviceTwinTest
     public void hasNextDeviceTwinQueryCollectionThrowsForNullQuery() throws IOException, IotHubException
     {
         //arrange
-        DeviceTwin deviceTwin = new DeviceTwin();
+        DeviceTwin deviceTwin = new DeviceTwin(STANDARD_CONNECTIONSTRING);
 
         //act
         deviceTwin.hasNext(null);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
@@ -204,7 +204,6 @@ public class QueryCollectionTest
         int actualPageSize = Deencapsulation.getField(queryCollection, "pageSize");
         QueryType actualQueryType = Deencapsulation.getField(queryCollection, "requestQueryType");
         boolean actualIsSqlQuery = Deencapsulation.getField(queryCollection, "isSqlQuery");
-        IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
 
@@ -212,7 +211,6 @@ public class QueryCollectionTest
         assertEquals(expectedPageSize, actualPageSize);
         assertEquals(expectedQueryType, actualQueryType);
         assertTrue(actualIsSqlQuery);
-        assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
         assertEquals(actualUrl, mockUrl);
     }
@@ -238,14 +236,12 @@ public class QueryCollectionTest
         int actualPageSize = Deencapsulation.getField(queryCollection, "pageSize");
         QueryType actualQueryType = Deencapsulation.getField(queryCollection, "requestQueryType");
         boolean actualIsSqlQuery = Deencapsulation.getField(queryCollection, "isSqlQuery");
-        IotHubConnectionString actualConnectionString = Deencapsulation.getField(queryCollection, "iotHubConnectionString");
         HttpMethod actualHttpMethod = Deencapsulation.getField(queryCollection, "httpMethod");
         URL actualUrl = Deencapsulation.getField(queryCollection, "url");
 
         assertEquals(expectedPageSize, actualPageSize);
         assertEquals(expectedQueryType, actualQueryType);
         assertFalse(actualIsSqlQuery);
-        assertEquals(actualConnectionString, mockConnectionString);
         assertEquals(actualHttpMethod, mockHttpMethod);
         assertEquals(actualUrl, mockUrl);
     }
@@ -320,9 +316,6 @@ public class QueryCollectionTest
             {
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
                 times = 1;
-
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, anyInt, anyInt, (Proxy) any);
-                times = 1;
             }
         };
     }
@@ -369,9 +362,6 @@ public class QueryCollectionTest
         new NonStrictExpectations()
         {
             {
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, (byte[]) any, anyString, anyInt, anyInt, (Proxy) any);
-                result = mockHttpResponse;
-
                 mockHttpResponse.getHeaderFields();
                 result = expectedValidResponseHeaders;
             }
@@ -387,9 +377,6 @@ public class QueryCollectionTest
         {
             {
                 DeviceOperations.setHeaders(expectedValidRequestHeaders);
-                times = 1;
-
-                DeviceOperations.request(mockConnectionString, mockUrl, mockHttpMethod, new byte[0], anyString, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -430,15 +417,6 @@ public class QueryCollectionTest
 
         //act
         Deencapsulation.invoke(queryCollection, "sendQueryRequest", new Class[] {QueryOptions.class}, mockQueryOptions);
-
-        //assert
-        new Verifications()
-        {
-            {
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyInt, anyInt, (Proxy) any);
-                times = 1;
-            }
-        };
     }
 
     //Tests_SRS_QUERYCOLLECTION_34_018: [The method shall read the continuation token (x-ms-continuation) and response type (x-ms-item-type) from the HTTP Headers and save it.]

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQueryTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQueryTest.java
@@ -7,6 +7,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
 import com.microsoft.azure.sdk.iot.service.devicetwin.QueryType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.RawTwinQuery;
@@ -32,6 +33,7 @@ public class RawTwinQueryTest
     @Mocked Query mockedQuery;
     @Mocked IotHubConnectionStringBuilder mockedIotHubConnectionStringBuilder;
     @Mocked IotHubConnectionString mockedIotHubConnectionString;
+    @Mocked IotHubServiceSasToken mockedSasToken;
 
     static final String VALID_CONNECTION_STRING = "testConnectionStaring";
     static String VALID_SQL_QUERY = null;
@@ -41,18 +43,6 @@ public class RawTwinQueryTest
     {
         VALID_SQL_QUERY = SqlQuery.createSqlQuery("tags.Floor, AVG(properties.reported.temperature) AS AvgTemperature",
                                                   SqlQuery.FromType.DEVICES, "tags.building = '43'", null).getQuery();
-    }
-
-    //Tests_SRS_RAW_QUERY_25_001: [ The constructor shall throw IllegalArgumentException if the input string is null or empty ]
-    //Tests_SRS_RAW_QUERY_25_003: [ The constructor shall create a new RawTwinQuery instance and return it ]
-    @Test
-    public void constructorSucceeds() throws IOException
-    {
-        //act
-        RawTwinQuery rawTwinQuery = RawTwinQuery.createFromConnectionString(VALID_CONNECTION_STRING);
-
-        //assert
-        assertNotNull(Deencapsulation.getField(rawTwinQuery, "iotHubConnectionString"));
     }
 
     //Tests_SRS_RAW_QUERY_25_001: [ The constructor shall throw IllegalArgumentException if the input string is null or empty ]
@@ -92,13 +82,6 @@ public class RawTwinQueryTest
         rawTwinQuery.query(VALID_SQL_QUERY);
 
         //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
-                times = 1;
-            }
-        };
     }
 
     //Tests_SRS_RAW_QUERY_25_004: [ The method shall throw IllegalArgumentException if the query is null or empty.]
@@ -143,26 +126,6 @@ public class RawTwinQueryTest
         rawTwinQuery.query(VALID_SQL_QUERY, 0);
     }
 
-    @Test (expected = IotHubException.class)
-    public void rawQueryThrowsOnNewQueryThrows() throws IotHubException, IOException
-    {
-        //arrange
-        RawTwinQuery rawTwinQuery = RawTwinQuery.createFromConnectionString(VALID_CONNECTION_STRING);
-
-        new NonStrictExpectations()
-        {
-            {
-                Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.RAW);
-                result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
-                result = new IotHubException();
-            }
-        };
-
-        //act
-        rawTwinQuery.query(VALID_SQL_QUERY);
-    }
-
     //Tests_SRS_RAW_QUERY_25_011: [ The method shall check if a response to query is avaliable by calling hasNext on the query object.]
     //Tests_SRS_RAW_QUERY_25_012: [ If a queryResponse is available, this method shall return true as is to the user. ]
     @Test
@@ -187,14 +150,6 @@ public class RawTwinQueryTest
         boolean result = rawTwinQuery.hasNext(testQuery);
 
         //assert
-        new Verifications()
-        {
-            {
-                 Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
-                times = 1;
-            }
-        };
-
         assertTrue(result);
     }
 
@@ -267,13 +222,6 @@ public class RawTwinQueryTest
         String result = rawTwinQuery.next(testQuery);
 
         //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
-                times = 1;
-            }
-        };
         assertEquals(expectedString, result);
     }
 


### PR DESCRIPTION
The twin client and the query clients are very intertwined, so I had to group them together for this PR