### PR TITLE
refactor(iot-service): Add AAD auth token caching for HTTP clients

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -178,7 +178,7 @@ public class RegistryManager
      */
     public RegistryManager(String hostName, TokenCredential credential, RegistryManagerOptions options)
     {
-        Objects.requireNonNull(credential, "credentialCache cannot be null");
+        Objects.requireNonNull(credential, "credential cannot be null");
         Objects.requireNonNull(options, "options cannot be null");
         if (Tools.isNullOrEmpty(hostName))
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.DeviceParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.JobPropertiesParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.RegistryStatisticsParser;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubExceptionManager;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
@@ -44,7 +45,7 @@ public class RegistryManager
     private static final int EXECUTOR_THREAD_POOL_SIZE = 10;
     private ExecutorService executor;
     private final String hostName;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential azureSasCredential;
     private IotHubConnectionString iotHubConnectionString;
 
@@ -177,7 +178,7 @@ public class RegistryManager
      */
     public RegistryManager(String hostName, TokenCredential credential, RegistryManagerOptions options)
     {
-        Objects.requireNonNull(credential, "credential cannot be null");
+        Objects.requireNonNull(credential, "credentialCache cannot be null");
         Objects.requireNonNull(options, "options cannot be null");
         if (Tools.isNullOrEmpty(hostName))
         {
@@ -186,7 +187,7 @@ public class RegistryManager
 
         this.executor = Executors.newFixedThreadPool(EXECUTOR_THREAD_POOL_SIZE);
         this.options = options;
-        this.credential = credential;
+        this.credentialCache = new TokenCredentialCache(credential);
         this.hostName = hostName;
     }
 
@@ -1547,9 +1548,9 @@ public class RegistryManager
         // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
         // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
         // one of the three options.
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+            return this.credentialCache.getAccessToken().getToken();
         }
         else if (this.azureSasCredential != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.service.auth;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't near
+ * expiry.
+ */
+public class TokenCredentialCache
+{
+    private final static int MINUTES_BEFORE_PROACTIVE_RENEWAL = 9;
+    private final TokenCredential tokenCredential;
+    private AccessToken accessToken;
+
+    /**
+     * Construct a new TokenCredentialCache instance.
+     * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
+     */
+    public TokenCredentialCache(TokenCredential tokenCredential)
+    {
+        Objects.requireNonNull(tokenCredential, "tokenCredential cannot be null");
+
+        this.tokenCredential = tokenCredential;
+    }
+
+    /**
+     * Get a valid AAD authentication token. This may be the same as a previously returned token if it is not near expiration time yet.
+     * @return a valid AAD authentication token.
+     */
+    public AccessToken getAccessToken()
+    {
+        if (this.accessToken == null)
+        {
+            this.accessToken = tokenCredential.getToken(new TokenRequestContext()).block();
+        }
+
+        if (isAccessTokenCloseToExpiry(this.accessToken))
+        {
+            this.accessToken = tokenCredential.getToken(new TokenRequestContext()).block();
+        }
+
+        return this.accessToken;
+    }
+
+    /**
+     * @return the TokenCredential instance that was set in the constructor.
+     */
+    public TokenCredential getTokenCredential()
+    {
+        return this.tokenCredential;
+    }
+
+    private static boolean isAccessTokenCloseToExpiry(AccessToken accessToken)
+    {
+        Duration remainingTimeToLive = Duration.between(Instant.now(), accessToken.getExpiresAt().toInstant());
+        if (remainingTimeToLive.toMinutes() < MINUTES_BEFORE_PROACTIVE_RENEWAL)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -33,17 +33,14 @@ public class TokenCredentialCache
     }
 
     /**
-     * Get a valid AAD authentication token. This may be the same as a previously returned token if it is not near expiration time yet.
+     * Get a valid AAD authentication token. This may be the same as a previously returned token if it is not near
+     * expiration time yet. If a token is less than or equal to 9 minutes away from expiring or is expired already, the
+     * token will be renewed. Otherwise, a cached token will be returned.
      * @return a valid AAD authentication token.
      */
     public AccessToken getAccessToken()
     {
-        if (this.accessToken == null)
-        {
-            this.accessToken = tokenCredential.getToken(new TokenRequestContext()).block();
-        }
-
-        if (isAccessTokenCloseToExpiry(this.accessToken))
+        if (this.accessToken == null || isAccessTokenCloseToExpiry(this.accessToken))
         {
             this.accessToken = tokenCredential.getToken(new TokenRequestContext()).block();
         }
@@ -62,11 +59,6 @@ public class TokenCredentialCache
     private static boolean isAccessTokenCloseToExpiry(AccessToken accessToken)
     {
         Duration remainingTimeToLive = Duration.between(Instant.now(), accessToken.getExpiresAt().toInstant());
-        if (remainingTimeToLive.toMinutes() <= MINUTES_BEFORE_PROACTIVE_RENEWAL)
-        {
-            return true;
-        }
-
-        return false;
+        return remainingTimeToLive.toMinutes() <= MINUTES_BEFORE_PROACTIVE_RENEWAL;
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -62,7 +62,7 @@ public class TokenCredentialCache
     private static boolean isAccessTokenCloseToExpiry(AccessToken accessToken)
     {
         Duration remainingTimeToLive = Duration.between(Instant.now(), accessToken.getExpiresAt().toInstant());
-        if (remainingTimeToLive.toMinutes() < MINUTES_BEFORE_PROACTIVE_RENEWAL)
+        if (remainingTimeToLive.toMinutes() <= MINUTES_BEFORE_PROACTIVE_RENEWAL)
         {
             return true;
         }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
@@ -32,7 +33,7 @@ public class DeviceMethod
 
     private DeviceMethodClientOptions options;
     private String hostName;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential azureSasCredential;
     private IotHubConnectionString iotHubConnectionString;
 
@@ -153,7 +154,7 @@ public class DeviceMethod
         }
 
         this.options = options;
-        this.credential = credential;
+        this.credentialCache = new TokenCredentialCache(credential);
         this.hostName = hostName;
     }
 
@@ -349,9 +350,9 @@ public class DeviceMethod
         }
 
         Job job;
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            job = new Job(this.hostName, this.credential);
+            job = new Job(this.hostName, this.credentialCache.getTokenCredential());
         }
         else if (this.azureSasCredential != null)
         {
@@ -375,9 +376,9 @@ public class DeviceMethod
         // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
         // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
         // one of the three options.
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+            return this.credentialCache.getAccessToken().getToken();
         }
         else if (this.azureSasCredential != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.serializer.QueryRequestParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
@@ -46,7 +47,7 @@ public class Query
 
     private IotHubConnectionString iotHubConnectionString;
     private AzureSasCredential azureSasCredential;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private URL url;
     private HttpMethod httpMethod;
 
@@ -128,7 +129,7 @@ public class Query
         this.requestContinuationToken = continuationToken;
 
             sendQueryRequest(
-                    this.credential,
+                    this.credentialCache,
                     this.azureSasCredential,
                     this.iotHubConnectionString,
                     this.url,
@@ -336,7 +337,7 @@ public class Query
     /**
      * Sends request for the query to the IotHub.
      *
-     * @param credential The RBAC authorization token provider. May be null if azureSasCredential or iotHubConnectionString is not.
+     * @param credentialCache The RBAC authorization token provider. May be null if azureSasCredential or iotHubConnectionString is not.
      * @param azureSasCredential The SAS authorization token provider. May be null if credential or iotHubConnectionString is not.
      * @param iotHubConnectionString The iot hub connection string that SAS tokens will be derived from. May be null if azureSasCredential or credential is not.
      * @param url URL to Query on.
@@ -349,7 +350,7 @@ public class Query
      * @throws IotHubException If HTTP response other then status ok is received.
      */
     public QueryResponse sendQueryRequest(
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             AzureSasCredential azureSasCredential,
             IotHubConnectionString iotHubConnectionString,
             URL url,
@@ -362,7 +363,7 @@ public class Query
         this.url = url;
         this.httpMethod = method;
         this.azureSasCredential = azureSasCredential;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
         this.iotHubConnectionString = iotHubConnectionString;
 
         this.httpConnectTimeout = httpConnectTimeout;
@@ -392,9 +393,9 @@ public class Query
         }
 
         String authorizationToken;
-        if (credential != null)
+        if (credentialCache != null)
         {
-            authorizationToken = credential.getToken(new TokenRequestContext()).block().getToken();
+            authorizationToken = credentialCache.getAccessToken().getToken();
         }
         else if (azureSasCredential != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.serializer.QueryRequestParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpRequest;
@@ -47,7 +48,7 @@ public class QueryCollection
 
     private IotHubConnectionString iotHubConnectionString;
     private AzureSasCredential azureSasCredential;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
 
     private Proxy proxy;
 
@@ -224,7 +225,7 @@ public class QueryCollection
             String query,
             int pageSize,
             QueryType requestQueryType,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             URL url,
             HttpMethod httpMethod,
             int httpConnectTimeout,
@@ -243,7 +244,7 @@ public class QueryCollection
         this.url = url;
         this.isSqlQuery = false;
         this.isInitialQuery = true;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
     }
 
     QueryCollection(
@@ -297,9 +298,9 @@ public class QueryCollection
         }
 
         String authorizationToken;
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            authorizationToken = this.credential.getToken(new TokenRequestContext()).block().getToken();
+            authorizationToken = this.credentialCache.getAccessToken().getToken();
         }
         else if (this.azureSasCredential != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 
@@ -27,7 +28,7 @@ public class RawTwinQuery
     private static final Integer DEFAULT_HTTP_CONNECT_TIMEOUT_MS = 24000; // 24 seconds
 
     private String hostName;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential azureSasCredential;
     private IotHubConnectionString iotHubConnectionString;
 
@@ -86,7 +87,7 @@ public class RawTwinQuery
         Objects.requireNonNull(credential);
 
         this.hostName = hostName;
-        this.credential = credential;
+        this.credentialCache = new TokenCredentialCache(credential);
     }
 
     /**
@@ -132,7 +133,7 @@ public class RawTwinQuery
         Query rawQuery = new Query(sqlQuery, pageSize, QueryType.RAW);
 
         rawQuery.sendQueryRequest(
-                this.credential,
+                this.credentialCache,
                 this.azureSasCredential,
                 this.iotHubConnectionString,
                 IotHubConnectionString.getUrlTwinQuery(this.hostName),
@@ -206,9 +207,9 @@ public class RawTwinQuery
         // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
         // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
         // one of the three options.
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+            return this.credentialCache.getAccessToken().getToken();
         }
         else if (this.azureSasCredential != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.BearerTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.SasTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.ServiceClientBearerTokenCredentialProvider;
@@ -134,7 +135,8 @@ public class DigitalTwinAsyncClient {
         Objects.requireNonNull(options);
         final SimpleModule stringModule = new SimpleModule("String Serializer");
         stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
-        BearerTokenProvider bearerTokenProvider = () -> credential.getToken(new TokenRequestContext()).block().getToken();
+        TokenCredentialCache tokenCredentialCache = new TokenCredentialCache(credential);
+        BearerTokenProvider bearerTokenProvider = () -> tokenCredentialCache.getAccessToken().getToken();
 
         JacksonAdapter adapter = new JacksonAdapter();
         adapter.serializer().registerModule(stringModule);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.devicetwin.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
@@ -37,7 +38,7 @@ public class JobClient
     private final static byte[] EMPTY_JSON = "{}".getBytes();
 
     private String hostName;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential azureSasCredential;
     private IotHubConnectionString iotHubConnectionString;
     private JobClientOptions options;
@@ -130,7 +131,7 @@ public class JobClient
         }
 
         this.hostName = hostName;
-        this.credential = credential;
+        this.credentialCache = new TokenCredentialCache(credential);
         this.options = options;
     }
 
@@ -505,7 +506,7 @@ public class JobClient
         Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
 
         deviceJobQuery.sendQueryRequest(
-            this.credential,
+            this.credentialCache,
             this.azureSasCredential,
             this.iotHubConnectionString,
             IotHubConnectionString.getUrlTwinQuery(this.hostName),
@@ -602,7 +603,7 @@ public class JobClient
         Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
 
         jobResponseQuery.sendQueryRequest(
-            this.credential,
+            this.credentialCache,
             this.azureSasCredential,
             this.iotHubConnectionString,
             IotHubConnectionString.getUrlQuery(this.hostName, jobTypeString, jobStatusString),
@@ -639,9 +640,9 @@ public class JobClient
         // Three different constructor types for this class, and each type provides either a TokenCredential implementation,
         // an AzureSasCredential instance, or just the connection string. The sas token can be retrieved from the non-null
         // one of the three options.
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            return this.credential.getToken(new TokenRequestContext()).block().getToken();
+            return this.credentialCache.getAccessToken().getToken();
         }
         else if (this.azureSasCredential != null)
         {

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCacheTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCacheTest.java
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tests.unit.com.microsoft.azure.sdk.iot.service.auth;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
+import com.sun.scenario.effect.Offset;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.joda.time.field.OffsetDateTimeField;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+
+public class TokenCredentialCacheTest
+{
+    @Mocked
+    TokenCredential mockTokenCredential;
+
+    @Mocked
+    AccessToken mockAccessToken;
+
+    @Mocked
+    AccessToken mockAccessToken2;
+
+    @Mocked
+    Mono<AccessToken> mockTokenTask;
+
+    @Test
+    public void tokenCredentialCachesToken()
+    {
+        TokenCredentialCache cache = new TokenCredentialCache(mockTokenCredential);
+
+        new Expectations()
+        {
+            {
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken;
+
+                mockAccessToken.getExpiresAt();
+                result = OffsetDateTime.MAX;
+            }
+        };
+
+        AccessToken accessToken = cache.getAccessToken();
+        AccessToken accessToken2 = cache.getAccessToken();
+
+        assertEquals(mockAccessToken, accessToken);
+        assertEquals(mockAccessToken, accessToken2);
+    }
+
+    @Test
+    public void tokenCredentialProactivelyRenewsToken()
+    {
+        TokenCredentialCache cache = new TokenCredentialCache(mockTokenCredential);
+
+        new Expectations()
+        {
+            {
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken;
+
+                mockAccessToken.getExpiresAt();
+                result = OffsetDateTime.MAX;
+            }
+        };
+
+        AccessToken accessToken = cache.getAccessToken();
+
+        // 8 minutes from the current time, should fit within the proactive renewal range
+        final long milliseconds = System.currentTimeMillis() + (8 * 60 * 1000);
+        new Expectations()
+        {
+            {
+                mockAccessToken.getExpiresAt();
+                result = Instant.ofEpochMilli(milliseconds).atOffset(ZoneOffset.UTC);
+
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken2;
+            }
+        };
+
+        // act
+        AccessToken accessToken2 = cache.getAccessToken();
+
+        // assert
+        assertEquals(mockAccessToken, accessToken);
+        assertEquals(mockAccessToken2, accessToken2);
+    }
+
+    @Test
+    public void tokenCredentialRenewsExpiredToken()
+    {
+        TokenCredentialCache cache = new TokenCredentialCache(mockTokenCredential);
+
+        new Expectations()
+        {
+            {
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken;
+
+                mockAccessToken.getExpiresAt();
+                result = OffsetDateTime.MAX;
+            }
+        };
+
+        AccessToken accessToken = cache.getAccessToken();
+
+        // Token expired one minute ago
+        final long milliseconds = System.currentTimeMillis() - (60 * 1000);
+        new Expectations()
+        {
+            {
+                mockAccessToken.getExpiresAt();
+                result = Instant.ofEpochMilli(milliseconds).atOffset(ZoneOffset.UTC);
+
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken2;
+            }
+        };
+
+        // act
+        AccessToken accessToken2 = cache.getAccessToken();
+
+        // assert
+        assertEquals(mockAccessToken, accessToken);
+        assertEquals(mockAccessToken2, accessToken2);
+    }
+
+    @Test
+    public void tokenCredentialDoesNotRenewTooProactively()
+    {
+        TokenCredentialCache cache = new TokenCredentialCache(mockTokenCredential);
+
+        new Expectations()
+        {
+            {
+                mockTokenCredential.getToken((TokenRequestContext) any).block();
+                result = mockAccessToken;
+
+                mockAccessToken.getExpiresAt();
+                result = OffsetDateTime.MAX;
+            }
+        };
+
+        AccessToken accessToken = cache.getAccessToken();
+
+        // 12 minutes from the current time, should not fit within the proactive renewal range, so the cached token shouldn't be renewed
+        final long milliseconds = System.currentTimeMillis() + (12 * 60 * 1000);
+        new Expectations()
+        {
+            {
+                mockAccessToken.getExpiresAt();
+                result = Instant.ofEpochMilli(milliseconds).atOffset(ZoneOffset.UTC);
+            }
+        };
+
+        // act
+        AccessToken accessToken2 = cache.getAccessToken();
+
+        // assert
+        assertEquals(mockAccessToken, accessToken);
+        assertEquals(mockAccessToken, accessToken2);
+    }
+}

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
@@ -233,52 +233,6 @@ public class DeviceOperationsTest
                 0);
     }
 
-    /* Tests_SRS_DEVICE_OPERATIONS_21_007: [If the SASToken is null or empty, the request shall throw IOException.] */
-    @Test (expected = IOException.class)
-    public void invokeThrowOnSasTokenNullFailed(@Mocked IotHubServiceSasToken iotHubServiceSasToken) throws Exception
-    {
-        //arrange
-        new NonStrictExpectations()
-        {
-            {
-                iotHubServiceSasToken.toString();
-                result = null;
-            }
-        };
-
-        //act
-        HttpResponse response = DeviceOperations.request(
-                IOT_HUB_CONNECTION_STRING,
-                new URL(STANDARD_URL),
-                HttpMethod.POST,
-                STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
-    }
-
-    /* Tests_SRS_DEVICE_OPERATIONS_21_007: [If the SASToken is null or empty, the request shall throw IOException.] */
-    @Test (expected = IOException.class)
-    public void invokeThrowOnSasTokenEmptyFailed(@Mocked IotHubServiceSasToken iotHubServiceSasToken) throws Exception
-    {
-        //arrange
-        new NonStrictExpectations()
-        {
-            {
-                iotHubServiceSasToken.toString();
-                result = "";
-            }
-        };
-
-        //act
-        HttpResponse response = DeviceOperations.request(
-                IOT_HUB_CONNECTION_STRING,
-                new URL(STANDARD_URL),
-                HttpMethod.POST,
-                STANDARD_PAYLOAD,
-                STANDARD_REQUEST_ID,
-                0);
-    }
-
     /* Tests_SRS_DEVICE_OPERATIONS_21_008: [The request shall create a new HttpRequest with the provided `url`, http `method`, and `payload`.] */
     @Test (expected = IOException.class)
     public void invokeThrowOnHttpRequestFailed(@Mocked IotHubServiceSasToken iotHubServiceSasToken) throws Exception
@@ -619,7 +573,7 @@ public class DeviceOperationsTest
                 httpRequest.setReadTimeoutMillis(DEFAULT_HTTP_TIMEOUT_MS);
                 times = 1;
                 httpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 httpRequest.send();
                 times = 1;
                 IotHubExceptionManager.httpResponseVerification(sendResponse);
@@ -690,7 +644,7 @@ public class DeviceOperationsTest
                 httpRequest.setReadTimeoutMillis(timeoutInMs + DEFAULT_HTTP_TIMEOUT_MS);
                 times = 1;
                 httpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 httpRequest.send();
                 times = 1;
                 IotHubExceptionManager.httpResponseVerification(sendResponse);

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -200,7 +200,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
                 TwinState.createFromTwinJson((String)any);
@@ -265,7 +265,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
                 TwinState.createFromTwinJson((String)any);
@@ -557,7 +557,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -677,7 +677,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -722,7 +722,7 @@ public class DeviceTwinTest
                 mockedHttpRequest.setReadTimeoutMillis(anyInt);
                 times = 1;
                 mockedHttpRequest.setHeaderField(anyString, anyString);
-                times = 4;
+                times = 6;
                 mockedHttpRequest.send();
                 times = 1;
             }
@@ -1214,7 +1214,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, anyString);
                 result = mockedJob;
                 times = 1;
             }
@@ -1244,7 +1244,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, anyString);
                 result = new IOException();
             }
         };
