### PR TITLE
break(dps-service): Remove deprecated APIs from DPS service package and samples

### DIFF
--- a/provisioning/provisioning-samples/service-bulkoperation-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceBulkOperationSample.java
+++ b/provisioning/provisioning-samples/service-bulkoperation-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceBulkOperationSample.java
@@ -36,7 +36,7 @@ public class ServiceBulkOperationSample
 
         // *********************************** Create a Provisioning Service Client ************************************
         ProvisioningServiceClient provisioningServiceClient =
-                ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+                new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // ******************************** Create a new bulk of individual enrollment *********************************
         System.out.println("\nCreate a new set of individualEnrollments...");

--- a/provisioning/provisioning-samples/service-enrollment-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceEnrollmentGroupSample.java
+++ b/provisioning/provisioning-samples/service-enrollment-group-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceEnrollmentGroupSample.java
@@ -50,7 +50,7 @@ public class ServiceEnrollmentGroupSample
 
         // *********************************** Create a Provisioning Service Client ************************************
         ProvisioningServiceClient provisioningServiceClient =
-                ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+                new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // *************************************** Create a new enrollmentGroup ****************************************
         System.out.println("\nCreate a new enrollmentGroup...");
@@ -59,8 +59,8 @@ public class ServiceEnrollmentGroupSample
                 new EnrollmentGroup(
                         enrollmentGroupId,
                         attestation);
-        enrollmentGroup.setIotHubHostNameFinal(IOTHUB_HOST_NAME);                // Optional parameter.
-        enrollmentGroup.setProvisioningStatusFinal(ProvisioningStatus.ENABLED);  // Optional parameter.
+        enrollmentGroup.setIotHubHostName(IOTHUB_HOST_NAME);                // Optional parameter.
+        enrollmentGroup.setProvisioningStatus(ProvisioningStatus.ENABLED);  // Optional parameter.
         System.out.println("\nAdd new enrollmentGroup...");
         EnrollmentGroup enrollmentGroupResult =  provisioningServiceClient.createOrUpdateEnrollmentGroup(enrollmentGroup);
         System.out.println("\nEnrollmentGroup created with success...");

--- a/provisioning/provisioning-samples/service-enrollment-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceEnrollmentSample.java
+++ b/provisioning/provisioning-samples/service-enrollment-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceEnrollmentSample.java
@@ -32,7 +32,7 @@ public class ServiceEnrollmentSample
 
         // *********************************** Create a Provisioning Service Client ************************************
         ProvisioningServiceClient provisioningServiceClient =
-                ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+                new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // ******************************** Create a new individualEnrollment config **********************************
         System.out.println("\nCreate a new individualEnrollment...");
@@ -43,9 +43,9 @@ public class ServiceEnrollmentSample
                         attestation);
 
         // The following parameters are optional. Remove it if you don't need.
-        individualEnrollment.setDeviceIdFinal(DEVICE_ID);
-        individualEnrollment.setIotHubHostNameFinal(IOTHUB_HOST_NAME);
-        individualEnrollment.setProvisioningStatusFinal(PROVISIONING_STATUS);
+        individualEnrollment.setDeviceId(DEVICE_ID);
+        individualEnrollment.setIotHubHostName(IOTHUB_HOST_NAME);
+        individualEnrollment.setProvisioningStatus(PROVISIONING_STATUS);
 
         // ************************************ Create the individualEnrollment *************************************
         System.out.println("\nAdd new individualEnrollment...");

--- a/provisioning/provisioning-samples/service-update-enrollment-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceUpdateEnrollmentSample.java
+++ b/provisioning/provisioning-samples/service-update-enrollment-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ServiceUpdateEnrollmentSample.java
@@ -43,7 +43,7 @@ public class ServiceUpdateEnrollmentSample
 
         // *********************************** Create a Provisioning Service Client ************************************
         ProvisioningServiceClient provisioningServiceClient =
-                ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+                new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // ************************************ Create a new individualEnrollment **************************************
         System.out.println("\nCreate a new individualEnrollment...");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
@@ -167,7 +167,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create a new individualEnrollment configurations.
      *     Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
@@ -201,7 +201,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the content of the previous individualEnrollment.
      *     IndividualEnrollment individualEnrollment =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -267,7 +267,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create two new individualEnrollment configurations.
      *     Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
@@ -342,7 +342,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     IndividualEnrollment enrollmentResult =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -404,7 +404,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     IndividualEnrollment enrollmentResult =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -454,7 +454,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the individualEnrollment information.
      *     deviceProvisioningServiceClient.deleteIndividualEnrollment(REGISTRATION_ID);
@@ -503,7 +503,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the individualEnrollment information.
      *     deviceProvisioningServiceClient.deleteIndividualEnrollment(REGISTRATION_ID, ANY_ETAG);
@@ -612,7 +612,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create a new enrollmentGroup configurations.
      *     Attestation attestation = X509Attestation.createFromSigningCertificates(PUBLIC_KEY_CERTIFICATE_STRING);
@@ -668,7 +668,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     EnrollmentGroup enrollmentGroupResult =  deviceProvisioningServiceClient.getEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -729,7 +729,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the enrollmentGroup information.
      *     EnrollmentGroup enrollmentGroupResult =  deviceProvisioningServiceClient.getEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -778,7 +778,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the enrollmentGroup information.
      *     deviceProvisioningServiceClient.deleteEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -826,7 +826,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the enrollmentGroup information.
      *     deviceProvisioningServiceClient.deleteEnrollmentGroup(ENROLLMENT_GROUP_ID, ANY_ETAG);
@@ -915,7 +915,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the deviceRegistrationState information.
      *     DeviceRegistrationState registrationStateResult =  deviceProvisioningServiceClient.getDeviceRegistrationState(REGISTRATION_ID);
@@ -962,7 +962,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the registration status information.
      *     DeviceRegistrationState registrationStateResult =  deviceProvisioningServiceClient.getDeviceRegistrationState(REGISTRATION_ID);
@@ -1009,7 +1009,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the registration status information.
      *     deviceProvisioningServiceClient.deleteDeviceRegistrationState(REGISTRATION_ID);
@@ -1055,7 +1055,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
+     *         new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the deviceRegistrationState information.
      *     deviceProvisioningServiceClient.deleteDeviceRegistrationState(REGISTRATION_ID, ANY_ETAG);

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
@@ -100,12 +100,19 @@ public final class ProvisioningServiceClient
     }
 
     /**
-     * PRIVATE CONSTRUCTOR
+     * Create a new instance of the {@code DeviceProvisioningServiceClient} that exposes
+     * the API to the Device Provisioning Service.
      *
-     * @param connectionString the {@code String} that contains the connection string for the Provisioning service.
-     * @throws IllegalArgumentException if the connectionString is {@code null}, empty, or invalid.
+     * <p> The Device Provisioning Service Client is created based on a <b>Provisioning Connection String</b>.
+     * <p> Once you create a Device Provisioning Service on Azure, you can get the connection string on the Azure portal.
+     *
+     * @see <a href="http://portal.azure.com/">Azure portal</a>
+     *
+     * @param connectionString the {@code String} that cares the connection string of the Device Provisioning Service.
+     * @return The {@code ProvisioningServiceClient} with the new instance of this object.
+     * @throws IllegalArgumentException if the connectionString is {@code null} or empty.
      */
