### PR TITLE
release(2021-05-10): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.30.0";
+    private static final String CLIENT_VERSION = "1.30.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.1') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.30.0</iot-device-client-version>
-        <iot-service-client-version>1.29.0</iot-service-client-version>
-        <iot-deps-version>0.11.3</iot-deps-version>
+        <iot-device-client-version>1.30.1</iot-device-client-version>
+        <iot-service-client-version>1.30.0</iot-service-client-version>
+        <iot-deps-version>0.12.0</iot-deps-version>
         <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.2</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.29.0";
+    public static final String serviceVersion = "1.30.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
Draft release notes:

## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.12.0)

- Add user assigned managed identity support for IoT hub import and export jobs (#1205) 

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.30.1)

- Updated reference to com.microsoft.azure.sdk.iot:iot-deps:0.12.0

### Bug fixes
- Fixed a bug where transport layer treated multiplexed connections with one or fewer devices as a non-multiplexed connection (#1198)
- Fixed a bug where the MultiplexingClient would close the entire multiplexed connection if a single multiplexed device session exhausted its retry attempts (#1202)
- Fixed a bug where DeviceClient would execute the connection status callback for an already disconnected multiplexed device when the user closed the multiplexed connection (#1202)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.30.0)

- Add user assigned managed identity support for IoT hub import and export jobs (#1205)
- Updated reference to com.microsoft.azure.sdk.iot:iot-deps:0.12.0

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.30.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.30.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.12.0/jar