### PR TITLE
fix(iot-dev): Fix bug where amqp layer treated single device multiplexed connections as though they weren't multiplexed

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -103,6 +103,11 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     DeviceIO(DeviceClientConfig config, long sendPeriodInMilliseconds, long receivePeriodInMilliseconds)
     {
+        this(config, sendPeriodInMilliseconds, receivePeriodInMilliseconds, false);
+    }
+
+    DeviceIO(DeviceClientConfig config, long sendPeriodInMilliseconds, long receivePeriodInMilliseconds, boolean isMultiplexing)
+    {
         if (config == null)
         {
             throw new IllegalArgumentException("Config cannot be null.");
@@ -119,7 +124,7 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
         /* Codes_SRS_DEVICE_IO_21_006: [The constructor shall set the `state` as `DISCONNECTED`.] */
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
-        this.transport = new IotHubTransport(config, this);
+        this.transport = new IotHubTransport(config, this, isMultiplexing);
 
         /* Codes_SRS_DEVICE_IO_21_037: [The constructor shall initialize the `sendPeriodInMilliseconds` with default value of 10 milliseconds.] */
         this.sendPeriodInMilliseconds = sendPeriodInMilliseconds;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
@@ -101,7 +101,7 @@ public class TransportClient
         if (this.deviceClientList.size() > 0)
         {
             // Codes_SRS_TRANSPORTCLIENT_12_011: [The function shall create a new DeviceIO using the first registered device client's configuration.]
-            this.deviceIO = new DeviceIO(deviceClientList.get(0).getConfig(), SEND_PERIOD_MILLIS, RECEIVE_PERIOD_MILLIS_AMQPS);
+            this.deviceIO = new DeviceIO(deviceClientList.get(0).getConfig(), SEND_PERIOD_MILLIS, RECEIVE_PERIOD_MILLIS_AMQPS, true);
             deviceClientList.get(0).setDeviceIO(this.deviceIO);
 
             // Codes_SRS_TRANSPORTCLIENT_12_012: [The function shall set the created DeviceIO to all registered device client.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -107,7 +107,7 @@ public class IotHubTransport implements IotHubListener
      * @param defaultConfig the config used for opening connections, retrieving retry policy, and checking protocol
      * @throws IllegalArgumentException if defaultConfig is null
      */
-    public IotHubTransport(DeviceClientConfig defaultConfig, IotHubConnectionStatusChangeCallback deviceIOConnectionStatusChangeCallback) throws IllegalArgumentException
+    public IotHubTransport(DeviceClientConfig defaultConfig, IotHubConnectionStatusChangeCallback deviceIOConnectionStatusChangeCallback, boolean isMultiplexing) throws IllegalArgumentException
     {
         if (defaultConfig == null)
         {
@@ -122,7 +122,7 @@ public class IotHubTransport implements IotHubListener
         this.deviceConnectionStates.put(defaultConfig.getDeviceId(), IotHubConnectionStatus.DISCONNECTED);
         this.proxySettings = defaultConfig.getProxySettings();
         this.connectionStatus = IotHubConnectionStatus.DISCONNECTED;
-        this.isMultiplexing = false;
+        this.isMultiplexing = isMultiplexing;
 
         this.deviceIOConnectionStatusChangeCallback = deviceIOConnectionStatusChangeCallback;
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -66,7 +66,7 @@ public class DeviceIOTest
         new NonStrictExpectations()
         {
             {
-                new IotHubTransport(mockConfig, (IotHubConnectionStatusChangeCallback) any);
+                new IotHubTransport(mockConfig, (IotHubConnectionStatusChangeCallback) any, false);
                 result = mockedTransport;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -108,7 +108,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //assert
         assertEquals(DISCONNECTED, Deencapsulation.getField(transport, "connectionStatus"));
@@ -122,7 +122,7 @@ public class IotHubTransportTest
     public void constructorThrowsForNullConfig()
     {
         //act
-        IotHubTransport transport = new IotHubTransport(null, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(null, mockedIotHubConnectionStatusChangeCallback, false);
     }
 
     //Tests_SRS_IOTHUBTRANSPORT_34_004: [This function shall retrieve a packet from the inProgressPackets queue with the message id from the provided message if there is one.]
@@ -138,7 +138,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -179,7 +179,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String messageId = "1234";
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
         inProgressPackets.put(messageId, mockedPacket);
@@ -221,7 +221,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String messageId = "1234";
         final IOException nonTransportException = new IOException();
         final Map<String, IotHubTransportPacket> inProgressPackets = new ConcurrentHashMap<>();
@@ -266,7 +266,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         transport.onMessageReceived(mockedTransportMessage, null);
@@ -302,7 +302,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
@@ -343,7 +343,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -387,7 +387,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
@@ -430,7 +430,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final IOException nonTransportException = new IOException();
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
@@ -479,7 +479,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String expectedConnectionId = "1234";
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
@@ -510,7 +510,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -540,7 +540,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -563,7 +563,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -609,7 +609,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Collection<DeviceClientConfig> configs = new ArrayList<>();
         configs.add(mockedConfig);
@@ -631,7 +631,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         transport.close(null, mockedTransportException);
@@ -677,7 +677,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
@@ -725,7 +725,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, new IOException());
@@ -746,7 +746,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         new NonStrictExpectations()
         {
@@ -783,7 +783,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         new Expectations()
         {
@@ -812,7 +812,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -844,7 +844,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -877,7 +877,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         new NonStrictExpectations(IotHubTransport.class)
         {
@@ -925,7 +925,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         ((Map<String, DeviceClientConfig>) Deencapsulation.getField(transport, "deviceClientConfigs")).put("someDeviceId", mockedConfig);
         Deencapsulation.setField(transport, "iotHubTransportConnection", null);
 
@@ -973,7 +973,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         ((Map<String, DeviceClientConfig>) Deencapsulation.getField(transport, "deviceClientConfigs")).put("someDeviceId", mockedConfig);
 
         //act
@@ -1016,7 +1016,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         ((Map<String, DeviceClientConfig>) Deencapsulation.getField(transport, "deviceClientConfigs")).put("someDeviceId", mockedConfig);
 
         //act
@@ -1058,7 +1058,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         ((Map<String, DeviceClientConfig>) Deencapsulation.getField(transport, "deviceClientConfigs")).put("someDeviceId", mockedConfig);
 
         //act
@@ -1098,7 +1098,7 @@ public class IotHubTransportTest
                 result = mockedAmqpsIotHubConnection;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         ((Map<String, DeviceClientConfig>) Deencapsulation.getField(transport, "deviceClientConfigs")).put("someDeviceId", mockedConfig);
 
         //act
@@ -1134,7 +1134,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1164,7 +1164,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1193,7 +1193,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1223,7 +1223,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
         Deencapsulation.setField(transport, "inProgressPackets", inProgressPackets);
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -1248,7 +1248,7 @@ public class IotHubTransportTest
             }
         };
 
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -1276,7 +1276,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -1304,7 +1304,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -1333,7 +1333,7 @@ public class IotHubTransportTest
             }
         };
 
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
 
         //act
@@ -1352,7 +1352,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "waitingPacketsQueue", waitingPacketsQueue);
@@ -1384,7 +1384,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         waitingPacketsQueue.add(mockedPacket);
@@ -1420,7 +1420,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final int MAX_MESSAGES_TO_SEND_PER_THREAD = Deencapsulation.getField(transport, "MAX_MESSAGES_TO_SEND_PER_THREAD");
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -1451,7 +1451,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         callbackPacketsQueue.add(mockedPacket);
         callbackPacketsQueue.add(mockedPacket);
@@ -1506,7 +1506,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1552,7 +1552,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1594,7 +1594,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportMessage> receivedMessagesQueue = new ConcurrentLinkedQueue<>();
         receivedMessagesQueue.add(mockedTransportMessage);
@@ -1621,7 +1621,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         transport.registerConnectionStateCallback(null, new Object());
@@ -1639,7 +1639,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final Object context = new Object();
 
         //act
@@ -1662,7 +1662,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         transport.registerConnectionStatusChangeCallback(null, new Object(), "someString");
@@ -1681,7 +1681,7 @@ public class IotHubTransportTest
             }
         };
 
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         transport.registerConnectionStatusChangeCallback(null, null, "someDeviceId");
@@ -1702,7 +1702,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1745,7 +1745,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final Object context = new Object();
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
         new Expectations()
@@ -1796,7 +1796,7 @@ public class IotHubTransportTest
             }
         };
 
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
 
         //act
@@ -1855,7 +1855,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "handleDisconnection", mockedTransportException);
@@ -1889,7 +1889,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations()
@@ -1920,7 +1920,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedIotHubTransportConnection);
 
         new Expectations(IotHubTransport.class)