@@ -1270,7 +1270,7 @@ public class DeviceTwinTest
             {
                 mockedConnectionString.toString();
                 result = connectionString;
-                Deencapsulation.newInstance(Job.class, new Class[]{String.class, TokenCredential.class}, anyString, any);
+                Deencapsulation.newInstance(Job.class, new Class[]{String.class}, anyString);
                 result = mockedJob;
             }
         };

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/JobTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/JobTest.java
@@ -78,21 +78,6 @@ public class JobTest
         Deencapsulation.newInstance(Job.class, new Class[]{String.class, String.class}, jobId, connectionString);
     }
 
-    /* Tests_SRS_JOB_21_002: [If a jobId is provided, the constructor shall use this jobId to identify the Job in the Iothub.] */
-    @Test
-    public void constructorReceiveUniqueJobId()
-    {
-        // arrange
-        final String jobId = "validJobId";
-        final String connectionString = "validConnectionString";
-
-        // act
-        Job job = Deencapsulation.newInstance(Job.class, new Class[]{String.class, String.class}, jobId, connectionString);
-
-        // assert
-        assertEquals(jobId, Deencapsulation.getField(job, "jobId"));
-    }
-
     /* Tests_SRS_JOB_21_003: [If no jobId is provided, the constructor shall generate a unique jobId to identify the Job in the Iothub.] */
     @Test
     public void constructorCreateUniqueJobId()
