### PR TITLE
fix some javadocs

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -115,7 +115,6 @@ public class RegistryManager
      * Constructor to create instance from connection string
      *
      * @param connectionString The iot hub connection string
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String connectionString)
     {
@@ -131,7 +130,6 @@ public class RegistryManager
      *
      * @param connectionString The iot hub connection string
      * @param options The connection options to use when connecting to the service.
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String connectionString, RegistryManagerOptions options)
     {
@@ -159,7 +157,6 @@ public class RegistryManager
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String hostName, TokenCredential credential)
     {
@@ -173,7 +170,6 @@ public class RegistryManager
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param options The connection options to use when connecting to the service.
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String hostName, TokenCredential credential, RegistryManagerOptions options)
     {
@@ -195,7 +191,6 @@ public class RegistryManager
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String hostName, AzureSasCredential azureSasCredential)
     {
@@ -208,7 +203,6 @@ public class RegistryManager
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The connection options to use when connecting to the service.
-     * @return The instance of RegistryManager
      */
     public RegistryManager(String hostName, AzureSasCredential azureSasCredential, RegistryManagerOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -80,7 +80,6 @@ public class ServiceClient
      * Create ServiceClient from the specified connection string
      * @param iotHubServiceClientProtocol  protocol to use
      * @param connectionString The connection string for the IotHub
-     * @return The created ServiceClient object
      */
     public ServiceClient(String connectionString, IotHubServiceClientProtocol iotHubServiceClientProtocol)
     {
@@ -92,7 +91,6 @@ public class ServiceClient
      * @param iotHubServiceClientProtocol  protocol to use
      * @param connectionString The connection string for the IotHub
      * @param options The connection options to use when connecting to the service.
-     * @return The created ServiceClient object
      */
     public ServiceClient(
             String connectionString,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -134,7 +134,6 @@ public class ServiceClient
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param iotHubServiceClientProtocol The protocol to open the connection with.
-     * @return The created {@link ServiceClient} instance.
      */
     public ServiceClient(
             String hostName,
@@ -156,7 +155,6 @@ public class ServiceClient
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param iotHubServiceClientProtocol The protocol to open the connection with.
      * @param options The connection options to use when connecting to the service.
-     * @return The created {@link ServiceClient} instance.
      */
     public ServiceClient(
             String hostName,
@@ -201,7 +199,6 @@ public class ServiceClient
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param iotHubServiceClientProtocol The protocol to open the connection with.
-     * @return The created {@link ServiceClient} instance.
      */
     public ServiceClient(
             String hostName,
@@ -221,7 +218,6 @@ public class ServiceClient
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param iotHubServiceClientProtocol The protocol to open the connection with.
      * @param options The connection options to use when connecting to the service.
-     * @return The created {@link ServiceClient} instance.
      */
     public ServiceClient(
             String hostName,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -91,7 +91,6 @@ public class DeviceMethod
      * Create a DeviceMethod instance from the information in the connection string.
      *
      * @param connectionString is the IoTHub connection string.
-     * @return an instance of the DeviceMethod.
      */
     public DeviceMethod(String connectionString)
     {
@@ -107,7 +106,6 @@ public class DeviceMethod
      *
      * @param connectionString is the IoTHub connection string.
      * @param options the configurable options for each operation on this client. May not be null.
-     * @return an instance of the DeviceMethod.
      */
     public DeviceMethod(String connectionString, DeviceMethodClientOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -126,7 +126,6 @@ public class DeviceMethod
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed. The provided tokens must be Json Web Tokens.
-     * @return the new DeviceMethod instance.
      */
     public DeviceMethod(String hostName, TokenCredential credential)
     {
@@ -140,7 +139,6 @@ public class DeviceMethod
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param options The connection options to use when connecting to the service.
-     * @return the new DeviceMethod instance.
      */
     public DeviceMethod(String hostName, TokenCredential credential, DeviceMethodClientOptions options)
     {
@@ -161,7 +159,6 @@ public class DeviceMethod
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return the new DeviceMethod instance.
      */
     public DeviceMethod(String hostName, AzureSasCredential azureSasCredential)
     {
@@ -174,7 +171,6 @@ public class DeviceMethod
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The connection options to use when connecting to the service.
-     * @return the new DeviceMethod instance.
      */
     public DeviceMethod(String hostName, AzureSasCredential azureSasCredential, DeviceMethodClientOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -123,7 +123,6 @@ public class DeviceTwin
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
-     * @return the new DeviceTwin instance.
      */
     public DeviceTwin(String hostName, TokenCredential credential)
     {
@@ -137,7 +136,6 @@ public class DeviceTwin
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param options The connection options to use when connecting to the service.
-     * @return the new DeviceTwin instance.
      */
     public DeviceTwin(String hostName, TokenCredential credential, DeviceTwinClientOptions options)
     {
@@ -158,7 +156,6 @@ public class DeviceTwin
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return the new DeviceTwin instance.
      */
     public DeviceTwin(String hostName, AzureSasCredential azureSasCredential)
     {
@@ -171,7 +168,6 @@ public class DeviceTwin
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The connection options to use when connecting to the service.
-     * @return the new DeviceTwin instance.
      */
     public DeviceTwin(String hostName, AzureSasCredential azureSasCredential, DeviceTwinClientOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -87,7 +87,6 @@ public class DeviceTwin
      * Constructor to create instance from connection string.
      *
      * @param connectionString The iot hub connection string.
-     * @return The instance of DeviceTwin.
      */
     public DeviceTwin(String connectionString)
     {
@@ -103,7 +102,6 @@ public class DeviceTwin
      *
      * @param connectionString The iot hub connection string.
      * @param options the configurable options for each operation on this client. May not be null.
-     * @return The instance of DeviceTwin.
      */
     public DeviceTwin(String connectionString, DeviceTwinClientOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -57,7 +57,6 @@ public class RawTwinQuery
      * Constructor to create instance from connection string
      *
      * @param connectionString The iot hub connection string
-     * @return The instance of RawTwinQuery
      */
     public RawTwinQuery(String connectionString)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -56,7 +56,6 @@ public class DigitalTwinAsyncClient {
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      *
      * @param connectionString The IoTHub connection string
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String connectionString) {
         this(connectionString,
@@ -71,7 +70,6 @@ public class DigitalTwinAsyncClient {
      *
      * @param connectionString The IoTHub connection string
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String connectionString, DigitalTwinClientOptions options) {
         Objects.requireNonNull(options);
@@ -111,7 +109,6 @@ public class DigitalTwinAsyncClient {
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed.
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, TokenCredential credential) {
         this(hostName,
@@ -129,7 +126,6 @@ public class DigitalTwinAsyncClient {
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed.
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, TokenCredential credential, DigitalTwinClientOptions options) {
         Objects.requireNonNull(options);
@@ -168,7 +164,6 @@ public class DigitalTwinAsyncClient {
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential) {
         this(hostName,
@@ -185,7 +180,6 @@ public class DigitalTwinAsyncClient {
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinAsyncClient.
      */
     public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential, DigitalTwinClientOptions options) {
         Objects.requireNonNull(options);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -80,6 +80,7 @@ public class DigitalTwinClient {
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
+     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential) {
         this(hostName,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -29,7 +29,6 @@ public class DigitalTwinClient {
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      * @param connectionString The IoT Hub connection string
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String connectionString) {
         this(connectionString,
@@ -43,7 +42,6 @@ public class DigitalTwinClient {
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      * @param connectionString The IoT Hub connection string
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String connectionString, DigitalTwinClientOptions options) {
         digitalTwinAsyncClient = new DigitalTwinAsyncClient(connectionString, options);
@@ -55,7 +53,6 @@ public class DigitalTwinClient {
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, TokenCredential credential) {
         this(hostName,
@@ -73,7 +70,6 @@ public class DigitalTwinClient {
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed.
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, TokenCredential credential, DigitalTwinClientOptions options) {
         digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, credential, options);
@@ -84,7 +80,6 @@ public class DigitalTwinClient {
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential) {
         this(hostName,
@@ -101,7 +96,6 @@ public class DigitalTwinClient {
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The optional settings for this client. May not be null.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential, DigitalTwinClientOptions options) {
         digitalTwinAsyncClient = new DigitalTwinAsyncClient(hostName, azureSasCredential, options);
@@ -110,7 +104,6 @@ public class DigitalTwinClient {
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      * @param connectionString The IoT Hub connection string
-     * @return The instantiated DigitalTwinClient.
      */
     public static DigitalTwinClient createFromConnectionString(String connectionString)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -80,7 +80,6 @@ public class DigitalTwinClient {
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return The instantiated DigitalTwinClient.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential) {
         this(hostName,
@@ -105,6 +104,7 @@ public class DigitalTwinClient {
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
      * @param connectionString The IoT Hub connection string
+     * @return The instantiated DigitalTwinClient.
      */
     public static DigitalTwinClient createFromConnectionString(String connectionString)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/models/DigitalTwinInvokeCommandRequestOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/models/DigitalTwinInvokeCommandRequestOptions.java
@@ -22,6 +22,7 @@ public final class DigitalTwinInvokeCommandRequestOptions {
 
     /**
      * Sets the time (in seconds) that the service waits for the device to come online.
+     * @return The number of seconds before connect timeouts occur for this request.
      */
     public Integer getConnectTimeoutInSeconds()
     {
@@ -31,6 +32,8 @@ public final class DigitalTwinInvokeCommandRequestOptions {
     /**
      * Sets the time (in seconds) that the service waits for the device to come online.
      * The default is 0 seconds (which means the device must already be online) and the maximum is 300 seconds.
+     *
+     * @param connectTimeoutInSeconds The number of seconds before connect timeouts occur for this request.
      */
     public void setConnectTimeoutInSeconds(Integer connectTimeoutInSeconds)
     {
@@ -39,6 +42,8 @@ public final class DigitalTwinInvokeCommandRequestOptions {
 
     /**
      * Gets the time (in seconds) that the service waits for the method invocation to return a response.
+     *
+     * @return The number of seconds before resposne timeouts occur for this request.
      */
     public Integer getResponseTimeoutInSeconds()
     {
@@ -48,6 +53,8 @@ public final class DigitalTwinInvokeCommandRequestOptions {
     /**
      * Sets the time (in seconds) that the service waits for the method invocation to return a response.
      * The default is 30 seconds, minimum is 5 seconds, and maximum is 300 seconds.
+     *
+     * @param responseTimeoutInSeconds The number of seconds before response timeouts occur for this request.
      */
     public void setResponseTimeoutInSeconds(Integer responseTimeoutInSeconds)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -65,7 +65,6 @@ public class JobClient
      * Constructor to create instance from connection string
      *
      * @param connectionString The iot hub connection string
-     * @return The instance of JobClient
      */
     public JobClient(String connectionString)
     {
@@ -80,7 +79,6 @@ public class JobClient
      *
      * @param connectionString The iot hub connection string
      * @param options The connection options to use when connecting to the service.
-     * @return The instance of JobClient
      */
     public JobClient(String connectionString, JobClientOptions options)
     {
@@ -101,7 +99,6 @@ public class JobClient
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed. The provided tokens must be Json Web Tokens.
-     * @return The new JobClient instance.
      */
     public JobClient(String hostName, TokenCredential credential)
     {
@@ -118,7 +115,6 @@ public class JobClient
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      * this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param options The connection options to use when connecting to the service.
-     * @return The new JobClient instance.
      */
     public JobClient(String hostName, TokenCredential credential, JobClientOptions options)
     {
@@ -140,7 +136,6 @@ public class JobClient
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
-     * @return The new JobClient instance.
      */
     public JobClient(String hostName, AzureSasCredential azureSasCredential)
     {
@@ -156,7 +151,6 @@ public class JobClient
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      * @param options The connection options to use when connecting to the service.
-     * @return The new JobClient instance.
      */
     public JobClient(String hostName, AzureSasCredential azureSasCredential, JobClientOptions options)
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
@@ -78,6 +78,7 @@ public class AmqpSend
      * @param sasToken The SAS token string
      * @param iotHubServiceClientProtocol protocol to use
      * @param proxyOptions the proxy options to tunnel through, if a proxy should be used.
+     * @param sslContext the custom SSL context to open the connection with.
      */
     public AmqpSend(
             String hostName,


### PR DESCRIPTION
Constructors shouldn't use the (at)returns since they always return the created instance. Several methods were missing (at)params or (at)returns statements as well