@@ -1970,7 +1970,7 @@ public class IotHubTransportTest
                 result = deviceId;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         final long expectedDelay = 0;
         final long duration = 0;
@@ -2034,7 +2034,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -2096,7 +2096,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -2159,7 +2159,7 @@ public class IotHubTransportTest
                 result = deviceId;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final long expectedDelay = 0;
         Deencapsulation.setField(transport, "taskScheduler", mockedTaskScheduler);
         new NonStrictExpectations()
@@ -2238,7 +2238,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new Expectations()
         {
@@ -2296,7 +2296,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
 
         //act
@@ -2343,7 +2343,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
 
         //act
@@ -2398,7 +2398,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", DISCONNECTED_RETRYING);
         new NonStrictExpectations()
         {
@@ -2437,7 +2437,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2483,7 +2483,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations(IotHubTransport.class)
         {
             {
@@ -2547,7 +2547,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2598,7 +2598,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
 
         //act
@@ -2625,7 +2625,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.CONNECTED);
         new Expectations(IotHubTransport.class)
         {
@@ -2670,7 +2670,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Deencapsulation.setField(transport, "connectionStatus", IotHubConnectionStatus.DISCONNECTED_RETRYING);
 
         //act
@@ -2696,7 +2696,7 @@ public class IotHubTransportTest
                 result = deviceId;
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         transport.registerConnectionStatusChangeCallback(mockedIotHubConnectionStatusChangeCallback, null, deviceId);
 
         //act
@@ -2730,7 +2730,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         final String deviceId = "someDevice";
         transport.registerConnectionStatusChangeCallback(null, null, deviceId);
 
@@ -2766,7 +2766,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2796,7 +2796,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2826,7 +2826,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2856,7 +2856,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2886,7 +2886,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         new NonStrictExpectations()
         {
             {
@@ -2925,7 +2925,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -2964,7 +2964,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -3003,7 +3003,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -3041,7 +3041,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -3077,7 +3077,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "checkForUnauthorizedException", testException);
@@ -3106,7 +3106,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -3156,7 +3156,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Deencapsulation.setField(transport, "inProgressPackets", inProgressMessages);
         Deencapsulation.setField(transport, "iotHubTransportConnection", mockedHttpsIotHubConnection);
@@ -3195,7 +3195,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -3254,7 +3254,7 @@ public class IotHubTransportTest
             }
         };
 
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -3307,7 +3307,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(transport, "callbackPacketsQueue", callbackPacketsQueue);
@@ -3349,7 +3349,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
         //act
         Deencapsulation.invoke(transport, "handleMessageException", new Class[] {IotHubTransportPacket.class, TransportException.class}, mockedPacket, new AmqpConnectionThrottledException());
@@ -3375,7 +3375,7 @@ public class IotHubTransportTest
                 result = "someDeviceId";
             }
         };
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
@@ -3423,7 +3423,7 @@ public class IotHubTransportTest
             }
         };
 
