### PR TITLE
fix(iot-device): Fix bug where TransportExceptions thrown in Amqp lay…

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -1143,8 +1143,6 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             }
             catch (HandlerException e)
             {
-                iotHubReactor.free();
-                
                 TransportException transportException = new TransportException(e);
 
                 // unclassified exceptions are treated as retryable in ProtonJExceptionParser, so they should be treated
@@ -1152,6 +1150,10 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                 transportException.setRetryable(true);
 
                 this.listener.onConnectionLost(transportException, connectionId);
+            }
+            finally
+            {
+                iotHubReactor.free();
             }
 
             return null;


### PR DESCRIPTION
…er open were thrown before cleaning up reactor and threadpool

InterruptedExceptions were behaving correctly, but TransportExceptions were not

The mistake I made here was assuming that the ReactorRunner thread that encounters these exceptions would itself throw a HandlerException and that the runner's catch block would close the reactor after encountering it. In reality, the reactor runner does not throw a HandlerException when the device hits an IOException or similar exception. Instead, the main thread monitoring this reactor thread is the one who throws the exception. Because of that, I had to move the reactor freeing responsibilities to the main thread as well to cover these error cases