### PR TITLE
feat(iot-service): Add DigitalTwinClientOptions support to digital twin clients

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
@@ -179,6 +179,30 @@ public class DigitalTwinClientTests extends IntegrationTest
         assertEquals(responseWithHeaders.body().getMetadata().getModelId(), E2ETestConstants.THERMOSTAT_MODEL_ID);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    @StandardTierHubOnlyTest
+    public void digitalTwinConstructorThrowsForNegativeConnectTimeout() {
+        // arrange
+        DigitalTwinClientOptions clientOptions =
+            DigitalTwinClientOptions.builder()
+                .httpConnectTimeout(-1)
+                .build();
+
+        digitalTwinClient = new DigitalTwinClient(IOTHUB_CONNECTION_STRING, clientOptions);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @StandardTierHubOnlyTest
+    public void digitalTwinConstructorThrowsForNegativeReadTimeout() {
+        // arrange
+        DigitalTwinClientOptions clientOptions =
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(-1)
+                .build();
+
+        digitalTwinClient = new DigitalTwinClient(IOTHUB_CONNECTION_STRING, clientOptions);
+    }
+
     @Test
     @StandardTierHubOnlyTest
     public void getDigitalTwinWithAzureSasCredential() {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
@@ -9,10 +9,13 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
 import com.microsoft.azure.sdk.iot.service.Device;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
+import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClient;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.UpdateOperationUtility;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGetHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.*;
@@ -24,6 +27,8 @@ import org.junit.*;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import tests.integration.com.microsoft.azure.sdk.iot.digitaltwin.helpers.E2ETestConstants;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
@@ -31,6 +36,8 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.Digital
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
@@ -54,6 +61,9 @@ public class DigitalTwinClientTests extends IntegrationTest
     private DeviceClient deviceClient;
     private DigitalTwinClient digitalTwinClient = null;
     private static final String DEVICE_ID_PREFIX = "DigitalTwinServiceClientTests_";
+    protected static HttpProxyServer proxyServer;
+    protected static String testProxyHostname = "127.0.0.1";
+    protected static int testProxyPort = 8769;
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(5 * 60); // 5 minutes max per method tested
@@ -70,15 +80,25 @@ public class DigitalTwinClientTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void setUpBeforeClass() throws IOException {
-        registryManager = RegistryManager.createFromConnectionString(IOTHUB_CONNECTION_STRING);
+    public static void setUpBeforeClass() {
+        registryManager =
+            new RegistryManager(
+                IOTHUB_CONNECTION_STRING,
+                RegistryManagerOptions.builder()
+                    .httpReadTimeout(0)
+                    .build());
     }
 
     @Before
     public void setUp() throws URISyntaxException, IOException, IotHubException {
         this.deviceClient = createDeviceClient(protocol);
         deviceClient.open();
-        digitalTwinClient = DigitalTwinClient.createFromConnectionString(IOTHUB_CONNECTION_STRING);
+        digitalTwinClient =
+            new DigitalTwinClient(
+                IOTHUB_CONNECTION_STRING,
+                DigitalTwinClientOptions.builder()
+                    .httpReadTimeout(0)
+                    .build());
     }
 
     @After
@@ -108,12 +128,51 @@ public class DigitalTwinClientTests extends IntegrationTest
         registryManager.close();
     }
 
+    @BeforeClass
+    public static void startProxy()
+    {
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+            .withPort(testProxyPort)
+            .start();
+    }
+
+    @AfterClass
+    public static void stopProxy()
+    {
+        proxyServer.stop();
+    }
+
     @Test
     @StandardTierHubOnlyTest
     public void getDigitalTwin() {
         // act
         BasicDigitalTwin response = digitalTwinClient.getDigitalTwin(deviceId, BasicDigitalTwin.class);
-        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders = digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
+        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders =
+            digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
+
+        // assert
+        assertEquals(response.getMetadata().getModelId(), E2ETestConstants.THERMOSTAT_MODEL_ID);
+        assertEquals(responseWithHeaders.body().getMetadata().getModelId(), E2ETestConstants.THERMOSTAT_MODEL_ID);
+    }
+
+    @Test
+    @StandardTierHubOnlyTest
+    public void getDigitalTwinWithProxy() {
+        // arrange
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        DigitalTwinClientOptions clientOptions =
+            DigitalTwinClientOptions.builder()
+                .proxyOptions(proxyOptions)
+                .httpReadTimeout(0)
+                .build();
+
+        digitalTwinClient = new DigitalTwinClient(IOTHUB_CONNECTION_STRING, clientOptions);
+
+        // act
+        BasicDigitalTwin response = digitalTwinClient.getDigitalTwin(deviceId, BasicDigitalTwin.class);
+        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders =
+            digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
 
         // assert
         assertEquals(response.getMetadata().getModelId(), E2ETestConstants.THERMOSTAT_MODEL_ID);
@@ -134,7 +193,8 @@ public class DigitalTwinClientTests extends IntegrationTest
 
         // act
         BasicDigitalTwin response = digitalTwinClient.getDigitalTwin(deviceId, BasicDigitalTwin.class);
-        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders = digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
+        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders =
+            digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
 
         // assert
         assertEquals(response.getMetadata().getModelId(), E2ETestConstants.THERMOSTAT_MODEL_ID);
@@ -174,7 +234,8 @@ public class DigitalTwinClientTests extends IntegrationTest
         optionsWithoutEtag.setIfMatch("*");
 
         // get digital twin and Etag before update
-        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders = digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
+        ServiceResponseWithHeaders<BasicDigitalTwin, DigitalTwinGetHeaders> responseWithHeaders =
+            digitalTwinClient.getDigitalTwinWithResponse(deviceId, BasicDigitalTwin.class);
         DigitalTwinUpdateRequestOptions optionsWithEtag = new DigitalTwinUpdateRequestOptions();
         optionsWithEtag.setIfMatch(responseWithHeaders.headers().eTag());
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -9,6 +9,7 @@ import com.azure.core.credential.TokenRequestContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.BearerTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.SasTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.ServiceClientBearerTokenCredentialProvider;
@@ -31,8 +32,13 @@ import rx.Observable;
 import rx.schedulers.Schedulers;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
 import static com.microsoft.azure.sdk.iot.service.digitaltwin.helpers.Tools.*;
 
 /**
@@ -52,6 +58,22 @@ public class DigitalTwinAsyncClient {
      * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String connectionString) {
+        this(connectionString,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     *
+     * @param connectionString The IoTHub connection string
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinAsyncClient.
+     */
+    public DigitalTwinAsyncClient(String connectionString, DigitalTwinClientOptions options) {
+        Objects.requireNonNull(options);
         ServiceConnectionString serviceConnectionString = ServiceConnectionStringParser.parseConnectionString(connectionString);
         SasTokenProvider sasTokenProvider = serviceConnectionString.createSasTokenProvider();
         String httpsEndpoint = serviceConnectionString.getHttpsEndpoint();
@@ -60,7 +82,18 @@ public class DigitalTwinAsyncClient {
 
         JacksonAdapter adapter = new JacksonAdapter();
         adapter.serializer().registerModule(stringModule);
+
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = null;
+        if (proxyOptions != null)
+        {
+            proxy = proxyOptions.getProxy();
+        }
+
         RestClient simpleRestClient = new RestClient.Builder()
+            .withConnectionTimeout(options.getHttpConnectTimeout(), TimeUnit.MILLISECONDS)
+            .withReadTimeout(options.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
+            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
             .withBaseUrl(httpsEndpoint)
             .withCredentials(new ServiceClientCredentialsProvider(sasTokenProvider))
             .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
@@ -80,14 +113,44 @@ public class DigitalTwinAsyncClient {
      * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, TokenCredential credential) {
+        this(hostName,
+            credential,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     * this library when they are needed.
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinAsyncClient.
+     */
+    public DigitalTwinAsyncClient(String hostName, TokenCredential credential, DigitalTwinClientOptions options) {
+        Objects.requireNonNull(options);
         final SimpleModule stringModule = new SimpleModule("String Serializer");
         stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
         BearerTokenProvider bearerTokenProvider = () -> credential.getToken(new TokenRequestContext()).block().getToken();
 
         JacksonAdapter adapter = new JacksonAdapter();
         adapter.serializer().registerModule(stringModule);
+
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = null;
+        if (proxyOptions != null)
+        {
+            proxy = proxyOptions.getProxy();
+        }
+
         RestClient simpleRestClient = new RestClient.Builder()
             .withBaseUrl(HTTPS_SCHEME + hostName) //hostname is only "my-iot-hub.azure-devices.net" so we need to add "https://"
+            .withConnectionTimeout(options.getHttpConnectTimeout(), TimeUnit.MILLISECONDS)
+            .withReadTimeout(options.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
+            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
             .withCredentials(new ServiceClientBearerTokenCredentialProvider(bearerTokenProvider))
             .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
             .withSerializerAdapter(adapter)
@@ -97,6 +160,7 @@ public class DigitalTwinAsyncClient {
         _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
     }
 
+
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      *
@@ -105,14 +169,43 @@ public class DigitalTwinAsyncClient {
      * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential) {
+        this(hostName,
+            azureSasCredential,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param azureSasCredential The SAS token provider that will be used for authentication.
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinAsyncClient.
+     */
+    public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential, DigitalTwinClientOptions options) {
+        Objects.requireNonNull(options);
         final SimpleModule stringModule = new SimpleModule("String Serializer");
         stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
         SasTokenProvider sasTokenProvider = azureSasCredential::getSignature;
 
         JacksonAdapter adapter = new JacksonAdapter();
         adapter.serializer().registerModule(stringModule);
+
+        ProxyOptions proxyOptions = options.getProxyOptions();
+        Proxy proxy = null;
+        if (proxyOptions != null)
+        {
+            proxy = proxyOptions.getProxy();
+        }
+
         RestClient simpleRestClient = new RestClient.Builder()
             .withBaseUrl(HTTPS_SCHEME + hostName) //hostname is only "my-iot-hub.azure-devices.net" so we need to add "https://"
+            .withConnectionTimeout(options.getHttpConnectTimeout(), TimeUnit.MILLISECONDS)
+            .withReadTimeout(options.getHttpReadTimeout(), TimeUnit.MILLISECONDS)
+            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
             .withCredentials(new ServiceClientCredentialsProvider(sasTokenProvider))
             .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
             .withSerializerAdapter(adapter)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -15,6 +15,9 @@ import com.microsoft.rest.*;
 import java.io.IOException;
 import java.util.List;
 
+import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
+
 /**
  * <p>
  * The Digital Twins Service Client contains methods to retrieve and update digital twin information, and invoke commands on a digital twin device.
@@ -29,7 +32,21 @@ public class DigitalTwinClient {
      * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String connectionString) {
-        digitalTwinAsyncClient = DigitalTwinAsyncClient.createFromConnectionString(connectionString);
+        this(connectionString,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     * @param connectionString The IoT Hub connection string
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinClient.
+     */
+    public DigitalTwinClient(String connectionString, DigitalTwinClientOptions options) {
+        digitalTwinAsyncClient = new DigitalTwinAsyncClient(connectionString, options);
     }
 
     /**
@@ -41,7 +58,25 @@ public class DigitalTwinClient {
      * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, TokenCredential credential) {
-        digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, credential);
+        this(hostName,
+            credential,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed.
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinClient.
+     */
+    public DigitalTwinClient(String hostName, TokenCredential credential, DigitalTwinClientOptions options) {
+        digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, credential, options);
     }
 
     /**
@@ -52,7 +87,24 @@ public class DigitalTwinClient {
      * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential) {
-        digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, azureSasCredential);
+        this(hostName,
+            azureSasCredential,
+            DigitalTwinClientOptions.builder()
+                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
+                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
+                .build());
+    }
+
+    /**
+     * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param azureSasCredential The SAS token provider that will be used for authentication.
+     * @param options The optional settings for this client. May not be null.
+     * @return The instantiated DigitalTwinClient.
+     */
+    public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential, DigitalTwinClientOptions options) {
+        digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, azureSasCredential, options);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -8,7 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * Configurable options for all digital twin client operations. This includes both {@link DigitalTwinClient} and {@link DigitalTwinAsyncClient}
+ * Configurable options for all digital twin client operations. This options bundle is used by both
+ * {@link DigitalTwinClient} and {@link DigitalTwinAsyncClient}.
  */
 @Builder
 public class DigitalTwinClientOptions

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.service.digitaltwin;
+
+import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Configurable options for all digital twin client operations. This includes both {@link DigitalTwinClient} and {@link DigitalTwinAsyncClient}
+ */
+@Builder
+public class DigitalTwinClientOptions
+{
+    protected static final Integer DEFAULT_HTTP_READ_TIMEOUT_MS = 24000; // 24 seconds
+    protected static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
+
+    /**
+     * The options that specify what proxy to tunnel through. If null, no proxy will be used
+     */
+    @Getter
+    private final ProxyOptions proxyOptions;
+
+    /**
+     * The http read timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when reading from
+     * Input stream after a connection is established to a resource. If the timeout expires before there is data available
+     * for read, a java.net.SocketTimeoutException is raised. A timeout of zero is interpreted as an infinite timeout.
+     * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
+     */
+    @Getter
+    private final int httpReadTimeout;
+
+    /**
+     * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
+     * before the connection can be established, a java.net.SocketTimeoutException is thrown.
+     * A timeout of zero is interpreted as an infinite timeout.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     */
+    @Getter
+    private final int httpConnectTimeout;
+}


### PR DESCRIPTION
same as other options objects; HTTP read and connect timeouts, and proxy support.

I've seen our nightly builds often fail on http read timeouts on digital twin tests, so this feature should help our tests be more resilient, too

I'm adding this to the RBAC preview code since that is where we are already adding a bunch of digital twin constructors.