-    private ProvisioningServiceClient(String connectionString)
+    public ProvisioningServiceClient(String connectionString)
     {
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_002: [The constructor shall throw IllegalArgumentException if the provided connectionString is null or empty.] */
         if(Tools.isNullOrEmpty(connectionString))
@@ -160,7 +167,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create a new individualEnrollment configurations.
      *     Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
@@ -194,7 +201,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the content of the previous individualEnrollment.
      *     IndividualEnrollment individualEnrollment =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -260,7 +267,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create two new individualEnrollment configurations.
      *     Attestation attestation = new TpmAttestation(TPM_ENDORSEMENT_KEY);
@@ -335,7 +342,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     IndividualEnrollment enrollmentResult =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -397,7 +404,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     IndividualEnrollment enrollmentResult =  deviceProvisioningServiceClient.getIndividualEnrollment(REGISTRATION_ID);
@@ -447,7 +454,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the individualEnrollment information.
      *     deviceProvisioningServiceClient.deleteIndividualEnrollment(REGISTRATION_ID);
@@ -496,7 +503,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the individualEnrollment information.
      *     deviceProvisioningServiceClient.deleteIndividualEnrollment(REGISTRATION_ID, ANY_ETAG);
@@ -605,7 +612,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Create a new enrollmentGroup configurations.
      *     Attestation attestation = X509Attestation.createFromSigningCertificates(PUBLIC_KEY_CERTIFICATE_STRING);
@@ -661,7 +668,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the individualEnrollment information.
      *     EnrollmentGroup enrollmentGroupResult =  deviceProvisioningServiceClient.getEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -722,7 +729,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the enrollmentGroup information.
      *     EnrollmentGroup enrollmentGroupResult =  deviceProvisioningServiceClient.getEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -771,7 +778,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the enrollmentGroup information.
      *     deviceProvisioningServiceClient.deleteEnrollmentGroup(ENROLLMENT_GROUP_ID);
@@ -819,7 +826,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the enrollmentGroup information.
      *     deviceProvisioningServiceClient.deleteEnrollmentGroup(ENROLLMENT_GROUP_ID, ANY_ETAG);
@@ -908,7 +915,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the deviceRegistrationState information.
      *     DeviceRegistrationState registrationStateResult =  deviceProvisioningServiceClient.getDeviceRegistrationState(REGISTRATION_ID);
@@ -955,7 +962,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Get the registration status information.
      *     DeviceRegistrationState registrationStateResult =  deviceProvisioningServiceClient.getDeviceRegistrationState(REGISTRATION_ID);
@@ -973,19 +980,6 @@ public final class ProvisioningServiceClient
     public void deleteDeviceRegistrationState(DeviceRegistrationState deviceRegistrationState) throws ProvisioningServiceClientException
     {
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_024: [The deleteDeviceRegistrationState shall delete the deviceRegistrationState for the provided DeviceRegistrationState by calling the delete in the registrationStatusManager.] */
-        registrationStatusManager.delete(deviceRegistrationState);
-    }
-
-    /**
-     * @deprecated As of release 1.0.0, replaced by {@link #deleteDeviceRegistrationState(DeviceRegistrationState)} ()}
-     * @param deviceRegistrationState the {@link DeviceRegistrationState} that identifies the deviceRegistrationState. It cannot be {@code null}.
-     * @throws ProvisioningServiceClientException if the Provisioning Device Service was not able to delete the
-     *                                            registration status information for the provided DeviceRegistrationState.
-     */
-    @Deprecated
-    public void deleteDeviceRegistrationStatus(DeviceRegistrationState deviceRegistrationState) throws ProvisioningServiceClientException
-    {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_024: [The deleteDeviceRegistrationStatus shall delete the deviceRegistrationState for the provided DeviceRegistrationState by calling the delete in the registrationStatusManager.] */
         registrationStatusManager.delete(deviceRegistrationState);
     }
 
@@ -1015,7 +1009,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the registration status information.
      *     deviceProvisioningServiceClient.deleteDeviceRegistrationState(REGISTRATION_ID);
@@ -1030,19 +1024,6 @@ public final class ProvisioningServiceClient
     public void deleteDeviceRegistrationState(String id) throws ProvisioningServiceClientException
     {
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_025: [The deleteDeviceRegistrationState shall delete the deviceRegistrationState for the provided id by calling the delete in the registrationStatusManager.] */
-        registrationStatusManager.delete(id, null);
-    }
-
-    /**
-     * @deprecated As of release 1.0.0, replaced by {@link #deleteDeviceRegistrationState(String)} ()}
-     * @param id the {@code String} that identifies the deviceRegistrationState. It cannot be {@code null} or empty.
-     * @throws ProvisioningServiceClientException if the Provisioning Device Service was not able to delete the
-     *                                            deviceRegistrationState information for the provided registrationId.
-     */
-    @Deprecated
-    public void deleteDeviceRegistrationStatus(String id) throws ProvisioningServiceClientException
-    {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_025: [The deleteDeviceRegistrationStatus shall delete the deviceRegistrationState for the provided id by calling the delete in the registrationStatusManager.] */
         registrationStatusManager.delete(id, null);
     }
 
@@ -1074,7 +1055,7 @@ public final class ProvisioningServiceClient
      * {
      *     // Create a Device Provisioning Service Client.
      *     DeviceProvisioningServiceClient deviceProvisioningServiceClient =
-     *         DeviceProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+     *         Devicenew ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
      *
      *     // Delete the deviceRegistrationState information.
      *     deviceProvisioningServiceClient.deleteDeviceRegistrationState(REGISTRATION_ID, ANY_ETAG);
@@ -1095,21 +1076,6 @@ public final class ProvisioningServiceClient
     }
 
     /**
-     * @deprecated As of release 1.0.0, replaced by {@link #deleteDeviceRegistrationState(String, String)} ()}
-     * @param id the {@code String} that identifies the deviceRegistrationState. It cannot be {@code null} or empty.
-     * @param eTag the {@code String} with the deviceRegistrationState eTag. It can be {@code null} or empty.
-     *             The Device Provisioning Service will ignore it in all of these cases.
-     * @throws ProvisioningServiceClientException if the Provisioning Device Service was not able to delete the
-     *                                            deviceRegistrationState information for the provided registrationId and eTag.
-     */
-    @Deprecated
-    public void deleteDeviceRegistrationStatus(String id, String eTag) throws ProvisioningServiceClientException
-    {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_026: [The deleteDeviceRegistrationStatus shall delete the deviceRegistrationState for the provided id and eTag by calling the delete in the registrationStatusManager.] */
-        registrationStatusManager.delete(id, eTag);
-    }
-
-    /**
      * Factory to create a registration status query.
      *
      * <p> This method will create a new registration status query for a specific enrollment group on the Device
@@ -1125,19 +1091,6 @@ public final class ProvisioningServiceClient
     public Query createEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, String enrollmentGroupId)
     {
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_027: [The createEnrollmentGroupRegistrationStateQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
-        return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId,0);
-    }
-
-    /**
-     * @deprecated As of release 1.0.0, replaced by {@link #createEnrollmentGroupRegistrationStateQuery(QuerySpecification, String)} ()}
-     * @param querySpecification the {@link QuerySpecification} with the SQL query. It cannot be {@code null}.
-     * @param enrollmentGroupId the {@code String} that identifies the enrollmentGroup. It cannot be {@code null} or empty.
-     * @return The {@link Query} iterator.
-     */
-    @Deprecated
-    public Query createEnrollmentGroupRegistrationStatusQuery(QuerySpecification querySpecification, String enrollmentGroupId)
-    {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_027: [The createEnrollmentGroupRegistrationStatusQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
         return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId,0);
     }
 
@@ -1163,21 +1116,6 @@ public final class ProvisioningServiceClient
     public Query createEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, String enrollmentGroupId, int pageSize)
     {
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_028: [The createEnrollmentGroupRegistrationStateQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
-        return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId, pageSize);
-    }
-
-    /**
-     * @deprecated As of release 1.0.0, replaced by {@link #createEnrollmentGroupRegistrationStateQuery(QuerySpecification, String, int)} ()}
-     * @param querySpecification the {@link QuerySpecification} with the SQL query. It cannot be {@code null}.
-     * @param enrollmentGroupId the {@code String} that identifies the enrollmentGroup. It cannot be {@code null} or empty.
-     * @param pageSize the {@code int} with the maximum number of items per iteration. It can be 0 for default, but not negative.
-     * @return The {@link Query} iterator.
-     * @throws IllegalArgumentException if the provided parameters are not correct.
-     */
-    @Deprecated
-    public Query createEnrollmentGroupRegistrationStatusQuery(QuerySpecification querySpecification, String enrollmentGroupId, int pageSize)
-    {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_028: [The createEnrollmentGroupRegistrationStatusQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
         return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId, pageSize);
     }
 }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
@@ -92,10 +92,12 @@ public final class ProvisioningServiceClient
      * @param connectionString the {@code String} that cares the connection string of the Device Provisioning Service.
      * @return The {@code ProvisioningServiceClient} with the new instance of this object.
      * @throws IllegalArgumentException if the connectionString is {@code null} or empty.
