### PR TITLE
feat(iot-dev): Add support for opening clients with retry

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -425,7 +425,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      * it fails. Both the operation timeout set in {@link #setOperationTimeout(long)} and the retry policy set in
      * {{@link #setRetryPolicy(RetryPolicy)}} will be respected while retrying to open the connection.
      *
-     * @throws IOException if a connection to an IoT Hub cannot be established.
+     * @throws IOException if a connection to an IoT hub cannot be established.
      */
     public void open(boolean withRetry) throws IOException
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -418,7 +418,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * Starts asynchronously sending and receiving messages from an IoT hub. If
      * the client is already open, the function shall do nothing.
      *
      * @param withRetry if true, this open call will apply the retry policy to allow for the open call to be retried if
@@ -457,13 +457,13 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Completes all current outstanding requests and closes the IoT Hub client.
+     * Completes all current outstanding requests and closes the IoT hub client.
      * Must be called to terminate the background thread that is sending data to
-     * IoT Hub. After {@code closeNow()} is called, the IoT Hub client is no longer
+     * IoT hub. After {@code closeNow()} is called, the IoT hub client is no longer
      * usable. If the client is already closed, the function shall do nothing.
      * @deprecated : As of release 1.1.25 this call is replaced by {@link #closeNow()}
      *
-     * @throws IOException if the connection to an IoT Hub cannot be closed.
+     * @throws IOException if the connection to an IoT hub cannot be closed.
      */
     @Deprecated
     public void close() throws IOException
@@ -497,15 +497,15 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Closes the IoT Hub client by releasing any resources held by client. When
+     * Closes the IoT hub client by releasing any resources held by client. When
      * closeNow is called all the messages that were in transit or pending to be
      * sent will be informed to the user in the callbacks and any existing
      * connection to IotHub will be closed.
      * Must be called to terminate the background thread that is sending data to
-     * IoT Hub. After {@code closeNow()} is called, the IoT Hub client is no longer
+     * IoT hub. After {@code closeNow()} is called, the IoT hub client is no longer
      * usable. If the client is already closed, the function shall do nothing.
      *
-     * @throws IOException if the connection to an IoT Hub cannot be closed.
+     * @throws IOException if the connection to an IoT hub cannot be closed.
      */
     public void closeNow() throws IOException
     {
@@ -539,7 +539,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Asynchronously upload a stream to the IoT Hub.
+     * Asynchronously upload a stream to the IoT hub.
      *
      * NOTE: IotHub does not currently support CA signed devices using file upload. Please use SAS based authentication or
      * self signed certificates.
@@ -602,7 +602,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Notify IoT Hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
+     * Notify IoT hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
      * @param notification The notification details, including if the file upload succeeded.
      * @throws IOException If this HTTPS request fails to send.
      * @deprecated This function is not actually async, so use {@link #completeFileUpload(FileUploadCompletionNotification)} to avoid confusion
@@ -614,7 +614,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     }
 
     /**
-     * Notify IoT Hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
+     * Notify IoT hub that a file upload has been completed, successfully or otherwise. See <a href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload">this documentation</a> for more details.
      * @param notification The notification details, including if the file upload succeeded.
      * @throws IOException If this HTTPS request fails to send.
      */
@@ -641,7 +641,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
@@ -674,7 +674,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
@@ -705,7 +705,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      * Starts the device twin. This device client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this device client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUpload;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUploadTask;
+import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.IoTHubConnectionType;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
@@ -419,6 +420,10 @@ public final class DeviceClient extends InternalClient implements Closeable
     /**
      * Starts asynchronously sending and receiving messages from an IoT Hub. If
      * the client is already open, the function shall do nothing.
+     *
+     * @param withRetry if true, this open call will apply the retry policy to allow for the open call to be retried if
+     * it fails. Both the operation timeout set in {@link #setOperationTimeout(long)} and the retry policy set in
+     * {{@link #setRetryPolicy(RetryPolicy)}} will be respected while retrying to open the connection.
      *
      * @throws IOException if a connection to an IoT Hub cannot be established.
      */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -413,6 +413,17 @@ public final class DeviceClient extends InternalClient implements Closeable
      */
     public void open() throws IOException
     {
+        this.open(false);
+    }
+
+    /**
+     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * the client is already open, the function shall do nothing.
+     *
+     * @throws IOException if a connection to an IoT Hub cannot be established.
+     */
+    public void open(boolean withRetry) throws IOException
+    {
         if (this.ioTHubConnectionType == IoTHubConnectionType.USE_MULTIPLEXING_CLIENT)
         {
             throw new UnsupportedOperationException(MULTIPLEXING_OPEN_ERROR_MESSAGE);
@@ -434,7 +445,7 @@ public final class DeviceClient extends InternalClient implements Closeable
         else
         {
             // Codes_SRS_DEVICECLIENT_21_006: [The open shall invoke super.open().]
-            super.open();
+            super.open(withRetry);
         }
 
         log.info("Device client opened successfully");
@@ -974,7 +985,7 @@ public final class DeviceClient extends InternalClient implements Closeable
                             else
                             {
                                 this.getDeviceIO().close();
-                                this.getDeviceIO().open();
+                                this.getDeviceIO().open(false);
                             }
                         }
                     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -149,7 +149,7 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      *
      * @throws IOException if a connection to an IoT Hub cannot be established.
      */
-    void open() throws IOException
+    void open(boolean withRetry) throws IOException
     {
         synchronized (this.stateLock)
         {
@@ -160,7 +160,7 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
             try
             {
-                this.transport.open();
+                this.transport.open(withRetry);
             }
             catch (DeviceClientException e)
             {
@@ -170,11 +170,11 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
     }
 
     // Functionally the same as "open()", but without wrapping any thrown TransportException into an IOException
-    void openWithoutWrappingException() throws TransportException
+    void openWithoutWrappingException(boolean withRetry) throws TransportException
     {
         try
         {
-            open();
+            open(withRetry);
         }
         catch (IOException e)
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -173,7 +173,7 @@ public class InternalClient
      * Starts asynchronously sending and receiving messages from an IoT Hub. If
      * the client is already open, the function shall do nothing.
      *
-     * @throws IOException if a connection to an IoT Hub cannot be established.
+     * @throws IOException if a connection to an IoT hub cannot be established.
      */
     public void open() throws IOException
     {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -169,17 +169,22 @@ public class InternalClient
         this.deviceIO = null;
     }
 
+    public void open() throws IOException
+    {
+        this.open(false);
+    }
+
     // The warning is for how getSasTokenAuthentication() may return null, but the check that our config uses SAS_TOKEN
     // auth is sufficient at confirming that getSasTokenAuthentication() will return a non-null instance
     @SuppressWarnings("ConstantConditions")
-    public void open() throws IOException
+    public void open(boolean withRetry) throws IOException
     {
         if (this.config.getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN && this.config.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary())
         {
             throw new SecurityException("Your SasToken is expired");
         }
 
-        this.deviceIO.open();
+        this.deviceIO.open(withRetry);
     }
 
     public void close() throws IOException
@@ -1032,7 +1037,7 @@ public class InternalClient
                         if (this.config.getSasTokenAuthentication().canRefreshToken())
                         {
                             this.deviceIO.close();
-                            this.deviceIO.open();
+                            this.deviceIO.open(false);
                         }
                     }
                     catch (IOException e)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -135,7 +135,7 @@ public class InternalClient
             this.config.modelId = clientOptions.getModelId();
         }
 
-        //Codes_SRS_INTERNALCLIENT_34_067: [The constructor shall initialize the IoT Hub transport for the protocol specified, creating a instance of the deviceIO.]
+        //Codes_SRS_INTERNALCLIENT_34_067: [The constructor shall initialize the IoT hub transport for the protocol specified, creating a instance of the deviceIO.]
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
@@ -220,7 +220,7 @@ public class InternalClient
     }
 
     /**
-     * Asynchronously sends an event message to the IoT Hub.
+     * Asynchronously sends an event message to the IoT hub.
      *
      * @param message the message to be sent.
      * @param callback the callback to be invoked when a response is received.
@@ -244,7 +244,7 @@ public class InternalClient
     }
 
     /**
-     * Asynchronously sends a batch of messages to the IoT Hub
+     * Asynchronously sends a batch of messages to the IoT hub
      * HTTPS messages will be sent in a single batch and MQTT and AMQP messages will be sent individually.
      * In case of HTTPS, This API call is an all-or-nothing single HTTPS message and the callback will be triggered only once.
      * Maximum payload size for HTTPS is 255KB
@@ -278,7 +278,7 @@ public class InternalClient
      *
      * This client will receive a callback each time a desired property is updated. That callback will either contain
      * the full desired properties set, or only the updated desired property depending on how the desired property was changed.
-     * IoT Hub supports a PUT and a PATCH on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
+     * IoT hub supports a PUT and a PATCH on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
      * will cause this device client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
      * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -169,11 +169,27 @@ public class InternalClient
         this.deviceIO = null;
     }
 
+    /**
+     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * the client is already open, the function shall do nothing.
+     *
+     * @throws IOException if a connection to an IoT Hub cannot be established.
+     */
     public void open() throws IOException
     {
         this.open(false);
     }
 
+    /**
+     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * the client is already open, the function shall do nothing.
+     *
+     * @param withRetry if true, this open call will apply the retry policy to allow for the open call to be retried if
+     * it fails. Both the operation timeout set in {@link #setOperationTimeout(long)} and the retry policy set in
+     * {{@link #setRetryPolicy(RetryPolicy)}} will be respected while retrying to open the connection.
+     *
+     * @throws IOException if a connection to an IoT Hub cannot be established.
+     */
     // The warning is for how getSasTokenAuthentication() may return null, but the check that our config uses SAS_TOKEN
     // auth is sufficient at confirming that getSasTokenAuthentication() will return a non-null instance
     @SuppressWarnings("ConstantConditions")

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -181,7 +181,7 @@ public class InternalClient
     }
 
     /**
-     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * Starts asynchronously sending and receiving messages from an IoT hub. If
      * the client is already open, the function shall do nothing.
      *
      * @param withRetry if true, this open call will apply the retry policy to allow for the open call to be retried if

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -188,7 +188,7 @@ public class InternalClient
      * it fails. Both the operation timeout set in {@link #setOperationTimeout(long)} and the retry policy set in
      * {{@link #setRetryPolicy(RetryPolicy)}} will be respected while retrying to open the connection.
      *
-     * @throws IOException if a connection to an IoT Hub cannot be established.
+     * @throws IOException if a connection to an IoT hub cannot be established.
      */
     // The warning is for how getSasTokenAuthentication() may return null, but the check that our config uses SAS_TOKEN
     // auth is sufficient at confirming that getSasTokenAuthentication() will return a non-null instance

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -170,7 +170,7 @@ public class InternalClient
     }
 
     /**
-     * Starts asynchronously sending and receiving messages from an IoT Hub. If
+     * Starts asynchronously sending and receiving messages from an IoT hub. If
      * the client is already open, the function shall do nothing.
      *
      * @throws IOException if a connection to an IoT hub cannot be established.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -181,7 +181,7 @@ public class ModuleClient extends InternalClient
      * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
      * the SDK no longer controls that when this constructor is used.
      *
-     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param hostName The host name of the IoT hub that this client will connect to.
      * @param deviceId The Id of the device containing the module that the connection will identify as.
      * @param moduleId The Id of the module that the connection will identify as.
      * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
@@ -197,7 +197,7 @@ public class ModuleClient extends InternalClient
      * this client such as setting the SAS token expiry time will throw {@link UnsupportedOperationException} since
      * the SDK no longer controls that when this constructor is used.
      *
-     * @param hostName The host name of the IoT Hub that this client will connect to.
+     * @param hostName The host name of the IoT hub that this client will connect to.
      * @param deviceId The Id of the device containing the module that the connection will identify as.
      * @param moduleId The Id of the module that the connection will identify as.
      * @param sasTokenProvider The provider of all SAS tokens that are used during authentication.
@@ -489,7 +489,7 @@ public class ModuleClient extends InternalClient
      * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
      * will cause this module client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
@@ -522,7 +522,7 @@ public class ModuleClient extends InternalClient
      * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
      * will cause this module client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
@@ -553,7 +553,7 @@ public class ModuleClient extends InternalClient
      * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
      * reported properties and desired properties. After that callback is received, this module client will receive a callback
      * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT Hub supports a PUT and a PATCH
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
      * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
      * will cause this module client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -17,11 +17,11 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A client for creating multiplexed connections to IoT Hub. A multiplexed connection allows for multiple device clients
+ * A client for creating multiplexed connections to IoT hub. A multiplexed connection allows for multiple device clients
  * to communicate to the service through a single AMQPS connection.
  * <p>
  * A given AMQPS connection requires a TLS connection, so multiplexing may be worthwhile if you want to limit the number
- * of TLS connections needed to connect multiple device clients to IoT Hub.
+ * of TLS connections needed to connect multiple device clients to IoT hub.
  * <p>
  * A given multiplexing client also has a fixed amount of worker threads regardless of how many device clients are
  * being multiplexed. Comparatively, every non-multiplexed device client instance has its own set of worker
@@ -262,7 +262,7 @@ public class MultiplexingClient
      * <p>
      * The registered device client must use symmetric key based authentication.
      * <p>
-     * The registered device client must belong to the same IoT Hub as all previously registered device clients.
+     * The registered device client must belong to the same IoT hub as all previously registered device clients.
      * <p>
      * If the provided device client is already registered to this multiplexing client, then then this method will do nothing.
      * <p>
@@ -314,7 +314,7 @@ public class MultiplexingClient
      * <p>
      * The registered device client must use symmetric key based authentication.
      * <p>
-     * The registered device client must belong to the same IoT Hub as all previously registered device clients.
+     * The registered device client must belong to the same IoT hub as all previously registered device clients.
      * <p>
      * If the provided device client is already registered to this multiplexing client, then then this method will do nothing.
      * <p>
@@ -366,7 +366,7 @@ public class MultiplexingClient
      * <p>
      * The registered device clients must use symmetric key based authentication.
      * <p>
-     * The registered device clients must belong to the same IoT Hub as all previously registered device clients.
+     * The registered device clients must belong to the same IoT hub as all previously registered device clients.
      * <p>
      * If any of these device clients are already registered to this multiplexing client, then then this method will
      * not do anything to that particular device client. All other provided device clients will still be registered though.
@@ -418,7 +418,7 @@ public class MultiplexingClient
      * <p>
      * The registered device clients must use symmetric key based authentication.
      * <p>
-     * The registered device clients must belong to the same IoT Hub as all previously registered device clients.
+     * The registered device clients must belong to the same IoT hub as all previously registered device clients.
      * <p>
      * If any of these device clients are already registered to this multiplexing client, then then this method will
      * not do anything to that particular device client. All other provided device clients will still be registered though.
@@ -483,7 +483,7 @@ public class MultiplexingClient
                     throw new UnsupportedOperationException(String.format("Multiplexed connections over AMQPS only support up to %d devices", MAX_MULTIPLEX_DEVICE_COUNT_AMQPS));
                 }
 
-                // Typically client side validation is duplicate work, but IoT Hub doesn't give a good error message when closing the
+                // Typically client side validation is duplicate work, but IoT hub doesn't give a good error message when closing the
                 // AMQPS_WS connection so this is the only way that users will know about this limit
                 if (this.protocol == IotHubClientProtocol.AMQPS_WS && this.multiplexedDeviceClients.size() > MAX_MULTIPLEX_DEVICE_COUNT_AMQPS_WS)
                 {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -142,12 +142,31 @@ public class MultiplexingClient
      */
     public void open() throws MultiplexingClientException
     {
+        this.open(false);
+    }
+
+    /**
+     * Opens this multiplexing client. This may be done before or after registering any number of device clients.
+     * <p>
+     * This call behaves synchronously, so if it returns without throwing, then all registered device clients were
+     * successfully opened.
+     * <p>
+     * If this client is already open, then this method will do nothing.
+     * <p>
+     * @throws MultiplexingClientException If any IO or authentication errors occur while opening the multiplexed connection.
+     * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or many of the registered devices failed to authenticate.
+     * Any devices not found in the map of registration exceptions provided by
+     * {@link MultiplexingClientDeviceRegistrationAuthenticationException#getRegistrationExceptions()} have registered successfully.
+     * Even when this is thrown, the AMQPS/AMQPS_WS connection is still open, and other clients may be registered to it.
+     */
+    public void open(boolean withRetry) throws MultiplexingClientException
+    {
         synchronized (this.operationLock)
         {
             log.info("Opening multiplexing client");
             try
             {
-                this.deviceIO.openWithoutWrappingException();
+                this.deviceIO.openWithoutWrappingException(withRetry);
             }
             catch (TransportException e)
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -153,6 +153,9 @@ public class MultiplexingClient
      * <p>
      * If this client is already open, then this method will do nothing.
      * <p>
+     * @param withRetry if true, this open call will apply the current retry policy to allow for the open call to be
+     * retried if it fails.
+     *
      * @throws MultiplexingClientException If any IO or authentication errors occur while opening the multiplexed connection.
      * @throws MultiplexingClientDeviceRegistrationAuthenticationException If one or many of the registered devices failed to authenticate.
      * Any devices not found in the map of registration exceptions provided by

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/TransportClient.java
@@ -129,7 +129,7 @@ public class TransportClient
             // Codes_SRS_TRANSPORTCLIENT_12_013: [The function shall open the transport in multiplexing mode.]
             //this.deviceIO.multiplexOpen(deviceClientList);
             // if client is added just open to get rid of multiplex open.
-            this.deviceIO.open();
+            this.deviceIO.open(false);
         }
 
         this.transportClientState = TransportClientState.OPENED;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -427,15 +427,7 @@ public class IotHubTransport implements IotHubListener
             // this loop either ends in throwing an exception when retry expires, or by a break statement upon a successful openConnection() call
             while (true)
             {
-                RetryPolicy retryPolicy;
-                if (isMultiplexing)
-                {
-                    retryPolicy = multiplexingRetryPolicy;
-                }
-                else
-                {
-                    retryPolicy = this.getDefaultConfig().getRetryPolicy();
-                }
+                RetryPolicy retryPolicy = isMultiplexing ?  multiplexingRetryPolicy : this.getDefaultConfig().getRetryPolicy();
 
                 try
                 {
@@ -444,7 +436,7 @@ public class IotHubTransport implements IotHubListener
                 }
                 catch (TransportException transportException)
                 {
-                    log.debug("Encountered an exception while opening the client. Consulting configured the retry policy to see if another attempt should be made.", transportException);
+                    log.debug("Encountered an exception while opening the client. Checking the configured retry policy to see if another attempt should be made.", transportException);
                     RetryDecision retryDecision = retryPolicy.getRetryDecision(connectionAttempt, transportException);
                     if (!retryDecision.shouldRetry())
                     {
@@ -460,6 +452,7 @@ public class IotHubTransport implements IotHubListener
 
                     try
                     {
+                        log.trace("The configured retry policy allows for another attempt. Sleeping for {} milliseconds before the next attempt", retryDecision.getDuration());
                         Thread.sleep(retryDecision.getDuration());
                     }
                     catch (InterruptedException e)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -390,6 +390,9 @@ public class IotHubTransport implements IotHubListener
      * If reconnection is occurring when this is called, this function shall block and wait for the reconnection
      * to finish before trying to open the connection
      *
+     * @param withRetry if true, this open call will apply the current retry policy to allow for the open call to be
+     * retried if it fails.
+     *
      * @throws TransportException if a communication channel cannot be established.
      */
     public void open(boolean withRetry) throws TransportException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -82,7 +82,7 @@ public class IotHubTransport implements IotHubListener
     final private Object multiplexingDeviceStateLock = new Object();
 
     // Keys are deviceIds. Helps with getting configs based on deviceIds
-    private final Map<String, DeviceClientConfig> deviceClientConfigs;
+    private final Map<String, DeviceClientConfig> deviceClientConfigs = new ConcurrentHashMap<>();
 
     private ScheduledExecutorService taskScheduler;
 
@@ -120,8 +120,6 @@ public class IotHubTransport implements IotHubListener
             throw new IllegalArgumentException("Config cannot be null");
         }
 
-        this.deviceClientConfigs = new ConcurrentHashMap<>();
-
         this.protocol = defaultConfig.getProtocol();
         this.hostName = defaultConfig.getIotHubHostname();
         this.deviceClientConfigs.put(defaultConfig.getDeviceId(), defaultConfig);
@@ -141,7 +139,6 @@ public class IotHubTransport implements IotHubListener
         this.proxySettings = proxySettings;
         this.connectionStatus = IotHubConnectionStatus.DISCONNECTED;
         this.deviceIOConnectionStatusChangeCallback = deviceIOConnectionStatusChangeCallback;
-        this.deviceClientConfigs = new ConcurrentHashMap<>();
         this.isMultiplexing = true;
     }
 
@@ -395,7 +392,7 @@ public class IotHubTransport implements IotHubListener
      *
      * @throws TransportException if a communication channel cannot be established.
      */
-    public void open() throws TransportException
+    public void open(boolean withRetry) throws TransportException
     {
         if (this.connectionStatus == IotHubConnectionStatus.CONNECTED)
         {
@@ -419,7 +416,60 @@ public class IotHubTransport implements IotHubListener
 
         this.taskScheduler = Executors.newScheduledThreadPool(1);
 
-        openConnection();
+        if (withRetry)
+        {
+            int connectionAttempt = 0;
+            long startTime = System.currentTimeMillis();
+
+            // this loop either ends in throwing an exception when retry expires, or by a break statement upon a successful openConnection() call
+            while (true)
+            {
+                RetryPolicy retryPolicy;
+                if (isMultiplexing)
+                {
+                    retryPolicy = multiplexingRetryPolicy;
+                }
+                else
+                {
+                    retryPolicy = this.getDefaultConfig().getRetryPolicy();
+                }
+
+                try
+                {
+                    openConnection();
+                    break; // openConnection() only returns without throwing if the connection attempt was successful
+                }
+                catch (TransportException transportException)
+                {
+                    log.debug("Encountered an exception while opening the client. Consulting configured the retry policy to see if another attempt should be made.", transportException);
+                    RetryDecision retryDecision = retryPolicy.getRetryDecision(connectionAttempt, transportException);
+                    if (!retryDecision.shouldRetry())
+                    {
+                        throw new TransportException("Retry expired while attempting to open the connection", transportException);
+                    }
+
+                    connectionAttempt++;
+
+                    if (hasOperationTimedOut(startTime))
+                    {
+                        throw new TransportException("Open operation timed out. The nested exception is the most recent exception thrown while attempting to open the connection", transportException);
+                    }
+
+                    try
+                    {
+                        Thread.sleep(retryDecision.getDuration());
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new TransportException("InterruptedException thrown while sleeping between connection attempts", e);
+                    }
+                }
+            }
+        }
+        else
+        {
+            openConnection();
+        }
 
         log.debug("Client connection opened successfully");
     }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -397,7 +397,7 @@ public class DeviceClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockedInternalClient, "open");
+                Deencapsulation.invoke(mockedInternalClient, "open", false);
                 times = 1;
             }
         };
@@ -450,7 +450,7 @@ public class DeviceClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 0;
             }
         };
@@ -959,7 +959,7 @@ public class DeviceClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -1006,7 +1006,7 @@ public class DeviceClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -1088,7 +1088,7 @@ public class DeviceClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -1171,7 +1171,7 @@ public class DeviceClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -1500,7 +1500,7 @@ public class DeviceClientTest
                 result = true;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 result =  new IOException();
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -86,7 +86,7 @@ public class DeviceIOTest
             final Executors executors,
             final ScheduledExecutorService scheduledExecutorService) throws IOException
     {
-        Deencapsulation.invoke(deviceIO, "open");
+        Deencapsulation.invoke(deviceIO, "open", false);
     }
 
     /* Tests_SRS_DEVICE_IO_21_001: [The constructor shall store the provided protocol and config information.] */
@@ -164,13 +164,13 @@ public class DeviceIOTest
         final Object deviceIO = newDeviceIO();
 
         // act
-        Deencapsulation.invoke(deviceIO, "open");
+        Deencapsulation.invoke(deviceIO, "open", false);
 
         // assert
         new Verifications()
         {
             {
-                mockedTransport.open();
+                mockedTransport.open(false);
             }
         };
     }
