### PR TITLE
release(2021-08-09): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.32.0";
+    private static final String CLIENT_VERSION = "1.32.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.32.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.32.1') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.32.0</iot-device-client-version>
+        <iot-device-client-version>1.32.1</iot-device-client-version>
         <iot-service-client-version>1.33.0</iot-service-client-version>
         <iot-deps-version>0.15.0</iot-deps-version>
         <provisioning-device-client-version>1.10.0</provisioning-device-client-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.32.1)

### Bug fixes

- Fixed bug where multiplexed deviceClients did not maintain twin and/or method subscriptions after reconnection (#1298)


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.32.1/jar


old
{
    "device": "1.32.0",
    "service": "1.33.0",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.6",
    "provisioningDevice": "1.10.0",
    "provisioningService": "1.9.0"
}

new
{
    "device": "1.32.1",
    "service": "1.33.0",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmEmulator": "1.1.2",
    "tpmHsm": "1.1.3",
    "diceEmulator": "1.1.1",
    "dice": "1.1.1",
    "x509": "1.1.6",
    "provisioningDevice": "1.10.0",
    "provisioningService": "1.9.0"
}
