### PR TITLE
refactor(iot-dev): Raise the max in flight messages limit for mqtt

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -32,6 +32,8 @@ abstract public class Mqtt implements MqttCallback
     private static final int QOS = 1;
     private static final int MAX_SUBSCRIBE_ACK_WAIT_TIME = 15 * 1000;
 
+    // relatively arbitrary, but only because Paho doesn't have any particular recommendations here. Just a high enough
+    // value that users who are building a gateway type solution don't find this value to be a bottleneck.
     static final int MAX_IN_FLIGHT_COUNT = 65000;
 
     private MqttAsyncClient mqttAsyncClient;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -32,8 +32,7 @@ abstract public class Mqtt implements MqttCallback
     private static final int QOS = 1;
     private static final int MAX_SUBSCRIBE_ACK_WAIT_TIME = 15 * 1000;
 
-    // paho mqtt only supports 10 messages in flight at the same time
-    private static final int MAX_IN_FLIGHT_COUNT = 10;
+    static final int MAX_IN_FLIGHT_COUNT = 65000;
 
     private MqttAsyncClient mqttAsyncClient;
     private final MqttConnectOptions connectOptions;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
+import static com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt.MAX_IN_FLIGHT_COUNT;
 
 @Slf4j
 public class MqttIotHubConnection implements IotHubTransportConnection, MqttMessageListener
@@ -182,6 +183,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
         connectOptions.setCleanSession(SET_CLEAN_SESSION);
         connectOptions.setMqttVersion(MQTT_VERSION);
         connectOptions.setUserName(iotHubUserName);
+        connectOptions.setMaxInflight(MAX_IN_FLIGHT_COUNT);
         ProxySettings proxySettings = config.getProxySettings();
         if (proxySettings != null)
         {


### PR DESCRIPTION
Clients using MQTT were limited to 10 messages in flight at a time, which hurt the client's ability to achieve higher messaging throughputs. Raising this value to a higher number. We can make this value configurable at some point in the future if someone asks for it, but this value should be enough to not hamstring anyone.

"In-flight" messages are messages that have been sent, but haven't been ack'd yet.