### PR TITLE
feat(iot-service): Add support for arbitrary token credential authentication scopes

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FeedbackReceiver.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.service;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpReceive;
 import lombok.extern.slf4j.Slf4j;
 
@@ -136,7 +137,7 @@ public class FeedbackReceiver extends Receiver
 
     FeedbackReceiver(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -146,13 +147,13 @@ public class FeedbackReceiver extends Receiver
             throw new IllegalArgumentException("hostName cannot be null or empty");
         }
 
-        Objects.requireNonNull(credential);
+        Objects.requireNonNull(credentialCache);
         Objects.requireNonNull(iotHubServiceClientProtocol);
 
         this.amqpReceive =
                 new AmqpReceive(
                         hostName,
-                        credential,
+                        credentialCache,
                         iotHubServiceClientProtocol,
                         proxyOptions,
                         sslContext);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/FileUploadNotificationReceiver.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.sdk.iot.service;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpFileUploadNotificationReceive;
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,7 +66,7 @@ public class FileUploadNotificationReceiver extends Receiver
 
     FileUploadNotificationReceiver(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -75,13 +76,13 @@ public class FileUploadNotificationReceiver extends Receiver
             throw new IllegalArgumentException("hostName cannot be null or empty");
         }
 
-        Objects.requireNonNull(credential);
+        Objects.requireNonNull(credentialCache);
         Objects.requireNonNull(iotHubServiceClientProtocol);
 
         this.amqpFileUploadNotificationReceive =
                 new AmqpFileUploadNotificationReceive(
                         hostName,
-                        credential,
+                        credentialCache,
                         iotHubServiceClientProtocol,
                         proxyOptions,
                         sslContext);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -170,7 +170,7 @@ public class RegistryManager
 
         this.executor = Executors.newFixedThreadPool(EXECUTOR_THREAD_POOL_SIZE);
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, options.getTokenCredentialAuthenticationScopes());
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -41,7 +41,7 @@ public class RegistryManagerOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -42,7 +42,7 @@ public class RegistryManagerOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -44,8 +44,8 @@ public class RegistryManagerOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -1,6 +1,6 @@
 package com.microsoft.azure.sdk.iot.service;
 
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -45,9 +45,9 @@ public class RegistryManagerOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -44,7 +44,7 @@ public class RegistryManagerOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.sdk.iot.service;
 
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -37,4 +38,16 @@ public class RegistryManagerOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.sdk.iot.service;
 
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,11 +18,22 @@ public class ServiceClientOptions
     @Getter
     private final ProxyOptions proxyOptions;
 
-
     /**
      * The SSL context to use when opening the AMQPS/AMQPS_WS connections. If not set, this library will generate the default
      * SSL context that trusts the IoT Hub public certificates.
      */
     @Getter
     private final SSLContext sslContext;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -30,7 +30,7 @@ public class ServiceClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -27,7 +27,7 @@ public class ServiceClientOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -1,6 +1,6 @@
 package com.microsoft.azure.sdk.iot.service;
 
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -31,9 +31,9 @@ public class ServiceClientOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -28,7 +28,7 @@ public class ServiceClientOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClientOptions.java
@@ -30,8 +30,8 @@ public class ServiceClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/AuthenticationScopes.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/AuthenticationScopes.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.service.auth;
+
+/**
+ * This class contains the most commonly used Azure Active Directory token audience scopes. They should be used as
+ * inputs when setting the authentication scopes in service client options classes such as
+ * {@link com.microsoft.azure.sdk.iot.service.RegistryManagerOptions}.
+ */
+public class AuthenticationScopes
+{
+    /**
+     * The default authentication scopes for IoT Hub. This value is the default value for all service client options, and
+     * is the correct value to use for all users of public cloud deployed IoT Hubs and for all users of private cloud
+     * deployed IoT Hubs other than those in the Fairfax cloud. For users of IoT Hubs deployed in the Fairfax cloud, the
+     * {@link #IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES} should be used instead of this.
+     */
+    public static final String[] IOTHUB_DEFAULT_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.net/.default"};
+
+    /**
+     * The authentication scopes for IoT Hubs deployed in the Fairfax private cloud. Users must provide this value when
+     * constructing the client's options when using role based access credentials.
+     */
+    public static final String[] IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
+}

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
@@ -27,7 +27,7 @@ public class IotHubAuthenticationScopes
 
     /**
      * The authentication scopes for IoT Hubs deployed in the Fairfax private cloud. Users must provide this value when
-     * constructing the client's options when using role based access credentials.
+     * constructing the client's options when using role-based access credentials.
      */
     public static final String[] FAIRFAX_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
