### PR TITLE
release(2021-06-07): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.30.2";
+    private static final String CLIENT_VERSION = "1.30.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.2') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.3') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,17 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.30.2</iot-device-client-version>
-        <iot-service-client-version>1.31.0</iot-service-client-version>
-        <iot-deps-version>0.13.0</iot-deps-version>
-        <provisioning-device-client-version>1.8.7</provisioning-device-client-version>
-        <provisioning-service-client-version>1.7.2</provisioning-service-client-version>
+        <iot-device-client-version>1.30.3</iot-device-client-version>
+        <iot-service-client-version>1.31.1</iot-service-client-version>
+        <iot-deps-version>0.13.1</iot-deps-version>
+        <provisioning-device-client-version>1.8.8</provisioning-device-client-version>
+        <provisioning-service-client-version>1.7.3</provisioning-service-client-version>
         <security-provider-version>1.4.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
-        <x509-provider-version>1.1.4</x509-provider-version>
+        <x509-provider-version>1.1.5</x509-provider-version>
     </properties>
     <build>
         <plugins>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.7";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.8";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.2";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.31.0";
+    public static final String serviceVersion = "1.31.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.13.1)

- Increase dependency versions for bouncycastle to 1.65 (#1232)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.30.3)

- Increase dependency versions for bouncycastle to 1.65 (#1232)

### Bug fixes
- Fixed a bug partially successful bulk registrations of devices to multiplexed connections didn't update local state properly (#1231)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.31.1)

- Increase dependency versions for bouncycastle to 1.65 (#1232)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.8.8)

- Increase dependency versions for bouncycastle to 1.65 (#1232)


## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.7.3)

- Increase dependency versions for bouncycastle to 1.65 (#1232)

## Java X509 Provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:1.1.5)

- Increase dependency versions for bouncycastle to 1.65 (#1232)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.30.3/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.31.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.13.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.8.8/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.7.3/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/x509-provider/1.1.5/jar

old
{
    "device": "1.30.2",
    "service": "1.31.0",
    "deps": "0.13.0",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.4",
    "provisioningDevice": "1.8.7",
    "provisioningService": "1.7.2"
}

new
{
    "device": "1.30.3",
    "service": "1.31.1",
    "deps": "0.13.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.5",
    "provisioningDevice": "1.8.8",
    "provisioningService": "1.7.3"
}