### PR TITLE
fix(iot-dev): Make multiplexed connections handle device registrations during reconnection more gracefully

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -105,6 +105,13 @@ public class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCa
                 // up on a retry attempt prior to the service opening the session remotely.
                 this.isClosing = true;
                 this.session.close();
+
+                if (session.getLocalState() == EndpointState.CLOSED)
+                {
+                    // Since session was never opened, there will be no callback for onSessionRemoteClose, so now is
+                    // the appropriate time to notify the connection layer that this session has finished closing.
+                    this.amqpsSessionStateCallback.onSessionClosedAsExpected(this.getDeviceId());
+                }
             }
             else
             {


### PR DESCRIPTION
Rather than throw an exception internally when a device gets unregistered during its own reconnection, simply end the reconnection process since the user doesn't want the device on the multiplexed connection anymore anyways