### PR TITLE
fix(iot-dev): Fix bug where transport layer treated multiplexed connections with one or fewer devices as a non-multiplexed connection

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1238,7 +1238,7 @@ public class IotHubTransport implements IotHubListener
             reconnectionAttempts++;
 
             RetryPolicy retryPolicy;
-            if (this.deviceClientConfigs.size() != 1)
+            if (isMultiplexing)
             {
                 retryPolicy = multiplexingRetryPolicy;
             }
@@ -1560,7 +1560,7 @@ public class IotHubTransport implements IotHubListener
             log.debug("Invoking connection status callbacks with new status details");
             invokeConnectionStateCallback(newConnectionStatus, reason);
 
-            if (deviceClientConfigs.size() < 2 || newConnectionStatus != IotHubConnectionStatus.CONNECTED)
+            if (!isMultiplexing || newConnectionStatus != IotHubConnectionStatus.CONNECTED)
             {
                 // When multiplexing, a different method will notify each device-specific callback when that device is online,
                 // but in cases when the tcp connection is lost and everything is disconnected retrying or disconnected, this is where the
@@ -1574,7 +1574,7 @@ public class IotHubTransport implements IotHubListener
             }
 
             // If multiplexing, fire the multiplexing state callback as long as it was set.
-            if (deviceClientConfigs.size() > 1 && this.multiplexingStateCallback != null)
+            if (isMultiplexing && this.multiplexingStateCallback != null)
             {
                 this.multiplexingStateCallback.execute(newConnectionStatus, reason, throwable, this.multiplexingStateCallbackContext);
             }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -252,16 +252,22 @@ public class MultiplexingClientTests extends IntegrationTest
     @Test
     public void connectionStatusCallbackExecutedWithNoDevices() throws Exception
     {
+        // Even with no devices registered to a multiplexed connection, the connection status callback should execute
+        // when the multiplexed connection opens and closes.
         testInstance.setup(0);
         ConnectionStatusChangeTracker connectionStatusChangeTracker = new ConnectionStatusChangeTracker();
         testInstance.multiplexingClient.registerConnectionStatusChangeCallback(connectionStatusChangeTracker, null);
         testInstance.multiplexingClient.open();
 
-        assertTrue(connectionStatusChangeTracker.isOpen);
+        assertTrue(
+            "Connection status callback never executed with CONNECTED status after opening multiplexing client with no devices registered",
+            connectionStatusChangeTracker.isOpen);
 
         testInstance.multiplexingClient.close();
-        assertFalse(connectionStatusChangeTracker.isOpen);
-        assertTrue(connectionStatusChangeTracker.clientClosedGracefully);
+
+        assertTrue(
+            "Connection status callback never executed with DISCONNECTED status and CLIENT_CLOSED reason.",
+            connectionStatusChangeTracker.clientClosedGracefully);
     }
 
     // MultiplexingClient should be able to open an AMQP connection to IoTHub with no device sessions, and should

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -249,6 +249,21 @@ public class MultiplexingClientTests extends IntegrationTest
         testInstance.multiplexingClient.close();
     }
 
+    @Test
+    public void connectionStatusCallbackExecutedWithNoDevices() throws Exception
+    {
+        testInstance.setup(0);
+        ConnectionStatusChangeTracker connectionStatusChangeTracker = new ConnectionStatusChangeTracker();
+        testInstance.multiplexingClient.registerConnectionStatusChangeCallback(connectionStatusChangeTracker, null);
+        testInstance.multiplexingClient.open();
+
+        assertTrue(connectionStatusChangeTracker.isOpen);
+
+        testInstance.multiplexingClient.close();
+        assertFalse(connectionStatusChangeTracker.isOpen);
+        assertTrue(connectionStatusChangeTracker.clientClosedGracefully);
+    }
+
     // MultiplexingClient should be able to open an AMQP connection to IoTHub with no device sessions, and should
     // allow for device sessions to be added and used later.
     @Test


### PR DESCRIPTION
The expected connection status callbacks were not executed due to this bug. For instance, opening a multiplexed connection with no devices registered wouldn't execute the multiplexing client level connection status callback.

This also fixes a similar bug where the multiplexing client level retry policy isn't used under the same conditions

#1188 for additional context