### PR TITLE
Bump additional version for 2/24/2021 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <provisioning-service-client-version>1.7.2</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
-        <tpm-provider-version>1.1.2</tpm-provider-version>
+        <tpm-provider-version>1.1.3</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
         <x509-provider-version>1.1.4</x509-provider-version>


### PR DESCRIPTION
Bump versions script had a bug in it that caused it to not bump the tpm-provider version. The bug has been fixed in that script, and this commit fixes that issue in the previous version bump commit