@@ -185,14 +185,14 @@ public class DeviceIOTest
         new NonStrictExpectations()
         {
             {
-                mockedTransport.open();
+                mockedTransport.open(false);
                 result = new DeviceClientException();
                 times = 1;
             }
         };
 
         // act
-        Deencapsulation.invoke(deviceIO, "open");
+        Deencapsulation.invoke(deviceIO, "open", false);
 
         // assert
         assertEquals("DISCONNECTED", Deencapsulation.getField(deviceIO, "state").toString());
@@ -537,7 +537,7 @@ public class DeviceIOTest
         final Object deviceIO = newDeviceIO();
         Deencapsulation.invoke(deviceIO, "setSendPeriodInMilliseconds",  lastInterval);
 
-        Deencapsulation.invoke(deviceIO, "open");
+        Deencapsulation.invoke(deviceIO, "open", false);
         assertEquals(lastInterval, Deencapsulation.getField(deviceIO, "sendPeriodInMilliseconds"));
 
         // act

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -297,7 +297,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         // act
-        Deencapsulation.invoke(client, "open");
+        Deencapsulation.invoke(client, "open", false);
 
         // assert
         new Verifications()
@@ -308,7 +308,7 @@ public class InternalClientTest
                         any, SEND_PERIOD_MILLIS, RECEIVE_PERIOD_MILLIS_AMQPS);
                 times = 1;
 
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 1;
             }
         };