-        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback);
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
         Map<String, IotHubTransportPacket> inProgressMessages = new HashMap<>();
         Queue<IotHubTransportPacket> callbackPacketsQueue = new ConcurrentLinkedQueue<>();
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -1053,7 +1053,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getProtocol();
                 result = IotHubClientProtocol.AMQPS;
-                new AmqpsIotHubConnection(mockedConfig);
+                new AmqpsIotHubConnection(mockedConfig, false);
                 result = mockedAmqpsIotHubConnection;
             }
         };
@@ -1094,7 +1094,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getProtocol();
                 result = IotHubClientProtocol.AMQPS_WS;
-                new AmqpsIotHubConnection(mockedConfig);
+                new AmqpsIotHubConnection(mockedConfig, false);
                 result = mockedAmqpsIotHubConnection;
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -280,7 +280,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         Set<DeviceClientConfig> deviceClientConfigs = Deencapsulation.getField(connection, "deviceClientConfigs");
         DeviceClientConfig actualConfig = deviceClientConfigs.iterator().next();
@@ -315,7 +315,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         //act
         connection.open();
@@ -343,7 +343,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         // act
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         // assert
         String actualHostName = Deencapsulation.getField(connection, "hostName");
@@ -372,7 +372,7 @@ public class AmqpsIotHubConnectionTest {
         };
 
         // act
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         // assert
         String actualHostName = Deencapsulation.getField(connection, "hostName");
