### PR TITLE
fix(deps): Fix MQTT subscribe timeout being 1 second

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttConnection.java
@@ -30,7 +30,7 @@ public class MqttConnection implements MqttCallback
     private static final int KEEP_ALIVE_INTERVAL = 230;
     private static final int MQTT_VERSION = 4;
     private static final boolean SET_CLEAN_SESSION = false;
-    static final int MAX_WAIT_TIME = 1000;
+    static final int SUBSCRIBE_REQUEST_MAX_WAIT_TIME_MILLISECONDS = 60 * 1000; // 1 minute
 
     private final MqttListener mqttListener;
 
@@ -229,7 +229,7 @@ public class MqttConnection implements MqttCallback
         try
         {
             IMqttToken subToken = this.mqttAsyncClient.subscribe(topic, retrieveQosValue(qos));
-            subToken.waitForCompletion(MAX_WAIT_TIME);
+            subToken.waitForCompletion(SUBSCRIBE_REQUEST_MAX_WAIT_TIME_MILLISECONDS);
         }
         catch (MqttException e)
         {


### PR DESCRIPTION
1 second timeout is a bit too short to accommodate when the service is a bit slower due to load. 1 minute is a bit more reasonable

#1123 

https://github.com/Azure/azure-iot-sdk-java/issues/1123#issuecomment-782443807