### PR TITLE
fix(sample): Fix issue in device reconnection sample

### DIFF
--- a/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -138,31 +138,25 @@ public class DeviceClientManager implements IotHubConnectionStatusChangeCallback
                     @Override
                     public void run() {
                         log.debug("Attempting reconnect for device client...");
-                        boolean connected = false;
-                        while (!connected) {
-                            synchronized (lock) {
-                                if (connectionStatus == ConnectionStatus.CONNECTED) {
-                                    try {
-                                        client.closeNow();
-                                    } catch (Exception e) {
-                                        log.warn("DeviceClient closeNow failed.", e);
-                                    } finally {
-                                        connectionStatus = ConnectionStatus.CONNECTING;
-                                    }
-                                } else {
-                                    log.debug("DeviceClient is currently connecting, or already connected; skipping...");
-                                    return;
+                        synchronized (lock) {
+                            if (connectionStatus == ConnectionStatus.CONNECTED) {
+                                try {
+                                    client.closeNow();
+                                } catch (Exception e) {
+                                    log.warn("DeviceClient closeNow failed.", e);
+                                } finally {
+                                    connectionStatus = ConnectionStatus.CONNECTING;
                                 }
-                            }
-
-                            try {
-                                doConnect();
-                                connected = true; // since doConnect() returned without throwing, the connection is open.
-                            } catch (IOException e) {
-                                log.error("Exception thrown while opening DeviceClient instance: ", e);
+                            } else {
+                                log.debug("DeviceClient is currently connecting, or already connected; skipping...");
+                                return;
                             }
                         }
-
+                        try {
+                            doConnect();
+                        } catch (IOException e) {
+                            log.error("Exception thrown while opening DeviceClient instance: ", e);
+                        }
                     }
                 }).start();
             } else {

--- a/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -60,10 +60,10 @@ public class DeviceClientManager implements IotHubConnectionStatusChangeCallback
                 return;
             }
         }
-        doConnect();
+        doConnectWithRetry();
     }
 
-    private void doConnect() throws IOException {
+    private void doConnectWithRetry() throws IOException {
         // Device client does not have retry on the initial open() call. Will need to be re-opened by the calling application
         while (connectionStatus == ConnectionStatus.CONNECTING) {
             synchronized (lock) {
@@ -153,7 +153,7 @@ public class DeviceClientManager implements IotHubConnectionStatusChangeCallback
                             }
                         }
                         try {
-                            doConnect();
+                            doConnectWithRetry();
                         } catch (IOException e) {
                             log.error("Exception thrown while opening DeviceClient instance: ", e);
                         }


### PR DESCRIPTION
~~The previous implementation did not try to open the connection again if a call to open() threw an exception. This new implementation will retry the open call if that happens.~~

So the only actual issue here is that the doConnect method appeared to not have retry baked in, but it actually did. I'd like to rename the method accordingly so that others don't make the same mistaken assumption that I made