+     * @deprecated This static constructor works exactly the same as {@link #ProvisioningServiceClient(String)}
+     * so it has been deprecated.
      */
+    @Deprecated
     public static ProvisioningServiceClient createFromConnectionString(String connectionString)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_001: [The createFromConnectionString shall create a new instance of this class using the provided connectionString.] */
         return new ProvisioningServiceClient(connectionString);
     }
 
@@ -114,22 +116,16 @@ public final class ProvisioningServiceClient
      */
     public ProvisioningServiceClient(String connectionString)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_002: [The constructor shall throw IllegalArgumentException if the provided connectionString is null or empty.] */
         if(Tools.isNullOrEmpty(connectionString))
         {
             throw new IllegalArgumentException("connectionString cannot be null or empty");
         }
 
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_003: [The constructor shall throw IllegalArgumentException if the ProvisioningConnectionString or one of the inner Managers failed to create a new instance.] */
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_004: [The constructor shall create a new instance of the ContractApiHttp class using the provided connectionString.] */
         ProvisioningConnectionString provisioningConnectionString = ProvisioningConnectionStringBuilder.createConnectionString(connectionString);
         ContractApiHttp contractApiHttp = ContractApiHttp.createFromConnectionString(provisioningConnectionString);
 
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_005: [The constructor shall create a new instance of the IndividualEnrollmentManger.] */
         this.individualEnrollmentManager = IndividualEnrollmentManager.createFromContractApiHttp(contractApiHttp);
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_006: [The constructor shall create a new instance of the EnrollmentGroupManager.] */
         this.enrollmentGroupManager = EnrollmentGroupManager.createFromContractApiHttp(contractApiHttp);
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_007: [The constructor shall create a new instance of the RegistrationStatusManager.] */
         this.registrationStatusManager = RegistrationStatusManager.createFromContractApiHttp(contractApiHttp);
     }
 
@@ -227,7 +223,6 @@ public final class ProvisioningServiceClient
      */
     public IndividualEnrollment createOrUpdateIndividualEnrollment(IndividualEnrollment individualEnrollment) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_008: [The createOrUpdateIndividualEnrollment shall create a new Provisioning individualEnrollment by calling the createOrUpdate in the individualEnrollmentManager.] */
         return individualEnrollmentManager.createOrUpdate(individualEnrollment);
     }
 
@@ -312,7 +307,6 @@ public final class ProvisioningServiceClient
             BulkOperationMode bulkOperationMode, Collection<IndividualEnrollment> individualEnrollments)
             throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_009: [The runBulkEnrollmentOperation shall do a Provisioning operation over individualEnrollment by calling the bulkOperation in the individualEnrollmentManager.] */
         return individualEnrollmentManager.bulkOperation(bulkOperationMode, individualEnrollments);
     }
 
@@ -359,7 +353,6 @@ public final class ProvisioningServiceClient
      */
     public IndividualEnrollment getIndividualEnrollment(String registrationId) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_010: [The getIndividualEnrollment shall retrieve the individualEnrollment information for the provided registrationId by calling the get in the individualEnrollmentManager.] */
         return individualEnrollmentManager.get(registrationId);
     }
 
@@ -422,7 +415,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteIndividualEnrollment(IndividualEnrollment individualEnrollment) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_011: [The deleteIndividualEnrollment shall delete the individualEnrollment for the provided individualEnrollment by calling the delete in the individualEnrollmentManager.] */
         individualEnrollmentManager.delete(individualEnrollment);
     }
 
@@ -469,7 +461,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteIndividualEnrollment(String registrationId) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_012: [The deleteIndividualEnrollment shall delete the individualEnrollment for the provided registrationId by calling the delete in the individualEnrollmentManager.] */
         individualEnrollmentManager.delete(registrationId, null);
     }
 
@@ -520,7 +511,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteIndividualEnrollment(String registrationId, String eTag) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_013: [The deleteIndividualEnrollment shall delete the individualEnrollment for the provided registrationId and etag by calling the delete in the individualEnrollmentManager.] */
         individualEnrollmentManager.delete(registrationId, eTag);
     }
 
@@ -539,7 +529,6 @@ public final class ProvisioningServiceClient
      */
     public Query createIndividualEnrollmentQuery(QuerySpecification querySpecification)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_014: [The createIndividualEnrollmentQuery shall create a new individual enrolment query by calling the createQuery in the individualEnrollmentManager.] */
         return individualEnrollmentManager.createQuery(querySpecification, 0);
     }
 
@@ -563,7 +552,6 @@ public final class ProvisioningServiceClient
      */
     public Query createIndividualEnrollmentQuery(QuerySpecification querySpecification, int pageSize)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_015: [The createIndividualEnrollmentQuery shall create a new individual enrolment query by calling the createQuery in the individualEnrollmentManager.] */
         return individualEnrollmentManager.createQuery(querySpecification, pageSize);
     }
 
@@ -638,7 +626,6 @@ public final class ProvisioningServiceClient
      */
     public EnrollmentGroup createOrUpdateEnrollmentGroup(EnrollmentGroup enrollmentGroup) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_016: [The createOrUpdateEnrollmentGroup shall create a new Provisioning enrollmentGroup by calling the createOrUpdate in the enrollmentGroupManager.] */
         return enrollmentGroupManager.createOrUpdate(enrollmentGroup);
     }
 
@@ -684,7 +671,6 @@ public final class ProvisioningServiceClient
      */
     public EnrollmentGroup getEnrollmentGroup(String enrollmentGroupId) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_017: [The getEnrollmentGroup shall retrieve the enrollmentGroup information for the provided enrollmentGroupId by calling the get in the enrollmentGroupManager.] */
         return enrollmentGroupManager.get(enrollmentGroupId);
     }
 
@@ -746,7 +732,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteEnrollmentGroup(EnrollmentGroup enrollmentGroup) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_018: [The deleteEnrollmentGroup shall delete the enrollmentGroup for the provided enrollmentGroup by calling the delete in the enrollmentGroupManager.] */
         enrollmentGroupManager.delete(enrollmentGroup);
     }
 
@@ -792,7 +777,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteEnrollmentGroup(String enrollmentGroupId) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_019: [The deleteEnrollmentGroup shall delete the enrollmentGroup for the provided enrollmentGroupId by calling the delete in the enrollmentGroupManager.] */
         enrollmentGroupManager.delete(enrollmentGroupId, null);
     }
 
@@ -842,7 +826,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteEnrollmentGroup(String enrollmentGroupId, String eTag) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_020: [The deleteEnrollmentGroup shall delete the enrollmentGroup for the provided enrollmentGroupId and eTag by calling the delete in the enrollmentGroupManager.] */
         enrollmentGroupManager.delete(enrollmentGroupId, eTag);
     }
 
@@ -861,7 +844,6 @@ public final class ProvisioningServiceClient
      */
     public Query createEnrollmentGroupQuery(QuerySpecification querySpecification)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_021: [The createEnrollmentGroupQuery shall create a new enrolmentGroup query by calling the createQuery in the enrollmentGroupManager.] */
         return enrollmentGroupManager.createQuery(querySpecification, 0);
     }
 
@@ -885,7 +867,6 @@ public final class ProvisioningServiceClient
      */
     public Query createEnrollmentGroupQuery(QuerySpecification querySpecification, int pageSize)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_022: [The createEnrollmentGroupQuery shall create a new enrolmentGroup query by calling the createQuery in the enrollmentGroupManager.] */
         return enrollmentGroupManager.createQuery(querySpecification, pageSize);
     }
 
@@ -931,7 +912,6 @@ public final class ProvisioningServiceClient
      */
     public DeviceRegistrationState getDeviceRegistrationState(String id) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_023: [The getDeviceRegistrationState shall retrieve the deviceRegistrationState information for the provided id by calling the get in the registrationStatusManager.] */
         return registrationStatusManager.get(id);
     }
 
@@ -979,7 +959,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteDeviceRegistrationState(DeviceRegistrationState deviceRegistrationState) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_024: [The deleteDeviceRegistrationState shall delete the deviceRegistrationState for the provided DeviceRegistrationState by calling the delete in the registrationStatusManager.] */
         registrationStatusManager.delete(deviceRegistrationState);
     }
 
@@ -1023,7 +1002,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteDeviceRegistrationState(String id) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_025: [The deleteDeviceRegistrationState shall delete the deviceRegistrationState for the provided id by calling the delete in the registrationStatusManager.] */
         registrationStatusManager.delete(id, null);
     }
 
