### PR TITLE
feat(service-client): Add support for user defined msi in import export jobs.

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/JobPropertiesParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/JobPropertiesParser.java
@@ -71,6 +71,11 @@ public class JobPropertiesParser
     @SerializedName(STORAGE_AUTHENTICATION_TYPE)
     private StorageAuthenticationType storageAuthenticationType;
 
+    private static final String IDENTITY = "identity";
+    @Expose
+    @SerializedName(IDENTITY)
+    private ManagedIdentity identity;
+
     /**
      * Empty constructor: Used only to keep GSON happy.
      */
@@ -119,6 +124,7 @@ public class JobPropertiesParser
         this.outputBlobContainerUri = parser.outputBlobContainerUri;
         this.failureReason = parser.failureReason;
         this.storageAuthenticationType = parser.storageAuthenticationType;
+        this.identity  = parser.identity;
 
         if (parser.endTimeUtcString != null)
         {
@@ -314,6 +320,15 @@ public class JobPropertiesParser
     }
 
     /**
+     * Getter for identity
+     *
+     * @return The managed identity used to access the storage account for import and export jobs.
+     */
+    public ManagedIdentity getIdentity() {
+        return identity;
+    }
+
+    /**
      * Setter for StartTimeUtc
      *
      * @param startTimeUtc the value to set StartTimeUtc to
@@ -428,5 +443,15 @@ public class JobPropertiesParser
     {
         //Codes_SRS_JOB_PROPERTIES_PARSER_34_029: [This method shall set the value of this object's failureReason equal to the provided value.]
         this.failureReason = failureReason;
+    }
+
+    /**
+     * Setter for identity
+     *
+     * @param identity the managed identity used to access the storage account for import and export jobs.
+     */
+    public void setIdentity(ManagedIdentity identity)
+    {
+        this.identity = identity;
     }
 }

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ManagedIdentity.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ManagedIdentity.java
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.microsoft.azure.sdk.iot.deps.serializer;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ManagedIdentity {
+    /**
+     * The managed identity used to access the storage account for IoT hub import and export jobs.
+     * For more information, see TODO
+     */
+    @Setter
+    @Getter
+    public String userAssignedIdentity;
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/JobProperties.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/JobProperties.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.sdk.iot.service;
 
 import com.microsoft.azure.sdk.iot.deps.serializer.JobPropertiesParser;
+import com.microsoft.azure.sdk.iot.deps.serializer.ManagedIdentity;
 import com.microsoft.azure.sdk.iot.deps.serializer.StorageAuthenticationType;
 
 import java.util.Date;
@@ -206,6 +207,22 @@ public class JobProperties
         this.excludeKeysInExport = excludeKeysInExport;
     }
 
