### PR TITLE
release(2021-02-24): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.29.1";
+    private static final String CLIENT_VERSION = "1.29.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.1') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.2') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,13 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.29.1</iot-device-client-version>
+        <iot-device-client-version>1.29.2</iot-device-client-version>
         <iot-service-client-version>1.27.1</iot-service-client-version>
-        <iot-deps-version>0.11.1</iot-deps-version>
-        <provisioning-device-client-version>1.8.6</provisioning-device-client-version>
+        <iot-deps-version>0.11.2</iot-deps-version>
+        <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.1</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>
-        <tpm-provider-emulator-version>1.1.1</tpm-provider-emulator-version>
+        <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.2</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.6";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.7";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.29.2)

### Bug fixes
- Fix potential NPE cases within MQTT layer (#1125)
- Fix AMQPS_WS not being able to send the expected 256 kB payload messages (#1129)

## Java Iot Deps (com.microsoft.azure.sdk.iot:iot-deps:0.11.2)

### Bug fixes
- Fix bug where mqtt subscribe timeout was only 1 second (#1126)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.7)

### Bug fixes
- Fix bug where mqtt provisioning device client registration could easily time out (#1126)

## TPM Security Provider (com.microsoft.azure.sdk.iot.provisioning.security:tpm-provider:1.1.3)

### Bug fixes
- Fix bug where SecurityProviderTpmHsm cleared the TPM's EK and SRK at constructor time (#1128)

old
{
    "device": "1.29.1",
    "service": "1.27.1",
    "deps": "0.11.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.2",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.6",
    "provisioningService": "1.7.1"
}


new
{
    "device": "1.29.2",
    "service": "1.27.1",
    "deps": "0.11.2",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.1",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.1"
}