### PR TITLE
fix(iot-service): Fix support for AAD authentication in Fairfax hubs

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -183,7 +183,7 @@ public class RegistryManager
 
         this.executor = Executors.newFixedThreadPool(EXECUTOR_THREAD_POOL_SIZE);
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, hostName);
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.sdk.iot.service.auth;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -15,24 +16,46 @@ import java.util.Objects;
  * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't near
  * expiry.
  */
+@Slf4j
 public class TokenCredentialCache
 {
     private final static int MINUTES_BEFORE_PROACTIVE_RENEWAL = 9;
     private final TokenCredential tokenCredential;
     private AccessToken accessToken;
+    private final String[] authenticationScopes;
 
-    public static final String[] IOTHUB_PUBLIC_SCOPE = new String[]{"https://iothubs.azure.net/.default"};
-    public static final String BEARER_TOKEN_PREFIX = "Bearer ";
+    private static final String[] IOTHUB_PUBLIC_SCOPES = new String[]{"https://iothubs.azure.net/.default"};
+    private static final String[] IOTHUB_FAIRFAX_SCOPES = new String[]{"https://iothubs.azure.us"};
+
+    // All IoT Hubs in the Fairfax cloud instance have a hostname that ends with this suffix
+    private static final String FAIRFAX_HUB_SUFFIX = "azure-devices.us";
+
+    private static final String BEARER_TOKEN_PREFIX = "Bearer ";
+
+    /**
+     * Construct a new TokenCredentialCache instance. This cache can only be used to generate authentication tokens
+     * for public cloud IoT Hubs and some private cloud IoT Hubs. For Fairfax IoT Hubs, use {@link #TokenCredentialCache(TokenCredential, String)}.
+     * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
+     */
+    @SuppressWarnings("unused") // Unused by our codebase, but removing it would be a breaking change
+    public TokenCredentialCache(TokenCredential tokenCredential)
+    {
+        this(tokenCredential, null);
+    }
 
     /**
      * Construct a new TokenCredentialCache instance.
      * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
+     * @param hostname The hostname of the IoT Hub that this token credential cache will generate tokens for.
+     * This argument is used to determine if the tokens generated should be compatible with public cloud IoT Hubs or
+     * with private cloud instances.
      */
-    public TokenCredentialCache(TokenCredential tokenCredential)
+    public TokenCredentialCache(TokenCredential tokenCredential, String hostname)
     {
         Objects.requireNonNull(tokenCredential, "tokenCredential cannot be null");
 
         this.tokenCredential = tokenCredential;
+        this.authenticationScopes = getAuthenticationScopes(hostname);
     }
 
     /**
@@ -45,7 +68,8 @@ public class TokenCredentialCache
     {
         if (this.accessToken == null || isAccessTokenCloseToExpiry(this.accessToken))
         {
-            this.accessToken = tokenCredential.getToken(new TokenRequestContext().addScopes(IOTHUB_PUBLIC_SCOPE)).block();
+            log.trace("Generating new access token.");
+            this.accessToken = tokenCredential.getToken(new TokenRequestContext().addScopes(this.authenticationScopes)).block();
         }
 
         return this.accessToken;
@@ -68,9 +92,41 @@ public class TokenCredentialCache
         return this.tokenCredential;
     }
 
+    /**
+     * Get the authentication scopes to be used when generating AAD access tokens.
+     * @param hostname The hostname of the IoT Hub that the tokens will be used to authenticate against.
+     * @return The authentication scopes to be used when generating AAD access tokens.
+     */
+    public static String[] getAuthenticationScopes(String hostname)
+    {
+        if (isFairfaxHub(hostname))
+        {
+            log.debug("Fairfax IoT Hub detected based on hostname, supplying Fairfax specific authentication scopes.");
+            return IOTHUB_FAIRFAX_SCOPES;
+        }
+
+        return IOTHUB_PUBLIC_SCOPES;
+    }
+
     private static boolean isAccessTokenCloseToExpiry(AccessToken accessToken)
     {
         Duration remainingTimeToLive = Duration.between(Instant.now(), accessToken.getExpiresAt().toInstant());
         return remainingTimeToLive.toMinutes() <= MINUTES_BEFORE_PROACTIVE_RENEWAL;
+    }
+
+    /**
+     * Checks if the provided hostname is associated with an IoT Hub deployed in the Fairfax cloud instance.
+     * @param hostname The hostname of the IoT Hub.
+     * @return True if the IoT Hub is deployed in the Fairfax cloud instance, and false otherwise.
+     */
+    private static boolean isFairfaxHub(String hostname)
+    {
+        if (hostname == null)
+        {
+            return false;
+        }
+
+        // Java doesn't have a case insensitive endsWith() function
+        return hostname.toLowerCase().endsWith(FAIRFAX_HUB_SUFFIX.toLowerCase());
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -103,7 +103,7 @@ public class TokenCredentialCache
     {
         if (isFairfaxHub(hostname))
         {
-            log.debug("Fairfax IoT Hub detected based on hostname, supplying Fairfax specific authentication scopes.");
+            log.debug("Fairfax IoT Hub detected based on hostname. Supplying Fairfax specific authentication scopes.");
             return IOTHUB_FAIRFAX_SCOPES;
         }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -13,8 +13,8 @@ import java.time.Instant;
 import java.util.Objects;
 
 /**
- * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't near
- * expiry.
+ * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't
+ * near expiry.
  */
 @Slf4j
 public class TokenCredentialCache
@@ -34,7 +34,8 @@ public class TokenCredentialCache
 
     /**
      * Construct a new TokenCredentialCache instance. This cache can only be used to generate authentication tokens
-     * for public cloud IoT Hubs and some private cloud IoT Hubs. For Fairfax IoT Hubs, use {@link #TokenCredentialCache(TokenCredential, String)}.
+     * for public cloud IoT Hubs and some private cloud IoT Hubs. For Fairfax IoT Hubs, use
+     * {@link #TokenCredentialCache(TokenCredential, String)}.
      * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
      */
     @SuppressWarnings("unused") // Unused by our codebase, but removing it would be a breaking change
@@ -69,7 +70,8 @@ public class TokenCredentialCache
         if (this.accessToken == null || isAccessTokenCloseToExpiry(this.accessToken))
         {
             log.trace("Generating new access token.");
-            this.accessToken = tokenCredential.getToken(new TokenRequestContext().addScopes(this.authenticationScopes)).block();
+            TokenRequestContext context = new TokenRequestContext().addScopes(this.authenticationScopes);
+            this.accessToken = tokenCredential.getToken(context).block();
         }
 
         return this.accessToken;

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -150,7 +150,7 @@ public class DeviceMethod
         }
 
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, hostName);
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -148,7 +148,7 @@ public class DeviceTwin
         }
 
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, hostName);
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -86,7 +86,7 @@ public class RawTwinQuery
         Objects.requireNonNull(credential);
 
         this.hostName = hostName;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, hostName);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -131,7 +131,7 @@ public class DigitalTwinAsyncClient {
         Objects.requireNonNull(options);
         final SimpleModule stringModule = new SimpleModule("String Serializer");
         stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
-        TokenCredentialCache tokenCredentialCache = new TokenCredentialCache(credential);
+        TokenCredentialCache tokenCredentialCache = new TokenCredentialCache(credential, hostName);
         BearerTokenProvider bearerTokenProvider = () -> tokenCredentialCache.getTokenString();
 
         JacksonAdapter adapter = new JacksonAdapter();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -127,7 +127,7 @@ public class JobClient
         }
 
         this.hostName = hostName;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, hostName);
         this.options = options;
     }
 


### PR DESCRIPTION
Fairfax hubs require a slightly different authentication scope. Other private cloud instances do not, though.

We'll hold off on merging this in until the service team is ready with their side of this as well