### PR TITLE
refactor(iot-service): Set default values in option objects

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubBadFormatException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubUnathorizedException;
 import lombok.extern.slf4j.Slf4j;
+import mockit.Deencapsulation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -136,6 +137,14 @@ public class RegistryManagerTests extends IntegrationTest
     {
         RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance();
         deviceLifecycle(testInstance);
+    }
+
+    @Test
+    public void testOptionsDefaults()
+    {
+        RegistryManagerOptions options = RegistryManagerOptions.builder().build();
+        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
+        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
     }
 
     @Test

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/RegistryManagerTests.java
@@ -7,7 +7,6 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.serviceclient;
 
 
 import com.azure.core.credential.AzureSasCredential;
-import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
 import com.microsoft.azure.sdk.iot.service.Configuration;
 import com.microsoft.azure.sdk.iot.service.ConfigurationContent;
@@ -26,10 +25,8 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubBadFormatException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubUnathorizedException;
 import lombok.extern.slf4j.Slf4j;
-import mockit.Deencapsulation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
@@ -137,14 +134,6 @@ public class RegistryManagerTests extends IntegrationTest
     {
         RegistryManagerTestInstance testInstance = new RegistryManagerTestInstance();
         deviceLifecycle(testInstance);
-    }
-
-    @Test
-    public void testOptionsDefaults()
-    {
-        RegistryManagerOptions options = RegistryManagerOptions.builder().build();
-        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
-        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
     }
 
     @Test

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -7,7 +7,6 @@ package com.microsoft.azure.sdk.iot.service;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.google.gson.JsonSyntaxException;
 import com.microsoft.azure.sdk.iot.deps.serializer.ConfigurationParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.DeviceParser;