@@ -1071,7 +1049,6 @@ public final class ProvisioningServiceClient
      */
     public void deleteDeviceRegistrationState(String id, String eTag) throws ProvisioningServiceClientException
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_026: [The deleteDeviceRegistrationState shall delete the deviceRegistrationState for the provided id and eTag by calling the delete in the registrationStatusManager.] */
         registrationStatusManager.delete(id, eTag);
     }
 
@@ -1090,7 +1067,6 @@ public final class ProvisioningServiceClient
      */
     public Query createEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, String enrollmentGroupId)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_027: [The createEnrollmentGroupRegistrationStateQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
         return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId,0);
     }
 
@@ -1115,7 +1091,6 @@ public final class ProvisioningServiceClient
      */
     public Query createEnrollmentGroupRegistrationStateQuery(QuerySpecification querySpecification, String enrollmentGroupId, int pageSize)
     {
-        /* SRS_PROVISIONING_SERVICE_CLIENT_21_028: [The createEnrollmentGroupRegistrationStateQuery shall create a new deviceRegistrationState query by calling the createQuery in the registrationStatusManager.] */
         return registrationStatusManager.createEnrollmentGroupQuery(querySpecification, enrollmentGroupId, pageSize);
     }
 }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroup.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroup.java
@@ -266,15 +266,15 @@ public class EnrollmentGroup extends Serializable
 
         if (result.iotHubHostName != null)
         {
-            this.setIotHubHostNameFinal(result.iotHubHostName);
+            this.setIotHubHostName(result.iotHubHostName);
         }
         if (result.provisioningStatus != null)
         {
-            this.setProvisioningStatusFinal(result.provisioningStatus);
+            this.setProvisioningStatus(result.provisioningStatus);
         }
         if (result.initialTwin != null)
         {
-            this.setInitialTwinFinal(result.initialTwin);
+            this.setInitialTwin(result.initialTwin);
         }
 
         if (result.createdDateTimeUtc != null)
@@ -289,7 +289,7 @@ public class EnrollmentGroup extends Serializable
 
         if (result.etag != null)
         {
-            this.setEtagFinal(result.etag);
+            this.setEtag(result.etag);
         }
 
         this.setIotHubs(result.getIotHubs());