+    /**
+     * @return The managed identity used to access the storage account for import and export jobs.
+     * For more information, see TODO
+     */
+    public ManagedIdentity getIdentity() {
+        return identity;
+    }
+
+    /**
+     * @param identity The managed identity used to access the storage account for import and export jobs.
+     * For more information, see TODOe
+     */
+    public void setIdentity(ManagedIdentity identity) {
+        this.identity = identity;
+    }
+
     public enum JobStatus
     {
         UNKNOWN,
@@ -237,6 +254,7 @@ public class JobProperties
     private boolean excludeKeysInExport;
     private String failureReason;
     private StorageAuthenticationType storageAuthenticationType;
+    private ManagedIdentity identity;
 
     /**
      * Constructs a new JobProperties object using a JobPropertiesParser object
@@ -254,6 +272,7 @@ public class JobProperties
         this.jobId = parser.getJobIdFinal();
         this.progress = parser.getProgress();
         this.startTimeUtc = parser.getStartTimeUtc();
+        this.identity = parser.getIdentity();
 
         if (parser.getStatus() != null)
         {
@@ -283,6 +302,7 @@ public class JobProperties
         jobPropertiesParser.setJobId(this.jobId);
         jobPropertiesParser.setProgress(this.progress);
         jobPropertiesParser.setStartTimeUtc(this.startTimeUtc);
+        jobPropertiesParser.setIdentity(this.identity);
         if (this.status != null)
         {
             jobPropertiesParser.setStatus(this.status.toString());
@@ -337,6 +357,32 @@ public class JobProperties
     }
 
     /**
+     * Creates an instance of JobProperties with parameters ready to start an Import job
+     *
+     * @param inputBlobContainerUri URI to a blob container that contains registry data to sync.
+     *                              Including a SAS token is dependent on the StorageAuthenticationType
+     * @param outputBlobContainerUri URI to a blob container. This is used to output the status of the job and the results.
+     *                               Including a SAS token is dependent on the StorageAuthenticationType
+     * @param storageAuthenticationType Specifies authentication type being used for connecting to storage account
+     * @param identity the managed identity used to access the storage account for import jobs.
+     * @return An instance of JobProperties
+     */
+    public static JobProperties createForImportJob(
+            String inputBlobContainerUri,
+            String outputBlobContainerUri,
+            StorageAuthenticationType storageAuthenticationType,
+            ManagedIdentity identity)
+    {
+        JobProperties importJobProperties = new JobProperties();
+        importJobProperties.setType(JobProperties.JobType.IMPORT);
+        importJobProperties.setInputBlobContainerUri(inputBlobContainerUri);
+        importJobProperties.setOutputBlobContainerUri(outputBlobContainerUri);
+        importJobProperties.setStorageAuthenticationType(storageAuthenticationType);
+        importJobProperties.setIdentity(identity);
+        return importJobProperties;
+    }
+
+    /**
      * Creates an instance of JobProperties with parameters ready to start an Export job
      *
      * @param outputBlobContainerUri URI to a blob container. This is used to output the status of the job and the results.
@@ -371,6 +417,31 @@ public class JobProperties
         exportJobProperties.setOutputBlobContainerUri(outputBlobContainerUri);
         exportJobProperties.setExcludeKeysInExport(excludeKeysInExport);
         exportJobProperties.setStorageAuthenticationType(storageAuthenticationType);
+        return exportJobProperties;
+    }
+
+    /**
+     * Creates an instance of JobProperties with parameters ready to start an Export job
+     *
+     * @param outputBlobContainerUri URI to a blob container. This is used to output the status of the job and the results.
+     *                               Including a SAS token is dependent on the StorageAuthenticationType
+     * @param excludeKeysInExport Indicates if authorization keys are included in export output
+     * @param storageAuthenticationType Specifies authentication type being used for connecting to storage account
+     * @param identity the managed identity used to access the storage account for export jobs.
+     * @return An instance of JobProperties
+     */
+    public static JobProperties createForExportJob(
+            String outputBlobContainerUri,
+            Boolean excludeKeysInExport,
+            StorageAuthenticationType storageAuthenticationType,
+            ManagedIdentity identity)
+    {
+        JobProperties exportJobProperties = new JobProperties();
+        exportJobProperties.setType(JobProperties.JobType.EXPORT);
+        exportJobProperties.setOutputBlobContainerUri(outputBlobContainerUri);
+        exportJobProperties.setExcludeKeysInExport(excludeKeysInExport);
+        exportJobProperties.setStorageAuthenticationType(storageAuthenticationType);
+        exportJobProperties.setIdentity(identity);
         return exportJobProperties;
     }
 }