@@ -63,10 +62,7 @@ public class RegistryManager
     {
         // This constructor was previously a default constructor that users could use because there was no other constructor declared.
         // However, we still prefer users use the createFromConnectionString method to build their clients.
-        options = RegistryManagerOptions.builder()
-                .httpConnectTimeout(RegistryManagerOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(RegistryManagerOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build();
+        options = RegistryManagerOptions.builder().build();
 
         // we don't use hostname in this constructor, so assign it an empty value to satisfy the field being marked final
         hostName = "";
@@ -85,12 +81,7 @@ public class RegistryManager
     @Deprecated
     public static RegistryManager createFromConnectionString(String connectionString) throws IOException
     {
-        RegistryManagerOptions options = RegistryManagerOptions.builder()
-                .httpConnectTimeout(RegistryManagerOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(RegistryManagerOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build();
-
-        return createFromConnectionString(connectionString, options);
+        return createFromConnectionString(connectionString, RegistryManagerOptions.builder().build());
     }
 
     /**
@@ -119,11 +110,7 @@ public class RegistryManager
      */
     public RegistryManager(String connectionString)
     {
-        this(connectionString,
-                RegistryManagerOptions.builder()
-                        .httpConnectTimeout(RegistryManagerOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                        .httpReadTimeout(RegistryManagerOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                        .build());
+        this(connectionString, RegistryManagerOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManagerOptions.java
@@ -25,14 +25,16 @@ public class RegistryManagerOptions
      * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
      */
     @Getter
-    private final int httpReadTimeout;
+    @Builder.Default
+    private final int httpReadTimeout = DEFAULT_HTTP_READ_TIMEOUT_MS;
 
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
      * before the connection can be established, a java.net.SocketTimeoutException is thrown.
-     * A timeout of zero is interpreted as an infinite timeout.
-     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     * A timeout of zero is interpreted as an infinite timeout. Must be a non-negative value.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
-    private final int httpConnectTimeout;
+    @Builder.Default
+    private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -5,7 +5,6 @@ package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.deps.serializer.MethodParser;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
@@ -50,12 +49,7 @@ public class DeviceMethod
     @Deprecated
     public static DeviceMethod createFromConnectionString(String connectionString) throws IOException
     {
-        return createFromConnectionString(
-            connectionString,
-            DeviceMethodClientOptions.builder()
-                .httpConnectTimeout(DeviceMethodClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(DeviceMethodClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build());
+        return createFromConnectionString(connectionString, DeviceMethodClientOptions.builder().build());
     }
 
     /**
@@ -94,11 +88,7 @@ public class DeviceMethod
      */
     public DeviceMethod(String connectionString)
     {
-        this(connectionString,
-            DeviceMethodClientOptions.builder()
-                .httpConnectTimeout(DeviceMethodClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(DeviceMethodClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build());
+        this(connectionString, DeviceMethodClientOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodClientOptions.java
@@ -26,7 +26,8 @@ public class DeviceMethodClientOptions
      * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
      */
     @Getter
-    private final int httpReadTimeout;
+    @Builder.Default
+    private final int httpReadTimeout = DEFAULT_HTTP_READ_TIMEOUT_MS;
 
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
@@ -35,5 +36,6 @@ public class DeviceMethodClientOptions
      * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
-    private final int httpConnectTimeout;
+    @Builder.Default
+    private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -7,7 +7,6 @@ package com.microsoft.azure.sdk.iot.service.devicetwin;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
@@ -59,12 +58,7 @@ public class DeviceTwin
     @Deprecated
     public static DeviceTwin createFromConnectionString(String connectionString) throws IOException
     {
-        return createFromConnectionString(
-                connectionString,
-                DeviceTwinClientOptions.builder()
-                    .httpConnectTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                    .httpReadTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                    .build());
+        return createFromConnectionString(connectionString, DeviceTwinClientOptions.builder().build());
     }
 
     /**
@@ -93,11 +87,7 @@ public class DeviceTwin
      */
     public DeviceTwin(String connectionString)
     {
-        this(connectionString,
-             DeviceTwinClientOptions.builder()
-                     .httpConnectTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                     .httpReadTimeout(DeviceTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                     .build());
+        this(connectionString, DeviceTwinClientOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinClientOptions.java
@@ -26,14 +26,16 @@ public class DeviceTwinClientOptions
      * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
      */
     @Getter
-    private final int httpReadTimeout;
+    @Builder.Default
+    private final int httpReadTimeout = DEFAULT_HTTP_READ_TIMEOUT_MS;
 
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
      * before the connection can be established, a java.net.SocketTimeoutException is thrown.
-     * A timeout of zero is interpreted as an infinite timeout.
-     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     * A timeout of zero is interpreted as an infinite timeout. Must be a non-negative value.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
-    private final int httpConnectTimeout;
+    @Builder.Default
+    private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -5,7 +5,6 @@ package com.microsoft.azure.sdk.iot.service.digitaltwin;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -19,15 +18,21 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.ServiceCon
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.ServiceConnectionStringParser;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGetHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinUpdateHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.implementation.DigitalTwinsImpl;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.implementation.IotHubGatewayServiceAPIsImpl;
-import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeRootLevelCommandHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinCommandResponse;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandRequestOptions;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinUpdateRequestOptions;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DeserializationHelpers;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DigitalTwinStringSerializer;
-import com.microsoft.azure.sdk.iot.service.digitaltwin.models.*;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import com.microsoft.rest.*;
+import com.microsoft.rest.RestClient;
+import com.microsoft.rest.ServiceResponse;
+import com.microsoft.rest.ServiceResponseBuilder;
+import com.microsoft.rest.ServiceResponseWithHeaders;
 import com.microsoft.rest.serializer.JacksonAdapter;
 import rx.Observable;
 import rx.schedulers.Schedulers;
@@ -38,8 +43,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
-import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
 import static com.microsoft.azure.sdk.iot.service.digitaltwin.helpers.Tools.*;
 
 /**
@@ -58,11 +61,7 @@ public class DigitalTwinAsyncClient {
      * @param connectionString The IoTHub connection string
      */
     public DigitalTwinAsyncClient(String connectionString) {
-        this(connectionString,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(connectionString, DigitalTwinClientOptions.builder().build());
     }
 
     /**
@@ -111,12 +110,7 @@ public class DigitalTwinAsyncClient {
      * this library when they are needed.
      */
     public DigitalTwinAsyncClient(String hostName, TokenCredential credential) {
-        this(hostName,
-            credential,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(hostName, credential, DigitalTwinClientOptions.builder().build());
     }
 
     /**
@@ -166,12 +160,7 @@ public class DigitalTwinAsyncClient {
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      */
     public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential) {
-        this(hostName,
-            azureSasCredential,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(hostName, azureSasCredential, DigitalTwinClientOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -9,14 +9,14 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGet
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinUpdateHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeRootLevelCommandHeaders;
-import com.microsoft.azure.sdk.iot.service.digitaltwin.models.*;
-import com.microsoft.rest.*;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinCommandResponse;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandRequestOptions;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinUpdateRequestOptions;
+import com.microsoft.rest.ServiceResponseWithHeaders;
 
 import java.io.IOException;
 import java.util.List;
-
-import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
-import static com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS;
 
 /**
  * <p>
@@ -31,11 +31,7 @@ public class DigitalTwinClient {
      * @param connectionString The IoT Hub connection string
      */
     public DigitalTwinClient(String connectionString) {
-        this(connectionString,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(connectionString, DigitalTwinClientOptions.builder().build());
     }
 
     /**
@@ -55,12 +51,7 @@ public class DigitalTwinClient {
      *                                    this library when they are needed.
      */
     public DigitalTwinClient(String hostName, TokenCredential credential) {
-        this(hostName,
-            credential,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(hostName, credential, DigitalTwinClientOptions.builder().build());
     }
 
     /**
@@ -82,12 +73,7 @@ public class DigitalTwinClient {
      * @param azureSasCredential The SAS token provider that will be used for authentication.
      */
     public DigitalTwinClient(String hostName, AzureSasCredential azureSasCredential) {
-        this(hostName,
-            azureSasCredential,
-            DigitalTwinClientOptions.builder()
-                .httpReadTimeout(DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .httpConnectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .build());
+        this(hostName, azureSasCredential, DigitalTwinClientOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -30,14 +30,16 @@ public class DigitalTwinClientOptions
      * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
      */
     @Getter
-    private final int httpReadTimeout;
+    @Builder.Default
+    private final int httpReadTimeout = DEFAULT_HTTP_READ_TIMEOUT_MS;
 
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
      * before the connection can be established, a java.net.SocketTimeoutException is thrown.
-     * A timeout of zero is interpreted as an infinite timeout.
-     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     * A timeout of zero is interpreted as an infinite timeout. Must be a non-negative value.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
-    private final int httpConnectTimeout;
+    @Builder.Default
+    private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -5,7 +5,6 @@ package com.microsoft.azure.sdk.iot.service.jobs;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.sdk.iot.deps.serializer.JobsParser;
 import com.microsoft.azure.sdk.iot.deps.serializer.MethodParser;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
@@ -16,7 +15,11 @@ import com.microsoft.azure.sdk.iot.service.ProxyOptions;
 import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
-import com.microsoft.azure.sdk.iot.service.devicetwin.*;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceOperations;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
@@ -26,7 +29,10 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Date;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Use the JobClient to schedule and cancel jobs for a group of devices using IoT hub.
@@ -68,10 +74,7 @@ public class JobClient
      */
     public JobClient(String connectionString)
     {
-        this(connectionString, JobClientOptions.builder()
-            .httpConnectTimeout(JobClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-            .httpReadTimeout(JobClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-            .build());
+        this(connectionString, JobClientOptions.builder().build());
     }
 
     /**
@@ -102,10 +105,7 @@ public class JobClient
      */
     public JobClient(String hostName, TokenCredential credential)
     {
-        this(hostName, credential, JobClientOptions.builder()
-                .httpConnectTimeout(JobClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(JobClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build());
+        this(hostName, credential, JobClientOptions.builder().build());
     }
 
     /**
@@ -139,10 +139,7 @@ public class JobClient
      */
     public JobClient(String hostName, AzureSasCredential azureSasCredential)
     {
-        this(hostName, azureSasCredential, JobClientOptions.builder()
-                .httpConnectTimeout(JobClientOptions.DEFAULT_HTTP_CONNECT_TIMEOUT_MS)
-                .httpReadTimeout(JobClientOptions.DEFAULT_HTTP_READ_TIMEOUT_MS)
-                .build());
+        this(hostName, azureSasCredential, JobClientOptions.builder().build());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientOptions.java
@@ -29,14 +29,16 @@ public class JobClientOptions
      * By default, this value is {@link #DEFAULT_HTTP_READ_TIMEOUT_MS}. Must be a non-negative value.
      */
     @Getter
-    private final int httpReadTimeout;
+    @Builder.Default
+    private final int httpReadTimeout = DEFAULT_HTTP_READ_TIMEOUT_MS;
 
     /**
      * The http connect timeout value, in milliseconds, to be used when connecting to the service. If the timeout expires
      * before the connection can be established, a java.net.SocketTimeoutException is thrown.
-     * A timeout of zero is interpreted as an infinite timeout.
-     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}. Must be a non-negative value.
+     * A timeout of zero is interpreted as an infinite timeout. Must be a non-negative value.
+     * By default, this value is {@link #DEFAULT_HTTP_CONNECT_TIMEOUT_MS}.
      */
     @Getter
-    private final int httpConnectTimeout;
+    @Builder.Default
+    private final int httpConnectTimeout = DEFAULT_HTTP_CONNECT_TIMEOUT_MS;
 }

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -151,6 +151,14 @@ public class RegistryManagerTest
     final String jobPropertiesJson = "{\"jobId\":\"some_guid\",\"type\":\"export\",\"progress\"" +
             ":0,\"outputBlobContainerUri\":\"https://myurl.com\",\"excludeKeysInExport\":true}";
 
+    @Test
+    public void testOptionsDefaults()
+    {
+        RegistryManagerOptions options = RegistryManagerOptions.builder().build();
+        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
+        assertEquals((int) Deencapsulation.getField(RegistryManagerOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
+    }
+
     // Tests_SRS_SERVICE_SDK_JAVA_REGISTRYMANAGER_12_001: [The constructor shall throw IllegalArgumentException if the input string is null or empty]
     // Assert
     @Test (expected = IllegalArgumentException.class)

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethodTest.java
@@ -8,18 +8,21 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethod;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceMethodClientOptions;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceOperations;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Job;
 import com.microsoft.azure.sdk.iot.service.devicetwin.MethodResult;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
-import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
-import mockit.*;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.Verifications;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.Proxy;
-import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,8 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for Device Method
@@ -179,6 +181,13 @@ public class DeviceMethodTest
             };
 
 
+    @Test
+    public void testOptionsDefaults()
+    {
+        DeviceMethodClientOptions options = DeviceMethodClientOptions.builder().build();
+        assertEquals((int) Deencapsulation.getField(DeviceMethodClientOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
+        assertEquals((int) Deencapsulation.getField(DeviceMethodClientOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
+    }
 
     /* Tests_SRS_DEVICEMETHOD_21_002: [The constructor shall create an IotHubConnectionStringBuilder object from the given connection string.] */
     /* Tests_SRS_DEVICEMETHOD_21_003: [The constructor shall create a new DeviceMethod instance and return it.] */

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwinTest.java
@@ -5,24 +5,50 @@
 
 package tests.unit.com.microsoft.azure.sdk.iot.service.devicetwin;
 
-import com.azure.core.credential.TokenCredential;
-import com.microsoft.azure.sdk.iot.deps.twin.*;
+import com.microsoft.azure.sdk.iot.deps.twin.ConfigurationInfo;
+import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinConnectionState;
+import com.microsoft.azure.sdk.iot.deps.twin.TwinState;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
-import com.microsoft.azure.sdk.iot.service.devicetwin.*;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinClientOptions;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Job;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryCollection;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryCollectionResponse;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryOptions;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.SqlQuery;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubExceptionManager;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpRequest;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
-import mockit.*;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.StrictExpectations;
+import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -103,6 +129,14 @@ public class DeviceTwinTest
             assertNotNull(val);
             assertEquals(p.getValue(), val);
         }
+    }
+
+    @Test
+    public void testOptionsDefaults()
+    {
+        DeviceTwinClientOptions options = DeviceTwinClientOptions.builder().build();
+        assertEquals((int) Deencapsulation.getField(DeviceTwinClientOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
+        assertEquals((int) Deencapsulation.getField(DeviceTwinClientOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
     }
 
     /*

--- a/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
+++ b/service/iot-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
@@ -14,15 +14,25 @@ import com.microsoft.azure.sdk.iot.service.IotHubConnectionString;
 import com.microsoft.azure.sdk.iot.service.IotHubConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
-import com.microsoft.azure.sdk.iot.service.devicetwin.*;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceOperations;
+import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
+import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
+import com.microsoft.azure.sdk.iot.service.devicetwin.QueryType;
+import com.microsoft.azure.sdk.iot.service.devicetwin.SqlQuery;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.jobs.JobClient;
+import com.microsoft.azure.sdk.iot.service.jobs.JobClientOptions;
 import com.microsoft.azure.sdk.iot.service.jobs.JobResult;
 import com.microsoft.azure.sdk.iot.service.jobs.JobStatus;
 import com.microsoft.azure.sdk.iot.service.jobs.JobType;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
-import mockit.*;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.Verifications;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,8 +45,7 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Unit test for job client
@@ -101,6 +110,14 @@ public class JobClientTest
 
         //assert
         assertNotNull(testJobClient);
+    }
+
+    @Test
+    public void testOptionsDefaults()
+    {
+        JobClientOptions options = JobClientOptions.builder().build();
+        assertEquals((int) Deencapsulation.getField(JobClientOptions.class, "DEFAULT_HTTP_READ_TIMEOUT_MS"), options.getHttpReadTimeout());
+        assertEquals((int) Deencapsulation.getField(JobClientOptions.class, "DEFAULT_HTTP_CONNECT_TIMEOUT_MS"), options.getHttpConnectTimeout());
     }
 
     /* Tests_SRS_JOBCLIENT_21_001: [The constructor shall throw IllegalArgumentException if the input string is null or empty.] */


### PR DESCRIPTION
Rather than set the default values for these fields in the constructor that builds these options objects, just set them in the options objects directly