@@ -424,7 +424,7 @@ public class EnrollmentGroup extends Serializable
 
         if (attestation instanceof X509Attestation)
         {
-            if (((X509Attestation)attestation).getRootCertificatesFinal() == null)
+            if (((X509Attestation)attestation).getRootCertificates() == null)
             {
                 throw new IllegalArgumentException("X509 attestation for EnrollmentGroup does not contains a valid certificate.");
             }
@@ -457,27 +457,7 @@ public class EnrollmentGroup extends Serializable
      * @param iotHubHostName the {@code String} with the new iotHubHostName. It cannot be {@code null}, empty, or invalid.
      * @throws IllegalArgumentException If the provided iotHubHostName is {@code null}, empty, or invalid.
      */
-    @Deprecated
-    public void setIotHubHostName(String iotHubHostName)
-    {
-        this.iotHubHostName = iotHubHostName;
-    }
-
-    /**
-     * Setter for the iotHubHostName.
-     *
-     * <p>
-     *     A valid iothub host name shall follow this criteria.
-     *         A case-sensitive string (up to 128 char long)
-     *         of ASCII 7-bit alphanumeric chars
-     *         + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.
-     *     A valid host name shall have, at least 2 parts separated by '.'.
-     * </p>
-     *
-     * @param iotHubHostName the {@code String} with the new iotHubHostName. It cannot be {@code null}, empty, or invalid.
-     * @throws IllegalArgumentException If the provided iotHubHostName is {@code null}, empty, or invalid.
-     */
-    public final void setIotHubHostNameFinal(String iotHubHostName)
+    public final void setIotHubHostName(String iotHubHostName)
     {
         this.iotHubHostName = iotHubHostName;
     }
@@ -502,28 +482,7 @@ public class EnrollmentGroup extends Serializable
      * @param initialTwin the {@code TwinState} with the new initialTwin. It cannot be {@code null}.
      * @throws IllegalArgumentException If the provided initialTwin is {@code null}.
      */
-    @Deprecated
-    public void setInitialTwin(TwinState initialTwin)
-    {
-        if (initialTwin == null)
-        {
-            throw new IllegalArgumentException("initialTwin cannot be null");
-        }
-
-        this.initialTwin = initialTwin;
-    }
-
-    /**
-     * Setter for the initialTwin.
-     *
-     * <p>
-     *     It provides a Twin precondition for the provisioned device.
-     * </p>
-     *
-     * @param initialTwin the {@code TwinState} with the new initialTwin. It cannot be {@code null}.
-     * @throws IllegalArgumentException If the provided initialTwin is {@code null}.
-     */
-    public final void setInitialTwinFinal(TwinState initialTwin)
+    public final void setInitialTwin(TwinState initialTwin)
     {
         if (initialTwin == null)
         {
@@ -550,34 +509,10 @@ public class EnrollmentGroup extends Serializable
      *     It provides a Status precondition for the provisioned device.
      * </p>
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setProvisioningStatusFinal(ProvisioningStatus)}
-     *
      * @param provisioningStatus the {@code ProvisioningStatus} with the new provisioningStatus. It cannot be {@code null}.
      * @throws IllegalArgumentException If the provided provisioningStatus is {@code null}.
      */
-    @Deprecated
-    public void setProvisioningStatus(ProvisioningStatus provisioningStatus)
-    {
-        if (provisioningStatus == null)
-        {
-            throw new IllegalArgumentException("provisioningStatus cannot be null");
-        }
-
-        this.provisioningStatus = provisioningStatus;
-    }
-
-
-    /**
-     * Setter for the provisioningStatus.
-     *
-     * <p>
-     *     It provides a Status precondition for the provisioned device.
-     * </p>
-     *
-     * @param provisioningStatus the {@code ProvisioningStatus} with the new provisioningStatus. It cannot be {@code null}.
-     * @throws IllegalArgumentException If the provided provisioningStatus is {@code null}.
-     */
-    public final void setProvisioningStatusFinal(ProvisioningStatus provisioningStatus)
+    public final void setProvisioningStatus(ProvisioningStatus provisioningStatus)
     {
         if (provisioningStatus == null)
         {
@@ -656,24 +591,10 @@ public class EnrollmentGroup extends Serializable
     /**
      * Setter for the etag.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setEtagFinal(String)}
-     *
      * @param etag the {@code String} with the new etag. It cannot be {@code null}, empty or invalid.
      * @throws IllegalArgumentException If the provided etag is {@code null}, empty or invalid.
      */
-    @Deprecated
-    public void setEtag(String etag)
-    {
-        this.etag = etag;
-    }
-
-    /**
-     * Setter for the etag.
-     *
-     * @param etag the {@code String} with the new etag. It cannot be {@code null}, empty or invalid.
-     * @throws IllegalArgumentException If the provided etag is {@code null}, empty or invalid.
-     */
-    public final void setEtagFinal(String etag)
+    public final void setEtag(String etag)
     {
         this.etag = etag;
     }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollment.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollment.java
@@ -262,15 +262,15 @@ public class IndividualEnrollment extends Serializable
 
         if (result.deviceId != null)
         {
-            this.setDeviceIdFinal(result.deviceId);
+            this.setDeviceId(result.deviceId);
         }
         if (result.iotHubHostName != null)
         {
-            this.setIotHubHostNameFinal(result.iotHubHostName);
+            this.setIotHubHostName(result.iotHubHostName);
         }
         if (result.provisioningStatus != null)
         {
-            this.setProvisioningStatusFinal(result.provisioningStatus);
+            this.setProvisioningStatus(result.provisioningStatus);
         }
         if (result.registrationState != null)
         {
@@ -300,12 +300,12 @@ public class IndividualEnrollment extends Serializable
 
         if (result.etag != null)
         {
-            this.setEtagFinal(result.etag);
+            this.setEtag(result.etag);
         }
 
         if (result.capabilities != null)
         {
-            this.setCapabilitiesFinal(result.capabilities);
+            this.setCapabilities(result.capabilities);
         }
 
         this.setIotHubs(result.getIotHubs());
@@ -377,25 +377,10 @@ public class IndividualEnrollment extends Serializable
     /**
      * Setter for the deviceId.
      *
-     *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setDeviceIdFinal(String)}
-     *
      * @param deviceId the {@code String} with the new deviceID. It cannot be {@code null}, empty, or invalid.
      * @throws IllegalArgumentException If the provided deviceId is {@code null}, empty, or invalid.
      */
-    @Deprecated
-    public void setDeviceId(String deviceId)
-    {
-        setDeviceIdFinal(deviceId);
-    }
-
-    /**
-     * Setter for the deviceId.
-     *
-     * @param deviceId the {@code String} with the new deviceID. It cannot be {@code null}, empty, or invalid.
-     * @throws IllegalArgumentException If the provided deviceId is {@code null}, empty, or invalid.
-     */
-    public final void setDeviceIdFinal(String deviceId)
+    public final void setDeviceId(String deviceId)
     {
         this.deviceId = deviceId;
     }
@@ -501,32 +486,10 @@ public class IndividualEnrollment extends Serializable
      * A valid host name shall have, at least 2 parts separated by '.'.
      * </p>
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setIotHubHostNameFinal(String)}
-     *
      * @param iotHubHostName the {@code String} with the new iotHubHostName. It cannot be {@code null}, empty, or invalid.
      * @throws IllegalArgumentException If the provided iotHubHostName is {@code null}, empty, or invalid.
      */
-    @Deprecated
-    public void setIotHubHostName(String iotHubHostName)
-    {
-        this.iotHubHostName = iotHubHostName;
-    }
-
-    /**
-     * Setter for the iotHubHostName.
-     *
-     * <p>
-     * A valid iothub host name shall follow this criteria.
-     * A case-sensitive string (up to 128 char long)
-     * of ASCII 7-bit alphanumeric chars
-     * + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.
-     * A valid host name shall have, at least 2 parts separated by '.'.
-     * </p>
-     *
-     * @param iotHubHostName the {@code String} with the new iotHubHostName. It cannot be {@code null}, empty, or invalid.
-     * @throws IllegalArgumentException If the provided iotHubHostName is {@code null}, empty, or invalid.
-     */
-    public final void setIotHubHostNameFinal(String iotHubHostName)
+    public final void setIotHubHostName(String iotHubHostName)
     {
         this.iotHubHostName = iotHubHostName;
     }
@@ -573,28 +536,11 @@ public class IndividualEnrollment extends Serializable
      * It provides a Status precondition for the provisioned device.
      * </p>
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setProvisioningStatusFinal(ProvisioningStatus)}
      *
      * @param provisioningStatus the {@code ProvisioningStatus} with the new provisioningStatus. It cannot be {@code null}.
      * @throws IllegalArgumentException If the provided provisioningStatus is {@code null}.
      */
-    @Deprecated
-    public void setProvisioningStatus(ProvisioningStatus provisioningStatus)
-    {
-        this.provisioningStatus = provisioningStatus;
-    }
-
-    /**
-     * Setter for the provisioningStatus.
-     *
-     * <p>
-     * It provides a Status precondition for the provisioned device.
-     * </p>
-     *
-     * @param provisioningStatus the {@code ProvisioningStatus} with the new provisioningStatus. It cannot be {@code null}.
-     * @throws IllegalArgumentException If the provided provisioningStatus is {@code null}.
-     */
-    public final void setProvisioningStatusFinal(ProvisioningStatus provisioningStatus)
+    public final void setProvisioningStatus(ProvisioningStatus provisioningStatus)
     {
         this.provisioningStatus = provisioningStatus;
     }
@@ -670,24 +616,10 @@ public class IndividualEnrollment extends Serializable
     /**
      * Setter for the etag.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setEtagFinal(String)}
-     *
      * @param etag the {@code String} with the new etag. It cannot be {@code null}, empty or invalid.
      * @throws IllegalArgumentException If the provided etag is {@code null}, empty or invalid.
      */
-    @Deprecated
-    public void setEtag(String etag)
-    {
-        this.etag = etag;
-    }
-
-    /**
-     * Setter for the etag.
-     *
-     * @param etag the {@code String} with the new etag. It cannot be {@code null}, empty or invalid.
-     * @throws IllegalArgumentException If the provided etag is {@code null}, empty or invalid.
-     */
-    public final void setEtagFinal(String etag)
+    public final void setEtag(String etag)
     {
         this.etag = etag;
     }
@@ -698,20 +630,9 @@ public class IndividualEnrollment extends Serializable
     }
 
     /**
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #setCapabilitiesFinal(DeviceCapabilities)}
-     *
      * @param capabilities the device capabilities to set
      */
-    @Deprecated
-    public void setCapabilities(DeviceCapabilities capabilities)
-    {
-        this.capabilities = capabilities;
-    }
-
-    /**
-     * @param capabilities the device capabilities to set
-     */
-    public final void setCapabilitiesFinal(DeviceCapabilities capabilities)
+    public final void setCapabilities(DeviceCapabilities capabilities)
     {
         this.capabilities = capabilities;
     }

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509Attestation.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509Attestation.java
@@ -102,9 +102,9 @@ public class X509Attestation extends Attestation
             throw new IllegalArgumentException("x509Attestation cannot be null");
         }
 
-        X509Certificates clientCertificates = x509Attestation.getClientCertificatesFinal();
-        X509Certificates rootCertificates = x509Attestation.getRootCertificatesFinal();
-        X509CAReferences caReferences = x509Attestation.getCAReferencesFinal();
+        X509Certificates clientCertificates = x509Attestation.getClientCertificates();
+        X509Certificates rootCertificates = x509Attestation.getRootCertificates();
+        X509CAReferences caReferences = x509Attestation.getCAReferences();
 
         /* SRS_X509_ATTESTATION_21_005: [The constructor shall throw IllegalArgumentException if `clientCertificates`, `rootCertificates`, and `caReferences` are null.] */
         /* SRS_X509_ATTESTATION_21_006: [The constructor shall throw IllegalArgumentException if more than one certificate type are not null.] */
@@ -239,27 +239,9 @@ public class X509Attestation extends Attestation
     /**
      * Getter for the clientCertificates.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getClientCertificatesFinal()}
-     *
      * @return the {@link X509Certificates} with the stored clientCertificates. it can be {@code null}.
      */
-    @Deprecated
-    public X509Certificates getClientCertificates()
-    {
-        /* SRS_X509_ATTESTATION_21_016: [The getClientCertificates shall return the stored clientCertificates.] */
-        if(this.clientCertificates == null)
-        {
-            return null;
-        }
-        return new X509Certificates(this.clientCertificates);
-    }
-
-    /**
-     * Getter for the clientCertificates.
-     *
-     * @return the {@link X509Certificates} with the stored clientCertificates. it can be {@code null}.
-     */
-    public final X509Certificates getClientCertificatesFinal()
+    public final X509Certificates getClientCertificates()
     {
         /* SRS_X509_ATTESTATION_21_016: [The getClientCertificates shall return the stored clientCertificates.] */
         if(this.clientCertificates == null)
@@ -272,27 +254,9 @@ public class X509Attestation extends Attestation
     /**
      * Getter for the rootCertificates.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getRootCertificatesFinal()}
-     *
      * @return the {@link X509Certificates} with the stored rootCertificates. it can be {@code null}.
      */
-    @Deprecated
-    public X509Certificates getRootCertificates()
-    {
-        /* SRS_X509_ATTESTATION_21_017: [The getRootCertificates shall return the stored rootCertificates.] */
-        if(this.rootCertificates == null)
-        {
-            return null;
-        }
-        return new X509Certificates(this.rootCertificates);
-    }
-
-    /**
-     * Getter for the rootCertificates.
-     *
-     * @return the {@link X509Certificates} with the stored rootCertificates. it can be {@code null}.
-     */
-    public final X509Certificates getRootCertificatesFinal()
+    public final X509Certificates getRootCertificates()
     {
         /* SRS_X509_ATTESTATION_21_017: [The getRootCertificates shall return the stored rootCertificates.] */
         if(this.rootCertificates == null)
@@ -305,27 +269,9 @@ public class X509Attestation extends Attestation
     /**
      * Getter for the caReferences.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getCAReferencesFinal()}
-     *
      * @return the {@link X509CAReferences} with the stored caReferences. it can be {@code null}.
      */
-    @Deprecated
-    public X509CAReferences getCAReferences()
-    {
-        /* SRS_X509_ATTESTATION_21_024: [The getCAReferences shall return the stored caReferences.] */
-        if(this.caReferences == null)
-        {
-            return null;
-        }
-        return new X509CAReferences(this.caReferences);
-    }
-
-    /**
-     * Getter for the caReferences.
-     *
-     * @return the {@link X509CAReferences} with the stored caReferences. it can be {@code null}.
-     */
-    public final X509CAReferences getCAReferencesFinal()
+    public final X509CAReferences getCAReferences()
     {
         /* SRS_X509_ATTESTATION_21_024: [The getCAReferences shall return the stored caReferences.] */
         if(this.caReferences == null)
@@ -348,12 +294,12 @@ public class X509Attestation extends Attestation
         /* SRS_X509_ATTESTATION_21_018: [If the clientCertificates is not null, the getPrimaryX509CertificateInfo shall return the info in the primary key of the clientCertificates.] */
         if(this.clientCertificates != null)
         {
-            return this.clientCertificates.getPrimaryFinal().getInfo();
+            return this.clientCertificates.getPrimary().getInfo();
         }
         /* SRS_X509_ATTESTATION_21_019: [If the rootCertificates is not null, the getPrimaryX509CertificateInfo shall return the info in the primary key of the rootCertificates.] */
         if(this.rootCertificates != null)
         {
-            return this.rootCertificates.getPrimaryFinal().getInfo();
+            return this.rootCertificates.getPrimary().getInfo();
         }
         /* SRS_X509_ATTESTATION_21_020: [If both clientCertificates and rootCertificates are null, the getPrimaryX509CertificateInfo shall throw IllegalArgumentException.] */
         throw new IllegalArgumentException("There is no valid certificate information.");
@@ -373,12 +319,12 @@ public class X509Attestation extends Attestation
         /* SRS_X509_ATTESTATION_21_021: [If the clientCertificates is not null, and it contains secondary key, the getSecondaryX509CertificateInfo shall return the info in the secondary key of the rootCertificates.] */
         if(this.clientCertificates != null)
         {
-            secondaryCertificate = this.clientCertificates.getSecondaryFinal();
+            secondaryCertificate = this.clientCertificates.getSecondary();
         }
         /* SRS_X509_ATTESTATION_21_022: [If the rootCertificates is not null, and it contains secondary key, the getSecondaryX509CertificateInfo shall return the info in the secondary key of the rootCertificates.] */
         if(this.rootCertificates != null)
         {
-            secondaryCertificate = this.rootCertificates.getSecondaryFinal();
+            secondaryCertificate = this.rootCertificates.getSecondary();
         }
 
         if(secondaryCertificate != null)

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CAReferences.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CAReferences.java
@@ -76,7 +76,7 @@ public class X509CAReferences
     public X509CAReferences(X509CAReferences x509CAReferences)
     {
         /* SRS_X509_CAREFERENCE_21_003: [The constructor shall throw IllegalArgumentException if the provide X509CAReferences is null or if its primary certificate is null.] */
-        if((x509CAReferences == null) || (x509CAReferences.getPrimaryFinal() == null))
+        if((x509CAReferences == null) || (x509CAReferences.getPrimary() == null))
         {
             throw new IllegalArgumentException("original x509CAReferences cannot be null and its primary certificate cannot be null.");
         }
@@ -88,23 +88,9 @@ public class X509CAReferences
     /**
      * Getter for the primary.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getPrimaryFinal()}
-     *
      * @return the {@code String} with the stored primary. It cannot be {@code null}.
      */
-    @Deprecated
-    public String getPrimary()
-    {
-        /* SRS_X509_CAREFERENCE_21_005: [The getPrimary shall return the stored primary.] */
-        return this.primary;
-    }
-
-    /**
-     * Getter for the primary.
-     *
-     * @return the {@code String} with the stored primary. It cannot be {@code null}.
-     */
-    public final String getPrimaryFinal()
+    public final String getPrimary()
     {
         /* SRS_X509_CAREFERENCE_21_005: [The getPrimary shall return the stored primary.] */
         return this.primary;
@@ -112,23 +98,9 @@ public class X509CAReferences
 
     /**
      * Getter for the secondary.
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getSecondaryFinal()}
-     *
      * @return the {@code String} with the stored secondary. It can be {@code null}.
      */
-    @Deprecated
-    public String getSecondary()
-    {
-        /* SRS_X509_CAREFERENCE_21_006: [The getSecondary shall return the stored secondary.] */
-        return this.secondary;
-    }
-
-    /**
-     * Getter for the secondary.
-     *
-     * @return the {@code String} with the stored secondary. It can be {@code null}.
-     */
-    public final String getSecondaryFinal()
+    public final String getSecondary()
     {
         /* SRS_X509_CAREFERENCE_21_006: [The getSecondary shall return the stored secondary.] */
         return this.secondary;

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509Certificates.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509Certificates.java
@@ -158,7 +158,7 @@ public class X509Certificates
     public X509Certificates(X509Certificates x509Certificates)
     {
         /* SRS_X509_CERTIFICATES_21_004: [The constructor shall throw IllegalArgumentException if the provide X509Certificates is null or if its primary certificate is null.] */
-        if((x509Certificates == null) || (x509Certificates.getPrimaryFinal() == null))
+        if ((x509Certificates == null) || (x509Certificates.getPrimary() == null))
         {
             throw new IllegalArgumentException("original x509Certificates cannot be null and its primary certificate cannot be null.");
         }
@@ -166,7 +166,7 @@ public class X509Certificates
         this.primary = new X509CertificateWithInfo(x509Certificates.primary);
 
         /* SRS_X509_CERTIFICATES_21_006: [If the secondary certificate is not null, the constructor shall create a new instance of the X509CertificateWithInfo using the provided secondary certificate, and store it as the secondary Certificate.] */
-        if(x509Certificates.secondary != null)
+        if (x509Certificates.secondary != null)
         {
             this.secondary = new X509CertificateWithInfo(x509Certificates.secondary);
         }
@@ -175,23 +175,9 @@ public class X509Certificates
     /**
      * Getter for the primary.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getPrimaryFinal()}
-     *
      * @return the {@link X509CertificateWithInfo} with the stored primary. It cannot be {@code null}.
      */
-    @Deprecated
-    public X509CertificateWithInfo getPrimary()
-    {
-        /* SRS_X509_CERTIFICATES_21_007: [The getPrimary shall return the stored primary.] */
-        return this.primary;
-    }
-
-    /**
-     * Getter for the primary.
-     *
-     * @return the {@link X509CertificateWithInfo} with the stored primary. It cannot be {@code null}.
-     */
-    public final X509CertificateWithInfo getPrimaryFinal()
+    public final X509CertificateWithInfo getPrimary()
     {
         /* SRS_X509_CERTIFICATES_21_007: [The getPrimary shall return the stored primary.] */
         return this.primary;
@@ -200,23 +186,9 @@ public class X509Certificates
     /**
      * Getter for the secondary.
      *
-     * @deprecated as of provisioning-service-client version 1.3.3, please use {@link #getSecondaryFinal()}
-     *
      * @return the {@link X509CertificateWithInfo} with the stored secondary. It can be {@code null}.
      */
-    @Deprecated
-    public X509CertificateWithInfo getSecondary()
-    {
-        /* SRS_X509_CERTIFICATES_21_008: [The getSecondary shall return the stored secondary.] */
-        return this.secondary;
-    }
-
-    /**
-     * Getter for the secondary.
-     *
-     * @return the {@link X509CertificateWithInfo} with the stored secondary. It can be {@code null}.
-     */
-    public final X509CertificateWithInfo getSecondaryFinal()
+    public final X509CertificateWithInfo getSecondary()
     {
         /* SRS_X509_CERTIFICATES_21_008: [The getSecondary shall return the stored secondary.] */
         return this.secondary;

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClientTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClientTest.java
@@ -61,7 +61,7 @@ public class ProvisioningServiceClientTest
             }
         };
 
-        return ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        return new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
     }
 
     private static final String PROVISIONING_CONNECTION_STRING = "HostName=valid-host-name.azure-devices-provisioning.net;SharedAccessKeyName=valid-key-name;SharedAccessKey=0000000000000000000000000000000000000000000=";
@@ -97,7 +97,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);
@@ -109,7 +109,7 @@ public class ProvisioningServiceClientTest
     {
         // arrange
         // act
-        ProvisioningServiceClient.createFromConnectionString(null);
+        new ProvisioningServiceClient(null);
 
         // assert
     }
@@ -120,7 +120,7 @@ public class ProvisioningServiceClientTest
     {
         // arrange
         // act
-        ProvisioningServiceClient.createFromConnectionString("");
+        new ProvisioningServiceClient("");
 
         // assert
     }
@@ -140,7 +140,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);
@@ -164,7 +164,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);
@@ -191,7 +191,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);
@@ -221,7 +221,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);
@@ -254,7 +254,7 @@ public class ProvisioningServiceClientTest
         };
 
         // act
-        ProvisioningServiceClient provisioningServiceClient = ProvisioningServiceClient.createFromConnectionString(PROVISIONING_CONNECTION_STRING);
+        ProvisioningServiceClient provisioningServiceClient = new ProvisioningServiceClient(PROVISIONING_CONNECTION_STRING);
 
         // assert
         assertNotNull(provisioningServiceClient);

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/BulkEnrollmentOperationTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/BulkEnrollmentOperationTest.java
@@ -73,16 +73,16 @@ public class BulkEnrollmentOperationTest
         IndividualEnrollment individualEnrollment1 = new IndividualEnrollment(
                 VALID_REGISTRATION_ID_1,
                 new TpmAttestation(VALID_ENDORSEMENT_KEY, VALID_STORAGE_ROOT_KEY));
-        individualEnrollment1.setDeviceIdFinal(VALID_DEVICE_ID);
-        individualEnrollment1.setIotHubHostNameFinal(VALID_IOTHUB_HOST_NAME);
-        individualEnrollment1.setProvisioningStatusFinal(ProvisioningStatus.ENABLED);
+        individualEnrollment1.setDeviceId(VALID_DEVICE_ID);
+        individualEnrollment1.setIotHubHostName(VALID_IOTHUB_HOST_NAME);
+        individualEnrollment1.setProvisioningStatus(ProvisioningStatus.ENABLED);
 
         IndividualEnrollment individualEnrollment2 = new IndividualEnrollment(
                 VALID_REGISTRATION_ID_2,
                 new TpmAttestation(VALID_ENDORSEMENT_KEY, null));
-        individualEnrollment2.setDeviceIdFinal(VALID_DEVICE_ID);
-        individualEnrollment2.setIotHubHostNameFinal(VALID_IOTHUB_HOST_NAME);
-        individualEnrollment2.setProvisioningStatusFinal(ProvisioningStatus.DISABLED);
+        individualEnrollment2.setDeviceId(VALID_DEVICE_ID);
+        individualEnrollment2.setIotHubHostName(VALID_IOTHUB_HOST_NAME);
+        individualEnrollment2.setProvisioningStatus(ProvisioningStatus.DISABLED);
 
         return new LinkedList<IndividualEnrollment>()
         {

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
@@ -100,24 +100,6 @@ public class EnrollmentGroupTest
         }
 
         @Mock
-        public void setProvisioningStatus(ProvisioningStatus provisioningStatus)
-        {
-            mockedProvisioningStatus = provisioningStatus;
-        }
-
-        @Mock
-        public void setInitialTwin(TwinState initialTwin)
-        {
-            mockedInitialTwin = initialTwin;
-        }
-
-        @Mock
-        public void setEtag(String etag)
-        {
-            mockedEtag = etag;
-        }
-
-        @Mock
         public JsonElement toJsonElement()
         {
             Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().disableHtmlEscaping().create();
@@ -132,8 +114,8 @@ public class EnrollmentGroupTest
         EnrollmentGroup enrollmentGroup = new EnrollmentGroup(
                 VALID_ENROLLMENT_GROUP_ID,
                 X509Attestation.createFromRootCertificates(PUBLIC_KEY_CERTIFICATE_STRING, null));
-        enrollmentGroup.setIotHubHostNameFinal(VALID_IOTHUB_HOST_NAME);
-        enrollmentGroup.setProvisioningStatusFinal(ProvisioningStatus.ENABLED);
+        enrollmentGroup.setIotHubHostName(VALID_IOTHUB_HOST_NAME);
+        enrollmentGroup.setProvisioningStatus(ProvisioningStatus.ENABLED);
         return enrollmentGroup;
     }
 
@@ -310,7 +292,7 @@ public class EnrollmentGroupTest
         Attestation attestation = enrollmentGroup.getAttestation();
         assertTrue("attestation is not x509", (attestation instanceof X509Attestation));
         X509Attestation x509Attestation = (X509Attestation)attestation;
-        X509CertificateWithInfo primary = x509Attestation.getRootCertificatesFinal().getPrimaryFinal();
+        X509CertificateWithInfo primary = x509Attestation.getRootCertificates().getPrimary();
         assertEquals(PUBLIC_KEY_CERTIFICATE_STRING, primary.getCertificate());
         X509CertificateInfo info = primary.getInfo();
         assertEquals(VALID_ENROLLMENT_GROUP_ID, info.getSha256Thumbprint());
@@ -730,7 +712,7 @@ public class EnrollmentGroupTest
     {
         // arrange
         EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-        enrollmentGroup.setInitialTwinFinal(new TwinState(
+        enrollmentGroup.setInitialTwin(new TwinState(
                 new TwinCollection() {{
                     put("tag1", "valueTag1");
                     put("tag2", "valueTag2");
@@ -781,7 +763,7 @@ public class EnrollmentGroupTest
     {
         // arrange
         EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
-        enrollmentGroup.setInitialTwinFinal(new TwinState(
+        enrollmentGroup.setInitialTwin(new TwinState(
                 new TwinCollection() {{
                     put("tag1", "valueTag1");
                     put("tag2", "valueTag2");
@@ -999,7 +981,7 @@ public class EnrollmentGroupTest
             {
                 Deencapsulation.invoke(mockedAttestationMechanism, "getAttestation");
                 result = mockedX509Attestation;
-                mockedX509Attestation.getRootCertificatesFinal();
+                mockedX509Attestation.getRootCertificates();
                 result = null;
             }
         };
@@ -1026,7 +1008,7 @@ public class EnrollmentGroupTest
             {
                 Deencapsulation.invoke(mockedAttestationMechanism, "getAttestation");
                 result = mockedX509Attestation;
-                mockedX509Attestation.getRootCertificatesFinal();
+                mockedX509Attestation.getRootCertificates();
                 result = mockedX509Certificates;
             }
         };
@@ -1109,7 +1091,7 @@ public class EnrollmentGroupTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Attestation.getRootCertificatesFinal();
+                mockedX509Attestation.getRootCertificates();
                 result = null;
             }
         };
@@ -1133,7 +1115,7 @@ public class EnrollmentGroupTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Attestation.getRootCertificatesFinal();
+                mockedX509Attestation.getRootCertificates();
                 result = mockedX509Certificates;
             }
         };
@@ -1183,7 +1165,7 @@ public class EnrollmentGroupTest
         assertNotEquals(newHostName, Deencapsulation.getField(enrollmentGroup, "iotHubHostName"));
 
         // act
-        enrollmentGroup.setIotHubHostNameFinal(newHostName);
+        enrollmentGroup.setIotHubHostName(newHostName);
 
         // assert
         assertEquals(newHostName, Deencapsulation.getField(enrollmentGroup, "iotHubHostName"));
@@ -1197,7 +1179,7 @@ public class EnrollmentGroupTest
         EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
 
         // act
-        enrollmentGroup.setInitialTwinFinal(null);
+        enrollmentGroup.setInitialTwin(null);
 
         // assert
     }
@@ -1211,7 +1193,7 @@ public class EnrollmentGroupTest
         assertNotEquals(mockedTwinState, Deencapsulation.getField(enrollmentGroup, "initialTwin"));
 
         // act
-        enrollmentGroup.setInitialTwinFinal(mockedTwinState);
+        enrollmentGroup.setInitialTwin(mockedTwinState);
 
         // assert
         assertEquals(mockedTwinState, Deencapsulation.getField(enrollmentGroup, "initialTwin"));
@@ -1225,7 +1207,7 @@ public class EnrollmentGroupTest
         EnrollmentGroup enrollmentGroup = makeStandardX509EnrollmentGroup();
 
         // act
-        enrollmentGroup.setProvisioningStatusFinal(null);
+        enrollmentGroup.setProvisioningStatus(null);
 
         // assert
     }
@@ -1239,7 +1221,7 @@ public class EnrollmentGroupTest
         assertNotEquals(ProvisioningStatus.DISABLED, Deencapsulation.getField(enrollmentGroup, "provisioningStatus"));
 
         // act
-        enrollmentGroup.setProvisioningStatusFinal(ProvisioningStatus.DISABLED);
+        enrollmentGroup.setProvisioningStatus(ProvisioningStatus.DISABLED);
 
         // assert
         assertEquals(ProvisioningStatus.DISABLED, Deencapsulation.getField(enrollmentGroup, "provisioningStatus"));

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/IndividualEnrollmentTest.java
@@ -80,21 +80,9 @@ public class IndividualEnrollmentTest
         }
 
         @Mock
-        public void setProvisioningStatus(ProvisioningStatus provisioningStatus)
-        {
-            mockedProvisioningStatus = provisioningStatus;
-        }
-
-        @Mock
         public void setInitialTwin(TwinState initialTwin)
         {
             mockedInitialTwin = initialTwin;
-        }
-
-        @Mock
-        public void setEtag(String etag)
-        {
-            mockedEtag = etag;
         }
 
         @Mock
@@ -112,9 +100,9 @@ public class IndividualEnrollmentTest
         IndividualEnrollment individualEnrollment = new IndividualEnrollment(
                 VALID_REGISTRATION_ID,
                 new TpmAttestation(VALID_ENDORSEMENT_KEY, VALID_STORAGE_ROOT_KEY));
-        individualEnrollment.setDeviceIdFinal(VALID_DEVICE_ID);
-        individualEnrollment.setIotHubHostNameFinal(VALID_IOTHUB_HOST_NAME);
-        individualEnrollment.setProvisioningStatusFinal(ProvisioningStatus.ENABLED);
+        individualEnrollment.setDeviceId(VALID_DEVICE_ID);
+        individualEnrollment.setIotHubHostName(VALID_IOTHUB_HOST_NAME);
+        individualEnrollment.setProvisioningStatus(ProvisioningStatus.ENABLED);
 
         return individualEnrollment;
     }
@@ -889,7 +877,7 @@ public class IndividualEnrollmentTest
         assertNotEquals(newHostName, Deencapsulation.getField(individualEnrollment, "iotHubHostName"));
 
         // act
-        individualEnrollment.setIotHubHostNameFinal(newHostName);
+        individualEnrollment.setIotHubHostName(newHostName);
 
         // assert
         assertEquals(newHostName, Deencapsulation.getField(individualEnrollment, "iotHubHostName"));
@@ -919,7 +907,7 @@ public class IndividualEnrollmentTest
         assertNotEquals(ProvisioningStatus.DISABLED, Deencapsulation.getField(individualEnrollment, "provisioningStatus"));
 
         // act
-        individualEnrollment.setProvisioningStatusFinal(ProvisioningStatus.DISABLED);
+        individualEnrollment.setProvisioningStatus(ProvisioningStatus.DISABLED);
 
         // assert
         assertEquals(ProvisioningStatus.DISABLED, Deencapsulation.getField(individualEnrollment, "provisioningStatus"));

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509AttestationTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509AttestationTest.java
@@ -469,7 +469,7 @@ public class X509AttestationTest
         X509Attestation x509Attestation = X509Attestation.createFromClientCertificates(PUBLIC_CERTIFICATE_STRING, PUBLIC_CERTIFICATE_STRING);
 
         // act - assert
-        assertNotNull(x509Attestation.getClientCertificatesFinal());
+        assertNotNull(x509Attestation.getClientCertificates());
     }
 
     /* SRS_X509_ATTESTATION_21_017: [The getRootCertificates shall return the stored rootCertificates.] */
@@ -481,7 +481,7 @@ public class X509AttestationTest
         X509Attestation x509Attestation = X509Attestation.createFromRootCertificates(PUBLIC_CERTIFICATE_STRING, PUBLIC_CERTIFICATE_STRING);
 
         // act - assert
-        assertNotNull(x509Attestation.getRootCertificatesFinal());
+        assertNotNull(x509Attestation.getRootCertificates());
     }
 
     /* SRS_X509_ATTESTATION_21_024: [The getCAReferences shall return the stored caReferences.] */
@@ -493,7 +493,7 @@ public class X509AttestationTest
         X509Attestation x509Attestation = X509Attestation.createFromCAReferences(CA_REFERENCES_STRING, CA_REFERENCES_STRING);
 
         // act - assert
-        assertNotNull(x509Attestation.getCAReferencesFinal());
+        assertNotNull(x509Attestation.getCAReferences());
     }
 
 
@@ -511,7 +511,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getPrimaryFinal();
+                mockedX509Certificates.getPrimary();
                 result = mockedX509CertificateWithInfo;
                 mockedX509CertificateWithInfo.getInfo();
                 result = mockedX509CertificateInfo;
@@ -541,7 +541,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getPrimaryFinal();
+                mockedX509Certificates.getPrimary();
                 result = mockedX509CertificateWithInfo;
                 mockedX509CertificateWithInfo.getInfo();
                 result = mockedX509CertificateInfo;
@@ -584,7 +584,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getSecondaryFinal();
+                mockedX509Certificates.getSecondary();
                 result = mockedX509CertificateWithInfo;
                 mockedX509CertificateWithInfo.getInfo();
                 result = mockedX509CertificateInfo;
@@ -612,7 +612,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getSecondaryFinal();
+                mockedX509Certificates.getSecondary();
                 result = null;
             }
         };
