### PR TITLE
release(2021-03-04): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.29.2";
+    private static final String CLIENT_VERSION = "1.29.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.2') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.3') {
         exclude module: 'slf4j-api'
         exclude module:'azure-storage'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.29.2</iot-device-client-version>
-        <iot-service-client-version>1.27.2</iot-service-client-version>
+        <iot-device-client-version>1.29.3</iot-device-client-version>
+        <iot-service-client-version>1.28.0</iot-service-client-version>
         <iot-deps-version>0.11.2</iot-deps-version>
         <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.2</provisioning-service-client-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static String serviceVersion = "1.27.2";
+    public static String serviceVersion = "1.28.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.29.3)

### Bug fixes
- Fix bug where AMQP layer didn't always release network resources (#1136, #1136) 

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.28.0)
- Add API to replace a twin (#1139)

old
{
    "device": "1.29.2",
    "service": "1.27.2",
    "deps": "0.11.2",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}

new
{
    "device": "1.29.3",
    "service": "1.28.0",
    "deps": "0.11.2",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}