### PR TITLE
fix(sample): Fix file upload sample.

### DIFF
--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSample.java
@@ -129,11 +129,10 @@ public class FileUploadSample
 
     private static void uploadFile(DeviceClient client, String baseDirectory, String relativeFileName) throws IOException, URISyntaxException {
         File file = new File(baseDirectory, relativeFileName);
-        try (InputStream inputStream = new FileInputStream(file))
-        {
-            long streamLength = file.length();
 
-            if(relativeFileName.startsWith("\\"))
+        try
+        {
+            if (relativeFileName.startsWith("\\"))
             {
                 relativeFileName = relativeFileName.substring(1);
             }
@@ -153,7 +152,7 @@ public class FileUploadSample
                         .endpoint(sasUriResponse.getBlobUri().toString())
                         .buildClient();
 
-                blobClient.upload(inputStream, streamLength);
+                blobClient.uploadFromFile(file.getPath());
             }
             catch (Exception e)
             {
@@ -167,15 +166,15 @@ public class FileUploadSample
                 e.printStackTrace();
                 return;
             }
-            finally
-            {
-                inputStream.close();
-            }
 
             FileUploadCompletionNotification completionNotification = new FileUploadCompletionNotification(sasUriResponse.getCorrelationId(), true);
             client.completeFileUpload(completionNotification);
 
             System.out.println("Finished file upload for file " + fileNameList.get(index));
+        }
+        finally
+        {
+            client.closeNow();
         }
     }
 }

--- a/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
+++ b/device/iot-device-samples/file-upload-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/FileUploadSimpleSample.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -85,14 +86,14 @@ public class FileUploadSimpleSample
 
             System.out.println("Using the Azure Storage SDK to upload file to Azure Storage...");
 
-            try (FileInputStream fileInputStream = new FileInputStream(file))
+            try
             {
                 BlobClient blobClient =
                     new BlobClientBuilder()
                         .endpoint(sasUriResponse.getBlobUri().toString())
                         .buildClient();
 
-                blobClient.upload(fileInputStream, file.length());
+                blobClient.uploadFromFile(fullFileName);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
Azure blobClient does not work with FileInputStream as it does not support mark/reset. We can either use BufferedFileInputStream or call uploadFromFile. The later is simpler so  I have updated the samples to use that. Now the samples upload files successfully without any exception. 