@@ -2146,7 +2146,7 @@ public class InternalClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -2253,7 +2253,7 @@ public class InternalClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -2335,7 +2335,7 @@ public class InternalClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -2418,7 +2418,7 @@ public class InternalClientTest
                 times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 times = 2;
             }
         };
@@ -2475,7 +2475,7 @@ public class InternalClientTest
                 result = true;
                 mockConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", false);
                 result =  new IOException();
             }
         };

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/TransportClientTest.java
@@ -139,7 +139,7 @@ public class TransportClientTest
         new Verifications()
         {
             {
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", anyBoolean);
                 times = 0;
             }
         };
@@ -183,7 +183,7 @@ public class TransportClientTest
             {
                 Deencapsulation.invoke(mockDeviceClient, "setDeviceIO", actualDeviceIO);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open");
+                Deencapsulation.invoke(mockDeviceIO, "open", anyBoolean);
                 times = 1;
             }
         };

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -240,6 +240,22 @@ public class MultiplexingClientTests extends IntegrationTest
     }
 
     @Test
+    public void openClientWithRetry() throws Exception
+    {
+        testInstance.setup(DEVICE_MULTIPLEX_COUNT);
+        testInstance.multiplexingClient.open(true);
+        testInstance.multiplexingClient.close();
+    }
+
+    @Test
+    public void openClientWithRetryWithoutRegisteredDevices() throws Exception
+    {
+        testInstance.setup(0);
+        testInstance.multiplexingClient.open(true);
+        testInstance.multiplexingClient.close();
+    }
+
+    @Test
     public void sendMessages() throws Exception
     {
         testInstance.setup(DEVICE_MULTIPLEX_COUNT);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -58,6 +58,14 @@ public class SendMessagesTests extends SendMessagesCommon
     }
 
     @Test
+    public void openClientWithRetry() throws Exception
+    {
+        this.testInstance.setup();
+        this.testInstance.identity.getClient().open(true);
+        this.testInstance.identity.getClient().closeNow();
+    }
+
+    @Test
     public void sendMessagesWithCustomSasTokenProvider() throws Exception
     {
         if (testInstance.authenticationType != SAS)


### PR DESCRIPTION
This adds an optional parameter to the open calls for device, module, and multiplexing client that allows for users to opt in to get retry on their open call.