### PR TITLE
refactor(samples): Refactor symmetric key enrollment group samples to show best practices

### DIFF
--- a/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ComputeDerivedSymmetricKeySample.java
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ComputeDerivedSymmetricKeySample.java
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
  * particular device, so this code is deliberately separate from the {@link ProvisioningSymmetricKeyEnrollmentGroupSample}
  * in this same directory. Users are advised to run this code to generate the derived symmetric key once, and to save
  * the derived key to the device. Users are not advised to derive the device symmetric key from the enrollment group
- * level key within each device as that is insecure.
+ * level key within each device as that is unsecure.
  */
 public class ComputeDerivedSymmetricKeySample
 {

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ComputeDerivedSymmetricKeySample.java
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ComputeDerivedSymmetricKeySample.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package samples.com.microsoft.azure.sdk.iot;
+
+import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This sample demonstrates how to derive the symmetric key for a particular device enrollment within an enrollment
+ * group. Best security practices dictate that the enrollment group level symmetric key should never be saved to a
+ * particular device, so this code is deliberately separate from the {@link ProvisioningSymmetricKeyEnrollmentGroupSample}
+ * in this same directory. Users are advised to run this code to generate the derived symmetric key once, and to save
+ * the derived key to the device. Users are not advised to derive the device symmetric key from the enrollment group
+ * level key within each device as that is insecure.
+ */
+public class ComputeDerivedSymmetricKeySample
+{
+    // The symmetric key of the enrollment group. Unlike with individual enrollments, this key cannot be used directly
+    // when provisioning a device. Instead, this sample will demonstrate how to derive the symmetric key for your
+    // particular device within the enrollment group.
+
+    // Note that this enrollment group level key should NOT be saved to each device. If leaked, this key would allow
+    // any device to spoof another device which is insecure. The derived key that this sample generates should be the
+    // only key saved to each device.
+    private static final String ENROLLMENT_GROUP_SYMMETRIC_KEY = "[Enter your group enrollment symmetric key here]";
+
+    // The Id to assign to this device when it is provisioned to an IoT Hub. This value is arbitrary outside of some
+    // character limitations. For sample purposes, this value is filled in for you, but it may be changed.
+    private static final String PROVISIONED_DEVICE_ID = "myProvisionedDevice";
+
+    public static void main(String[] args) throws Exception
+    {
+        // For the sake of security, you shouldn't save keys into String variables as that places them in heap memory. For the sake
+        // of simplicity within this sample, though, we will save it as a string. Typically this key would be loaded as byte[] so that
+        // it can be removed from stack memory.
+        byte[] derivedSymmetricKey =
+            SecurityProviderSymmetricKey
+                .ComputeDerivedSymmetricKey(
+                    ENROLLMENT_GROUP_SYMMETRIC_KEY.getBytes(StandardCharsets.UTF_8),
+                    PROVISIONED_DEVICE_ID);
+
+        System.out.println("Your derived symmetric key for group enrollments is: ");
+        System.out.println(new String(derivedSymmetricKey, StandardCharsets.UTF_8));
+    }
+}

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ProvisioningSymmetricKeyEnrollmentGroupSample.java
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ProvisioningSymmetricKeyEnrollmentGroupSample.java
@@ -17,7 +17,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 /**
- * Symmetric Key authenticated enrollment group sample
+ * Symmetric Key authenticated enrollment group sample. In order to demonstrate best security practices, this sample
+ * does not take the enrollment group level symmetric key as an input. Instead, it only takes the device specific derived
+ * symmetric key. To learn how to derive this device specific symmetric key, see the {@link ComputeDerivedSymmetricKeySample}
+ * in this same directory.
  */
 @SuppressWarnings("CommentedOutCode") // Ignored in samples as we use these comments to show other options.
 public class ProvisioningSymmetricKeyEnrollmentGroupSample
@@ -28,12 +31,14 @@ public class ProvisioningSymmetricKeyEnrollmentGroupSample
     // Typically "global.azure-devices-provisioning.net"
     private static final String GLOBAL_ENDPOINT = "[Your Provisioning Service Global Endpoint here]";
 
-    // The symmetric key of the enrollment group. Unlike with individual enrollments, this key cannot be used directly when provisioning a device.
-    // Instead, this sample will demonstrate how to derive the symmetric key for your particular device within the enrollment group.
-    private static final String ENROLLMENT_GROUP_SYMMETRIC_KEY = "[Enter your Symmetric Key here]";
+    // Not to be confused with the symmetric key of the enrollment group itself, this key is derived from the symmetric
+    // key of the enrollment group and the desired device id of the device to provision. See the
+    // "ComputeDerivedSymmetricKeySample" code in this same directory for instructions on how to derive this key.
+    private static final String DERIVED_ENROLLMENT_GROUP_SYMMETRIC_KEY = "[Enter your derived symmetric key here]";
 
     // The Id to assign to this device when it is provisioned to an IoT Hub. This value is arbitrary outside of some
-    // character limitations. For sample purposes, this value is filled in for you, but it may be changed.
+    // character limitations. For sample purposes, this value is filled in for you, but it may be changed. This value
+    // must be consistent with the device id used when deriving the symmetric key that is used in this sample.
     private static final String PROVISIONED_DEVICE_ID = "myProvisionedDevice";
 
     // Uncomment one line to choose which protocol you'd like to use
@@ -86,14 +91,10 @@ public class ProvisioningSymmetricKeyEnrollmentGroupSample
         Scanner scanner = new Scanner(System.in);
         DeviceClient deviceClient = null;
 
-        // Since enrollment groups can be used to provision more than one device, the service requires you to derive the
-        // symmetric key for your device to provision based on the symmetric key of the enrollment group, and the desired
-        // device Id of the device you are provisioning
-
         // For the sake of security, you shouldn't save keys into String variables as that places them in heap memory. For the sake
         // of simplicity within this sample, though, we will save it as a string. Typically this key would be loaded as byte[] so that
         // it can be removed from stack memory.
-        byte[] derivedSymmetricKey = SecurityProviderSymmetricKey.ComputeDerivedSymmetricKey(ENROLLMENT_GROUP_SYMMETRIC_KEY.getBytes(StandardCharsets.UTF_8), PROVISIONED_DEVICE_ID);
+        byte[] derivedSymmetricKey = DERIVED_ENROLLMENT_GROUP_SYMMETRIC_KEY.getBytes(StandardCharsets.UTF_8);
 
         securityClientSymmetricKey = new SecurityProviderSymmetricKey(derivedSymmetricKey, PROVISIONED_DEVICE_ID);
 


### PR DESCRIPTION
We need to separate the derivation of the device-specific symmetric key to a different sample as per the service team's recommendation. Users shouldn't save the enrollment group level key to each device, and that's what our sample showed previously