@@ -640,7 +640,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getSecondaryFinal();
+                mockedX509Certificates.getSecondary();
                 result = mockedX509CertificateWithInfo;
                 mockedX509CertificateWithInfo.getInfo();
                 result = mockedX509CertificateInfo;
@@ -668,7 +668,7 @@ public class X509AttestationTest
         new NonStrictExpectations()
         {
             {
-                mockedX509Certificates.getSecondaryFinal();
+                mockedX509Certificates.getSecondary();
                 result = null;
             }
         };

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CAReferencesTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CAReferencesTest.java
@@ -112,8 +112,8 @@ public class X509CAReferencesTest
         X509CAReferences x509CAReferences = Deencapsulation.newInstance(X509CAReferences.class, new Class[] {String.class, String.class},CA_REFERENCE_STRING, CA_REFERENCE_STRING);
 
         // act - assert
-        assertEquals(CA_REFERENCE_STRING, x509CAReferences.getPrimaryFinal());
-        assertEquals(CA_REFERENCE_STRING, x509CAReferences.getSecondaryFinal());
+        assertEquals(CA_REFERENCE_STRING, x509CAReferences.getPrimary());
+        assertEquals(CA_REFERENCE_STRING, x509CAReferences.getSecondary());
     }
 
     /* SRS_X509_CAREFERENCE_21_007: [The X509CAReferences shall provide an empty constructor to make GSON happy.] */

