### PR TITLE
release(2021-04-28): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.29.5";
+    private static final String CLIENT_VERSION = "1.30.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.29.4";
+    private static final String CLIENT_VERSION = "1.29.5";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.4') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.5') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.29.5') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.0') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/iot-e2e-tests/iot-e2e-jvm-tests/pom.xml
+++ b/iot-e2e-tests/iot-e2e-jvm-tests/pom.xml
@@ -90,22 +90,13 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>with-deps</shadedClassifierName>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <includes>
+                        <!--By default, only test files that end in ___Test.java are recognized as tests. This statement extends that to ___Tests.java files-->
+                        <include>*Tests.java</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.29.5</iot-device-client-version>
+        <iot-device-client-version>1.30.0</iot-device-client-version>
         <iot-service-client-version>1.29.0</iot-service-client-version>
         <iot-deps-version>0.11.3</iot-deps-version>
         <provisioning-device-client-version>1.8.7</provisioning-device-client-version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.29.4</iot-device-client-version>
-        <iot-service-client-version>1.28.0</iot-service-client-version>
-        <iot-deps-version>0.11.2</iot-deps-version>
+        <iot-device-client-version>1.29.5</iot-device-client-version>
+        <iot-service-client-version>1.29.0</iot-service-client-version>
+        <iot-deps-version>0.11.3</iot-deps-version>
         <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.2</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.28.0";
+    public static final String serviceVersion = "1.29.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Deps (com.microsoft.azure.sdk.iot:iot-device-client:0.11.3)
- Moved some AMQP layer code from IoT Hub service client to IoT Hub deps so that it could be shared with IoT Hub device client (#1184)


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.30.0)
- Added support for tracking state of outgoing messages (#1190)
 
### Bug fixes
- Fix bug where file upload APIs didn't throw an exception if they receive an unsuccessful IoT Hub level status code (#1186)
- Fix regression where MQTT layer did not use new SAS token during reconnection logic. This regression affected device client versions 1.29.2, 1.29.3, and 1.29.4 (#1165)
- Fix bug where MQTT layer did not URL encode modelId when connecting to service (#1168)
- Fix deadlock within MQTT layer when client opens with message callback set and cloud to device message queue is full (#1155)
- Upgrade Azure Storage dependency version (#1158)
- Fix bug where Amqp layer treated multiplexed connections with only a single device the same way as a non-multiplexed connection (#1192)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.29.0)
- Add support for ParentScope feature (#1181)
- Add support for role based authentication as a credential option for all service clients (#1184)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.30.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.29.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.11.3/jar

old
{
    "device": "1.29.4",
    "service": "1.28.0",
    "deps": "0.11.2",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}

new
{
    "device": "1.30.0",
    "service": "1.29.0",
    "deps": "0.11.3",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}