@@ -123,29 +108,7 @@ public class JobTest
         new Verifications()
         {
             {
-                JobClient.createFromConnectionString(connectionString);
-                times = 1;
-            }
-        };
-    }
-
-    /* Tests_SRS_JOB_21_004: [The constructor shall create a new instance of JobClient to manage the Job.] */
-    @Test
-    public void constructor2CreateJobClient() throws IOException
-    {
-        // arrange
-        final String jobId = "validJobId";
-        final String connectionString = "validConnectionString";
-
-        // act
-        Job job = Deencapsulation.newInstance(Job.class, new Class[]{String.class, String.class}, jobId, connectionString);
-
-        // assert
-        assertNotNull(Deencapsulation.getField(job, "jobClient"));
-        new Verifications()
-        {
-            {
-                JobClient.createFromConnectionString(connectionString);
+                new JobClient(connectionString);
                 times = 1;
             }
         };
@@ -161,7 +124,7 @@ public class JobTest
         new NonStrictExpectations()
         {
             {
-                JobClient.createFromConnectionString(connectionString);
+                new JobClient(connectionString);
                 result = new IOException();
                 times = 1;
             }
@@ -169,27 +132,6 @@ public class JobTest
 
         // act
         Deencapsulation.newInstance(Job.class, new Class[]{String.class}, connectionString);
-    }
-
-    /* Tests_SRS_JOB_21_005: [The constructor shall throw IOException if it failed to create a new instance of the JobClient. Threw by the JobClient constructor.] */
-    @Test (expected = IOException.class)
-    public void constructor2ThrowOnJobClientCreation() throws IOException
-    {
-        // arrange
-        final String jobId = "validJobId";
-        final String connectionString = "validConnectionString";
-
-        new NonStrictExpectations()
-        {
-            {
-                JobClient.createFromConnectionString(connectionString);
-                result = new IOException();
-                times = 1;
-            }
-        };
-
-        // act
-        Deencapsulation.newInstance(Job.class, new Class[]{String.class, String.class}, jobId, connectionString);
     }
 
     /* Tests_SRS_JOB_21_006: [If the updateTwin is null, the scheduleUpdateTwin shall throws IllegalArgumentException.] */
@@ -623,21 +565,4 @@ public class JobTest
         // act
         job.cancel();
     }
