### PR TITLE
feat(iot-dev): Add ability to configure the maximum number of messages sent per send thread

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -796,6 +796,11 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in milliseconds
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *
+     *	    - <b>SetMaxMessagesSentPerThread</b> - this option is applicable to all protocols.
+     *	      This option specifies how many messages a given send thread should attempt to send before exiting.
+     *	      This option can be used in conjunction with "SetSendInterval" to control the how frequently and in what
+     *	      batch size messages are sent.
+     *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.
@@ -861,6 +866,7 @@ public final class DeviceClient extends InternalClient implements Closeable
             case SET_HTTPS_READ_TIMEOUT:
             case SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT:
             case SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT:
+            case SET_MAX_MESSAGES_SENT_PER_THREAD:
             {
                 break;
             }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -799,7 +799,8 @@ public final class DeviceClient extends InternalClient implements Closeable
      *	    - <b>SetMaxMessagesSentPerThread</b> - this option is applicable to all protocols.
      *	      This option specifies how many messages a given send thread should attempt to send before exiting.
      *	      This option can be used in conjunction with "SetSendInterval" to control the how frequently and in what
-     *	      batch size messages are sent.
+     *	      batch size messages are sent. By default, this client sends 10 messages per send thread, and spawns
+     *	      a send thread every 10 milliseconds. This gives a theoretical throughput of 1000 messages per second.
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -116,22 +116,16 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
         IotHubClientProtocol protocol = config.getProtocol();
         config.setUseWebsocket(protocol == IotHubClientProtocol.AMQPS_WS || protocol == MQTT_WS);
 
-        /* Codes_SRS_DEVICE_IO_21_037: [The constructor shall initialize the `sendPeriodInMilliseconds` with default value of 10 milliseconds.] */
         this.sendPeriodInMilliseconds = sendPeriodInMilliseconds;
-        /* Codes_SRS_DEVICE_IO_21_038: [The constructor shall initialize the `receivePeriodInMilliseconds` with default value of each protocol.] */
         this.receivePeriodInMilliseconds = receivePeriodInMilliseconds;
 
-        /* Codes_SRS_DEVICE_IO_21_006: [The constructor shall set the `state` as `DISCONNECTED`.] */
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
         this.transport = new IotHubTransport(config, this, isMultiplexing);
 
-        /* Codes_SRS_DEVICE_IO_21_037: [The constructor shall initialize the `sendPeriodInMilliseconds` with default value of 10 milliseconds.] */
         this.sendPeriodInMilliseconds = sendPeriodInMilliseconds;
-        /* Codes_SRS_DEVICE_IO_21_038: [The constructor shall initialize the `receivePeriodInMilliseconds` with default value of each protocol.] */
         this.receivePeriodInMilliseconds = receivePeriodInMilliseconds;
 
-        /* Codes_SRS_DEVICE_IO_21_006: [The constructor shall set the `state` as `DISCONNECTED`.] */
         this.state = IotHubConnectionStatus.DISCONNECTED;
     }
 
@@ -208,6 +202,11 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
         this.transport.setMultiplexingRetryPolicy(retryPolicy);
     }
 
+    void setMaxNumberOfMessagesSentPerSendThread(int maxNumberOfMessagesSentPerSendThread)
+    {
+        this.transport.setMaxNumberOfMessagesSentPerSendThread(maxNumberOfMessagesSentPerSendThread);
+    }
+
     /**
      * Handles logic common to all open functions.
      */
@@ -264,7 +263,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
                 this.receiveTaskScheduler.shutdown();
             }
 
-            /* Codes_SRS_DEVICE_IO_21_019: [The close shall close the transport.] */
             try
             {
                 this.transport.close(IotHubConnectionStatusChangeReason.CLIENT_CLOSE, null);
@@ -275,7 +273,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
                 throw new IOException(e);
             }
 
-            /* Codes_SRS_DEVICE_IO_21_021: [The close shall set the `state` as `CLOSE`.] */
             this.state = IotHubConnectionStatus.DISCONNECTED;
         }
     }