@@ -385,7 +385,7 @@ public class AmqpsIotHubConnectionTest {
     {
         baseExpectations();
 
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
 
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
@@ -410,7 +410,7 @@ public class AmqpsIotHubConnectionTest {
         final CountDownLatch authLatch = new CountDownLatch(0);
         final CountDownLatch workerLinkLatch = new CountDownLatch(0);
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
 
         new Expectations()
@@ -437,7 +437,7 @@ public class AmqpsIotHubConnectionTest {
         final CountDownLatch authLatch = new CountDownLatch(0);
         final CountDownLatch workerLinkLatch = new CountDownLatch(0);
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
 
         new Expectations()
@@ -462,7 +462,7 @@ public class AmqpsIotHubConnectionTest {
         // arrange
         baseExpectations();
 
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         new NonStrictExpectations()
         {
@@ -495,7 +495,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
         setLatches(connection);
 
@@ -538,7 +538,7 @@ public class AmqpsIotHubConnectionTest {
                 result = true;
             }
         };
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
         setLatches(connection);
 
@@ -559,7 +559,7 @@ public class AmqpsIotHubConnectionTest {
     {
         baseExpectations();
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "connection", mockConnection);
         Deencapsulation.setField(connection, "reactor", mockReactor);
 
@@ -592,7 +592,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         Deencapsulation.setField(connection, "reactor", mockReactor);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
@@ -630,7 +630,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
         Deencapsulation.setField(connection, "executorService", mockExecutorService);
@@ -686,7 +686,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Queue<AmqpsSessionHandler> amqpsSessionHandlerList = new ConcurrentLinkedQueue<>();
         amqpsSessionHandlerList.add(mockAmqpsSessionHandler);
         Deencapsulation.setField(connection, "sessionHandlers", amqpsSessionHandlerList);
@@ -734,7 +734,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         connection.onReactorInit(mockEvent);
 
@@ -769,7 +769,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         connection.onReactorInit(mockEvent);
 
@@ -804,7 +804,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         connection.onReactorInit(mockEvent);
 
@@ -838,7 +838,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         this.setLatches(connection);
         Deencapsulation.setField(connection, "connection", mockConnection);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.DISCONNECTED);
@@ -884,7 +884,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         this.setLatches(connection);
         Deencapsulation.setField(connection, "connection", mockConnection);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.DISCONNECTED);
@@ -928,7 +928,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.onConnectionInit(mockEvent);
 
         new Verifications()
@@ -967,7 +967,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "amqpsCbsSessionHandler", mockAmqpsCbsSessionHandler);
 
         connection.onConnectionBound(mockEvent);
@@ -987,7 +987,7 @@ public class AmqpsIotHubConnectionTest {
     {
         // arrange
         baseExpectations();
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         
         // act
         connection.setListener(mockedIotHubListener);
@@ -1011,7 +1011,7 @@ public class AmqpsIotHubConnectionTest {
             }
         };
         baseExpectations();
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         connection.setListener(mockedIotHubListener);
         new NonStrictExpectations()
         {
@@ -1041,7 +1041,7 @@ public class AmqpsIotHubConnectionTest {
     {
         //arrange
         baseExpectations();
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.CONNECTED);
 
         //act
@@ -1068,7 +1068,7 @@ public class AmqpsIotHubConnectionTest {
     {
         //arrange
         baseExpectations();
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "state", IotHubConnectionStatus.DISCONNECTED);
 
         //act
@@ -1096,7 +1096,7 @@ public class AmqpsIotHubConnectionTest {
         Queue<com.microsoft.azure.sdk.iot.device.Message> messagesToSend = new ConcurrentLinkedQueue<>();
         baseExpectations();
 
-        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
 
         Deencapsulation.setField(connection, "messagesToSend", messagesToSend);
 
@@ -1114,7 +1114,7 @@ public class AmqpsIotHubConnectionTest {
         //arrange
         String expectedConnectionId = "1234";
         baseExpectations();
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "connectionId", expectedConnectionId);
 
         //act
@@ -1128,7 +1128,7 @@ public class AmqpsIotHubConnectionTest {
     public void onMessageAcknowledgedAccepted()
     {
         // arrange
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         new Expectations()
@@ -1146,7 +1146,7 @@ public class AmqpsIotHubConnectionTest {
     public void onMessageAcknowledgedReleased()
     {
         // arrange
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         new Expectations()
@@ -1169,7 +1169,7 @@ public class AmqpsIotHubConnectionTest {
     public void onMessageAcknowledgedRejected(@Mocked final Rejected mockRejected)
     {
         // arrange
-        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig);
+        AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
         Deencapsulation.setField(connection, "listener", mockedIotHubListener);
 
         new Expectations()

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1078,6 +1078,8 @@ public class MultiplexingClientTests extends IntegrationTest
     public void multiplexedConnectionRecoversFromDeviceSessionDropsSequential() throws Exception
     {
         testInstance.setup(DEVICE_MULTIPLEX_COUNT);
+        ConnectionStatusChangeTracker multiplexedConnectionStatusChangeTracker = new ConnectionStatusChangeTracker();
+        testInstance.multiplexingClient.registerConnectionStatusChangeCallback(multiplexedConnectionStatusChangeTracker, null);
         ConnectionStatusChangeTracker[] connectionStatusChangeTrackers = new ConnectionStatusChangeTracker[DEVICE_MULTIPLEX_COUNT];
 
         for (int i = 0; i < DEVICE_MULTIPLEX_COUNT; i++)
@@ -1120,6 +1122,8 @@ public class MultiplexingClientTests extends IntegrationTest
 
         // double check that the recovery of any particular device did not cause a device earlier in the array to lose connection
         testSendingMessagesFromMultiplexedClients(testInstance.deviceClientArray);
+
+        assertFalse(multiplexedConnectionStatusChangeTracker.wentDisconnectedRetrying);
 
         testInstance.multiplexingClient.close();
 


### PR DESCRIPTION
A multiplexed connection shouldn't drop just because one of its devices dropped its session, even if that is the only session.

#1187