-
-    /* Tests_SRS_JOB_21_022: [The getJobId shall return the store value of jobId.] */
-    @Test
-    public void getJobIdSucceed() throws IOException, IotHubException
-    {
-        // arrange
-        final String jobId = "validJobId";
-        final String connectionString = "validConnectionString";
-        Job job = Deencapsulation.newInstance(Job.class, new Class[]{String.class, String.class}, jobId, connectionString);
-
-        // act
-        String result = job.getJobId();
-
-        // assert
-        assertEquals(jobId, result);
-    }
-
 }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
@@ -8,6 +8,7 @@ package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 import com.microsoft.azure.sdk.iot.deps.serializer.ParserUtility;
 import com.microsoft.azure.sdk.iot.deps.serializer.QueryRequestParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.devicetwin.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
@@ -57,6 +58,9 @@ public class QueryCollectionTest
 
     @Mocked
     DeviceOperations mockDeviceOperations;
+
+    @Mocked
+    IotHubServiceSasToken mockIotHubServiceSasToken;
 
     private static final String expectedRequestContinuationToken = "someContinuationToken";
     private static final String expectedResponseContinuationToken = "someNewContinuationToken";

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
@@ -5,12 +5,15 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.jobs;
 
+import com.azure.core.credential.AzureSasCredential;
 import com.microsoft.azure.sdk.iot.deps.serializer.JobsParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.MethodParser;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.devicetwin.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.jobs.JobClient;
