### PR TITLE
fix(iot-dev): Fix bug where multiplexingClient throws unexpectedly on close

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -701,14 +701,23 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     {
         if (this.isMultiplexing)
         {
-            if (this.savedException == null)
+            if (this.state != IotHubConnectionStatus.CONNECTED)
             {
-                this.savedException = new MultiplexingDeviceUnauthorizedException("One or more multiplexed devices failed to authenticate");
-            }
+                if (this.savedException == null)
+                {
+                    this.savedException = new MultiplexingDeviceUnauthorizedException("One or more multiplexed devices failed to authenticate");
+                }
 
-            if (this.savedException instanceof MultiplexingDeviceUnauthorizedException)
+                if (this.savedException instanceof MultiplexingDeviceUnauthorizedException)
+                {
+                    ((MultiplexingDeviceUnauthorizedException)this.savedException).addRegistrationException(deviceId, transportException);
+                }
+            }
+            else
             {
-                ((MultiplexingDeviceUnauthorizedException)this.savedException).addRegistrationException(deviceId, transportException);
+                // When the muxed connection is already open, no need to save the exception to this.savedException
+                // The call to onMultiplexedDeviceSessionRegistrationFailed will propagate the exception up to the
+                // transport layer to handle accordingly.
             }
         }
         else
@@ -1036,10 +1045,12 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
             }
 
             configsUnregisteredSuccessfully.add(configToUnregister);
+            this.deviceSessionsOpenedLatches.remove(configToUnregister.getDeviceId());
             configToUnregister = configsToUnregisterIterator.hasNext() ? configsToUnregisterIterator.next() : null;
         }
 
         this.multiplexingClientsToUnregister.removeAll(configsUnregisteredSuccessfully);
+        this.deviceClientConfigs.removeAll(configsUnregisteredSuccessfully);
     }
 
     private void initializeStateLatches()


### PR DESCRIPTION
If a DeviceClient is registered to a multiplexing client and fails to authenticate, the register call will throw as expected. However, the multiplexing client would also throw the same exception later once the multiplexing client is closed. This fix makes it so the multiplexing client doesn't "hold on" to this registration exception and re-report it on close.

```java
DeviceClient badDeviceClient = new DeviceClient("some connection string with a bad device key", AMQPS);
MultiplexingClient muxClient = new MultiplexingClient(/* not relevant */);

muxClient.open();

try
{
    muxClient.registerDeviceClient(badDeviceClient);
}
catch (Exception e)
{
    //expected to throw, ignore it
}

//Before the fix, this method would throw an UnauthorizedException that was saved from the above register call
muxClient.close();
```