### PR TITLE
refactor(e2e): Remove redundant multiplexing test, fix deviceTwinWithVersionTest to recycle identities

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -88,7 +88,7 @@ import static junit.framework.TestCase.*;
 @RunWith(Parameterized.class)
 public class MultiplexingClientTests extends IntegrationTest
 {
-    private static final int DEVICE_MULTIPLEX_COUNT = 10;
+    private static final int DEVICE_MULTIPLEX_COUNT = 3;
 
     private static final int MESSAGE_SEND_TIMEOUT_MILLIS = 60 * 1000;
     private static final int FAULT_INJECTION_RECOVERY_TIMEOUT_MILLIS = 2 * 60 * 1000;
@@ -472,33 +472,6 @@ public class MultiplexingClientTests extends IntegrationTest
         log.debug("Open time: " + (finishOpenTime - startOpenTime) / 1000.0);
         log.debug("Send time: " + (finishSendTime - startSendTime) / 1000.0);
         log.debug("Close time: " + (finishCloseTime - startCloseTime) / 1000.0);
-    }
-
-    @ContinuousIntegrationTest
-    @Test
-    public void sendMessagesMaxDevicesAllowedRegisterAfterOpen() throws Exception
-    {
-        // Right now, AMQP connections can do up to 1000 devices which is consistent with the IoTHub advertised limit
-        // But AMQPS_WS is limited to ~500 for some reason. Still needs investigation.
-        if (testInstance.protocol == IotHubClientProtocol.AMQPS)
-        {
-            testInstance.setup(MultiplexingClient.MAX_MULTIPLEX_DEVICE_COUNT_AMQPS);
-        }
-        else
-        {
-            testInstance.setup(MultiplexingClient.MAX_MULTIPLEX_DEVICE_COUNT_AMQPS_WS);
-        }
-
-        // unregister all but the 0th device so that they can all be registered after opening the connection
-        testInstance.multiplexingClient.unregisterDeviceClients(testInstance.deviceClientArray.subList(1, testInstance.deviceClientArray.size()));
-
-        testInstance.multiplexingClient.open();
-
-        testInstance.multiplexingClient.registerDeviceClients(testInstance.deviceClientArray);
-
-        testSendingMessagesFromMultiplexedClients(testInstance.deviceClientArray);
-
-        testInstance.multiplexingClient.close();
     }
 
     @Test

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinClientOptions;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
@@ -27,6 +28,7 @@ import org.junit.runners.Parameterized;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.DeviceConnectionString;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestDeviceIdentity;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.ContinuousIntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubTest;
@@ -188,6 +190,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
     {
         public IotHubClientProtocol protocol;
         private com.microsoft.azure.sdk.iot.service.Device deviceForRegistryManager;
+        public TestDeviceIdentity testDeviceIdentity;
 
         private final DeviceTwin twinServiceClient;
         private DeviceTwinWithVersionTestDevice deviceTwinWithVersionTestDevice;
@@ -214,12 +217,10 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
     public void createDevice() throws Exception
     {
         testInstance.deviceTwinWithVersionTestDevice = new DeviceTwinWithVersionTestDevice();
-        testInstance.deviceTwinWithVersionTestDevice.deviceId = "java-twin-version-e2e-test-".concat(UUID.randomUUID().toString());
         testInstance.deviceTwinWithVersionTestDevice.receivedProperties = new HashSet<>();
 
-        testInstance.deviceForRegistryManager = com.microsoft.azure.sdk.iot.service.Device.createFromId(testInstance.deviceTwinWithVersionTestDevice.deviceId, null, null);
-        testInstance.deviceForRegistryManager = Tools.addDeviceWithRetry(testInstance.registryManager, testInstance.deviceForRegistryManager);
-
+        testInstance.testDeviceIdentity = Tools.getTestDevice(iotHubConnectionString, testInstance.protocol, AuthenticationType.SAS, true);
+        testInstance.deviceForRegistryManager = testInstance.testDeviceIdentity.getDevice();
     }
 
     @After
@@ -231,13 +232,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
             testInstance.deviceTwinWithVersionTestDevice.deviceClient = null;
         }
 
-        if (testInstance != null && testInstance.deviceTwinWithVersionTestDevice != null)
-        {
-            testInstance.deviceTwinWithVersionTestDevice.expectedProperties = null;
-            testInstance.deviceTwinWithVersionTestDevice.reportedPropertyVersion = null;
-            testInstance.deviceTwinWithVersionTestDevice.receivedProperties = null;
-            testInstance.deviceTwinWithVersionTestDevice.deviceTwinStatus = STATUS.UNKNOWN;
-        }
+        Tools.disposeTestIdentity(testInstance.testDeviceIdentity, iotHubConnectionString);
     }
 
     @Test

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
@@ -221,6 +221,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
 
         testInstance.testDeviceIdentity = Tools.getTestDevice(iotHubConnectionString, testInstance.protocol, AuthenticationType.SAS, true);
         testInstance.deviceForRegistryManager = testInstance.testDeviceIdentity.getDevice();
+        testInstance.deviceTwinWithVersionTestDevice.deviceId = testInstance.testDeviceIdentity.getDeviceId();
     }
 
     @After


### PR DESCRIPTION
deviceTwinWithVersion tests were still creating and removing test identities on their own rather than going through the centralized function that allows for recycling of test identities

The multiplexing test is arguably redundant because we already have a test that you can open a mux connection with the max number of devices. The only difference is registering the devices before vs after open. Since we already have a test that makes sure that registering after open works just like registering before open, there is no need for this test.