@@ -25,6 +28,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashSet;
@@ -73,6 +77,9 @@ public class JobClientTest
 
     @Mocked
     URL mockedURL;
+
+    @Mocked
+    IotHubServiceSasToken mockIotHubServiceSasToken;
 
     @Before
     public void setUp() throws IOException
@@ -128,7 +135,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = new IllegalArgumentException();
             }
         };
@@ -158,7 +165,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -185,10 +192,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -222,7 +229,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -249,10 +256,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -290,7 +297,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -317,10 +324,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -403,7 +410,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -430,7 +437,7 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = new MalformedURLException();
             }
         };
@@ -543,7 +550,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -570,10 +577,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -590,7 +597,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 times = 1;
             }
         };
@@ -616,7 +623,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -643,10 +650,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -663,7 +670,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -690,7 +697,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -717,10 +724,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = new IOException();
             }
         };
@@ -751,7 +758,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 mockedDeviceTwinDevice.getTags();
@@ -778,10 +785,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -868,7 +875,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -880,7 +887,7 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = new MalformedURLException();
             }
         };
@@ -1055,7 +1062,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -1067,10 +1074,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1101,7 +1108,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -1113,10 +1120,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1133,7 +1140,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 times = 1;
             }
         };
@@ -1156,7 +1163,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -1168,10 +1175,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1182,13 +1189,13 @@ public class JobClientTest
         JobClient testJobClient = JobClient.createFromConnectionString(connectionString);
 
         //act
