### PR TITLE
doc(iot-service): Add links to new service documentation around role based authentication

### DIFF
--- a/service/iot-service-samples/role-based-authorization-sample/readme.md
+++ b/service/iot-service-samples/role-based-authorization-sample/readme.md
@@ -9,6 +9,8 @@ please see [this overview][rbac-overview].
 From the SDK side, users are required to implement the [TokenCredential][token-credential] interface so that the client 
 code can use role-based access tokens to authenticate with the service.
 
+From the service side, you can read [this document][rbac-ms-doc] for additional details.
+
 ## TokenCredential implementations
 
 While users can create their own implementations of the TokenCredential interface, the Azure Identity SDK has several 
@@ -30,3 +32,4 @@ ClientSecretCredential instance and using it when constructing multiple service 
 [default-azure-credential]: https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/identity/azure-identity/src/main/java/com/azure/identity/DefaultAzureCredential.java
 [client-secret-credential]: https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/identity/azure-identity/src/main/java/com/azure/identity/ClientSecretCredential.java
 [interactive-browser-credential]: https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/identity/azure-identity/src/main/java/com/azure/identity/InteractiveBrowserCredential.java
+[rbac-ms-doc]: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -39,7 +39,9 @@ import java.util.UUID;
 
 /**
  * This sample demonstrates how to use the constructors in the various service clients that take an instance of
- * {@link TokenCredential} in order to authenticate with role based access credentials.
+ * {@link TokenCredential} in order to authenticate with role based access credentials. For additional details
+ * about the service side configurations required to use role based authentication on your IoT Hub, see
+ * <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac">this link</a>
  */
 public class RoleBasedAuthenticationSample
 {


### PR DESCRIPTION
These links will help users figure out how to setup the service side configurations to do AAD auth.