### PR TITLE
release(2021-05-24): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.30.1";
+    private static final String CLIENT_VERSION = "1.30.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.1') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.2') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.30.1</iot-device-client-version>
-        <iot-service-client-version>1.30.0</iot-service-client-version>
-        <iot-deps-version>0.12.0</iot-deps-version>
+        <iot-device-client-version>1.30.2</iot-device-client-version>
+        <iot-service-client-version>1.31.0</iot-service-client-version>
+        <iot-deps-version>0.13.0</iot-deps-version>
         <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.2</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.30.0";
+    public static final String serviceVersion = "1.31.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.13.0)

- Added support for Twin metadata properties, applicable when using configuration (#1219)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.30.2)

- DeviceClient/ModuleClient now throws an UnsupportedOperationException when using twin/method APIs over HTTP rather than failing with service error (#1204)

### Bug fixes
- Fixed a bug where multiplexed connections couldn't handle device registrations during reconnection (#1209)
- Fixed a bug where multiplexing client retry logic did not abandon reconnection when a non-retryable exception is thrown (#1218)
- Fixed a bug where registering a device to an active multiplexed connection times out if the registration fails due to an issue like if the device is disabled (#1218)
- Fixed a bug where opening a multiplexing client times out if one or more of the registered devices is disabled. Now the open call will succeed, but the connection status of the disabled device will go DISCONNECTED shortly afterwards (#1218)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.31.0)

- Added support for Twin metadata properties, applicable when using configuration (#1219)


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.30.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.31.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.13.0/jar


old
{
    "device": "1.30.1",
    "service": "1.30.0",
    "deps": "0.12.0",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}


new
{
    "device": "1.30.2",
    "service": "1.31.0",
    "deps": "0.13.0",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}