-        JobResult jobResult = testJobClient.scheduleDeviceMethod(jobId, queryCondition, methodName, null, null, payload, startTimeUtc, maxExecutionTimeInSeconds);
+        testJobClient.scheduleDeviceMethod(jobId, queryCondition, methodName, null, null, payload, startTimeUtc, maxExecutionTimeInSeconds);
 
         //assert
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1212,7 +1219,7 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -1224,10 +1231,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = new IOException();
             }
         };
@@ -1255,7 +1262,7 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
                 new MethodParser(methodName, null, null, payload);
@@ -1267,10 +1274,10 @@ public class JobClientTest
                 mockedJobsParser.toJson();
                 result = json;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1341,10 +1348,10 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = new MalformedURLException();
             }
         };
@@ -1372,13 +1379,13 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1401,7 +1408,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 times = 1;
             }
         };
@@ -1418,13 +1425,13 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.GET, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1447,45 +1454,10 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.GET, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
-    }
-
-    /* Tests_SRS_JOBCLIENT_21_027: [If the getJob failed to send a GET request, it shall throw IOException.] */
-    /* Tests_SRS_JOBCLIENT_21_028: [If the getJob failed to verify the iothub response, it shall throw IotHubException.] */
-    @Test (expected = IOException.class)
-    public void getJobThrowsOnSendGET() throws IOException, IotHubException
-    {
-        //arrange
-        final String connectionString = "testString";
-        final String jobId = "validJobId";
-        JobClient testJobClient = null;
-        new NonStrictExpectations()
-        {
-            {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
-                result = mockedIotHubConnectionString;
-
-                mockedIotHubConnectionString.getUrlJobs(jobId);
-                result = mockedURL;
-
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
-                result = new IOException();
-            }
-        };
-        try
-        {
-            testJobClient = JobClient.createFromConnectionString(connectionString);
-        }
-        catch (IllegalArgumentException e)
-        {
-            assertTrue("Test did not run because createFromConnectionString failed to create new instance of the JobClient", true);
-        }
-
-        //act
-        testJobClient.getJob(jobId);
     }
 
     /* Tests_SRS_JOBCLIENT_21_029: [The getJob shall parse the iothub response and return it as JobResult.] */
