### PR TITLE
fix(iot-dev): Fix bug where AMQP reactor isn't free'd if closing encounters an exception

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -273,16 +273,14 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             }
             catch (InterruptedException e)
             {
-                this.executorServicesCleanup();
                 throw new TransportException("Interrupted while closing proton reactor", e);
             }
-
-            this.executorServicesCleanup();
 
             log.trace("Amqp connection closed successfully");
         }
         finally
         {
+            this.executorServicesCleanup();
             this.reactor.free();
             this.state = IotHubConnectionStatus.DISCONNECTED;
         }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -280,6 +280,8 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
         finally
         {
+            // always clean up the executor service, free the reactor and set the state as DISCONNECTED even when the close
+            // isn't successful. Failing to free the reactor in particular leaks network resources
             this.executorServicesCleanup();
             this.reactor.free();
             this.state = IotHubConnectionStatus.DISCONNECTED;

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -561,6 +561,8 @@ public class AmqpsIotHubConnectionTest {
 
         final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
         Deencapsulation.setField(connection, "connection", mockConnection);
+        Deencapsulation.setField(connection, "reactor", mockReactor);
+
         this.setLatches(connection);
 
         new NonStrictExpectations()
@@ -592,6 +594,7 @@ public class AmqpsIotHubConnectionTest {
 
         final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
 
+        Deencapsulation.setField(connection, "reactor", mockReactor);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(connection, "executorService", mockExecutorService);
         Deencapsulation.setField(connection, "connection", mockConnection);
@@ -632,6 +635,7 @@ public class AmqpsIotHubConnectionTest {
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(connection, "executorService", mockExecutorService);
         Deencapsulation.setField(connection, "connection", mockConnection);
+        Deencapsulation.setField(connection, "reactor", mockReactor);
         setLatches(connection);
 
         connection.close();
@@ -651,6 +655,8 @@ public class AmqpsIotHubConnectionTest {
                 mockExecutorService.shutdownNow();
                 times = 1;
                 mockScheduledExecutorService.shutdownNow();
+                times = 1;
+                mockReactor.free();
                 times = 1;
             }
         };


### PR DESCRIPTION
continuing on from #1135, this change ensures that even if the AMQP layer encounters an exception while closing manually, that the reactor is always free'd at the end

#1135 for additional context