@@ -8,19 +8,26 @@ package com.microsoft.azure.sdk.iot.service.auth;
  * inputs when setting the authentication scopes in service client options classes such as
  * {@link com.microsoft.azure.sdk.iot.service.RegistryManagerOptions}.
  */
-public class AuthenticationScopes
+public class IotHubAuthenticationScopes
 {
+    // This private constructor exists to prevent users from constructing an instance of this class. This class
+    // is just used to house static values, so it will never need to be instantiated.
+    private IotHubAuthenticationScopes()
+    {
+
+    }
+
     /**
      * The default authentication scopes for IoT Hub. This value is the default value for all service client options, and
      * is the correct value to use for all users of public cloud deployed IoT Hubs and for all users of private cloud
      * deployed IoT Hubs other than those in the Fairfax cloud. For users of IoT Hubs deployed in the Fairfax cloud, the
-     * {@link #IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES} should be used instead of this.
+     * {@link #FAIRFAX_AUTHENTICATION_SCOPES} should be used instead of this.
      */
-    public static final String[] IOTHUB_DEFAULT_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.net/.default"};
+    public static final String[] DEFAULT_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.net/.default"};
 
     /**
      * The authentication scopes for IoT Hubs deployed in the Fairfax private cloud. Users must provide this value when
      * constructing the client's options when using role based access credentials.
      */
-    public static final String[] IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
+    public static final String[] FAIRFAX_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
@@ -20,8 +20,8 @@ public class IotHubAuthenticationScopes
     /**
      * The default authentication scopes for IoT Hub. This value is the default value for all service client options, and
      * is the correct value to use for all users of public cloud deployed IoT Hubs and for all users of private cloud
-     * deployed IoT Hubs other than those in the Fairfax cloud. For users of IoT Hubs deployed in the Fairfax cloud, the
-     * {@link #FAIRFAX_AUTHENTICATION_SCOPES} should be used instead of this.
+     * deployed IoT Hubs other than those in the Azure Government cloud. For users of IoT Hubs deployed in the Azure Government cloud, the
+     * {@link #GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES} should be used instead of this.
      */
     public static final String[] DEFAULT_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.net/.default"};
 
@@ -29,5 +29,5 @@ public class IotHubAuthenticationScopes
      * The authentication scopes for IoT Hubs deployed in the Fairfax private cloud. Users must provide this value when
      * constructing the client's options when using role-based access credentials.
      */
-    public static final String[] FAIRFAX_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
+    public static final String[] GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.us/.default"};
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/IotHubAuthenticationScopes.java
@@ -20,7 +20,7 @@ public class IotHubAuthenticationScopes
     /**
      * The default authentication scopes for IoT Hub. This value is the default value for all service client options, and
      * is the correct value to use for all users of public cloud deployed IoT Hubs and for all users of private cloud
-     * deployed IoT Hubs other than those in the Azure Government cloud. For users of IoT Hubs deployed in the Azure Government cloud, the
+     * deployed IoT Hubs other than those in the Azure USA Government cloud. For users of IoT Hubs deployed in the Azure USA Government cloud, the
      * {@link #GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES} should be used instead of this.
      */
     public static final String[] DEFAULT_AUTHENTICATION_SCOPES = new String[]{"https://iothubs.azure.net/.default"};

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -6,33 +6,52 @@ package com.microsoft.azure.sdk.iot.service.auth;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
+import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+
 /**
- * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't near
- * expiry.
+ * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't
+ * near expiry.
  */
+@Slf4j
 public class TokenCredentialCache
 {
     private final static int MINUTES_BEFORE_PROACTIVE_RENEWAL = 9;
     private final TokenCredential tokenCredential;
     private AccessToken accessToken;
+    private final String[] authenticationScopes;
 
-    public static final String[] IOTHUB_PUBLIC_SCOPE = new String[]{"https://iothubs.azure.net/.default"};
-    public static final String BEARER_TOKEN_PREFIX = "Bearer ";
+    private static final String BEARER_TOKEN_PREFIX = "Bearer ";
+
+    /**
+     * Construct a new TokenCredentialCache instance. This cache can only be used to generate authentication tokens
+     * for public cloud IoT Hubs and some private cloud IoT Hubs. For Fairfax IoT Hubs, use
+     * {@link #TokenCredentialCache(TokenCredential, String[])}.
+     * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
+     */
+    @SuppressWarnings("unused") // Unused by our codebase, but removing it would be a breaking change
+    public TokenCredentialCache(TokenCredential tokenCredential)
+    {
+        this(tokenCredential, IOTHUB_DEFAULT_AUTHENTICATION_SCOPES);
+    }
 
     /**
      * Construct a new TokenCredentialCache instance.
      * @param tokenCredential The tokenCredential instance that this cache will use to generate new tokens.
+     * @param authenticationScopes The authentication scopes to be used when generating authentication tokens.
      */
-    public TokenCredentialCache(TokenCredential tokenCredential)
+    public TokenCredentialCache(TokenCredential tokenCredential, String[] authenticationScopes)
     {
         Objects.requireNonNull(tokenCredential, "tokenCredential cannot be null");
+        Objects.requireNonNull(authenticationScopes, "authenticationScopes cannot be null");
 
         this.tokenCredential = tokenCredential;
+        this.authenticationScopes = authenticationScopes;
     }
 
     /**
@@ -45,7 +64,8 @@ public class TokenCredentialCache
     {
         if (this.accessToken == null || isAccessTokenCloseToExpiry(this.accessToken))
         {
-            this.accessToken = tokenCredential.getToken(new TokenRequestContext().addScopes(IOTHUB_PUBLIC_SCOPE)).block();
+            log.trace("Generating new access token.");
+            this.accessToken = tokenCredential.getToken(getTokenRequestContext()).block();
         }
 
         return this.accessToken;
@@ -66,6 +86,15 @@ public class TokenCredentialCache
     public TokenCredential getTokenCredential()
     {
         return this.tokenCredential;
+    }
+
+    /**
+     * Get the authentication scopes to be used when generating AAD access tokens.
+     * @return The authentication scopes to be used when generating AAD access tokens.
+     */
+    public TokenRequestContext getTokenRequestContext()
+    {
+        return new TokenRequestContext().addScopes(this.authenticationScopes);
     }
 
     private static boolean isAccessTokenCloseToExpiry(AccessToken accessToken)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -38,8 +38,6 @@ public class TokenCredentialCache
     public TokenCredentialCache(TokenCredential tokenCredential)
     {
         this(tokenCredential, DEFAULT_AUTHENTICATION_SCOPES);
-
-        new IotHubAuthenticationScopes();
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/auth/TokenCredentialCache.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
-import static com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+import static com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 
 /**
  * This class generates AAD authentication tokens from a TokenCredential but caches previous tokens when they aren't
@@ -37,7 +37,9 @@ public class TokenCredentialCache
     @SuppressWarnings("unused") // Unused by our codebase, but removing it would be a breaking change
     public TokenCredentialCache(TokenCredential tokenCredential)
     {
-        this(tokenCredential, IOTHUB_DEFAULT_AUTHENTICATION_SCOPES);
+        this(tokenCredential, DEFAULT_AUTHENTICATION_SCOPES);
+
+        new IotHubAuthenticationScopes();
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -140,7 +140,7 @@ public class DeviceMethod
         }
 
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, options.getTokenCredentialAuthenticationScopes());
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -43,7 +43,7 @@ public class DeviceMethodClientOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -42,7 +42,7 @@ public class DeviceMethodClientOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -1,7 +1,7 @@
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -46,9 +46,9 @@ public class DeviceMethodClientOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -38,4 +39,16 @@ public class DeviceMethodClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -45,8 +45,8 @@ public class DeviceMethodClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -45,7 +45,7 @@ public class DeviceMethodClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -138,7 +138,7 @@ public class DeviceTwin
         }
 
         this.options = options;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, options.getTokenCredentialAuthenticationScopes());
         this.hostName = hostName;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -1,7 +1,7 @@
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -46,9 +46,9 @@ public class DeviceTwinClientOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -42,7 +42,7 @@ public class DeviceTwinClientOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -45,8 +45,8 @@ public class DeviceTwinClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -45,7 +45,7 @@ public class DeviceTwinClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -38,4 +39,16 @@ public class DeviceTwinClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -43,7 +43,7 @@ public class DeviceTwinClientOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -69,7 +69,7 @@ public class RawTwinQuery
     }
 
     /**
-     * Construct a raw twin query client that uses role based access tokens for authentication.
+     * Construct a raw twin query client that uses role-based access tokens for authentication.
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
@@ -89,7 +89,7 @@ public class RawTwinQuery
     }
 
     /**
-     * Construct a raw twin query client that uses role based access tokens for authentication.
+     * Construct a raw twin query client that uses role-based access tokens for authentication.
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -7,11 +7,10 @@ package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.Tools;
-import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
@@ -96,7 +95,7 @@ public class RawTwinQuery
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
      *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
      * @param authenticationScopes The Azure Active Directory authentication scopes to use when constructing
-     * authentication tokens to authenticate against IoT Hub with. See {@link com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes}
+     * authentication tokens to authenticate against IoT Hub with. See {@link IotHubAuthenticationScopes}
      * for more details.
      */
     public RawTwinQuery(String hostName, TokenCredential credential, String[] authenticationScopes)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -70,7 +70,7 @@ public class RawTwinQuery
     }
 
     /**
-     * Constructor to create instance from connection string
+     * Construct a raw twin query client that uses role based access tokens for authentication.
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
@@ -90,7 +90,30 @@ public class RawTwinQuery
     }
 
     /**
-     * Constructor to create instance from connection string
+     * Construct a raw twin query client that uses role based access tokens for authentication.
+     *
+     * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
+     * @param credential The custom {@link TokenCredential} that will provide authentication tokens to
+     *                                    this library when they are needed. The provided tokens must be Json Web Tokens.
+     * @param authenticationScopes The Azure Active Directory authentication scopes to use when constructing
+     * authentication tokens to authenticate against IoT Hub with. See {@link com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes}
+     * for more details.
+     */
+    public RawTwinQuery(String hostName, TokenCredential credential, String[] authenticationScopes)
+    {
+        if (Tools.isNullOrEmpty(hostName))
+        {
+            throw new IllegalArgumentException("hostName cannot be null or empty");
+        }
+
+        Objects.requireNonNull(credential);
+
+        this.hostName = hostName;
+        this.credentialCache = new TokenCredentialCache(credential, authenticationScopes);
+    }
+
+    /**
+     * Constructor to create instance from an {@link AzureSasCredential} instance.
      *
      * @param hostName The hostname of your IoT Hub instance (For instance, "your-iot-hub.azure-devices.net")
      * @param azureSasCredential The custom {@link TokenCredential} that will provide authentication tokens to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -53,7 +53,7 @@ import static com.microsoft.azure.sdk.iot.service.digitaltwin.helpers.Tools.*;
 public class DigitalTwinAsyncClient {
     private final DigitalTwinsImpl _protocolLayer;
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String HTTPS_SCHEME= "https://";
+    private static final String HTTPS_SCHEME = "https://";
 
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
@@ -125,8 +125,10 @@ public class DigitalTwinAsyncClient {
         Objects.requireNonNull(options);
         final SimpleModule stringModule = new SimpleModule("String Serializer");
         stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
-        TokenCredentialCache tokenCredentialCache = new TokenCredentialCache(credential);
-        BearerTokenProvider bearerTokenProvider = () -> tokenCredentialCache.getTokenString();
+        TokenCredentialCache tokenCredentialCache =
+            new TokenCredentialCache(credential, options.getTokenCredentialAuthenticationScopes());
+
+        BearerTokenProvider bearerTokenProvider = tokenCredentialCache::getTokenString;
 
         JacksonAdapter adapter = new JacksonAdapter();
         adapter.serializer().registerModule(stringModule);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -4,6 +4,8 @@
 package com.microsoft.azure.sdk.iot.service.digitaltwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -42,4 +44,16 @@ public class DigitalTwinClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -49,7 +49,7 @@ public class DigitalTwinClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -49,8 +49,8 @@ public class DigitalTwinClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -46,7 +46,7 @@ public class DigitalTwinClientOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -47,7 +47,7 @@ public class DigitalTwinClientOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -4,8 +4,7 @@
 package com.microsoft.azure.sdk.iot.service.digitaltwin;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
-import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -51,9 +50,9 @@ public class DigitalTwinClientOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -127,7 +127,7 @@ public class JobClient
         }
 
         this.hostName = hostName;
-        this.credentialCache = new TokenCredentialCache(credential);
+        this.credentialCache = new TokenCredentialCache(credential, options.getTokenCredentialAuthenticationScopes());
         this.options = options;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -48,8 +48,8 @@ public class JobClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
+     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -45,7 +45,7 @@ public class JobClientOptions
 
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
-     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -46,7 +46,7 @@ public class JobClientOptions
     /**
      * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
-     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -4,7 +4,7 @@
 package com.microsoft.azure.sdk.iot.service.jobs;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -49,9 +49,9 @@ public class JobClientOptions
      * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
      * Fairfax cloud. For Fairfax cloud users, this value must be set to
-     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     * {@link IotHubAuthenticationScopes#FAIRFAX_AUTHENTICATION_SCOPES}.
      */
     @Getter
     @Builder.Default
-    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
+    private final String[] tokenCredentialAuthenticationScopes = IotHubAuthenticationScopes.DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -4,6 +4,7 @@
 package com.microsoft.azure.sdk.iot.service.jobs;
 
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -41,4 +42,16 @@ public class JobClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
+
+    /**
+     * The authentication scopes to use when requesting authentication tokens from Azure Active Directory for
+     * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role based
+     * access credentials rather than symmetric key based credentials. This value defaults to the authentication scopes
+     * that are used for all public cloud deployments and all private cloud deployments other than those in the
+     * Fairfax cloud. For Fairfax cloud users, this value must be set to
+     * {@link AuthenticationScopes#IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES}.
+     */
+    @Getter
+    @Builder.Default
+    private final String[] tokenCredentialAuthenticationScopes = AuthenticationScopes.IOTHUB_DEFAULT_AUTHENTICATION_SCOPES;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -48,7 +48,7 @@ public class JobClientOptions
      * authenticating with IoT Hub. This value is only used by the client if the client is configured to use role-based
      * access credentials rather than symmetric key-based credentials. This value defaults to the authentication scopes
      * that are used for all public cloud deployments and all private cloud deployments other than those in the
-     * Azure Government cloud. For Azure Government cloud users, this value must be set to
+     * Azure USA Government cloud. For Azure USA Government cloud users, this value must be set to
      * {@link IotHubAuthenticationScopes#GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES}.
      */
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.deps.ws.impl.WebSocketImpl;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
@@ -49,7 +50,7 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
     protected final String hostName;
     protected String userName;
     protected String sasToken;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential sasTokenProvider;
     protected IotHubServiceClientProtocol iotHubServiceClientProtocol;
     protected ProxyOptions proxyOptions;
@@ -107,7 +108,7 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
 
     protected AmqpConnectionHandler(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -118,10 +119,10 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
         }
 
         Objects.requireNonNull(iotHubServiceClientProtocol);
-        Objects.requireNonNull(credential);
+        Objects.requireNonNull(credentialCache);
 
         this.hostName = hostName;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
 
         commonConstructorSetup(iotHubServiceClientProtocol, proxyOptions, sslContext);
     }
@@ -237,9 +238,9 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
         // session where authentication will take place.
         Session cbsSession = event.getConnection().session();
 
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
-            new CbsSessionHandler(cbsSession, this, this.credential);
+            new CbsSessionHandler(cbsSession, this, this.credentialCache);
         }
         else if (this.sasTokenProvider != null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
@@ -9,6 +9,7 @@ import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
@@ -109,13 +110,13 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
 
     AmqpFeedbackReceivedHandler(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
     {
-        super(hostName, credential, iotHubServiceClientProtocol, proxyOptions, sslContext);
+        super(hostName, credentialCache, iotHubServiceClientProtocol, proxyOptions, sslContext);
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadNotificationParser;
 import com.microsoft.azure.sdk.iot.service.FileUploadNotification;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLContext;
@@ -27,7 +28,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
     private final String hostName;
     private String userName;
     private String sasToken;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential sasTokenProvider;
     private AmqpFileUploadNotificationReceivedHandler amqpReceiveHandler;
     private FileUploadNotification fileUploadNotification;
@@ -98,7 +99,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
 
     public AmqpFileUploadNotificationReceive(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -107,7 +108,7 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.proxyOptions = proxyOptions;
         this.sslContext = sslContext;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
     }
 
     public AmqpFileUploadNotificationReceive(
@@ -138,11 +139,11 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
 
     private void initializeHandler()
     {
-        if (this.credential != null)
+        if (this.credentialCache != null)
         {
             amqpReceiveHandler = new AmqpFileUploadNotificationReceivedHandler(
                 this.hostName,
-                this.credential,
+                this.credentialCache,
                 this.iotHubServiceClientProtocol,
                 this,
                 this.proxyOptions,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
@@ -9,6 +9,7 @@ import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.proton.Proton;
@@ -69,13 +70,13 @@ public class AmqpFileUploadNotificationReceivedHandler extends AmqpConnectionHan
 
     AmqpFileUploadNotificationReceivedHandler(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             AmqpFeedbackReceivedEvent amqpFeedbackReceivedEvent,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
     {
-        super(hostName, credential, iotHubServiceClientProtocol, proxyOptions, sslContext);
+        super(hostName, credentialCache, iotHubServiceClientProtocol, proxyOptions, sslContext);
         this.amqpFeedbackReceivedEvent = amqpFeedbackReceivedEvent;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.service.FeedbackBatch;
 import com.microsoft.azure.sdk.iot.service.FeedbackBatchMessage;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLContext;
@@ -27,7 +28,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
     private final String hostName;
     private String userName;
     private String sasToken;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential sasTokenProvider;
     private AmqpFeedbackReceivedHandler amqpReceiveHandler;
     private final IotHubServiceClientProtocol iotHubServiceClientProtocol;
@@ -98,7 +99,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
 
     public AmqpReceive(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -107,7 +108,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.proxyOptions = proxyOptions;
         this.sslContext = sslContext;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
     }
 
     public AmqpReceive(
@@ -137,11 +138,11 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
 
     private void initializeHandler()
     {
-        if (credential != null)
+        if (credentialCache != null)
         {
             amqpReceiveHandler = new AmqpFeedbackReceivedHandler(
                 this.hostName,
-                this.credential,
+                this.credentialCache,
                 this.iotHubServiceClientProtocol,
                 this,
                 this.proxyOptions,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSend.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.Message;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,7 +31,7 @@ public class AmqpSend
     protected final String hostName;
     protected String userName;
     protected String sasToken;
-    private TokenCredential credential;
+    private TokenCredentialCache credentialCache;
     private AzureSasCredential sasTokenProvider;
     protected AmqpSendHandler amqpSendHandler;
     protected IotHubServiceClientProtocol iotHubServiceClientProtocol;
@@ -112,7 +113,7 @@ public class AmqpSend
 
     public AmqpSend(
             String hostName,
-            TokenCredential credential,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
@@ -123,10 +124,10 @@ public class AmqpSend
         }
 
         Objects.requireNonNull(iotHubServiceClientProtocol);
-        Objects.requireNonNull(credential);
+        Objects.requireNonNull(credentialCache);
 
         this.hostName = hostName;
-        this.credential = credential;
+        this.credentialCache = credentialCache;
         this.iotHubServiceClientProtocol = iotHubServiceClientProtocol;
         this.proxyOptions = proxyOptions;
         this.sslContext = sslContext;
@@ -182,12 +183,12 @@ public class AmqpSend
     {
         synchronized(this)
         {
-            if (this.credential != null)
+            if (this.credentialCache != null)
             {
                 amqpSendHandler =
                         new AmqpSendHandler(
                                 this.hostName,
-                                this.credential,
+                                this.credentialCache,
                                 this.iotHubServiceClientProtocol,
                                 this.proxyOptions,
                                 this.sslContext);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -9,6 +9,7 @@ import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
 import com.microsoft.azure.sdk.iot.service.ProxyOptions;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -108,12 +109,12 @@ public class AmqpSendHandler extends AmqpConnectionHandler
 
     AmqpSendHandler(
             String hostName,
-            TokenCredential tokenProvider,
+            TokenCredentialCache credentialCache,
             IotHubServiceClientProtocol iotHubServiceClientProtocol,
             ProxyOptions proxyOptions,
             SSLContext sslContext)
     {
-        super(hostName, tokenProvider, iotHubServiceClientProtocol, proxyOptions, sslContext);
+        super(hostName, credentialCache, iotHubServiceClientProtocol, proxyOptions, sslContext);
     }
 
     AmqpSendHandler(

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -80,7 +80,7 @@ public class RoleBasedAuthenticationSample
         // private clouds outside of Azure Stack deployments.
         RegistryManagerOptions fairfaxHubOptions = RegistryManagerOptions
             .builder()
-            .tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.FAIRFAX_AUTHENTICATION_SCOPES)
+            .tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES)
             .build();
     }
 

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -20,7 +20,7 @@ import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
 import com.microsoft.azure.sdk.iot.service.ServiceClient;
 import com.microsoft.azure.sdk.iot.service.ServiceClientOptions;
-import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
+import com.microsoft.azure.sdk.iot.service.auth.IotHubAuthenticationScopes;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethod;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethodClientOptions;
@@ -29,7 +29,6 @@ import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinClientOptions;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
 import com.microsoft.azure.sdk.iot.service.devicetwin.SqlQuery;
-import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClient;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.jobs.JobClient;
 import com.microsoft.azure.sdk.iot.service.jobs.JobClientOptions;
@@ -81,7 +80,7 @@ public class RoleBasedAuthenticationSample
         // private clouds outside of Azure Stack deployments.
         RegistryManagerOptions fairfaxHubOptions = RegistryManagerOptions
             .builder()
-            .tokenCredentialAuthenticationScopes(AuthenticationScopes.IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES)
+            .tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.FAIRFAX_AUTHENTICATION_SCOPES)
             .build();
     }
 

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -284,7 +284,11 @@ public class RoleBasedAuthenticationSample
     {
         // JobClient has some configurable options for HTTP read and connect timeouts, as well as for setting proxies.
         // For this sample, the default options will be used though.
-        DeviceMethodClientOptions options = DeviceMethodClientOptions.builder().build();
+        DeviceMethodClientOptions options =
+            DeviceMethodClientOptions
+                .builder()
+                //.tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government Cloud.
+                .build();
 
         // This constructor takes in your implementation of TokenCredential which allows you to use RBAC authentication
         // rather than symmetric key based authentication that comes with constructors that take connection strings.

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -39,8 +39,8 @@ import java.util.UUID;
 
 /**
  * This sample demonstrates how to use the constructors in the various service clients that take an instance of
- * {@link TokenCredential} in order to authenticate with role based access credentials. For additional details
- * about the service side configurations required to use role based authentication on your IoT Hub, see
+ * {@link TokenCredential} in order to authenticate with role-based access credentials. For additional details
+ * about the service side configurations required to use role-based authentication on your IoT Hub, see
  * <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-dev-guide-azure-ad-rbac">this link</a>
  */
 public class RoleBasedAuthenticationSample

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -20,6 +20,7 @@ import com.microsoft.azure.sdk.iot.service.RegistryManager;
 import com.microsoft.azure.sdk.iot.service.RegistryManagerOptions;
 import com.microsoft.azure.sdk.iot.service.ServiceClient;
 import com.microsoft.azure.sdk.iot.service.ServiceClientOptions;
+import com.microsoft.azure.sdk.iot.service.auth.AuthenticationScopes;
 import com.microsoft.azure.sdk.iot.service.auth.AuthenticationType;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethod;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethodClientOptions;
@@ -74,6 +75,14 @@ public class RoleBasedAuthenticationSample
         runJobClientSample(iotHubHostName, credential);
 
         runDeviceMethodClientSample(iotHubHostName, credential, newDeviceId);
+
+        // For users of IoT Hubs deployed in the Fairfax private cloud, your service client's options must specify these
+        // authentication scopes. The default authentication scopes are valid for all other deployments in public or
+        // private clouds outside of Azure Stack deployments.
+        RegistryManagerOptions fairfaxHubOptions = RegistryManagerOptions
+            .builder()
+            .tokenCredentialAuthenticationScopes(AuthenticationScopes.IOTHUB_FAIRFAX_AUTHENTICATION_SCOPES)
+            .build();
     }
 
     private static String runRegistryManagerSample(String iotHubHostName, TokenCredential credential)

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -6,6 +6,7 @@
 package samples.com.microsoft.azure.sdk.iot;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.identity.AzureAuthorityHosts;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.microsoft.azure.sdk.iot.deps.serializer.ErrorCodeDescription;
 import com.microsoft.azure.sdk.iot.service.Device;
@@ -60,6 +61,9 @@ public class RoleBasedAuthenticationSample
                 .tenantId(parsedArguments.getTenantId())
                 .clientId(parsedArguments.getClientId())
                 .clientSecret(parsedArguments.getClientSecret())
+                //.authorityHost(AzureAuthorityHosts.AZURE_GOVERNMENT) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government cloud
+                //.authorityHost(AzureAuthorityHosts.AZURE_GERMANY) // Uncomment this line if your IoT Hub is deployed in the Azure Germany cloud
+                //.authorityHost(AzureAuthorityHosts.AZURE_CHINA) // Uncomment this line if your IoT Hub is deployed in the Azure China cloud
                 .build();
 
         // "my-azure-iot-hub.azure-devices.net" for example
@@ -74,21 +78,17 @@ public class RoleBasedAuthenticationSample
         runJobClientSample(iotHubHostName, credential);
 
         runDeviceMethodClientSample(iotHubHostName, credential, newDeviceId);
-
-        // For users of IoT Hubs deployed in the Fairfax private cloud, your service client's options must specify these
-        // authentication scopes. The default authentication scopes are valid for all other deployments in public or
-        // private clouds outside of Azure Stack deployments.
-        RegistryManagerOptions fairfaxHubOptions = RegistryManagerOptions
-            .builder()
-            .tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES)
-            .build();
     }
 
     private static String runRegistryManagerSample(String iotHubHostName, TokenCredential credential)
     {
         // RegistryManager has some configurable options for HTTP read and connect timeouts, as well as for setting proxies.
         // For this sample, the default options will be used though.
-        RegistryManagerOptions options = RegistryManagerOptions.builder().build();
+        RegistryManagerOptions options =
+            RegistryManagerOptions
+                .builder()
+                //.tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government Cloud.
+                .build();
 
         // This constructor takes in your implementation of TokenCredential which allows you to use RBAC authentication
         // rather than symmetric key based authentication that comes with constructors that take connection strings.
@@ -117,7 +117,11 @@ public class RoleBasedAuthenticationSample
     {
         // DeviceTwin has some configurable options for HTTP read and connect timeouts, as well as for setting proxies.
         // For this sample, the default options will be used though.
-        DeviceTwinClientOptions options = DeviceTwinClientOptions.builder().build();
+        DeviceTwinClientOptions options =
+            DeviceTwinClientOptions
+                .builder()
+                //.tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government Cloud.
+                .build();
 
         // This constructor takes in your implementation of TokenCredential which allows you to use RBAC authentication
         // rather than symmetric key based authentication that comes with constructors that take connection strings.
@@ -146,7 +150,11 @@ public class RoleBasedAuthenticationSample
     {
         // ServiceClient has some configurable options for setting a custom SSLContext, as well as for setting proxies.
         // For this sample, the default options will be used though.
-        ServiceClientOptions options = ServiceClientOptions.builder().build();
+        ServiceClientOptions options =
+            ServiceClientOptions
+                .builder()
+                //.tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government Cloud.
+                .build();
 
         // This constructor takes in your implementation of TokenCredential which allows you to use RBAC authentication
         // rather than symmetric key based authentication that comes with constructors that take connection strings.
@@ -236,7 +244,11 @@ public class RoleBasedAuthenticationSample
     {
         // JobClient has some configurable options for HTTP read and connect timeouts, as well as for setting proxies.
         // For this sample, the default options will be used though.
-        JobClientOptions options = JobClientOptions.builder().build();
+        JobClientOptions options =
+            JobClientOptions
+                .builder()
+                //.tokenCredentialAuthenticationScopes(IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES) // Uncomment this line if your IoT Hub is deployed in the Azure USA Government Cloud.
+                .build();
 
         // This constructor takes in your implementation of TokenCredential which allows you to use RBAC authentication
         // rather than symmetric key based authentication that comes with constructors that take connection strings.


### PR DESCRIPTION
```java
// Fairfax options
String[] scopes = IotHubAuthenticationScopes.GOVERNMENT_CLOUD_AUTHENTICATION_SCOPES;
RegistryManagerOptions fairfaxOptions = RegistryManagerOptions
    .builder()
    .tokenCredentialAuthenticationScopes(scopes)
    .build();

// Default options
RegistryManagerOptions defaultOptions = RegistryManagerOptions.builder().build();

RegistryManager registryManager = new RegistryManager(hostName, tokenCredential, fairfaxOptions);
```