### PR TITLE
refactor(iot-dev): Add log statements for setOption methods

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -887,6 +887,7 @@ public class InternalClient
     {
         if (value != null)
         {
+            log.info("Setting path to trusted certificate");
             this.config.getAuthenticationProvider().setPathToIotHubTrustedCert((String) value);
         }
     }
@@ -902,6 +903,7 @@ public class InternalClient
 
             if (value instanceof Integer)
             {
+                log.info("Setting HTTPS connect timeout to {} milliseconds", value);
                 this.config.setHttpsConnectTimeout((int) value);
             }
             else
@@ -922,6 +924,7 @@ public class InternalClient
 
             if (value instanceof Integer)
             {
+                log.info("Setting HTTPS read timeout to {} milliseconds", value);
                 this.config.setHttpsReadTimeout((int) value);
             }
             else
@@ -946,6 +949,7 @@ public class InternalClient
                 try
                 {
                     verifyRegisteredIfMultiplexing();
+                    log.info("Setting send period to {} milliseconds", value);
                     this.deviceIO.setSendPeriodInMilliseconds((long) value);
                 }
                 catch (IOException e)
@@ -970,6 +974,7 @@ public class InternalClient
                 try
                 {
                     verifyRegisteredIfMultiplexing();
+                    log.info("Setting receive period to {} milliseconds", value);
                     this.deviceIO.setReceivePeriodInMilliseconds((long) value);
                 }
                 catch (IOException e)
@@ -1007,6 +1012,7 @@ public class InternalClient
                 throw new IllegalArgumentException("value is not long = " + value);
             }
 
+            log.info("Setting generated SAS token lifespans to {} seconds", validTimeInSeconds);
             this.config.getSasTokenAuthentication().setTokenValidSecs(validTimeInSeconds);
 
             if (this.deviceIO != null)
@@ -1052,6 +1058,7 @@ public class InternalClient
 
             if (value instanceof Integer)
             {
+                log.info("Setting generated AMQP authentication session timeout to {} seconds", value);
                 this.config.setAmqpOpenAuthenticationSessionTimeout((int) value);
             }
             else
@@ -1072,6 +1079,7 @@ public class InternalClient
 
             if (value instanceof Integer)
             {
+                log.info("Setting generated AMQP device session timeout to {} seconds", value);
                 this.config.setAmqpOpenDeviceSessionsTimeout((int) value);
             }
             else


### PR DESCRIPTION
These options can drastically alter how the SDK behaves, so for future debugging purposes, they should be logged when set