--- a/service/iot-service-samples/device-manager-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceManagerImportExportWithIdentitySample.java
+++ b/service/iot-service-samples/device-manager-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceManagerImportExportWithIdentitySample.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.deps.serializer.ManagedIdentity;
+import com.microsoft.azure.sdk.iot.deps.serializer.StorageAuthenticationType;
+import com.microsoft.azure.sdk.iot.service.JobProperties;
+import com.microsoft.azure.sdk.iot.service.RegistryManager;
+import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import java.io.IOException;
+
+/* A sample to illustrate how to perform import and export jobs using managed identity to access the storage account.
+    This sample will copy all the devices in the source hub to the destination hub.
+    For this sample to succeed, the managed identity should be configured to access the storage account used for import and export.
+    For more information on configuration, see TODO <see href=""/>.
+    For more information on managed identities, see <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview"/>
+ */
+public class DeviceManagerImportExportWithIdentitySample {
+    private static final String sourceHubConnectionString  = System.getenv("SOURCE_IOTHUB_CONNECTION_STRING");
+    private static final String destinationHubConnectionString  = System.getenv("DESTINATION_IOTHUB_CONNECTION_STRING");
+    private static final String blobContainerUri  = System.getenv("BLOB_CONTAINER_URI");
+    private static final String userDefinedManagedIdentityResourceId  = System.getenv("USER_DEFINED_MSI_RESOURCE_ID");
+
+    public static void main(String[] args) throws IOException, IotHubException, InterruptedException
+    {
+        System.out.println("Exporting devices from source hub to " + blobContainerUri + "/devices.txt.");
+        ExportDevices();
+        System.out.println("Exporting devices completed.");
+
+        System.out.println("Importing devices from " + blobContainerUri + "/devices.txt to destination hub.");
+        ImportDevices();
+        System.out.println("Importing devices completed.");
+    }
+
+    public static void ExportDevices() throws IOException, IotHubException, InterruptedException {
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(sourceHubConnectionString);
+
+        // If StorageAuthenticationType is set to IdentityBased and userAssignedIdentity property is
+        // not null, the jobs will use user defined managed identity. If the IoT hub is not
+        // configured with the user defined managed identity specified in userAssignedIdentity,
+        // the job will fail.
+        // If StorageAuthenticationType is set to IdentityBased the userAssignedIdentity property is
+        // null, the jobs will use system defined identity. If the IoT hub is not configured with the
+        // user defined managed identity, the job will fail.
+        // If StorageAuthenticationType is set to IdentityBased and neither user defined nor system defined
+        // managed identities are configured on the hub, the job will fail.
+        ManagedIdentity identity = new ManagedIdentity();
+        identity.setUserAssignedIdentity(userDefinedManagedIdentityResourceId);
+
+        JobProperties jobProperties = new JobProperties();
+        jobProperties.setOutputBlobContainerUri(blobContainerUri);
+        jobProperties.setStorageAuthenticationType(StorageAuthenticationType.IDENTITY);
+        jobProperties.setIdentity(identity);
+
+        JobProperties exportJob = registryManager.exportDevices(jobProperties);
+
+        while(true)
+        {
+            exportJob = registryManager.getJob(exportJob.getJobId());
+            if (exportJob.getStatus() == JobProperties.JobStatus.COMPLETED)
+            {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
+        registryManager.close();
+    }
+
+    public static void ImportDevices() throws IOException, IotHubException, InterruptedException {
+        RegistryManager registryManager = RegistryManager.createFromConnectionString(destinationHubConnectionString);
+
+        // If StorageAuthenticationType is set to IdentityBased and userAssignedIdentity property is
+        // not null, the jobs will use user defined managed identity. If the IoT hub is not
+        // configured with the user defined managed identity specified in userAssignedIdentity,
+        // the job will fail.
+        // If StorageAuthenticationType is set to IdentityBased the userAssignedIdentity property is
+        // null, the jobs will use system defined identity. If the IoT hub is not configured with the
+        // user defined managed identity, the job will fail.
+        // If StorageAuthenticationType is set to IdentityBased and neither user defined nor system defined
+        // managed identities are configured on the hub, the job will fail.
+        ManagedIdentity identity = new ManagedIdentity();
+        identity.setUserAssignedIdentity(userDefinedManagedIdentityResourceId);
+
+        JobProperties jobProperties = new JobProperties();
+        jobProperties.setOutputBlobContainerUri(blobContainerUri);
+        jobProperties.setInputBlobContainerUri(blobContainerUri);
+        jobProperties.setStorageAuthenticationType(StorageAuthenticationType.IDENTITY);
+        jobProperties.setIdentity(identity);
+
+        JobProperties exportJob = registryManager.importDevices(jobProperties);
+
+        while(true)
+        {
+            exportJob = registryManager.getJob(exportJob.getJobId());
+            if (exportJob.getStatus() == JobProperties.JobStatus.COMPLETED)
+            {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
+        registryManager.close();
+    }
+}


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

The JobProperties can now have a new property called 'identity'. If we pass the correct identity in the import/export jobs, the IoThub will use it internally to interact with the storage account to do things like upload devices.txt. From the SDK's perspective, we support this new property and the capability to use it in import and export jobs.
This PR has:
* Adding the new identity property to job properties
* Sample to show the usage of this in import and export jobs

This PR is against a feature branch. There are no gates enabled yet because the feature is only available on a whitelisted subscription. 