### PR TITLE
feat(iot-service): Add Twin Client API to replace a twin

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
@@ -71,6 +71,82 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
 
     @Test
     @StandardTierHubOnlyTest
+    public void testReplaceTwin() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
+    {
+        // arrange
+        if (testInstance.protocol != IotHubClientProtocol.AMQPS || testInstance.authenticationType != AuthenticationType.SAS)
+        {
+            //Test is for service client operations, so no need to parameterize on device client protocols or authentication types
+            return;
+        }
+
+        super.setUpNewDeviceAndModule(false);
+
+        String propertyKey = "someKey";
+        String propertyValue = "someValue";
+        String propertyUpdateKey = "someUpdatedKey";
+        String propertyUpdateValue = "someUpdatedValue";
+        String tagKey = "someKey";
+        String tagValue = "someValue";
+        String tagUpdateKey = "someUpdatedKey";
+        String tagUpdateValue = "someUpdatedValue";
+
+        testInstance.twinServiceClient.getTwin(deviceUnderTest.sCDeviceForTwin);
+
+        Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> desiredProperties = new HashSet<>();
+        Set<com.microsoft.azure.sdk.iot.service.devicetwin.Pair> tags = new HashSet<>();
+        desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(propertyKey, propertyValue));
+        tags.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(tagKey, tagValue));
+        deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
+        deviceUnderTest.sCDeviceForTwin.setTags(tags);
+        deviceUnderTest.sCDeviceForTwin = testInstance.twinServiceClient.replaceTwin(deviceUnderTest.sCDeviceForTwin);
+
+        // Check that the twin has the expected desired properties and tags
+        testInstance.twinServiceClient.getTwin(deviceUnderTest.sCDeviceForTwin);
+        assertEquals(1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
+        com.microsoft.azure.sdk.iot.service.devicetwin.Pair actualDesiredProperty =
+            deviceUnderTest.sCDeviceForTwin.getDesiredProperties().iterator().next();
+
+        assertEquals(propertyKey, actualDesiredProperty.getKey());
+        assertEquals(propertyValue, actualDesiredProperty.getValue());
+
+        assertEquals(1, deviceUnderTest.sCDeviceForTwin.getTags().size());
+        com.microsoft.azure.sdk.iot.service.devicetwin.Pair actualTags =
+            deviceUnderTest.sCDeviceForTwin.getTags().iterator().next();
+
+        assertEquals(tagKey, actualTags.getKey());
+        assertEquals(tagValue, actualTags.getValue());
+
+        // Test replacing the old desired properties and tags with a new set of desired properties and tags
+        desiredProperties.clear();
+        tags.clear();
+
+        desiredProperties.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(propertyUpdateKey, propertyUpdateValue));
+        tags.add(new com.microsoft.azure.sdk.iot.service.devicetwin.Pair(tagUpdateKey, tagUpdateValue));
+        deviceUnderTest.sCDeviceForTwin.setDesiredProperties(desiredProperties);
+        deviceUnderTest.sCDeviceForTwin.setTags(tags);
+        deviceUnderTest.sCDeviceForTwin = testInstance.twinServiceClient.replaceTwin(deviceUnderTest.sCDeviceForTwin);
+
+        // Check that the twin's desired properties consist only of the updated values. If replace works as expected, then the old values
+        // should be gone entirely
+        testInstance.twinServiceClient.getTwin(deviceUnderTest.sCDeviceForTwin);
+        assertEquals(1, deviceUnderTest.sCDeviceForTwin.getDesiredProperties().size());
+        actualDesiredProperty = deviceUnderTest.sCDeviceForTwin.getDesiredProperties().iterator().next();
+
+        assertEquals(propertyUpdateKey, actualDesiredProperty.getKey());
+        assertEquals(propertyUpdateValue, actualDesiredProperty.getValue());
+
+        // Check that the twin's tags consist only of the updated values. If replace works as expected, then the old values
+        // should be gone entirely
+        assertEquals(1, deviceUnderTest.sCDeviceForTwin.getTags().size());
+        actualTags = deviceUnderTest.sCDeviceForTwin.getTags().iterator().next();
+
+        assertEquals(tagUpdateKey, actualTags.getKey());
+        assertEquals(tagUpdateValue, actualTags.getValue());
+    }
+
+    @Test
+    @StandardTierHubOnlyTest
     public void testSubscribeToDesiredArrayProperties() throws IOException, InterruptedException, IotHubException, GeneralSecurityException, ModuleClientException, URISyntaxException
     {
         super.setUpNewDeviceAndModule();

--- a/service/iot-service-samples/device-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceTwinSample.java
+++ b/service/iot-service-samples/device-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceTwinSample.java
@@ -47,8 +47,11 @@ public class DeviceTwinSample
             // ============================== get initial twin properties =============================
             getInitialState(twinClient, device);
 
-            // ================================ change desired property ===============================
-            changeDesiredProperties(twinClient, device);
+            // ================================ patch desired property ===============================
+            patchDesiredProperties(twinClient, device);
+
+            // ================================ replace desired property ===============================
+            replaceDesiredProperties(twinClient, device);
 
             // ============================ schedule update desired property ==========================
             scheduleUpdateDesiredProperties(twinClient, device);
@@ -82,7 +85,7 @@ public class DeviceTwinSample
         device.setTags(tags);
     }
 
-    private static void changeDesiredProperties(DeviceTwin twinClient, DeviceTwinDevice device) throws IOException, IotHubException
+    private static void patchDesiredProperties(DeviceTwin twinClient, DeviceTwinDevice device) throws IOException, IotHubException
     {
         Set<Pair> desiredProperties = new HashSet<>();
         desiredProperties.add(new Pair("temp", new Random().nextInt(TEMPERATURE_RANGE)));
@@ -91,6 +94,22 @@ public class DeviceTwinSample
 
         System.out.println("Updating Device twin (new temp, hum)");
         twinClient.updateTwin(device);
+
+        System.out.println("Getting the updated Device twin");
+        twinClient.getTwin(device);
+        System.out.println(device);
+    }
+
+    private static void replaceDesiredProperties(DeviceTwin twinClient, DeviceTwinDevice device) throws IOException, IotHubException
+    {
+        Set<Pair> desiredProperties = new HashSet<>();
+        desiredProperties.add(new Pair("temp", new Random().nextInt(TEMPERATURE_RANGE)));
+        device.setDesiredProperties(desiredProperties);
+
+        // By replacing the twin rather than patching it, any desired properties that existed on the twin prior to this call
+        // that aren't present on the new set of desired properties will be deleted.
+        System.out.println("Replacing Device twin");
+        device = twinClient.replaceTwin(device);
 
         System.out.println("Getting the updated Device twin");
         twinClient.getTwin(device);


### PR DESCRIPTION
Previously, the client only exposed a PATCH API. #719 shows that customers are interested in having a replace API as well.