### PR TITLE
fix(iot-device): Fix bug where AMQPS_WS clients couldn't send messages with payloads up to 256 kB

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -54,6 +54,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private static final String WEB_SOCKET_SUB_PROTOCOL = "AMQPWSB10";
     private static final String WEB_SOCKET_QUERY = "iothub-no-client-cert=true";
     private static final int MAX_MESSAGE_PAYLOAD_SIZE = 256 * 1024; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at most that much space
+    private static final int MAX_FRAME_SIZE = 4 * 1024;
     private static final int WEB_SOCKET_PORT = 443;
 
     private static final int AMQP_PORT = 5671;
@@ -815,16 +816,21 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     {
         try
         {
+            ReactorOptions options = new ReactorOptions();
+
+            // If this option isn't set, proton defaults to 16 * 1024 max frame size. This used to default to 4 * 1024,
+            // and this change to 16 * 1024 broke the websocket implementation that we layer on top of proton-j.
+            // By setting this frame size back to 4 * 1024, AMQPS_WS clients can send messages with payloads up to the
+            // expected 256 * 1024 bytes. For more context, see https://github.com/Azure/azure-iot-sdk-java/issues/742
+            options.setMaxFrameSize(MAX_FRAME_SIZE);
+
             if (this.authenticationType == DeviceClientConfig.AuthType.X509_CERTIFICATE)
             {
-                ReactorOptions options = new ReactorOptions();
+                // x509 authentication does not use SASL, so disable it
                 options.setEnableSaslByDefault(false);
-                return Proton.reactor(options, this);
             }
-            else
-            {
-                return Proton.reactor(this);
-            }
+
+            return Proton.reactor(options, this);
         }
         catch (IOException e)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -136,7 +136,6 @@ public class SendMessagesCommon extends IntegrationTest
     protected List<MessageAndResult> NORMAL_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> LARGE_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> MULTIPLE_SMALL_MESSAGES_TO_SEND = new ArrayList<>();
-    protected List<MessageAndResult> LARGE_MESSAGES_TO_SEND_AMQPS_WS = new ArrayList<>();
     protected List<MessageAndResult> TCP_CONNECTION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> AMQP_CONNECTION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
     protected List<MessageAndResult> AMQP_SESSION_DROP_MESSAGES_TO_SEND = new ArrayList<>();
@@ -469,7 +468,6 @@ public class SendMessagesCommon extends IntegrationTest
         AMQP_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND = new ArrayList<>();
         MQTT_GRACEFUL_SHUTDOWN_MESSAGES_TO_SEND = new ArrayList<>();
         LARGE_MESSAGES_TO_SEND = new ArrayList<>();
-        LARGE_MESSAGES_TO_SEND_AMQPS_WS = new ArrayList<>();
         MULTIPLE_SMALL_MESSAGES_TO_SEND = new ArrayList<>();
 
         MessageAndResult normalMessageAndExpectedResult = new MessageAndResult(new Message("test message"), IotHubStatusCode.OK_EMPTY);
@@ -537,7 +535,6 @@ public class SendMessagesCommon extends IntegrationTest
 
             NORMAL_MESSAGES_TO_SEND.add(new MessageAndResult(new Message("test message" + UUID.randomUUID() ), IotHubStatusCode.OK_EMPTY));
             LARGE_MESSAGES_TO_SEND.add(new MessageAndResult(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE]), IotHubStatusCode.OK_EMPTY));
-            LARGE_MESSAGES_TO_SEND_AMQPS_WS.add(new MessageAndResult(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE_AMQPS_WS]), IotHubStatusCode.OK_EMPTY));
         }
 
         for (int i = 0 ; i < NUM_SMALL_MESSAGES; i++){

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -104,15 +104,7 @@ public class SendMessagesTests extends SendMessagesCommon
     {
         this.testInstance.setup();
 
-        if (this.testInstance.protocol == AMQPS_WS)
-        {
-            // AMQPS_WS still has a bug that limits message size to 16 kb. All other protocols can do 256 kb
-            IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, LARGE_MESSAGES_TO_SEND_AMQPS_WS, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
-        }
-        else
-        {
-            IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, LARGE_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
-        }
+        IotHubServicesCommon.sendMessages(testInstance.client, testInstance.protocol, LARGE_MESSAGES_TO_SEND, RETRY_MILLISECONDS, SEND_TIMEOUT_MILLISECONDS, 0, null);
     }
 
     @Test


### PR DESCRIPTION
Before this fix, they could send messages up to 16 kB, but this fix brings the limit in line with the IoT Hub size limits, and makes AMQPS_WS consistent with all other protocols.

For additional context: https://github.com/Azure/azure-iot-sdk-java/issues/742