### PR TITLE
fix(device): encode ModelId during MQTT connect

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -121,8 +121,8 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
             password = null;
         }
 
-        //URLEncoder follows HTML spec for encoding urls, which includes substituting space characters with '+'
-        // We want "%20" for spaces, not '+', however, so replace them manually after utf-8 encoding
+        // URLEncoder follows HTML spec for encoding urls, which includes substituting space characters with '+'
+        // We want "%20" for spaces, not '+', however, so replace them manually after utf-8 encoding.
         String userAgentString = this.config.getProductInfo().getUserAgentString();
         String clientUserAgentIdentifier;
         try
@@ -131,7 +131,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
         }
         catch (UnsupportedEncodingException e)
         {
-            throw new TransportException("Failed to get URLEncode the user agent string", e);
+            throw new TransportException("Failed to URLEncode the user agent string", e);
         }
 
         String deviceId = this.config.getDeviceId();
@@ -153,7 +153,16 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
         }
         else
         {
-            serviceParams = TransportUtils.IOTHUB_API_VERSION + "&" + MODEL_ID + "=" + modelId;
+            try
+            {
+                // URLEncoder follows HTML spec for encoding urls, which includes substituting space characters with '+'
+                // We want "%20" for spaces, not '+', however, so replace them manually after utf-8 encoding.
+                serviceParams = TransportUtils.IOTHUB_API_VERSION + "&" + MODEL_ID + "=" + URLEncoder.encode(modelId, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20");
+            }
+            catch (UnsupportedEncodingException e)
+            {
+                throw new TransportException("Failed to URLEncode the modelId string", e);
+            }
         }
 
         String iotHubUserName = this.config.getIotHubHostname() + "/" + clientId + "/?api-version=" + serviceParams + "&" + clientUserAgentIdentifier;


### PR DESCRIPTION
Same as [this change](https://github.com/Azure/azure-iot-sdk-csharp/commit/666df0e5607fdd9d462cdf4227afc54342bf7dba) in the .NET repo, the device's model Id should be URL encoded before being added to the URI, because it is user-supplied data and could potentially have characters that would break the URI.