### PR TITLE
fix(iot-dev): Fix bug where AMQP layer doesn't release resources after failing to open

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -1125,6 +1125,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             }
             catch (HandlerException e)
             {
+                iotHubReactor.free();
+                
                 TransportException transportException = new TransportException(e);
 
                 // unclassified exceptions are treated as retryable in ProtonJExceptionParser, so they should be treated

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/IotHubReactor.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/IotHubReactor.java
@@ -31,4 +31,9 @@ public class IotHubReactor
         this.reactor.process();
         this.reactor.free();
     }
+
+    public void free()
+    {
+        this.reactor.free();
+    }
 }


### PR DESCRIPTION
reactor.free() releases file descriptors that were grabbed by proton reactor. Since the connection failed to open, there is no need to hang on to them.

#1135 for more context