### PR TITLE
release(2021-08-03): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.31.0";
+    private static final String CLIENT_VERSION = "1.32.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.31.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.32.0') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.31.0</iot-device-client-version>
-        <iot-service-client-version>1.32.0</iot-service-client-version>
-        <iot-deps-version>0.14.0</iot-deps-version>
-        <provisioning-device-client-version>1.9.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.8.0</provisioning-service-client-version>
+        <iot-device-client-version>1.32.0</iot-device-client-version>
+        <iot-service-client-version>1.33.0</iot-service-client-version>
+        <iot-deps-version>0.15.0</iot-deps-version>
+        <provisioning-device-client-version>1.10.0</provisioning-device-client-version>
+        <provisioning-service-client-version>1.9.0</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.9.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.10.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.8.0";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.32.0";
+    public static final String serviceVersion = "1.33.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
Note that this is the first release since an LTS release, so all packages have received a minor bump even if they just received bug fixes

## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.15.0)

### Bug fixes

 - Fix issue where non-alphanumeric ASCII characters could be used for temporary keystore password (#1265)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.32.0)

 - Add ability to configure the maximum number of messages sent per send thread (#1291)
 - Add support for opening clients with retry (#1266) 
 - Raise maximum number of in flight messages allowed in an MQTT connection (#1280)

### Bug fixes

 - Fix bug where multiplexingClient throws unexpectedly on close (#1292)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.33.0)

 - Increase dependency version of iot-deps to latest

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.10.0)

 - Increase dependency version of iot-deps to latest

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.9.0)

 - Increase dependency version of iot-deps to latest

### Bug fixes

 - Fix issues with deserializing enrollments (#1289)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.32.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/1.33.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/0.15.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/1.10.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/1.9.0/jar


old
{
    "device": "1.31.0",
    "service": "1.32.0",
    "deps": "0.14.0",
    "securityProvider": "1.5.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.6",
    "provisioningDevice": "1.9.0",
    "provisioningService": "1.8.0"
}

new
{
    "device": "1.32.0",
    "service": "1.33.0",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.6",
    "provisioningDevice": "1.10.0",
    "provisioningService": "1.9.0"
}