@@ -321,7 +318,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
                                Object callbackContext,
                                String deviceId)
     {
-        /* Codes_SRS_DEVICE_IO_21_024: [If the client is closed, the sendEventAsync shall throw an IllegalStateException.] */
         if (!this.isOpen())
         {
             throw new IllegalStateException(
@@ -329,19 +325,16 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
                             + "an IoT Hub client that is closed.");
         }
 
-        /* Codes_SRS_DEVICE_IO_21_023: [If the message given is null, the sendEventAsync shall throw an IllegalArgumentException.] */
         if (message == null)
         {
             throw new IllegalArgumentException("Cannot send message 'null'.");
         }
 
-        // Codes_SRS_DEVICE_IO_12_001: [The function shall set the deviceId on the message if the deviceId parameter is not null.]
         if (deviceId != null)
         {
             message.setConnectionDeviceId(deviceId);
         }
 
-        /* Codes_SRS_DEVICE_IO_21_022: [The sendEventAsync shall add the message, with its associated callback and callback context, to the transport.] */
         transport.addMessage(message, callback, callbackContext, deviceId);
     }
 
@@ -352,7 +345,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public long getReceivePeriodInMilliseconds()
     {
-        /* Codes_SRS_DEVICE_IO_21_026: [The getReceivePeriodInMilliseconds shall return the programed receive period in milliseconds.] */
         return this.receivePeriodInMilliseconds;
     }
 