@@ -1499,13 +1471,13 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobs(jobId);
+                IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.GET, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.GET, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1581,10 +1553,10 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 result = new MalformedURLException();
             }
         };
@@ -1612,13 +1584,13 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.POST, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1641,7 +1613,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 times = 1;
             }
         };
@@ -1658,13 +1630,13 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, new byte[]{}, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.POST, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1687,7 +1659,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.POST, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1705,13 +1677,13 @@ public class JobClientTest
         new NonStrictExpectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(mockedIotHubConnectionString, mockedURL, HttpMethod.POST, (byte[])any, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.POST, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = new IOException();
             }
         };
@@ -1739,13 +1711,13 @@ public class JobClientTest
         new Expectations()
         {
             {
-                IotHubConnectionStringBuilder.createConnectionString(connectionString);
+                IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
                 result = mockedIotHubConnectionString;
 
-                mockedIotHubConnectionString.getUrlJobsCancel(jobId);
+                IotHubConnectionString.getUrlJobsCancel(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, (byte[]) any, (String)any, 0);
+                DeviceOperations.request(anyString, mockedURL, (HttpMethod) any, (byte[]) any, (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1792,7 +1764,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.POST, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1856,7 +1828,7 @@ public class JobClientTest
             {
                 Deencapsulation.newInstance(Query.class, new Class[] {String.class, Integer.class, QueryType.class}, anyString, anyInt, QueryType.DEVICE_JOB);
                 result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.POST, anyInt, anyInt, (Proxy) any);
                 result = new IotHubException();
             }
         };
@@ -1891,7 +1863,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.GET, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1919,7 +1891,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.GET, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1946,27 +1918,6 @@ public class JobClientTest
 
         //act
         testJobClient.queryJobResponse(JOB_TYPE_DEFAULT, JOB_STATUS_DEFAULT, 0);
-    }
-
-    @Test (expected = IotHubException.class)
-    public void queryJobResponseThrowsOnNewQueryThrows(@Mocked Query mockedQuery) throws IotHubException, IOException
-    {
-        //arrange
-        final String connectionString = "testString";
-        JobClient testJobClient = JobClient.createFromConnectionString(connectionString);
-
-        new NonStrictExpectations()
-        {
-            {
-                Deencapsulation.newInstance(Query.class, new Class[] {Integer.class, QueryType.class}, anyInt, QueryType.JOB_RESPONSE);
-                result = mockedQuery;
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.GET, any);
-                result = new IotHubException();
-            }
-        };
-
-        //act
-        testJobClient.queryJobResponse(JOB_TYPE_DEFAULT, JOB_STATUS_DEFAULT);
     }
 
     //Tests_SRS_JOBCLIENT_25_047: [hasNextJob shall return true if the next job exist, false other wise.]
@@ -1996,7 +1947,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.POST, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -2077,13 +2028,13 @@ public class JobClientTest
         Query testQuery = testJobClient.queryDeviceJob(VALID_SQL_QUERY);
 
         //act
-        JobResult result = testJobClient.getNextJob(testQuery);
+        testJobClient.getNextJob(testQuery);
 
         //assert
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedQuery, "sendQueryRequest", new Class[] {IotHubConnectionString.class, URL.class, HttpMethod.class, Long.class}, any, any, HttpMethod.POST, any);
+                mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.POST, anyInt, anyInt, (Proxy) any);
                 times = 1;
                 Deencapsulation.newInstance(JobResult.class, new Class [] {byte[].class}, expectedString.getBytes());
                 times = 1;


### PR DESCRIPTION
AMQP client doesn't need it since it has proactive renewal in place already.