### PR TITLE
Release 2021 06 17

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.30.3";
+    private static final String CLIENT_VERSION = "1.31.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.30.3') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.31.0') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         <iot-device-client-version>1.31.0</iot-device-client-version>
         <iot-service-client-version>1.32.0</iot-service-client-version>
         <iot-deps-version>0.14.0</iot-deps-version>
-        <provisioning-device-client-version>1.8.8</provisioning-device-client-version>
-        <provisioning-service-client-version>1.7.3</provisioning-service-client-version>
+        <provisioning-device-client-version>1.9.0</provisioning-device-client-version>
+        <provisioning-service-client-version>1.8.0</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,17 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.30.3</iot-device-client-version>
-        <iot-service-client-version>1.31.1</iot-service-client-version>
-        <iot-deps-version>0.13.1</iot-deps-version>
+        <iot-device-client-version>1.31.0</iot-device-client-version>
+        <iot-service-client-version>1.32.0</iot-service-client-version>
+        <iot-deps-version>0.14.0</iot-deps-version>
         <provisioning-device-client-version>1.8.8</provisioning-device-client-version>
         <provisioning-service-client-version>1.7.3</provisioning-service-client-version>
-        <security-provider-version>1.4.0</security-provider-version>
+        <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
-        <x509-provider-version>1.1.5</x509-provider-version>
+        <x509-provider-version>1.1.6</x509-provider-version>
     </properties>
     <build>
         <plugins>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.8.8";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.9.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.7.3";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.8.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/readme.md
+++ b/readme.md
@@ -177,8 +177,8 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
 | Maven Package | Github Branch | LTS Status | LTS Start Date | Maintenance End Date | Removed Date |
 | :-----------: | :-----------: | :--------: | :------------: | :------------------: | :----------: |
-| [2020-7-7](https://github.com/Azure/azure-iot-sdk-java/releases/tag/lts_7_2020) | lts_07_2020   | Active     | 2020-7-7     | 2020-12-31            | 2021-6-30   |
-| [2020-01-27](https://github.com/Azure/azure-iot-sdk-java/releases/tag/LTS_01_2020) | lts_01_2020   | Deprecated     | 2020-01-27     | 2020-06-30            | 2020-12-31   |
+| [2021-6-17](https://github.com/Azure/azure-iot-sdk-java/releases/tag/lts_6_2021) | lts_06_2021   | Active     | 2020-6-17     | 2021-12-31            | 2022-6-30   |
+| [2020-7-7](https://github.com/Azure/azure-iot-sdk-java/releases/tag/lts_7_2020) | lts_07_2020   | Removed     | 2020-7-7     | 2020-12-31            | 2021-6-30   |
 
 * <sup>1</sup> All scheduled dates are subject to change by the Azure IoT SDK team.
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.31.1";
+    public static final String serviceVersion = "1.32.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
This release is an LTS release. See here for more details on what this means:
https://github.com/Azure/azure-iot-sdk-java#long-term-support

## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.14.0)

- Increase dependency versions for bouncycastle to 1.69 (#1245)
- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.31.0)

- Increase dependency versions for bouncycastle to 1.69 (#1245)
- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.32.0)

- Increase dependency versions for bouncycastle to 1.69 (#1245)
- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

### Bug fixes
- Fixed a bug where subsequent calls to receive file upload notifications and feedback messages failed (#1238)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.9.0)

- Increase dependency versions for bouncycastle to 1.69 (#1245)
- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.8.0)

- Increase dependency versions for bouncycastle to 1.69 (#1245)
- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

## Java X509 Provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:1.1.6)

- Increase dependency versions for bouncycastle to 1.69 (#1245)

## Java Security Provider (com.microsoft.azure.sdk.iot.provisioning.security:security-provider:1.5.0)

- Add new Digicert Global Root G2 certificate to trusted root chain (#1247)

Note that this release is the first release where all the packages will be compatible with both the current IoT Hub public certificate (which is being phased out) and compatible with the new IoT Hub public certificate that will be arriving June 2022.

More information about this upcoming change in IoT Hub and DPS certificate roots can be seen here: https://techcommunity.microsoft.com/t5/internet-of-things/azure-iot-tls-critical-changes-are-almost-here-and-why-you/ba-p/2393169

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.31.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.32.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.14.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.9.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.8.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/x509-provider/1.1.6/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/security-provider/1.2.0/jar

old
{
    "device": "1.30.3",
    "service": "1.31.1",
    "deps": "0.13.1",
    "securityProvider": "1.4.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.5",
    "provisioningDevice": "1.8.8",
    "provisioningService": "1.7.3"
}

new
{
    "device": "1.31.0",
    "service": "1.32.0",
    "deps": "0.14.0",
    "securityProvider": "1.5.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.6",
    "provisioningDevice": "1.9.0",
    "provisioningService": "1.8.0"
}