### PR TITLE
refactor(iot-dev): Upgrade azure storage SDK dependency to the latest

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -57,15 +57,15 @@
             <version>${iot-deps-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-storage</artifactId>
-            <version>8.1.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>12.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.paho</groupId>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTask.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.azure.sdk.iot.device.fileupload;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadCompletionNotification;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriRequest;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
@@ -12,8 +14,6 @@ import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.ResponseMessage;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -138,11 +138,15 @@ public final class FileUploadTask implements Runnable
 
         try
         {
-            CloudBlockBlob blob = new CloudBlockBlob(sasUriResponse.getBlobUri());
-            blob.upload(inputStream, streamLength);
+            BlobClient blobClient =
+                new BlobClientBuilder()
+                    .endpoint(sasUriResponse.getBlobUri().toString())
+                    .buildClient();
+
+            blobClient.upload(inputStream, streamLength);
             fileUploadCompletionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), true, 0, "Succeed to upload to storage.");
         }
-        catch (StorageException | IOException | IllegalArgumentException | URISyntaxException e)
+        catch (Exception e)
         {
             log.error("File upload failed to upload the stream to the blob", e);
         }

--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
@@ -3,14 +3,18 @@
 
 package samples.com.microsoft.azure.sdk.iot;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadCompletionNotification;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriRequest;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,11 +146,14 @@ public class FileUploadSample
 
             try
             {
-                // Note that other versions of the Azure Storage SDK can be used here instead. The latest can be found here:
-                // https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/storage#azure-storage-sdk-client-library-for-java
                 System.out.println("Uploading file " + fileNameList.get(index) + " with the retrieved SAS URI...");
-                CloudBlockBlob blob = new CloudBlockBlob(sasUriResponse.getBlobUri());
-                blob.upload(inputStream, streamLength);
+
+                BlobClient blobClient =
+                    new BlobClientBuilder()
+                        .endpoint(sasUriResponse.getBlobUri().toString())
+                        .buildClient();
+
+                blobClient.upload(inputStream, streamLength);
             }
             catch (Exception e)
             {

--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
@@ -3,12 +3,13 @@
 
 package samples.com.microsoft.azure.sdk.iot;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadCompletionNotification;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriRequest;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -86,10 +87,12 @@ public class FileUploadSimpleSample
 
             try (FileInputStream fileInputStream = new FileInputStream(file))
             {
-                // Note that other versions of the Azure Storage SDK can be used here instead. The latest can be found here:
-                // https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/storage#azure-storage-sdk-client-library-for-java
-                CloudBlockBlob blob = new CloudBlockBlob(sasUriResponse.getBlobUri());
-                blob.upload(fileInputStream, file.length());
+                BlobClient blobClient =
+                    new BlobClientBuilder()
+                        .endpoint(sasUriResponse.getBlobUri().toString())
+                        .buildClient();
+
+                blobClient.upload(fileInputStream, file.length());
             }
             catch (Exception e)
             {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ExportImportTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ExportImportTests.java
@@ -13,6 +13,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.blob.specialized.BlobInputStream;
+import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.microsoft.azure.sdk.iot.deps.serializer.ExportImportDeviceParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.StorageAuthenticationType;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
@@ -344,7 +345,7 @@ public class ExportImportTests extends IntegrationTest
         // Creating the Azure storage blob and uploading the serialized string of devices
         InputStream stream = new ByteArrayInputStream(blobToImport);
         String importBlobName = "devices.txt";
-        BlobClient importBlob = importContainer.getBlobClient(importBlobName);
+        BlockBlobClient importBlob = importContainer.getBlobClient(importBlobName).getBlockBlobClient();
         importBlob.delete();
         importBlob.upload(stream, blobToImport.length);
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ExportImportTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ExportImportTests.java
@@ -5,17 +5,33 @@
 
 package tests.integration.com.microsoft.azure.sdk.iot.iothub.serviceclient;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.sas.BlobContainerSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.blob.specialized.BlobInputStream;
 import com.microsoft.azure.sdk.iot.deps.serializer.ExportImportDeviceParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.StorageAuthenticationType;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
-import com.microsoft.azure.sdk.iot.service.*;
+import com.microsoft.azure.sdk.iot.service.Device;
+import com.microsoft.azure.sdk.iot.service.DeviceStatus;
+import com.microsoft.azure.sdk.iot.service.ExportImportDevice;
+import com.microsoft.azure.sdk.iot.service.ImportMode;
+import com.microsoft.azure.sdk.iot.service.JobProperties;
+import com.microsoft.azure.sdk.iot.service.RegistryManager;
+import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationMechanism;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubTooManyDevicesException;
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.*;
 import mockit.Deencapsulation;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import sun.misc.IOUtils;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
@@ -26,11 +42,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.*;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.UUID;
 
 import static junit.framework.TestCase.fail;
 
@@ -49,13 +69,13 @@ public class ExportImportTests extends IntegrationTest
     protected static String storageAccountConnectionString = "";
     private static String deviceId = "java-crud-e2e-test";
 
-    private static CloudBlobContainer importContainer;
-    private static CloudBlobContainer exportContainer;
+    private static BlobContainerClient importContainer;
+    private static BlobContainerClient exportContainer;
 
     private static RegistryManager registryManager;
 
     @BeforeClass
-    public static void setUp() throws URISyntaxException, InvalidKeyException, StorageException, IOException
+    public static void setUp() throws URISyntaxException, InvalidKeyException, IOException
     {
         iotHubConnectionString = Tools.retrieveEnvironmentVariableValue(TestConstants.IOT_HUB_CONNECTION_STRING_ENV_VAR_NAME);
         isBasicTierHub = Boolean.parseBoolean(Tools.retrieveEnvironmentVariableValue(TestConstants.IS_BASIC_TIER_HUB_ENV_VAR_NAME));
@@ -66,18 +86,17 @@ public class ExportImportTests extends IntegrationTest
         String uuid = UUID.randomUUID().toString();
         deviceId = deviceId.concat("-" + uuid);
 
-        CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageAccountConnectionString);
-        CloudBlobClient blobClient = storageAccount.createCloudBlobClient();
+        BlobServiceClient blobClient = new BlobServiceClientBuilder().connectionString(storageAccountConnectionString).buildClient();
 
         // Creating the export storage container and getting its URI
         String exportContainerName = "exportcontainersample-" + uuid;
-        exportContainer = blobClient.getContainerReference(exportContainerName);
-        exportContainer.createIfNotExists();
+        exportContainer = blobClient.getBlobContainerClient(exportContainerName);
+        exportContainer.create();
 
         // Creating the import storage container and getting its URI
         String importContainerName = "importcontainersample-" + uuid;
-        importContainer = blobClient.getContainerReference(importContainerName);
-        importContainer.createIfNotExists();
+        importContainer = blobClient.getBlobContainerClient(importContainerName);
+        importContainer.create();
     }
 
     @AfterClass
@@ -98,8 +117,8 @@ public class ExportImportTests extends IntegrationTest
         runImportJob(devicesToBeDeleted, ImportMode.Delete, Optional.empty());
 
         //Cleaning up the containers
-        importContainer.deleteIfExists();
-        exportContainer.deleteIfExists();
+        importContainer.delete();
+        exportContainer.delete();
 
         if (registryManager != null)
         {
@@ -228,7 +247,12 @@ public class ExportImportTests extends IntegrationTest
             {
                 if (storageAuthenticationType.isPresent())
                 {
-                    JobProperties exportJobProperties = JobProperties.createForExportJob(containerSasUri, excludeKeys, storageAuthenticationType.get());
+                    JobProperties exportJobProperties =
+                        JobProperties.createForExportJob(
+                            containerSasUri,
+                            excludeKeys,
+                            storageAuthenticationType.get());
+
                     exportJob = registryManager.exportDevices(exportJobProperties);
                 }
                 else
@@ -266,12 +290,12 @@ public class ExportImportTests extends IntegrationTest
         }
 
         String exportedDevicesJson = "";
-        for(ListBlobItem blobItem : exportContainer.listBlobs())
+        for (BlobItem blobItem : exportContainer.listBlobs())
         {
-            if (blobItem instanceof CloudBlockBlob)
-            {
-                CloudBlockBlob retrievedBlob = (CloudBlockBlob) blobItem;
-                exportedDevicesJson = retrievedBlob.downloadText();
+            BlobInputStream stream = exportContainer.getBlobClient(blobItem.getName()).openInputStream();
+
+            try (Scanner scanner = new Scanner(stream, StandardCharsets.UTF_8.name())) {
+                exportedDevicesJson = scanner.next();
             }
         }
 
@@ -320,8 +344,8 @@ public class ExportImportTests extends IntegrationTest
         // Creating the Azure storage blob and uploading the serialized string of devices
         InputStream stream = new ByteArrayInputStream(blobToImport);
         String importBlobName = "devices.txt";
-        CloudBlockBlob importBlob = importContainer.getBlockBlobReference(importBlobName);
-        importBlob.deleteIfExists();
+        BlobClient importBlob = importContainer.getBlobClient(importBlobName);
+        importBlob.delete();
         importBlob.upload(stream, blobToImport.length);
 
         // Starting the import job
@@ -376,24 +400,20 @@ public class ExportImportTests extends IntegrationTest
         }
     }
 
-    private static String getContainerSasUri(CloudBlobContainer container) throws InvalidKeyException, StorageException
+    private static String getContainerSasUri(BlobContainerClient blobContainerClient)
     {
-        //Set the expiry time and permissions for the container.
-        //In this case no start time is specified, so the shared access signature becomes valid immediately.
-        SharedAccessBlobPolicy sasConstraints = new SharedAccessBlobPolicy();
-        Date expirationDate = Date.from(Instant.now().plus(Duration.ofDays(1)));
-        sasConstraints.setSharedAccessExpiryTime(expirationDate);
-        EnumSet<SharedAccessBlobPermissions> permissions = EnumSet.of(
-                SharedAccessBlobPermissions.WRITE,
-                SharedAccessBlobPermissions.LIST,
-                SharedAccessBlobPermissions.READ,
-                SharedAccessBlobPermissions.DELETE);
-        sasConstraints.setPermissions(permissions);
+        OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+        BlobContainerSasPermission permission =
+            new BlobContainerSasPermission()
+                .setReadPermission(true)
+                .setAddPermission(true)
+                .setCreatePermission(true)
+                .setDeletePermission(true)
+                .setListPermission(true);
 
-        //Generate the shared access signature on the container, setting the constraints directly on the signature.
-        String sasContainerToken = container.generateSharedAccessSignature(sasConstraints, null);
+        BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(expiryTime, permission)
+            .setStartTime(OffsetDateTime.now());
 
-        //Return the URI string for the container, including the SAS token.
-        return container.getUri() + "?" + sasContainerToken;
+        return blobContainerClient.generateSas(values);
     }
 }

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -86,18 +86,6 @@
             <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-storage</artifactId>
-            <version>4.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
A lot of client objects changed names since we took this old dependency (4 major version bumps total), so a lot of code had to be rewritten to use this latest version

This is a nice change on it's own, but it is largely driven by some compatibility issues that the old azure storage SDK has was the incoming azure identity library AAD auth changes. Since both master and preview would benefit from this change, this code will be merged into master first, and preview will get it when we merge master into preview shortly thereafter