--- a/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CertificatesTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/provisioning/service/configs/X509CertificatesTest.java
@@ -179,8 +179,8 @@ public class X509CertificatesTest
         X509Certificates x509Certificates = Deencapsulation.newInstance(X509Certificates.class, new Class[] {String.class, String.class},PUBLIC_CERTIFICATE_STRING, PUBLIC_CERTIFICATE_STRING);
 
         // act - assert
-        assertNotNull(x509Certificates.getPrimaryFinal());
-        assertNotNull(x509Certificates.getSecondaryFinal());
+        assertNotNull(x509Certificates.getPrimary());
+        assertNotNull(x509Certificates.getSecondary());
     }
 
     /* SRS_X509_CERTIFICATES_21_009: [The X509Certificates shall provide an empty constructor to make GSON happy.] */


### PR DESCRIPTION
For the provisioning service client, unlike other service clients, we didn't have any deprecated constructors/factory methods. However, to maintain parity with the service clients in the IoT hub packages that have constructors rather than factory methods, I'm proposing:

current
```java
public static ProvisioningServiceClient createFromConnectionString(String connectionString);

// note that this is currently private
private ProvisioningServiceClient(String connectionString)
```

proposed:
```java
//not deleted since it wasn't deprecated
public static ProvisioningServiceClient createFromConnectionString(String connectionString);

//private -> public
public ProvisioningServiceClient(String connectionString)
```

This change would only be additive, not breaking