@@ -365,26 +357,28 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public void setReceivePeriodInMilliseconds(long newIntervalInMilliseconds) throws IOException
     {
-        /* Codes_SRS_DEVICE_IO_21_030: [If the the provided interval is zero or negative, the setReceivePeriodInMilliseconds shall throw IllegalArgumentException.] */
         if(newIntervalInMilliseconds <= 0L)
         {
             throw new IllegalArgumentException("receive interval can not be zero or negative");
         }
 
-        /* Codes_SRS_DEVICE_IO_21_027: [The setReceivePeriodInMilliseconds shall store the new receive period in milliseconds.] */
         this.receivePeriodInMilliseconds = newIntervalInMilliseconds;
 
-        /* Codes_SRS_DEVICE_IO_21_028: [If the task scheduler already exists, the setReceivePeriodInMilliseconds shall change the `scheduleAtFixedRate` for the receiveTask to the new value.] */
         if (this.receiveTaskScheduler != null)
         {
-            /* Codes_SRS_DEVICE_IO_21_029: [If the `receiveTask` is null, the setReceivePeriodInMilliseconds shall throw IOException.] */
             if (this.receiveTask == null)
             {
                 throw new IOException("transport receive task not set");
             }
 
-            this.receiveTaskScheduler.scheduleAtFixedRate(this.receiveTask, 0,
-                    this.receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
+            // close the old scheduler and start a new one with the new receive period
+            this.receiveTaskScheduler.shutdown();
+            this.receiveTaskScheduler = Executors.newScheduledThreadPool(1);
+            this.receiveTaskScheduler.scheduleAtFixedRate(
+                this.receiveTask,
+                0,
+                this.receivePeriodInMilliseconds,
+                TimeUnit.MILLISECONDS);
         }
     }
 
@@ -395,7 +389,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public long getSendPeriodInMilliseconds()
     {
-        /* Codes_SRS_DEVICE_IO_21_032: [The getSendPeriodInMilliseconds shall return the programed send period in milliseconds.] */
         return this.sendPeriodInMilliseconds;
     }
 
@@ -408,26 +401,28 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public void setSendPeriodInMilliseconds(long newIntervalInMilliseconds) throws IOException
     {
-        /* Codes_SRS_DEVICE_IO_21_036: [If the the provided interval is zero or negative, the setSendPeriodInMilliseconds shall throw IllegalArgumentException.] */
         if(newIntervalInMilliseconds <= 0L)
         {
             throw new IllegalArgumentException("send interval can not be zero or negative");
         }
 
-        /* Codes_SRS_DEVICE_IO_21_033: [The setSendPeriodInMilliseconds shall store the new send period in milliseconds.] */
         this.sendPeriodInMilliseconds = newIntervalInMilliseconds;
 
-        /* Codes_SRS_DEVICE_IO_21_034: [If the task scheduler already exists, the setSendPeriodInMilliseconds shall change the `scheduleAtFixedRate` for the sendTask to the new value.] */
         if (this.sendTaskScheduler != null)
         {
-            /* Codes_SRS_DEVICE_IO_21_035: [If the `sendTask` is null, the setSendPeriodInMilliseconds shall throw IOException.] */
             if (this.sendTask == null)
             {
                 throw new IOException("transport send task not set");
             }
 
-            this.sendTaskScheduler.scheduleAtFixedRate(this.sendTask, 0,
-                    this.sendPeriodInMilliseconds, TimeUnit.MILLISECONDS);
+            // close the old scheduler and start a new one with the new send period
+            this.sendTaskScheduler.shutdown();
+            this.sendTaskScheduler = Executors.newScheduledThreadPool(1);
+            this.sendTaskScheduler.scheduleAtFixedRate(
+                this.sendTask,
+                0,
+                this.sendPeriodInMilliseconds,
+                TimeUnit.MILLISECONDS);
         }
     }
 
@@ -438,7 +433,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public IotHubClientProtocol getProtocol()
     {
-        /* Codes_SRS_DEVICE_IO_21_025: [The getProtocol shall return the protocol for transport.] */
         return this.transport.getProtocol();
     }
 
@@ -460,7 +454,6 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     public boolean isEmpty()
     {
-        /* Codes_SRS_DEVICE_IO_21_039: [The isEmpty shall return the transport queue state, true if the queue is empty, false if there is pending messages in the queue.] */
         return this.transport.isEmpty();
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -492,7 +492,8 @@ public class InternalClient
      *	    - <b>SetMaxMessagesSentPerThread</b> - this option is applicable to all protocols.
      *	      This option specifies how many messages a given send thread should attempt to send before exiting.
      *	      This option can be used in conjunction with "SetSendInterval" to control the how frequently and in what
-     *	      batch size messages are sent.
+     *	      batch size messages are sent. By default, this client sends 10 messages per send thread, and spawns
+     *	      a send thread every 10 milliseconds. This gives a theoretical throughput of 1000 messages per second.
      *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -1126,17 +1126,20 @@ public class InternalClient
 
     void setOption_SetMaxMessagesSentPerThread(Object value)
     {
-        if (value != null)
+        if (value == null)
         {
-            if (value instanceof Integer)
-            {
-                log.info("Setting maximum number of messages sent per send thread {} messages", value);
-                this.deviceIO.setMaxNumberOfMessagesSentPerSendThread((int) value);
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not int = " + value);
-            }
+            throw new IllegalArgumentException("Value cannot be null");
+        }
+
+
+        if (value instanceof Integer)
+        {
+            log.info("Setting maximum number of messages sent per send thread {} messages", value);
+            this.deviceIO.setMaxNumberOfMessagesSentPerSendThread((int) value);
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not int = " + value);
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -30,6 +30,7 @@ public class InternalClient
     // SET_RECEIVE_INTERVAL is used for setting the interval for handling MQTT and AMQP messages.
     static final String SET_RECEIVE_INTERVAL = "SetReceiveInterval";
     static final String SET_SEND_INTERVAL = "SetSendInterval";
+    static final String SET_MAX_MESSAGES_SENT_PER_THREAD = "SetMaxMessagesSentPerThread";
     static final String SET_CERTIFICATE_PATH = "SetCertificatePath";
 	static final String SET_CERTIFICATE_AUTHORITY = "SetCertificateAuthority";
     static final String SET_SAS_TOKEN_EXPIRY_TIME = "SetSASTokenExpiryTime";
@@ -488,6 +489,11 @@ public class InternalClient
      *	      in case of MQTT and AMQP protocols, this option specifies the interval in milliseconds
      *	      between spawning a thread that dequeues a message from the SDK's queue of received messages.
      *
+     *	    - <b>SetMaxMessagesSentPerThread</b> - this option is applicable to all protocols.
+     *	      This option specifies how many messages a given send thread should attempt to send before exiting.
+     *	      This option can be used in conjunction with "SetSendInterval" to control the how frequently and in what
+     *	      batch size messages are sent.
+     *
      *	    - <b>SetCertificatePath</b> - this option is applicable only
      *	      when the transport configured with this client is AMQP. This
      *	      option specifies the path to the certificate used to verify peer.
@@ -562,6 +568,11 @@ public class InternalClient
                 case SET_SEND_INTERVAL:
                 {
                     setOption_SetSendInterval(value);
+                    break;
+                }
+                case SET_MAX_MESSAGES_SENT_PER_THREAD:
+                {
+                    setOption_SetMaxMessagesSentPerThread(value);
                     break;
                 }
                 case SET_CERTIFICATE_PATH:
@@ -1105,6 +1116,22 @@ public class InternalClient
             {
                 log.info("Setting generated AMQP device session timeout to {} seconds", value);
                 this.config.setAmqpOpenDeviceSessionsTimeout((int) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("value is not int = " + value);
+            }
+        }
+    }
+
+    void setOption_SetMaxMessagesSentPerThread(Object value)
+    {
+        if (value != null)
+        {
+            if (value instanceof Integer)
+            {
+                log.info("Setting maximum number of messages sent per send thread {} messages", value);
+                this.deviceIO.setMaxNumberOfMessagesSentPerSendThread((int) value);
             }
             else
             {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -36,6 +36,7 @@ public class MultiplexingClient
 {
     public static final long DEFAULT_SEND_PERIOD_MILLIS = 10L;
     public static final long DEFAULT_RECEIVE_PERIOD_MILLIS = 10L;
+    public static final int DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
     static final long DEFAULT_REGISTRATION_TIMEOUT_MILLISECONDS = 60 * 1000; // 1 minute
     static final long DEFAULT_UNREGISTRATION_TIMEOUT_MILLISECONDS = 60 * 1000; // 1 minute
     private static final String OPEN_ERROR_MESSAGE = "Failed to open the multiplexing connection";
@@ -103,10 +104,11 @@ public class MultiplexingClient
         this.proxySettings = options != null ? options.getProxySettings() : null;
         long sendPeriod = options != null ? options.getSendPeriod() : DEFAULT_SEND_PERIOD_MILLIS;
         long receivePeriod = options != null ? options.getReceivePeriod() : DEFAULT_RECEIVE_PERIOD_MILLIS;
+        int sendMessagesPerThread = options != null ? options.getMaxMessagesSentPerSendThread() : DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD;
 
         if (sendPeriod < 0)
         {
-            throw new IllegalArgumentException("send period can not be negative");
+            throw new IllegalArgumentException("Send period cannot be negative");
         }
         else if (sendPeriod == 0) //default builder value for this option, signals that user didn't set a value
         {
@@ -115,15 +117,21 @@ public class MultiplexingClient
 
         if (receivePeriod < 0)
         {
-            throw new IllegalArgumentException("receive period can not be negative");
+            throw new IllegalArgumentException("Receive period cannot be negative");
         }
         else if (receivePeriod == 0) //default builder value for this option, signals that user didn't set a value
         {
             receivePeriod = DEFAULT_RECEIVE_PERIOD_MILLIS;
         }
 
+        if (sendMessagesPerThread == 0) //default builder value for this option, signals that user didn't set a value
+        {
+            sendMessagesPerThread = DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD;
+        }
+
         this.sslContext = options != null ? options.getSslContext() : null;
         this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, sendPeriod, receivePeriod);
+        this.deviceIO.setMaxNumberOfMessagesSentPerSendThread(sendMessagesPerThread);
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
@@ -14,8 +14,8 @@ import javax.net.ssl.SSLContext;
  * level settings on these parameters.
  */
 @Builder
-public class MultiplexingClientOptions {
-
+public class MultiplexingClientOptions
+{
     /**
      * The details of the proxy to connect to, if set. If not set, the multiplexing client will not connect through a proxy.
      */
@@ -32,7 +32,7 @@ public class MultiplexingClientOptions {
 
     /**
      * The period, in seconds, for how often a thread will spawn to handle queued outgoing messages. For instance, if this
-     * is set to 10, then a thread will spawn every 10 seconds. If unset, this will default to {@link MultiplexingClient#DEFAULT_SEND_PERIOD_MILLIS}
+     * is set to 10, then a thread will spawn every 10 seconds. If unset, this will default to {@link MultiplexingClient#DEFAULT_SEND_PERIOD_MILLIS}.
      */
     @Getter
     @Setter
@@ -40,9 +40,18 @@ public class MultiplexingClientOptions {
 
     /**
      * The period, in seconds, for how often a thread will spawn to handle queued incoming messages. For instance, if this
-     * is set to 10, then a thread will spawn every 10 seconds. If unset, this will default to {@link MultiplexingClient#DEFAULT_RECEIVE_PERIOD_MILLIS}
+     * is set to 10, then a thread will spawn every 10 seconds. If unset, this will default to {@link MultiplexingClient#DEFAULT_RECEIVE_PERIOD_MILLIS}.
      */
     @Getter
     @Setter
     private long receivePeriod;
+
+    /**
+     * This option specifies how many messages a given send thread should attempt to send before exiting.
+     * This option can be used in conjunction with the "sendPeriod" option to control the how frequently and in what
+     * batch size messages are sent. If unset, this will default to {@link MultiplexingClient#DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD}.
+     */
+    @Getter
+    @Setter
+    private int maxMessagesSentPerSendThread;
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -30,12 +30,14 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 @Slf4j
 public class IotHubTransport implements IotHubListener
 {
-    private static final int MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
+    private static final int DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
 
     // For tracking the state of this layer in particular. If multiplexing, this value may be CONNECTED while a
     // device specific state is DISCONNECTED_RETRYING. If this state is DISCONNECTED_RETRYING, then the multiplexed
     // connection will be completely torn down and re-opened.
     private volatile IotHubConnectionStatus connectionStatus;
+
+    private int maxNumberOfMessagesToSendPerThread = DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD;
 
     // for multiplexing. A particular device can be disconnected retrying while the tcp connection is fine and the other
     // device sessions are open.
@@ -574,7 +576,7 @@ public class IotHubTransport implements IotHubListener
             return;
         }
 
-        int timeSlice = MAX_MESSAGES_TO_SEND_PER_THREAD;
+        int timeSlice = maxNumberOfMessagesToSendPerThread;
 
         while (this.connectionStatus == IotHubConnectionStatus.CONNECTED && timeSlice-- > 0)
         {
@@ -883,6 +885,16 @@ public class IotHubTransport implements IotHubListener
                 }
             }
         }
+    }
+
+    public void setMaxNumberOfMessagesSentPerSendThread(int maxNumberOfMessagesSentPerSendThread)
+    {
+        if (maxNumberOfMessagesSentPerSendThread < 0)
+        {
+            throw new IllegalArgumentException("Maximum messages sent per thread cannot be negative");
+        }
+
+        this.maxNumberOfMessagesToSendPerThread = maxNumberOfMessagesSentPerSendThread;
     }
 
     /**

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -1422,7 +1422,7 @@ public class IotHubTransportTest
         };
 
         final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
-        final int MAX_MESSAGES_TO_SEND_PER_THREAD = Deencapsulation.getField(transport, "MAX_MESSAGES_TO_SEND_PER_THREAD");
+        final int MAX_MESSAGES_TO_SEND_PER_THREAD = Deencapsulation.getField(transport, "DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD");
         Deencapsulation.setField(transport, "connectionStatus", CONNECTED);
         Queue<IotHubTransportPacket> waitingPacketsQueue = new ConcurrentLinkedQueue<>();
         for (int i = 0; i < MAX_MESSAGES_TO_SEND_PER_THREAD + 1; i++)


### PR DESCRIPTION
Also fix a bug where setting the send and/or receive period after opening the client didn't change the period.


For additional context here, the Java SDK has a periodic thread that checks for queued messages to send, and that thread currently only sends 10 messages at most, even if more messages are queued. This feature allows users to configure this value instead of leaving it hardcoded.