### PR TITLE
fix(iot-dev): clarify/fix how partial successes work for MultiplexingClient bulk registrations

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -136,7 +136,8 @@ public class MultiplexingClient
      * <p>
      * @throws MultiplexingClientException If any IO or authentication errors occur while opening the multiplexed connection.
      * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or many of the registered devices failed to authenticate.
-     * Any devices not found in the map of registration exceptions provided by this exception have registered successfully.
+     * Any devices not found in the map of registration exceptions provided by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()} have registered successfully.
      * Even when this is thrown, the AMQPS/AMQPS_WS connection is still open, and other clients may be registered to it.
      */
     public void open() throws MultiplexingClientException
@@ -248,8 +249,10 @@ public class MultiplexingClient
      * <p>
      * @throws InterruptedException If the thread gets interrupted while waiting for the registration to succeed. This
      * will never be thrown if the multiplexing client is not open yet.
-     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register. Details for each failure can be found
-     * in this exception.
+     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If the device failed to register. Details for
+     * this failure can be found nested within the map given by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()}. If this exception is
+     * thrown, the device was not registered, and therefore it does not need to be unregistered.
      * @throws com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientDeviceRegistrationTimeoutException If this operation takes longer than the default timeout allows.
      * @throws MultiplexingClientException If any other Exception is thrown, it will be nested into this exception.
      * @param deviceClient The device client to associate with this multiplexing client.
@@ -298,8 +301,10 @@ public class MultiplexingClient
      * <p>
      * @throws InterruptedException If the thread gets interrupted while waiting for the registration to succeed. This
      * will never be thrown if the multiplexing client is not open yet.
-     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register. Details for each failure can be found
-     * in this exception.
+     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If the device failed to register. Details for
+     * this failure can be found nested within the map given by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()}. If this exception is
+     * thrown, the device was not registered, and therefore it does not need to be unregistered.
      * @throws com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientDeviceRegistrationTimeoutException If this operation takes longer than the provided timeout allows.
      * @throws MultiplexingClientException If any other Exception is thrown, it will be nested into this exception.
      * @param deviceClient The device client to associate with this multiplexing client.
@@ -349,8 +354,12 @@ public class MultiplexingClient
      * <p>
      * @throws InterruptedException If the thread gets interrupted while waiting for the registration to succeed. This
      * will never be thrown if the multiplexing client is not open yet.
-     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register. Details for each failure can be found
-     * in this exception. Any devices not found in the map of registration exceptions provided by this exception have registered successfully.
+     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register.
+     * Details for each failure can be found in the map provided by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()}. Any devices not
+     * found in the map of registration exceptions provided by this exception have registered successfully. Any devices
+     * that are found in the map of registration exceptions provided by this exception were not registered, and therefore
+     * do not need to be unregistered.
      * @throws com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientDeviceRegistrationTimeoutException If this operation takes longer than the default timeout allows.
      * @throws MultiplexingClientException If any other Exception is thrown, it will be nested into this exception.
      * @param deviceClients The device clients to associate with this multiplexing client.
@@ -397,8 +406,12 @@ public class MultiplexingClient
      * <p>
      * @throws InterruptedException If the thread gets interrupted while waiting for the registration to succeed. This
      * will never be thrown if the multiplexing client is not open yet.
-     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register. Details for each failure can be found
-     * in this exception. Any devices not found in the map of registration exceptions provided by this exception have registered successfully.
+     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or more devices failed to register.
+     * Details for each failure can be found in the map provided by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()}. Any devices not
+     * found in the map of registration exceptions provided by this exception have registered successfully. Any devices
+     * that are found in the map of registration exceptions provided by this exception were not registered, and therefore
+     * do not need to be unregistered.
      * @throws com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientDeviceRegistrationTimeoutException If this operation takes longer than the provided timeout allows.
      * @throws MultiplexingClientException If any other Exception is thrown, it will be nested into this exception.
      * @param deviceClients The device clients to associate with this multiplexing client.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -776,6 +776,10 @@ public class IotHubTransport implements IotHubListener
                     }
 
                     registrationException.addRegistrationException(deviceId, deviceRegistrationException);
+
+                    // Since the registration failed, need to remove the device from the list of multiplexed devices
+                    DeviceClientConfig configThatFailedToRegister = this.deviceClientConfigs.remove(deviceId);
+                    ((AmqpsIotHubConnection) this.iotHubTransportConnection).unregisterMultiplexedDevice(configThatFailedToRegister);
                 }
             }
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1672,6 +1672,8 @@ public class MultiplexingClientTests extends IntegrationTest
                 }
             }
 
+            assertFalse("Device failed to be registered, but the multiplexing client still reports it as registered",
+                testInstance.multiplexingClient.isDeviceRegistered(deviceToDisable.getDeviceId()));
 
             // Verify that the other devices on the multiplexed connection were unaffected
             for (int i = 1; i < DEVICE_MULTIPLEX_COUNT; i++)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1675,6 +1675,12 @@ public class MultiplexingClientTests extends IntegrationTest
             assertFalse("Device failed to be registered, but the multiplexing client still reports it as registered",
                 testInstance.multiplexingClient.isDeviceRegistered(deviceToDisable.getDeviceId()));
 
+            for (int i = 1; i < DEVICE_MULTIPLEX_COUNT; i++)
+            {
+                assertTrue("One device failed to be registered, but the other devices should still have been registered.",
+                    testInstance.multiplexingClient.isDeviceRegistered(testInstance.deviceClientArray.get(i).getConfig().getDeviceId()));
+            }
+
             // Verify that the other devices on the multiplexed connection were unaffected
             for (int i = 1; i < DEVICE_MULTIPLEX_COUNT; i++)
             {


### PR DESCRIPTION
When registering X devices to an open connection and 1 of them is disabled, the register call will throw a MultiplexingClientDeviceRegistrationAuthenticationException, but X-1 devices successfully added their session to the active multiplexed connection. This needed to be clarified since the javadocs didn't call this out.

There are two bug fixes here. The first bug fix is simply that the transport layer forgot to remove the device from the set of registered devices if it failed to register in a scenario like the above. It was never successfully registered, so the transport layer should have the same state. 

The second bug is that the MultiplexingClient layer should update it's state accordingly in these partial success scenarios as well. Previously, if it threw an exception in a scenario like the above, its local state would show that all X devices are not registered, even when X-1 of them have open sessions on the actual multiplexed connection. I added a few assert statement to an existing test to validate this change.

One commit on this PR is just to delete some pesky outdated comments