### PR TITLE
break(iot-dev): Rename device/module client APIs for consistency

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientType.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientType.java
@@ -1,12 +1,11 @@
-package com.microsoft.azure.sdk.iot.device.transport.amqps;
+package com.microsoft.azure.sdk.iot.device;
 
 /**
- * Type of the connection
+ * The type of the device client. Used to differentiate between device clients that own their own connection from device
+ * clients that are multiplexing.
  */
-public enum IoTHubConnectionType
+public enum ClientType
 {
-    UNKNOWN,
-
     /**
      * The connection type is a non-multiplexed, single device identity connection.
      */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -42,7 +42,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     private static final long RECEIVE_PERIOD_MILLIS_MQTT = 10L;
     private static final long RECEIVE_PERIOD_MILLIS_HTTPS = 25*60*1000; /*25 minutes*/
 
-    private ClientType clientType = ClientType.SINGLE_CLIENT;
+    private DeviceClientType deviceClientType = DeviceClientType.SINGLE_CLIENT;
 
     private FileUpload fileUpload;
 
@@ -221,7 +221,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      */
     public void open(boolean withRetry) throws IOException
     {
-        if (this.clientType == ClientType.USE_MULTIPLEXING_CLIENT)
+        if (this.deviceClientType == DeviceClientType.USE_MULTIPLEXING_CLIENT)
         {
             throw new UnsupportedOperationException(MULTIPLEXING_OPEN_ERROR_MESSAGE);
         }
@@ -243,7 +243,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     @Deprecated
     public void close() throws IOException
     {
-        if (this.clientType == ClientType.USE_MULTIPLEXING_CLIENT)
+        if (this.deviceClientType == DeviceClientType.USE_MULTIPLEXING_CLIENT)
         {
             throw new UnsupportedOperationException(MULTIPLEXING_CLOSE_ERROR_MESSAGE);
         }
@@ -267,7 +267,7 @@ public final class DeviceClient extends InternalClient implements Closeable
      */
     public void closeNow() throws IOException
     {
-        if (this.clientType == ClientType.USE_MULTIPLEXING_CLIENT)
+        if (this.deviceClientType == DeviceClientType.USE_MULTIPLEXING_CLIENT)
         {
             throw new UnsupportedOperationException(MULTIPLEXING_CLOSE_ERROR_MESSAGE);
         }
@@ -318,7 +318,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     // Used by multiplexing clients to signal to this client what kind of multiplexing client is using this device client
     void markAsMultiplexed()
     {
-        this.clientType = ClientType.USE_MULTIPLEXING_CLIENT;
+        this.deviceClientType = DeviceClientType.USE_MULTIPLEXING_CLIENT;
     }
 
     private static long getReceivePeriod(IotHubClientProtocol protocol)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientType.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientType.java
@@ -4,7 +4,7 @@ package com.microsoft.azure.sdk.iot.device;
  * The type of the device client. Used to differentiate between device clients that own their own connection from device
  * clients that are multiplexing.
  */
-public enum ClientType
+public enum DeviceClientType
 {
     /**
      * The connection type is a non-multiplexed, single device identity connection.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/FileUpload.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/FileUpload.java
@@ -6,7 +6,6 @@ package com.microsoft.azure.sdk.iot.device;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadCompletionNotification;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriRequest;
 import com.microsoft.azure.sdk.iot.deps.serializer.FileUploadSasUriResponse;
-import com.microsoft.azure.sdk.iot.deps.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubServiceException;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsMethod;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -369,7 +369,7 @@ public class InternalClient
     }
 
     /**
-     * Registers a callback to be executed when the connection status of the device changes. The callback will be fired
+     * Sets the callback to be executed when the connection status of the device changes. The callback will be fired
      * with a status and a reason why the device's status changed. When the callback is fired, the provided context will
      * be provided alongside the status and reason.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -888,16 +888,9 @@ public class InternalClient
     {
         if (value instanceof Long)
         {
-            try
-            {
-                verifyRegisteredIfMultiplexing();
-                log.info("Setting send period to {} milliseconds", value);
-                this.deviceIO.setSendPeriodInMilliseconds((long) value);
-            }
-            catch (IOException e)
-            {
-                throw new IOError(e);
-            }
+            verifyRegisteredIfMultiplexing();
+            log.info("Setting send period to {} milliseconds", value);
+            this.deviceIO.setSendPeriodInMilliseconds((long) value);
         }
         else
         {
@@ -909,16 +902,9 @@ public class InternalClient
     {
         if (value instanceof Long)
         {
-            try
-            {
-                verifyRegisteredIfMultiplexing();
-                log.info("Setting receive period to {} milliseconds", value);
-                this.deviceIO.setReceivePeriodInMilliseconds((long) value);
-            }
-            catch (IOException e)
-            {
-                throw new IOError(e);
-            }
+            verifyRegisteredIfMultiplexing();
+            log.info("Setting receive period to {} milliseconds", value);
+            this.deviceIO.setReceivePeriodInMilliseconds((long) value);
         }
         else
         {

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -135,7 +135,7 @@ public class InternalClient
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
-    //unused
+    //for mocking purposes only
     InternalClient()
     {
         this.config = null;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -782,11 +782,11 @@ public class InternalClient
     }
 
     /**
-     * Subscribes to device methods
+     * Subscribes to direct methods
      *
-     * @param methodCallback Callback on which device methods shall be invoked. Cannot be {@code null}.
+     * @param methodCallback Callback on which direct methods shall be invoked. Cannot be {@code null}.
      * @param methodCallbackContext Context for device method callback. Can be {@code null}.
-     * @param methodStatusCallback Callback for providing IotHub status for device methods. Cannot be {@code null}.
+     * @param methodStatusCallback Callback for providing IotHub status for direct methods. Cannot be {@code null}.
      * @param methodStatusCallbackContext Context for device method status callback. Can be {@code null}.
      *
      * @throws IOException if called when client is not opened.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -5,14 +5,19 @@
 
 package com.microsoft.azure.sdk.iot.device;
 
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethod;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceTwin;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Pair;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.PropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertiesCallback;
+import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
-import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,17 +31,17 @@ import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 public class InternalClient
 {
     // SET_MINIMUM_POLLING_INTERVAL is used for setting the interval for https message polling.
-    static final String SET_MINIMUM_POLLING_INTERVAL = "SetMinimumPollingInterval";
+    private static final String SET_MINIMUM_POLLING_INTERVAL = "SetMinimumPollingInterval";
     // SET_RECEIVE_INTERVAL is used for setting the interval for handling MQTT and AMQP messages.
-    static final String SET_RECEIVE_INTERVAL = "SetReceiveInterval";
-    static final String SET_SEND_INTERVAL = "SetSendInterval";
-    static final String SET_MAX_MESSAGES_SENT_PER_THREAD = "SetMaxMessagesSentPerThread";
-    static final String SET_SAS_TOKEN_EXPIRY_TIME = "SetSASTokenExpiryTime";
-    static final String SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT = "SetAmqpOpenAuthenticationSessionTimeout";
-    static final String SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT = "SetAmqpOpenDeviceSessionsTimeout";
+    private static final String SET_RECEIVE_INTERVAL = "SetReceiveInterval";
+    private static final String SET_SEND_INTERVAL = "SetSendInterval";
+    private static final String SET_MAX_MESSAGES_SENT_PER_THREAD = "SetMaxMessagesSentPerThread";
+    private static final String SET_SAS_TOKEN_EXPIRY_TIME = "SetSASTokenExpiryTime";
+    private static final String SET_AMQP_OPEN_AUTHENTICATION_SESSION_TIMEOUT = "SetAmqpOpenAuthenticationSessionTimeout";
+    private static final String SET_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT = "SetAmqpOpenDeviceSessionsTimeout";
 
-    static final String SET_HTTPS_CONNECT_TIMEOUT = "SetHttpsConnectTimeout";
-    static final String SET_HTTPS_READ_TIMEOUT = "SetHttpsReadTimeout";
+    private static final String SET_HTTPS_CONNECT_TIMEOUT = "SetHttpsConnectTimeout";
+    private static final String SET_HTTPS_READ_TIMEOUT = "SetHttpsReadTimeout";
 
     private static final String TWIN_OVER_HTTP_ERROR_MESSAGE =
         "Twin operations are only supported over MQTT, MQTT_WS, AMQPS, and AMQPS_WS";
@@ -45,7 +50,7 @@ public class InternalClient
         "Direct methods are only supported over MQTT, MQTT_WS, AMQPS, and AMQPS_WS";
 
     DeviceClientConfig config;
-    DeviceIO deviceIO;
+    private DeviceIO deviceIO;
 
     boolean isMultiplexed = false;
 
@@ -57,7 +62,6 @@ public class InternalClient
 
     InternalClient(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis, ClientOptions clientOptions)
     {
-        /* Codes_SRS_INTERNALCLIENT_21_004: [If the connection string is null or empty, the function shall throw an IllegalArgumentException.] */
         commonConstructorVerification(iotHubConnectionString, protocol);
 
         this.config = new DeviceClientConfig(iotHubConnectionString, clientOptions);
@@ -76,52 +80,36 @@ public class InternalClient
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
-    InternalClient(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, SSLContext sslContext, long sendPeriodMillis, long receivePeriod)
-    {
-        commonConstructorVerification(iotHubConnectionString, protocol);
-
-        this.config = new DeviceClientConfig(iotHubConnectionString, sslContext);
-        this.config.setProtocol(protocol);
-        this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriod);
-    }
-
     InternalClient(String uri, String deviceId, SecurityProvider securityProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis, ClientOptions clientOptions) throws URISyntaxException, IOException
     {
         if (protocol == null)
         {
-            //Codes_SRS_INTERNALCLIENT_34_072: [If the provided protocol is null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("The transport protocol cannot be null");
         }
 
         if (securityProvider == null)
         {
-            //Codes_SRS_INTERNALCLIENT_34_073: [If the provided securityProvider is null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("securityProvider cannot be null");
         }
 
         if (uri == null || uri.isEmpty())
         {
-            //Codes_SRS_INTERNALCLIENT_34_074: [If the provided uri is null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("URI cannot be null or empty");
         }
 
         if (deviceId == null || deviceId.isEmpty())
         {
-            //Codes_SRS_INTERNALCLIENT_34_075: [If the provided deviceId is null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("deviceId cannot be null or empty");
         }
 
-        //Codes_SRS_INTERNALCLIENT_34_065: [The provided uri and device id will be used to create an iotHubConnectionString that will be saved in config.]
         IotHubConnectionString connectionString = new IotHubConnectionString(uri, deviceId, null, null);
 
-        //Codes_SRS_INTERNALCLIENT_34_066: [The provided security provider will be saved in config.]
         this.config = new DeviceClientConfig(connectionString, securityProvider);
         this.config.setProtocol(protocol);
         if (clientOptions != null) {
             this.config.modelId = clientOptions.getModelId();
         }
 
-        //Codes_SRS_INTERNALCLIENT_34_067: [The constructor shall initialize the IoT hub transport for the protocol specified, creating a instance of the deviceIO.]
         this.deviceIO = new DeviceIO(this.config, sendPeriodMillis, receivePeriodMillis);
     }
 
@@ -150,7 +138,6 @@ public class InternalClient
     //unused
     InternalClient()
     {
-        // Codes_SRS_INTERNALCLIENT_12_028: [The constructor shall shall set the config, deviceIO and tranportClient to null.]
         this.config = null;
         this.deviceIO = null;
     }
@@ -221,11 +208,7 @@ public class InternalClient
     public void sendEventAsync(Message message, IotHubEventCallback callback, Object callbackContext)
     {
         verifyRegisteredIfMultiplexing();
-
-        //Codes_SRS_INTERNALCLIENT_34_045: [This function shall set the provided message's connection device id to the config's saved device id.]
         message.setConnectionDeviceId(this.config.getDeviceId());
-
-        //Codes_SRS_INTERNALCLIENT_21_010: [The sendEventAsync shall asynchronously send the message using the deviceIO connection.]
         deviceIO.sendEventAsync(message, callback, callbackContext, this.config.getDeviceId());
     }
 
@@ -264,38 +247,35 @@ public class InternalClient
      *
      * This client will receive a callback each time a desired property is updated. That callback will either contain
      * the full desired properties set, or only the updated desired property depending on how the desired property was changed.
-     * IoT hub supports a PUT and a PATCH on the twin. The PUT will cause this device client to receive the full desired properties set, and the PATCH
-     * will cause this device client to only receive the updated desired properties. Similarly, the version
+     * IoT hub supports a PUT and a PATCH on the twin. The PUT will cause this client to receive the full desired properties set, and the PATCH
+     * will cause this client to only receive the updated desired properties. Similarly, the version
      * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
      * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
      * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
      * updates, not partial updates.
      *
-     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
-     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
+     * See <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param onDesiredPropertyChange the Map for desired properties and their corresponding callback and context. Can be {@code null}.
      *
      * @throws IOException if called when client is not opened or called before starting twin.
      */
-    public void subscribeToDesiredProperties(Map<Property, Pair<PropertyCallBack<String, Object>, Object>> onDesiredPropertyChange) throws IOException
+    public void subscribeToDesiredPropertiesAsync(Map<Property, Pair<PropertyCallBack<String, Object>, Object>> onDesiredPropertyChange) throws IOException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
 
         if (this.twin == null)
         {
-            //Codes_SRS_INTERNALCLIENT_25_029: [If the client has not started twin before calling this method, the function shall throw an IOException.]
             throw new IOException("Start twin before using it");
         }
 
         if (!this.deviceIO.isOpen())
         {
-            //Codes_SRS_INTERNALCLIENT_25_030: [If the client has not been open, the function shall throw an IOException.]
             throw new IOException("Open the client connection before using it.");
         }
 
-        //Codes_SRS_INTERNALCLIENT_25_031: [This method shall subscribe to desired properties by calling subscribeDesiredPropertiesNotification on the twin object.]
         this.twin.subscribeDesiredPropertiesNotification(onDesiredPropertyChange);
     }
 
@@ -306,24 +286,21 @@ public class InternalClient
      *
      * @throws IOException if called when client is not opened or called before starting twin.
      */
-    public void subscribeToTwinDesiredProperties(Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange) throws IOException
+    public void subscribeToTwinDesiredPropertiesAsync(Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange) throws IOException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
 
         if (this.twin == null)
         {
-            //Codes_SRS_INTERNALCLIENT_34_087: [If the client has not started twin before calling this method, the function shall throw an IOException.]
             throw new IOException("Start twin before using it");
         }
 
         if (!this.deviceIO.isOpen())
         {
-            //Codes_SRS_INTERNALCLIENT_34_086: [If the client has not been open, the function shall throw an IOException.]
             throw new IOException("Open the client connection before using it.");
         }
 
-        //Codes_SRS_INTERNALCLIENT_34_085: [This method shall subscribe to desired properties by calling subscribeDesiredPropertiesNotification on the twin object.]
         this.twin.subscribeDesiredPropertiesTwinPropertyNotification(onDesiredPropertyChange);
     }
 
@@ -335,9 +312,9 @@ public class InternalClient
      * @throws IOException if called when client is not opened or called before starting twin.
      * @throws IllegalArgumentException if reportedProperties is null or empty.
      */
-    public void sendReportedProperties(Set<Property> reportedProperties) throws IOException, IllegalArgumentException
+    public void sendReportedPropertiesAsync(Set<Property> reportedProperties) throws IOException, IllegalArgumentException
     {
-        this.sendReportedProperties(reportedProperties, null, null, null, null, null);
+        this.sendReportedPropertiesAsync(reportedProperties, null, null, null, null, null);
     }
 
     /**
@@ -349,12 +326,13 @@ public class InternalClient
      * @throws IOException if called when client is not opened or called before starting twin.
      * @throws IllegalArgumentException if reportedProperties is null or empty or if version is negative
      */
-    public void sendReportedProperties(Set<Property> reportedProperties, int version) throws IOException, IllegalArgumentException
+    public void sendReportedPropertiesAsync(Set<Property> reportedProperties, int version) throws IOException, IllegalArgumentException
     {
-        if (version < 0) {
+        if (version < 0)
+        {
             throw new IllegalArgumentException("Version cannot be negative.");
         }
-        this.sendReportedProperties(reportedProperties, version, null, null, null, null);
+        this.sendReportedPropertiesAsync(reportedProperties, version, null, null, null, null);
     }
 
     /**
@@ -363,9 +341,9 @@ public class InternalClient
      * @throws IOException if called when client is not opened or called before starting twin.
      * @throws IllegalArgumentException if reportedProperties is null or empty or if version specified in {#reportedPropertiesParameters} is negative
      */
-    public void sendReportedProperties(ReportedPropertiesParameters reportedPropertiesParameters) throws IOException, IllegalArgumentException
+    public void sendReportedPropertiesAsync(ReportedPropertiesParameters reportedPropertiesParameters) throws IOException, IllegalArgumentException
     {
-        this.sendReportedProperties(reportedPropertiesParameters.getReportedProperties(), reportedPropertiesParameters.getVersion(), reportedPropertiesParameters.getCorrelatingMessageCallback(), reportedPropertiesParameters.getCorrelatingMessageCallbackContext(), reportedPropertiesParameters.getReportedPropertiesCallback(), reportedPropertiesParameters.getReportedPropertiesCallbackContext());
+        this.sendReportedPropertiesAsync(reportedPropertiesParameters.getReportedProperties(), reportedPropertiesParameters.getVersion(), reportedPropertiesParameters.getCorrelatingMessageCallback(), reportedPropertiesParameters.getCorrelatingMessageCallbackContext(), reportedPropertiesParameters.getReportedPropertiesCallback(), reportedPropertiesParameters.getReportedPropertiesCallbackContext());
     }
 
     /**
@@ -373,14 +351,14 @@ public class InternalClient
      *
      * @param reportedProperties the Set for desired properties and their corresponding callback and context. Cannot be {@code null}.
      * @param version the Reported property version. Cannot be negative.
-     * @param reportedPropertiesCallback the Reported property callback to be set for this message. If set to {@code null} it will fall back to {@link #sendReportedProperties(Set, int)}.
+     * @param reportedPropertiesCallback the Reported property callback to be set for this message. If set to {@code null} it will fall back to {@link #sendReportedPropertiesAsync(Set, int)}.
      * @param reportedPropertiesCallbackContext the Reported property callback context to be set for this message.
      * @param correlatingMessageCallback the correlation callback for this message.
      * @param correlatingMessageCallbackContext the correlation callback context for this message.
      * @throws IOException if called when client is not opened or called before starting twin.
-     * @throws IllegalArgumentException if reportedProperties is null or empty or if version is negatve
+     * @throws IllegalArgumentException if reportedProperties is null or empty or if version is negative
      */
-    public void sendReportedProperties(Set<Property> reportedProperties, Integer version, CorrelatingMessageCallback correlatingMessageCallback, Object correlatingMessageCallbackContext, IotHubEventCallback reportedPropertiesCallback, Object reportedPropertiesCallbackContext) throws IOException, IllegalArgumentException
+    public void sendReportedPropertiesAsync(Set<Property> reportedProperties, Integer version, CorrelatingMessageCallback correlatingMessageCallback, Object correlatingMessageCallbackContext, IotHubEventCallback reportedPropertiesCallback, Object reportedPropertiesCallbackContext) throws IOException, IllegalArgumentException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
@@ -403,7 +381,7 @@ public class InternalClient
      * @param callbackContext a context to be passed to the callback. Can be {@code null}.
      * @throws IllegalArgumentException if provided callback is null
      */
-    public void registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext) throws IllegalArgumentException
+    public void setConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback callback, Object callbackContext) throws IllegalArgumentException
     {
         this.connectionStatusChangeCallback = callback;
         this.connectionStatusChangeCallbackContext = callbackContext;
@@ -422,7 +400,6 @@ public class InternalClient
      */
     public void setRetryPolicy(RetryPolicy retryPolicy)
     {
-        //Codes_SRS_INTERNALCLIENT_28_001: [The function shall set the device config's RetryPolicy .]
         this.config.setRetryPolicy(retryPolicy);
     }
 
@@ -434,13 +411,11 @@ public class InternalClient
      */
     public void setOperationTimeout(long timeout) throws IllegalArgumentException
     {
-        // Codes_SRS_INTERNALCLIENT_34_070: [The function shall set the device config's operation timeout .]
         this.config.setOperationTimeout(timeout);
     }
 
     public ProductInfo getProductInfo()
     {
-        // Codes_SRS_INTERNALCLIENT_34_071: [This function shall return the product info saved in config.]
         return this.config.getProductInfo();
     }
 
@@ -513,19 +488,15 @@ public class InternalClient
      */
     // The warning is for how getSasTokenAuthentication() may return null, but the check that our config uses SAS_TOKEN
     // auth is sufficient at confirming that getSasTokenAuthentication() will return a non-null instance
-    @SuppressWarnings("ConstantConditions")
     public void setOption(String optionName, Object value)
     {
         if (optionName == null)
         {
-            // Codes_SRS_DEVICECLIENT_02_015: [If optionName is null or not an option handled by the client, then
-            // it shall throw IllegalArgumentException.]
             throw new IllegalArgumentException("optionName is null");
         }
         else if (value == null)
         {
-            // Codes_SRS_DEVICECLIENT_12_026: [The function shall trow IllegalArgumentException if the value is null.]
-            throw new IllegalArgumentException("optionName is null");
+            throw new IllegalArgumentException("value is null");
         }
         else
         {
@@ -534,16 +505,7 @@ public class InternalClient
                 case SET_MINIMUM_POLLING_INTERVAL:
                 case SET_RECEIVE_INTERVAL:
                 {
-                    if (this.deviceIO.isOpen())
-                    {
-                        throw new IllegalStateException("setOption " + optionName +
-                                " only works when the transport is closed");
-                    }
-                    else
-                    {
-                        setOption_SetMinimumPollingInterval(value);
-                    }
-
+                    setOption_SetMinimumPollingInterval(value);
                     break;
                 }
                 case SET_SEND_INTERVAL:
@@ -590,7 +552,19 @@ public class InternalClient
     }
 
     /**
-     * Starts the device twin.
+     * Starts the twin for this client. This client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback is received, this client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
+     * on the twin. The PUT will cause this client to receive the full desired properties set, and the PATCH
+     * will cause this client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
+     *
+     * See <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
@@ -603,10 +577,9 @@ public class InternalClient
      * @throws UnsupportedOperationException if called more than once on the same device
      * @throws IOException if called when client is not opened
      */
-    <Type1, Type2> void startTwinInternal(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
+    public <Type1, Type2> void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
                                  PropertyCallBack<Type1, Type2> genericPropertyCallBack, Object genericPropertyCallBackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
-
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
@@ -653,7 +626,19 @@ public class InternalClient
     }
 
     /**
-     * Starts the device twin.
+     * Starts the twin for this client. This client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback is received, this client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
+     * on the twin. The PUT will cause this client to receive the full desired properties set, and the PATCH
+     * will cause this client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
+     *
+     * See <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
@@ -663,9 +648,8 @@ public class InternalClient
      * @throws IllegalArgumentException if the callback is {@code null}
      * @throws UnsupportedOperationException if called more than once on the same device
      * @throws IOException if called when client is not opened
-     * @throws IllegalArgumentException if either callback is null
      */
-    void startTwinInternal(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
+    public void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
                                  TwinPropertyCallBack genericPropertyCallBack, Object genericPropertyCallBackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
@@ -674,43 +658,50 @@ public class InternalClient
 
         if (!this.deviceIO.isOpen())
         {
-            //Codes_SRS_INTERNALCLIENT_34_081: [If device io has not been opened yet, this function shall throw an IOException.]
             throw new IOException("Open the client connection before using it.");
         }
 
         if (twinStatusCallback == null || genericPropertyCallBack == null)
         {
-            //Codes_SRS_INTERNALCLIENT_34_082: [If either callback is null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Callback cannot be null");
         }
         if (this.twin == null)
         {
-            //Codes_SRS_INTERNALCLIENT_34_084: [This function shall initialize a DeviceTwin object and invoke getDeviceTwin on it.]
             twin = new DeviceTwin(this.deviceIO, this.config, twinStatusCallback, twinStatusCallbackContext,
                     genericPropertyCallBack, genericPropertyCallBackContext);
             twin.getDeviceTwin();
         }
         else
         {
-            //Codes_SRS_INTERNALCLIENT_34_083: [If either callback is null, this function shall throw an IllegalArgumentException.]
             throw new UnsupportedOperationException("You have already initialised twin");
         }
     }
 
     /**
-     * Starts the device twin.
+     * Starts the twin. This client will receive a callback with the current state of the full twin, including
+     * reported properties and desired properties. After that callback is received, this client will receive a callback
+     * each time a desired property is updated. That callback will either contain the full desired properties set, or
+     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
+     * on the twin. The PUT will cause this client to receive the full desired properties set, and the PATCH
+     * will cause this client to only receive the updated desired properties. Similarly, the version
+     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
+     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
+     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
+     * updates, not partial updates.
+     *
+     * See <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/replacedevicetwin">PUT</a> and
+     * <a href="https://docs.microsoft.com/rest/api/iothub/service/twin/updatedevicetwin">PATCH</a>
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
      * @param genericPropertiesCallBack the TwinPropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.     *
+     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.
      *
      * @throws IllegalArgumentException if the callback is {@code null}
      * @throws UnsupportedOperationException if called more than once on the same device
      * @throws IOException if called when client is not opened
-     * @throws IllegalArgumentException if either callback is null
      */
-    void startTwinInternal(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
+    public void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
                            TwinPropertiesCallback genericPropertiesCallBack, Object genericPropertyCallBackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
@@ -745,30 +736,27 @@ public class InternalClient
     }
 
     /**
-     * Get the current desired properties for this client
-     * @throws IOException if the iot hub cannot be reached
-     * @throws IOException if the twin has not been initialized yet
-     * @throws IOException if the client has not been opened yet
+     * Get the twin for this client. This method sends a request for the twin to the service and will asynchronously
+     * provide the retrieved twin to the callback provided in {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallBack, Object)}.
+     *
+     * Users must call {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallBack, Object)} before using this method.
+     * @throws IOException if the iot hub cannot be reached.
      */
-    void getTwinInternal() throws IOException
+    public void getTwinAsync() throws IOException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
 
         if (this.twin == null)
         {
-            //Codes_SRS_INTERNALCLIENT_21_040: [If the client has not started twin before calling this method, the function shall throw an IOException.]
             throw new IOException("Start twin before using it");
         }
 
         if (!this.deviceIO.isOpen())
         {
-
-            //Codes_SRS_INTERNALCLIENT_21_041: [If the client has not been open, the function shall throw an IOException.]
             throw new IOException("Open the client connection before using it.");
         }
 
-        //Codes_SRS_INTERNALCLIENT_21_042: [The function shall get all desired properties by calling getDeviceTwin.]
         this.twin.getDeviceTwin();
     }
 
@@ -787,27 +775,25 @@ public class InternalClient
     {
         if (callback == null && context != null)
         {
-            /* Codes_SRS_INTERNALCLIENT_11_014: [If the callback is null but the context is non-null, the function shall throw an IllegalArgumentException.] */
             throw new IllegalArgumentException("Cannot give non-null context for a null callback.");
         }
 
-        /* Codes_SRS_INTERNALCLIENT_11_013: [The function shall set the message callback, with its associated context.] */
         this.config.setMessageCallback(callback, context);
     }
 
     /**
-     * Subscribes to methods
+     * Subscribes to device methods
      *
-     * @param methodCallback Callback on which methods shall be invoked. Cannot be {@code null}.
-     * @param methodCallbackContext Context for method callback. Can be {@code null}.
-     * @param methodStatusCallback Callback for providing IotHub status for methods. Cannot be {@code null}.
-     * @param methodStatusCallbackContext Context for method status callback. Can be {@code null}.
+     * @param methodCallback Callback on which device methods shall be invoked. Cannot be {@code null}.
+     * @param methodCallbackContext Context for device method callback. Can be {@code null}.
+     * @param methodStatusCallback Callback for providing IotHub status for device methods. Cannot be {@code null}.
+     * @param methodStatusCallbackContext Context for device method status callback. Can be {@code null}.
      *
      * @throws IOException if called when client is not opened.
      * @throws IllegalArgumentException if either callback are null.
      */
-    void subscribeToMethodsInternal(DeviceMethodCallback methodCallback, Object methodCallbackContext,
-                                              IotHubEventCallback methodStatusCallback, Object methodStatusCallbackContext)
+    public void subscribeToMethodsAsync(DeviceMethodCallback methodCallback, Object methodCallbackContext,
+                                        IotHubEventCallback methodStatusCallback, Object methodStatusCallbackContext)
             throws IOException
     {
         verifyRegisteredIfMultiplexing();
@@ -862,206 +848,151 @@ public class InternalClient
         }
     }
 
-    void setOption_SetHttpsConnectTimeout(Object value)
+    private void setOption_SetHttpsConnectTimeout(Object value)
     {
-        if (value != null)
+        if (this.config.getProtocol() != HTTPS)
         {
-            if (this.config.getProtocol() != HTTPS)
-            {
-                throw new UnsupportedOperationException("Cannot set the https connect timeout when using protocol " + this.config.getProtocol());
-            }
+            throw new UnsupportedOperationException("Cannot set the https connect timeout when using protocol " + this.config.getProtocol());
+        }
 
-            if (value instanceof Integer)
-            {
-                log.info("Setting HTTPS connect timeout to {} milliseconds", value);
-                this.config.setHttpsConnectTimeout((int) value);
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not int = " + value);
-            }
+        if (value instanceof Integer)
+        {
+            log.info("Setting HTTPS connect timeout to {} milliseconds", value);
+            this.config.setHttpsConnectTimeout((int) value);
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not int = " + value);
         }
     }
 
-    void setOption_SetHttpsReadTimeout(Object value)
+    private void setOption_SetHttpsReadTimeout(Object value)
     {
-        if (value != null)
+        if (this.config.getProtocol() != HTTPS)
         {
-            if (this.config.getProtocol() != HTTPS)
-            {
-                throw new UnsupportedOperationException("Cannot set the https read timeout when using protocol " + this.config.getProtocol());
-            }
+            throw new UnsupportedOperationException("Cannot set the https read timeout when using protocol " + this.config.getProtocol());
+        }
 
-            if (value instanceof Integer)
-            {
-                log.info("Setting HTTPS read timeout to {} milliseconds", value);
-                this.config.setHttpsReadTimeout((int) value);
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not int = " + value);
-            }
+        if (value instanceof Integer)
+        {
+            log.info("Setting HTTPS read timeout to {} milliseconds", value);
+            this.config.setHttpsReadTimeout((int) value);
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not int = " + value);
         }
     }
 
-    void setOption_SetSendInterval(Object value)
+    private void setOption_SetSendInterval(Object value)
     {
-        if (value != null)
+        if (value instanceof Long)
         {
-            // Codes_SRS_DEVICECLIENT_21_041: ["SetSendInterval" needs to have value type long.]
-            if (value instanceof Long)
+            try
             {
-                try
-                {
-                    verifyRegisteredIfMultiplexing();
-                    log.info("Setting send period to {} milliseconds", value);
-                    this.deviceIO.setSendPeriodInMilliseconds((long) value);
-                }
-                catch (IOException e)
-                {
-                    throw new IOError(e);
-                }
+                verifyRegisteredIfMultiplexing();
+                log.info("Setting send period to {} milliseconds", value);
+                this.deviceIO.setSendPeriodInMilliseconds((long) value);
             }
-            else
+            catch (IOException e)
             {
-                throw new IllegalArgumentException("value is not long = " + value);
+                throw new IOError(e);
             }
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not long = " + value);
         }
     }
 
-    void setOption_SetMinimumPollingInterval(Object value)
+    private void setOption_SetMinimumPollingInterval(Object value)
     {
-        if (value != null)
+        if (value instanceof Long)
         {
-            // Codes_SRS_DEVICECLIENT_02_018: ["SetMinimumPollingInterval" needs to have type long].
-            if (value instanceof Long)
+            try
             {
-                try
-                {
-                    verifyRegisteredIfMultiplexing();
-                    log.info("Setting receive period to {} milliseconds", value);
-                    this.deviceIO.setReceivePeriodInMilliseconds((long) value);
-                }
-                catch (IOException e)
-                {
-                    throw new IOError(e);
-                }
+                verifyRegisteredIfMultiplexing();
+                log.info("Setting receive period to {} milliseconds", value);
+                this.deviceIO.setReceivePeriodInMilliseconds((long) value);
             }
-            else
+            catch (IOException e)
             {
-                throw new IllegalArgumentException("value is not long = " + value);
+                throw new IOError(e);
             }
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not long = " + value);
         }
     }
 
     // The warning is for how getSasTokenAuthentication() may return null, but the check that our config uses SAS_TOKEN
     // auth is sufficient at confirming that getSasTokenAuthentication() will return a non-null instance
-    @SuppressWarnings("ConstantConditions")
-    void setOption_SetSASTokenExpiryTime(Object value)
+    private void setOption_SetSASTokenExpiryTime(Object value)
     {
-        if (this.config.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN)
+        if (this.config.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN || this.config.getSasTokenAuthentication() == null)
         {
             throw new IllegalStateException("Cannot set sas token validity time when not using sas token authentication");
         }
 
-        if (value != null)
+        long validTimeInSeconds;
+
+        if (value instanceof Long)
         {
-            long validTimeInSeconds;
+            validTimeInSeconds = (long) value;
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not long = " + value);
+        }
 
-            if (value instanceof Long)
-            {
-                validTimeInSeconds = (long) value;
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not long = " + value);
-            }
+        log.info("Setting generated SAS token lifespans to {} seconds", validTimeInSeconds);
+        this.config.getSasTokenAuthentication().setTokenValidSecs(validTimeInSeconds);
+    }
 
-            log.info("Setting generated SAS token lifespans to {} seconds", validTimeInSeconds);
-            this.config.getSasTokenAuthentication().setTokenValidSecs(validTimeInSeconds);
+    private void setOption_SetAmqpOpenAuthenticationSessionTimeout(Object value)
+    {
+        if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
+        {
+            throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using protocol " + this.config.getProtocol());
+        }
 
-            if (this.deviceIO != null)
-            {
-                if (this.deviceIO.isOpen())
-                {
-                    try
-                    {
-                        /* Codes_SRS_DEVICECLIENT_25_024: [**"SetSASTokenExpiryTime" shall restart the transport
-                         *                                  1. If the device currently uses device key and
-                         *                                  2. If transport is already open
-                         *                                 after updating expiry time
-                         */
-                        if (this.config.getSasTokenAuthentication().canRefreshToken())
-                        {
-                            this.deviceIO.close();
-                            this.deviceIO.open(false);
-                        }
-                    }
-                    catch (IOException e)
-                    {
-                        // Codes_SRS_DEVICECLIENT_12_027: [The function shall throw IOError if either the deviceIO or the tranportClient's open() or closeNow() throws.]
-                        throw new IOError(e);
-                    }
-                }
-            }
+        if (this.config.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN)
+        {
+            throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using authentication type " + this.config.getAuthenticationType());
+        }
+
+        if (value instanceof Integer)
+        {
+            log.info("Setting generated AMQP authentication session timeout to {} seconds", value);
+            this.config.setAmqpOpenAuthenticationSessionTimeout((int) value);
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not int = " + value);
         }
     }
 
-    void setOption_SetAmqpOpenAuthenticationSessionTimeout(Object value)
+    private void setOption_SetAmqpOpenDeviceSessionsTimeout(Object value)
     {
-        if (value != null)
+        if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
         {
-            if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
-            {
-                throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using protocol " + this.config.getProtocol());
-            }
+            throw new UnsupportedOperationException("Cannot set the open device session timeout when using protocol " + this.config.getProtocol());
+        }
 
-            if (this.config.getAuthenticationType() != DeviceClientConfig.AuthType.SAS_TOKEN)
-            {
-                throw new UnsupportedOperationException("Cannot set the open authentication session timeout when using authentication type " + this.config.getAuthenticationType());
-            }
-
-            if (value instanceof Integer)
-            {
-                log.info("Setting generated AMQP authentication session timeout to {} seconds", value);
-                this.config.setAmqpOpenAuthenticationSessionTimeout((int) value);
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not int = " + value);
-            }
+        if (value instanceof Integer)
+        {
+            log.info("Setting generated AMQP device session timeout to {} seconds", value);
+            this.config.setAmqpOpenDeviceSessionsTimeout((int) value);
+        }
+        else
+        {
+            throw new IllegalArgumentException("value is not int = " + value);
         }
     }
 
-    void setOption_SetAmqpOpenDeviceSessionsTimeout(Object value)
+    private void setOption_SetMaxMessagesSentPerThread(Object value)
     {
-        if (value != null)
-        {
-            if (this.config.getProtocol() != AMQPS && this.config.getProtocol() != AMQPS_WS)
-            {
-                throw new UnsupportedOperationException("Cannot set the open device session timeout when using protocol " + this.config.getProtocol());
-            }
-
-            if (value instanceof Integer)
-            {
-                log.info("Setting generated AMQP device session timeout to {} seconds", value);
-                this.config.setAmqpOpenDeviceSessionsTimeout((int) value);
-            }
-            else
-            {
-                throw new IllegalArgumentException("value is not int = " + value);
-            }
-        }
-    }
-
-    void setOption_SetMaxMessagesSentPerThread(Object value)
-    {
-        if (value == null)
-        {
-            throw new IllegalArgumentException("Value cannot be null");
-        }
-
-
         if (value instanceof Integer)
         {
             log.info("Setting maximum number of messages sent per send thread {} messages", value);
@@ -1147,16 +1078,20 @@ public class InternalClient
         return this.isMultiplexed;
     }
 
-    private void verifyReportedProperties(Set<Property> reportedProperties) throws IOException {
-        if (this.twin == null) {
+    private void verifyReportedProperties(Set<Property> reportedProperties) throws IOException
+    {
+        if (this.twin == null)
+        {
             throw new IOException("Start twin before using it");
         }
 
-        if (!this.deviceIO.isOpen()) {
+        if (!this.deviceIO.isOpen())
+        {
             throw new IOException("Open the client connection before using it.");
         }
 
-        if (reportedProperties == null || reportedProperties.isEmpty()) {
+        if (reportedProperties == null || reportedProperties.isEmpty())
+        {
             throw new IllegalArgumentException("Reported properties set cannot be null or empty.");
         }
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -319,7 +319,6 @@ public class ModuleClient extends InternalClient
                 return new ModuleClient(
                     iotHubAuthenticationProvider,
                     protocol,
-                    SEND_PERIOD_MILLIS,
                     getReceivePeriod(protocol));
             }
             catch (IOException | TransportException | HsmException | URISyntaxException | CertificateException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException e)
@@ -329,10 +328,9 @@ public class ModuleClient extends InternalClient
         }
     }
 
-    @SuppressWarnings("SameParameterValue") // The SEND_PERIOD is currently 10ms for all protocols, but can be made configurable in the future.
-    private ModuleClient(IotHubAuthenticationProvider iotHubAuthenticationProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis)
+    private ModuleClient(IotHubAuthenticationProvider iotHubAuthenticationProvider, IotHubClientProtocol protocol, long receivePeriodMillis)
     {
-        super(iotHubAuthenticationProvider, protocol, sendPeriodMillis, receivePeriodMillis);
+        super(iotHubAuthenticationProvider, protocol, SEND_PERIOD_MILLIS, receivePeriodMillis);
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -7,10 +7,6 @@ package com.microsoft.azure.sdk.iot.device;
 
 
 import com.microsoft.azure.sdk.iot.deps.auth.IotHubSSLContext;
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceMethodCallback;
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.PropertyCallBack;
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertiesCallback;
-import com.microsoft.azure.sdk.iot.device.DeviceTwin.TwinPropertyCallBack;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.auth.SignatureProvider;
 import com.microsoft.azure.sdk.iot.device.edge.HttpsHsmTrustBundleProvider;
@@ -82,11 +78,8 @@ public class ModuleClient extends InternalClient
      */
     public ModuleClient(String connectionString, IotHubClientProtocol protocol) throws IllegalArgumentException, UnsupportedOperationException, URISyntaxException
     {
-        //Codes_SRS_MODULECLIENT_34_006: [This function shall invoke the super constructor.]
         super(new IotHubConnectionString(connectionString), protocol, SEND_PERIOD_MILLIS, getReceivePeriod(protocol), null);
 
-        //Codes_SRS_MODULECLIENT_34_007: [If the provided protocol is not MQTT, AMQPS, MQTT_WS, or AMQPS_WS, this function shall throw an UnsupportedOperationException.]
-        //Codes_SRS_MODULECLIENT_34_004: [If the provided connection string does not contain a module id, this function shall throw an IllegalArgumentException.]
         commonConstructorVerifications(protocol, this.config);
     }
 
@@ -180,13 +173,11 @@ public class ModuleClient extends InternalClient
         log.info("Creating module client from environment with protocol {}...", protocol);
         Map<String, String> envVariables = System.getenv();
 
-        //Codes_SRS_MODULECLIENT_34_013: [This function shall check for a saved edgehub connection string.]
         log.debug("Checking for an edgehub connection string...");
         String connectionString = envVariables.get(EdgehubConnectionstringVariableName);
         if (connectionString == null)
         {
-            log.debug("No edgehub connection string was configured, checking for an IoThub connection string...");
-            //Codes_SRS_MODULECLIENT_34_019: [If no edgehub connection string is present, this function shall check for a saved iothub connection string.]
+            log.debug("No edgehub connection string was configured, checking for an IoT hub connection string...");
             connectionString = envVariables.get(IothubConnectionstringVariableName);
         }
 
@@ -245,9 +236,6 @@ public class ModuleClient extends InternalClient
         else
         {
             log.info("No connection string was configured for this module, so it will get its credentials from the edgelet");
-            //Codes_SRS_MODULECLIENT_34_014: [This function shall check for environment variables for edgedUri, deviceId, moduleId,
-            // hostname, authScheme, gatewayHostname, and generationId. If any of these other than gatewayHostname is missing,
-            // this function shall throw a ModuleClientException.]
             String edgedUri = envVariables.get(IotEdgedUriVariableName);
             String deviceId = envVariables.get(DeviceIdVariableName);
             String moduleId = envVariables.get(ModuleIdVariableName);
@@ -288,7 +276,6 @@ public class ModuleClient extends InternalClient
 
             if (!authScheme.equalsIgnoreCase(SasTokenAuthScheme))
             {
-                //Codes_SRS_MODULECLIENT_34_030: [If the auth scheme environment variable is not "SasToken", this function shall throw a moduleClientException.]
                 throw new ModuleClientException("Unsupported authentication scheme. Supported scheme is " + SasTokenAuthScheme + ".");
             }
 
@@ -343,7 +330,7 @@ public class ModuleClient extends InternalClient
     }
 
     @SuppressWarnings("SameParameterValue") // The SEND_PERIOD is currently 10ms for all protocols, but can be made configurable in the future.
-    private ModuleClient(IotHubAuthenticationProvider iotHubAuthenticationProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis) throws IOException, TransportException
+    private ModuleClient(IotHubAuthenticationProvider iotHubAuthenticationProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis)
     {
         super(iotHubAuthenticationProvider, protocol, sendPeriodMillis, receivePeriodMillis);
     }
@@ -361,27 +348,19 @@ public class ModuleClient extends InternalClient
     {
         if (outputName == null || outputName.isEmpty())
         {
-            //Codes_SRS_MODULECLIENT_34_001: [If the provided outputName is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("outputName cannot be null or empty");
         }
 
-        //Codes_SRS_MODULECLIENT_34_002: [This function shall set the provided message with the provided outputName.]
         message.setOutputName(outputName);
-
-        //Codes_SRS_MODULECLIENT_34_003: [This function shall invoke super.sendEventAsync(message, callback, callbackContext).]
         this.sendEventAsync(message, callback, callbackContext);
     }
 
     @Override
     public void sendEventAsync(Message message, IotHubEventCallback callback, Object callbackContext) throws IllegalArgumentException
     {
-        //Codes_SRS_MODULECLIENT_34_040: [This function shall set the message's connection moduleId to the config's saved module id.]
         message.setConnectionModuleId(this.config.getModuleId());
-
-        //Codes_SRS_MODULECLIENT_34_041: [This function shall invoke super.sendEventAsync(message, callback, callbackContext).]
         super.sendEventAsync(message, callback, callbackContext);
     }
-
 
     /**
      * Invoke a method on a device
@@ -389,26 +368,23 @@ public class ModuleClient extends InternalClient
      * @param methodRequest the request containing the method to invoke on the device
      * @return the result of the method call
      * @throws ModuleClientException if the method cannot be invoked
-     * @throws IllegalArgumentException if deviceid is null or empty
+     * @throws IllegalArgumentException if deviceId is null or empty
      */
     public MethodResult invokeMethod(String deviceId, MethodRequest methodRequest) throws ModuleClientException, IllegalArgumentException
     {
         if (deviceId == null || deviceId.isEmpty())
         {
-            //Codes_SRS_MODULECLIENT_34_039: [If the provided deviceId is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("DeviceId cannot be null or empty");
         }
 
         try
         {
-            //Codes_SRS_MODULECLIENT_34_033: [This function shall create an HttpsTransportManager and use it to invoke the method on the device.]
             HttpsTransportManager httpsTransportManager = new HttpsTransportManager(this.config);
             httpsTransportManager.open();
             return httpsTransportManager.invokeMethod(methodRequest, deviceId, "");
         }
         catch (URISyntaxException | IOException | TransportException e)
         {
-            //Codes_SRS_MODULECLIENT_34_034: [If this function encounters an exception, it shall throw a moduleClientException with that exception nested.]
             throw new ModuleClientException("Could not invoke method", e);
         }
     }
@@ -420,156 +396,30 @@ public class ModuleClient extends InternalClient
      * @param methodRequest the request containing the method to invoke on the device
      * @return the result of the method call
      * @throws ModuleClientException if the method cannot be invoked
-     * @throws IllegalArgumentException if deviceid is null or empty, or if moduleid is null or empty
+     * @throws IllegalArgumentException if deviceId is null or empty, or if moduleId is null or empty
      */
     public MethodResult invokeMethod(String deviceId, String moduleId, MethodRequest methodRequest) throws ModuleClientException, IllegalArgumentException
     {
         if (deviceId == null || deviceId.isEmpty())
         {
-            //Codes_SRS_MODULECLIENT_34_037: [If the provided deviceId is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("DeviceId cannot be null or empty");
         }
 
         if (moduleId == null || moduleId.isEmpty())
         {
-            //Codes_SRS_MODULECLIENT_34_038: [If the provided deviceId is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("DeviceId cannot be null or empty");
         }
 
         try
         {
-            //Codes_SRS_MODULECLIENT_34_035: [This function shall create an HttpsTransportManager and use it to invoke the method on the module.]
             HttpsTransportManager httpsTransportManager = new HttpsTransportManager(this.config);
             httpsTransportManager.open();
             return httpsTransportManager.invokeMethod(methodRequest, deviceId, moduleId);
         }
         catch (URISyntaxException | IOException | TransportException e)
         {
-            //Codes_SRS_MODULECLIENT_34_036: [If this function encounters an exception, it shall throw a moduleClientException with that exception nested.]
             throw new ModuleClientException("Could not invoke method", e);
         }
-    }
-
-    /**
-     * Retrieves the twin's latest desired properties
-     * @throws IOException if the iothub cannot be reached
-     */
-    public void getTwin() throws IOException
-    {
-        this.getTwinInternal();
-    }
-
-    /**
-     * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback is received, this module client will receive a callback
-     * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
-     * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
-     * will cause this module client to only receive the updated desired properties. Similarly, the version
-     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
-     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
-     * updates, not partial updates.
-     *
-     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
-     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
-     *
-     * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
-     * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertyCallBack the PropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.
-     * @param <Type1> The type of the desired property key. Since the twin is a json object, the key will always be a String.
-     * @param <Type2> The type of the desired property value.
-     *
-     * @throws IllegalArgumentException if the callback is {@code null}
-     * @throws UnsupportedOperationException if called more than once on the same device
-     * @throws IOException if called when client is not opened
-     */
-    public <Type1, Type2> void startTwin(IotHubEventCallback deviceTwinStatusCallback, Object deviceTwinStatusCallbackContext,
-                          PropertyCallBack<Type1, Type2> genericPropertyCallBack, Object genericPropertyCallBackContext)
-            throws IOException, IllegalArgumentException, UnsupportedOperationException
-    {
-        this.startTwinInternal(deviceTwinStatusCallback, deviceTwinStatusCallbackContext, genericPropertyCallBack, genericPropertyCallBackContext);
-    }
-
-    /**
-     * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback is received, this module client will receive a callback
-     * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
-     * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
-     * will cause this module client to only receive the updated desired properties. Similarly, the version
-     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
-     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
-     * updates, not partial updates.
-     *
-     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
-     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
-     *
-     * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
-     * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertyCallBack the TwinPropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.     *
-     *
-     * @throws IllegalArgumentException if the callback is {@code null}
-     * @throws UnsupportedOperationException if called more than once on the same device
-     * @throws IOException if called when client is not opened
-     */
-    public void startTwin(IotHubEventCallback deviceTwinStatusCallback, Object deviceTwinStatusCallbackContext,
-                          TwinPropertyCallBack genericPropertyCallBack, Object genericPropertyCallBackContext)
-            throws IOException, IllegalArgumentException, UnsupportedOperationException
-    {
-        this.startTwinInternal(deviceTwinStatusCallback, deviceTwinStatusCallbackContext, genericPropertyCallBack, genericPropertyCallBackContext);
-    }
-
-    /**
-     * Starts the module twin. This module client will receive a callback with the current state of the full twin, including
-     * reported properties and desired properties. After that callback is received, this module client will receive a callback
-     * each time a desired property is updated. That callback will either contain the full desired properties set, or
-     * only the updated desired property depending on how the desired property was changed. IoT hub supports a PUT and a PATCH
-     * on the twin. The PUT will cause this module client to receive the full desired properties set, and the PATCH
-     * will cause this module client to only receive the updated desired properties. Similarly, the version
-     * of each desired property will be incremented from a PUT call, and only the actually updated desired property will
-     * have its version incremented from a PATCH call. The java service client library uses the PATCH call when updated desired properties,
-     * but it builds the patch such that all properties are included in the patch. As a result, the device side will receive full twin
-     * updates, not partial updates.
-     *
-     * See <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/replacemoduletwin">PUT</a> and
-     * <a href="https://docs.microsoft.com/en-us/rest/api/iothub/service/twin/updatemoduletwin">PATCH</a>
-     *
-     * @param deviceTwinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
-     * @param deviceTwinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertiesCallBack the TwinPropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.
-     *
-     * @throws IllegalArgumentException if the callback is {@code null}
-     * @throws UnsupportedOperationException if called more than once on the same device
-     * @throws IOException if called when client is not opened
-     */
-    public void startTwin(IotHubEventCallback deviceTwinStatusCallback, Object deviceTwinStatusCallbackContext,
-                                TwinPropertiesCallback genericPropertiesCallBack, Object genericPropertyCallBackContext)
-            throws IOException, IllegalArgumentException, UnsupportedOperationException
-    {
-        this.startTwinInternal(deviceTwinStatusCallback, deviceTwinStatusCallbackContext, genericPropertiesCallBack, genericPropertyCallBackContext);
-    }
-
-    /**
-     * Subscribes to method invocations on this module. This does not include method invocations on the device the module belongs to
-     *
-     * @param methodCallback Callback on which device methods shall be invoked. Cannot be {@code null}.
-     * @param methodCallbackContext Context for device method callback. Can be {@code null}.
-     * @param methodStatusCallback Callback for providing IotHub status for device methods. Cannot be {@code null}.
-     * @param methodStatusCallbackContext Context for device method status callback. Can be {@code null}.
-     *
-     * @throws IOException if called when client is not opened.
-     * @throws IllegalArgumentException if either callback are null.
-     */
-    public void subscribeToMethod(DeviceMethodCallback methodCallback, Object methodCallbackContext,
-                                  IotHubEventCallback methodStatusCallback, Object methodStatusCallbackContext)
-            throws IOException, IllegalArgumentException
-    {
-        this.subscribeToMethodsInternal(methodCallback, methodCallbackContext, methodStatusCallback, methodStatusCallbackContext);
     }
 
     /**
@@ -606,17 +456,14 @@ public class ModuleClient extends InternalClient
     {
         if (inputName == null || inputName.isEmpty())
         {
-            //Codes_SRS_MODULECLIENT_34_011: [If the provided inputName is null or empty, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("InputName must not be null or empty");
         }
 
         if (callback == null && context != null)
         {
-            //Codes_SRS_MODULECLIENT_34_010: [If the provided callback is null and the provided context is not null, this function shall throw an IllegalArgumentException.]
             throw new IllegalArgumentException("Cannot give non-null context for a null callback.");
         }
 
-        //Codes_SRS_MODULECLIENT_34_012: [This function shall save the provided callback with context in config tied to the provided inputName.]
         this.config.setMessageCallback(inputName, callback, context);
         return this;
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -5,11 +5,9 @@ import com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientException
 import com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingDeviceUnauthorizedException;
 import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
-import com.microsoft.azure.sdk.iot.device.transport.amqps.IoTHubConnectionType;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLContext;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -500,7 +498,7 @@ public class MultiplexingClient
 
                 deviceClientToRegister.setAsMultiplexed();
                 deviceClientToRegister.setDeviceIO(this.deviceIO);
-                deviceClientToRegister.setConnectionType(IoTHubConnectionType.USE_MULTIPLEXING_CLIENT);
+                deviceClientToRegister.markAsMultiplexed();
 
                 // Set notifies us if the device client is already in the set
                 boolean deviceAlreadyRegistered = this.multiplexedDeviceClients.containsKey(deviceClientToRegister.getConfig().getDeviceId());
@@ -702,7 +700,7 @@ public class MultiplexingClient
      *
      * <p>Note that this callback will not be fired for device specific connection status changes. In order to be notified
      * when a particular device's connection status changes, you will need to register a connection status change callback
-     * on that device client instance using {@link DeviceClient#registerConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback, Object)}.
+     * on that device client instance using {@link DeviceClient#setConnectionStatusChangeCallback(IotHubConnectionStatusChangeCallback, Object)}.
      *
      * <p>Note that the thread used to deliver this callback should not be used to call open()/closeNow() on the client
      * that this callback belongs to. All open()/closeNow() operations should be done on a separate thread</p>

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ReportedPropertiesParameters.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ReportedPropertiesParameters.java
@@ -5,7 +5,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.Property;
 import java.util.Set;
 
 /**
- * Convenience class for the sendReportedProperties method in the DeviceClient
+ * Convenience class for the sendReportedPropertiesAsync method in the DeviceClient
  */
 public class ReportedPropertiesParameters {
 
@@ -40,7 +40,7 @@ public class ReportedPropertiesParameters {
     }
 
     /**
-     * Set the correlation callback for the sendReportedProperties method
+     * Set the correlation callback for the sendReportedPropertiesAsync method
      *
      * @param correlatingMessageCallback A callback that will monitor the message lifecycle. Value can be {@code null}.
      */
@@ -49,7 +49,7 @@ public class ReportedPropertiesParameters {
     }
 
     /**
-     * Set the correlation callback for the sendReportedProperties method
+     * Set the correlation callback for the sendReportedPropertiesAsync method
      *
      * @param correlatingMessageCallback A callback that will monitor the message lifecycle. Value can be {@code null}.
      * @param correlatingMessageCallbackContext The context for the callback. Value can be {@code null}.
@@ -60,7 +60,7 @@ public class ReportedPropertiesParameters {
     }
 
     /**
-     * Set the event callback for the sendReportedProperties method
+     * Set the event callback for the sendReportedPropertiesAsync method
      *
      * @param reportedPropertiesCallback A callback that will be executed once the messaage has been sent and acknowledged. Value can be {@code null}.
      */
@@ -69,7 +69,7 @@ public class ReportedPropertiesParameters {
     }
 
     /**
-     * Set the event callback for the sendReportedProperties method
+     * Set the event callback for the sendReportedPropertiesAsync method
      *
      * @param reportedPropertiesCallback A callback that will be executed once the messaage has been sent and acknowledged. Value can be {@code null}.
      * @param reportedPropertiesCallbackContext The context for the callback. Value can be {@code null}.

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceClientTest.java
@@ -4,7 +4,7 @@
 package tests.unit.com.microsoft.azure.sdk.iot.device;
 
 import com.microsoft.azure.sdk.iot.device.ClientOptions;
-import com.microsoft.azure.sdk.iot.device.ClientType;
+import com.microsoft.azure.sdk.iot.device.DeviceClientType;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.DeviceClientConfig;
 import com.microsoft.azure.sdk.iot.device.DeviceIO;
@@ -24,11 +24,10 @@ import mockit.NonStrictExpectations;
 import mockit.Verifications;
 import org.junit.Test;
 
-import java.io.IOError;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static com.microsoft.azure.sdk.iot.device.ClientType.SINGLE_CLIENT;
+import static com.microsoft.azure.sdk.iot.device.DeviceClientType.SINGLE_CLIENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -96,8 +95,8 @@ public class DeviceClientTest
         new Verifications()
         {
             {
-                ClientType clientType = Deencapsulation.getField(client, "clientType");
-                assertEquals(SINGLE_CLIENT, clientType);
+                DeviceClientType deviceClientType = Deencapsulation.getField(client, "deviceClientType");
+                assertEquals(SINGLE_CLIENT, deviceClientType);
 
                 new DeviceClientConfig(mockIotHubConnectionString, mockedClientOptions);
             }

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -653,26 +653,6 @@ public class DeviceIOTest
         assertFalse(isOpen);
     }
 
-    //Tests_SRS_DEVICE_IO_34_020: [This function shall register the callback with the transport.]
-    @Test
-    public void registerConnectionStatusChangeCallbackSuccess(@Mocked final IotHubConnectionStatusChangeCallback mockedStateCB)
-    {
-        //arrange
-        final Object deviceIO = newDeviceIO();
-        final String deviceId = "someDeviceId";
-
-        //act
-        Deencapsulation.invoke(deviceIO, "registerConnectionStatusChangeCallback", mockedStateCB, Object.class, deviceId);
-
-        //assert
-        new Verifications()
-        {
-            {
-                mockedTransport.registerConnectionStatusChangeCallback(mockedStateCB, null, deviceId);
-                times = 1;
-            }
-        };
-    }
     @Test
     public void isOpenWhenReconnecting()
             throws IOException

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -556,7 +556,7 @@ public class InternalClientTest
     }
 
     /*
-     **Tests_SRS_INTERNALCLIENT_25_025: [**The function shall create a new instance of class Device Twin and request all twin properties by calling getDeviceTwin**]**
+     **Tests_SRS_INTERNALCLIENT_25_025: [**The function shall create a new instance of class Device Twin and request all twin properties by calling getTwinAsync**]**
      */
     @Test
     public void startDeviceTwinSucceeds(@Mocked final DeviceTwin mockedDeviceTwin,
@@ -578,7 +578,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //assert
         new Verifications()
@@ -613,7 +613,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, null, null, mockedPropertyCB, null);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, null, null, mockedPropertyCB, null);
 
         //assert
         new Verifications()
@@ -649,7 +649,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinInternal", mockedStatusCB, null, (PropertyCallBack) null, null);
+        Deencapsulation.invoke(client, "startTwinAsync", mockedStatusCB, null, (PropertyCallBack) null, null);
 
     }
 
@@ -675,12 +675,12 @@ public class InternalClientTest
 
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+            Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
         }
         catch (UnsupportedOperationException expected)
         {
@@ -719,7 +719,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         //act
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
     }
 
     /*
@@ -744,10 +744,10 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
-        Deencapsulation.invoke(client, "subscribeToDesiredProperties", mockMap);
+        Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", mockMap);
 
         //assert
         new Verifications()
@@ -778,10 +778,10 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
-        Deencapsulation.invoke(client, "subscribeToDesiredProperties", new Class[] {Map.class}, NULL_OBJECT);
+        Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", new Class[] {Map.class}, NULL_OBJECT);
 
         //assert
         new Verifications()
@@ -815,12 +815,12 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "subscribeToDesiredProperties", mockMap);
+            Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", mockMap);
         }
         catch (Exception expected)
         {
@@ -860,7 +860,7 @@ public class InternalClientTest
         //act
         try
         {
-            Deencapsulation.invoke(client, "subscribeToDesiredProperties", mockMap);
+            Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", mockMap);
         }
         catch (Exception expected)
         {
@@ -898,10 +898,10 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
-        Deencapsulation.invoke(client, "sendReportedProperties", mockSet);
+        Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet);
 
         //assert
         new Verifications()
@@ -931,10 +931,10 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
-        Deencapsulation.invoke(client, "sendReportedProperties", mockSet, 10);
+        Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet, 10);
 
         //assert
         new Verifications()
@@ -969,7 +969,7 @@ public class InternalClientTest
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", mockSet);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet);
         }
         catch (Exception expected)
         {
@@ -1006,7 +1006,7 @@ public class InternalClientTest
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", mockSet, 10);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet, 10);
         }
         catch (Exception expected)
         {
@@ -1047,7 +1047,7 @@ public class InternalClientTest
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", mockSet);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet);
         }
         catch (Exception expected)
         {
@@ -1085,7 +1085,7 @@ public class InternalClientTest
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", mockSet, 10);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet, 10);
         }
         catch (Exception expected)
         {
@@ -1122,12 +1122,12 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", null);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", null);
         }
         catch (IllegalArgumentException expected)
         {
@@ -1161,12 +1161,12 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", new Class[] {Set.class, int.class}, null, 10);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", new Class[] {Set.class, int.class}, null, 10);
         }
         catch (IllegalArgumentException expected)
         {
@@ -1204,12 +1204,12 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "sendReportedProperties", mockSet, -1);
+            Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet, -1);
         }
         catch (IllegalArgumentException expected)
         {
@@ -1227,7 +1227,7 @@ public class InternalClientTest
     }
 
     /*
-    Tests_SRS_INTERNALCLIENT_25_038: [**This method shall subscribe to device methods by calling subscribeToDeviceMethod on DeviceMethod object which it created.**]**
+    Tests_SRS_INTERNALCLIENT_25_038: [**This method shall subscribe to device methods by calling subscribeToMethodsAsync on DeviceMethod object which it created.**]**
      */
     @Test
     public void subscribeToDeviceMethodSucceeds(@Mocked final IotHubEventCallback mockedStatusCB,
@@ -1249,7 +1249,7 @@ public class InternalClientTest
 
         //act
 
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
 
         //assert
         new Verifications()
@@ -1283,7 +1283,7 @@ public class InternalClientTest
         final InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         //act
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, null, mockedStatusCB, null);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, null, mockedStatusCB, null);
     }
 
     /*
@@ -1307,7 +1307,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, null, null, mockedStatusCB, null);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, null, null, mockedStatusCB, null);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -1328,7 +1328,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", mockedDeviceMethodCB, null, null, null);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", mockedDeviceMethodCB, null, null, null);
     }
 
     /*
@@ -1350,10 +1350,10 @@ public class InternalClientTest
         };
         final InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
 
         // act
-        Deencapsulation.invoke(client, "subscribeToMethodsInternal", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "subscribeToMethodsAsync", new Class[] {DeviceMethodCallback.class, Object.class, IotHubEventCallback.class, Object.class}, mockedDeviceMethodCB, NULL_OBJECT, mockedStatusCB, NULL_OBJECT);
 
         // assert
         new Verifications()
@@ -1411,28 +1411,6 @@ public class InternalClientTest
         // assert
         assertNull(Deencapsulation.getField(client, "config"));
         assertNull(Deencapsulation.getField(client, "deviceIO"));
-    }
-
-    //Tests_SRS_INTERNALCLIENT_34_069: [This function shall register the provided callback and context with its device IO instance.]
-    @Test
-    public void registerConnectionStatusChangeCallbackRegistersCallbackWithDeviceIO()
-    {
-        //arrange
-        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, IotHubClientProtocol.AMQPS, SEND_PERIOD, RECEIVE_PERIOD, null);
-        Deencapsulation.setField(client, "deviceIO", mockDeviceIO);
-        final Object context = new Object();
-
-        //act
-        Deencapsulation.invoke(client, "registerConnectionStatusChangeCallback",  new Class[] {IotHubConnectionStatusChangeCallback.class, Object.class}, mockedIotHubConnectionStatusChangeCallback, context);
-
-        //assert
-        new Verifications()
-        {
-            {
-                Deencapsulation.invoke(mockDeviceIO, "registerConnectionStatusChangeCallback", new Class[] {IotHubConnectionStatusChangeCallback.class, Object.class, String.class}, mockedIotHubConnectionStatusChangeCallback, context, null);
-                times = 1;
-            }
-        };
     }
 
     //Tests_SRS_INTERNALCLIENT_28_001: [The function shall set the device config's RetryPolicy .]
@@ -1532,11 +1510,11 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         client.open();
-        Deencapsulation.invoke(client, "startTwinInternal", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, null, mockedPropertyCB, null);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, null, mockedPropertyCB, null);
         mockDevice.setDesiredPropertyCallback(new Property("Desired", null), null, null);
 
         //act
-        client.subscribeToDesiredProperties(mockDevice.getDesiredProp());
+        client.subscribeToDesiredPropertiesAsync(mockDevice.getDesiredProp());
 
         //assert
         new Verifications()
@@ -1556,7 +1534,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, IotHubClientProtocol.AMQPS, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         //act
-        Deencapsulation.invoke(client, "getTwinInternal");
+        Deencapsulation.invoke(client, "getTwinAsync");
     }
 
     //Tests_SRS_INTERNALCLIENT_21_041: [If the client has not been open, the function shall throw an IOException.]
@@ -1578,10 +1556,10 @@ public class InternalClientTest
         };
 
         //act
-        Deencapsulation.invoke(client, "getTwinInternal");
+        Deencapsulation.invoke(client, "getTwinAsync");
     }
 
-    //Tests_SRS_INTERNALCLIENT_21_042: [The function shall get all desired properties by calling getDeviceTwin.]
+    //Tests_SRS_INTERNALCLIENT_21_042: [The function shall get all desired properties by calling getTwinAsync.]
     @Test
     public void getDeviceTwinSuccess(final @Mocked DeviceTwin mockedDeviceTwin) throws URISyntaxException, IOException
     {
@@ -1600,7 +1578,7 @@ public class InternalClientTest
         };
 
         //act
-        Deencapsulation.invoke(client, "getTwinInternal");
+        Deencapsulation.invoke(client, "getTwinAsync");
 
         //assert
         new Verifications()
@@ -1621,7 +1599,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         // act
-        Deencapsulation.invoke(client, "startTwinInternal", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
+        Deencapsulation.invoke(client, "startTwinAsync", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
     }
 
     //Tests_SRS_INTERNALCLIENT_34_082: [If either callback is null, this function shall throw an IllegalArgumentException.]
@@ -1641,7 +1619,7 @@ public class InternalClientTest
         };
 
         // act
-        Deencapsulation.invoke(client, "startTwinInternal", (IotHubEventCallback) null, new Object(), mockedTwinPropertyCallback, new Object());
+        Deencapsulation.invoke(client, "startTwinAsync", (IotHubEventCallback) null, new Object(), mockedTwinPropertyCallback, new Object());
     }
 
     //Tests_SRS_INTERNALCLIENT_34_083: [If either callback is null, this function shall throw an IllegalArgumentException.]
@@ -1662,10 +1640,10 @@ public class InternalClientTest
         };
 
         // act
-        Deencapsulation.invoke(client, "startTwinInternal", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
+        Deencapsulation.invoke(client, "startTwinAsync", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
     }
 
-    //Tests_SRS_INTERNALCLIENT_34_084: [This function shall initialize a DeviceTwin object and invoke getDeviceTwin on it.]
+    //Tests_SRS_INTERNALCLIENT_34_084: [This function shall initialize a DeviceTwin object and invoke getTwinAsync on it.]
     @Test
     public void startDeviceTwinSuccess(final @Mocked DeviceTwin mockedDeviceTwin) throws IOException
     {
@@ -1687,7 +1665,7 @@ public class InternalClientTest
         };
 
         // act
-        Deencapsulation.invoke(client, "startTwinInternal", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
+        Deencapsulation.invoke(client, "startTwinAsync", mockedIotHubEventCallback, new Object(), mockedTwinPropertyCallback, new Object());
 
         //assert
         assertNotNull(Deencapsulation.getField(client, "twin"));
@@ -1712,7 +1690,7 @@ public class InternalClientTest
         Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
-        client.subscribeToTwinDesiredProperties(onDesiredPropertyChange);
+        client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);
     }
 
     //Tests_SRS_INTERNALCLIENT_34_086: [If the client has not been open, the function shall throw an IOException.]
@@ -1735,7 +1713,7 @@ public class InternalClientTest
         Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
-        client.subscribeToTwinDesiredProperties(onDesiredPropertyChange);
+        client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);
     }
 
     //Tests_SRS_INTERNALCLIENT_34_085: [This method shall subscribe to desired properties by calling subscribeDesiredPropertiesNotification on the twin object.]
@@ -1758,7 +1736,7 @@ public class InternalClientTest
         final Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
-        client.subscribeToTwinDesiredProperties(onDesiredPropertyChange);
+        client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);
 
         //assert
         assertNotNull(Deencapsulation.getField(client, "twin"));
@@ -1879,32 +1857,6 @@ public class InternalClientTest
 
         // act
         client.setOption("SetMinimumPollingInterval", "thisIsNotALong");
-    }
-
-    //Tests_SRS_INTERNALCLIENT_02_005: [Setting the option can only be done before open call.]
-    @Test (expected = IllegalStateException.class)
-    public void setOptionMinimumPollingIntervalAfterOpenFails()
-            throws IOException, URISyntaxException
-    {
-        // arrange
-        final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;DeviceId=testdevice;"
-                + "SharedAccessKey=adjkl234j52=";
-        final IotHubClientProtocol protocol = IotHubClientProtocol.HTTPS;
-        new NonStrictExpectations()
-        {
-            {
-                mockDeviceIO.isOpen();
-                result = true;
-                mockDeviceIO.getProtocol();
-                result = IotHubClientProtocol.HTTPS;
-            }
-        };
-        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
-        client.open();
-        long value = 3;
-
-        // act
-        client.setOption("SetMinimumPollingInterval", value);
     }
 
     //Tests_SRS_INTERNALCLIENT_02_016: ["SetMinimumPollingInterval" - time in milliseconds between 2 consecutive polls.]
@@ -2114,12 +2066,8 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                mockDeviceIO.close();
-                times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open", false);
-                times = 2;
             }
         };
     }
@@ -2221,12 +2169,8 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                mockDeviceIO.close();
-                times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open", false);
-                times = 2;
             }
         };
     }
@@ -2303,12 +2247,8 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                mockDeviceIO.close();
-                times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open", false);
-                times = 2;
             }
         };
     }
@@ -2386,82 +2326,10 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                mockDeviceIO.close();
-                times = 1;
                 mockConfig.getSasTokenAuthentication().setTokenValidSecs(value);
                 times = 1;
-                Deencapsulation.invoke(mockDeviceIO, "open", false);
-                times = 2;
             }
         };
-    }
-
-    // Tests_SRS_INTERNALCLIENT_12_027: [The function shall throw IOError if either the deviceIO or the tranportClient's open() or closeNow() throws.]
-    @Test (expected = IOError.class)
-    public void setOptionClientSASTokenExpiryTimeAfterClientOpenAMQPThrowsDeviceIOClose()
-            throws IOException, URISyntaxException
-    {
-        // arrange
-        new NonStrictExpectations()
-        {
-            {
-                mockDeviceIO.isOpen();
-                result = true;
-                mockDeviceIO.getProtocol();
-                result = IotHubClientProtocol.HTTPS;
-                mockConfig.getSasTokenAuthentication().canRefreshToken();
-                result = true;
-                mockConfig.getAuthenticationType();
-                result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockDeviceIO.close();
-                result =  new IOException();
-            }
-        };
-        final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;DeviceId=testdevice;"
-                + "SharedAccessKey=adjkl234j52=";
-        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-
-        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
-        Deencapsulation.setField(client, "config", mockConfig);
-        Deencapsulation.setField(client, "deviceIO", mockDeviceIO);
-        final long value = 60;
-
-        // act
-        client.setOption("SetSASTokenExpiryTime", value);
-    }
-
-    // Tests_SRS_INTERNALCLIENT_12_027: [The function shall throw IOError if either the deviceIO or the tranportClient's open() or closeNow() throws.]
-    @Test (expected = IOError.class)
-    public void setOptionClientSASTokenExpiryTimeAfterClientOpenAMQPThrowsTransportDeviceIOOpen()
-            throws IOException, URISyntaxException
-    {
-        // arrange
-        new NonStrictExpectations()
-        {
-            {
-                mockDeviceIO.isOpen();
-                result = true;
-                mockDeviceIO.getProtocol();
-                result = IotHubClientProtocol.HTTPS;
-                mockConfig.getSasTokenAuthentication().canRefreshToken();
-                result = true;
-                mockConfig.getAuthenticationType();
-                result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                Deencapsulation.invoke(mockDeviceIO, "open", false);
-                result =  new IOException();
-            }
-        };
-        final String connString = "HostName=iothub.device.com;CredentialType=SharedAccessKey;DeviceId=testdevice;"
-                + "SharedAccessKey=adjkl234j52=";
-        final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-
-        InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
-        Deencapsulation.setField(client, "config", mockConfig);
-        Deencapsulation.setField(client, "deviceIO", mockDeviceIO);
-        final long value = 60;
-
-        // act
-        client.setOption("SetSASTokenExpiryTime", value);
     }
 
     @Test (expected = IllegalStateException.class)

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
@@ -610,8 +610,8 @@ public class ModuleClientTest
                 result = expectedTrustedCerts;
 
                 Deencapsulation.newInstance(ModuleClient.class,
-                        new Class[] {IotHubAuthenticationProvider.class, IotHubClientProtocol.class, long.class, long.class},
-                        mockedModuleAuthenticationWithHsm, (IotHubClientProtocol) any, anyLong, anyLong);
+                        new Class[] {IotHubAuthenticationProvider.class, IotHubClientProtocol.class, long.class},
+                        mockedModuleAuthenticationWithHsm, (IotHubClientProtocol) any, anyLong);
             }
         };
 


### PR DESCRIPTION
Move all the common code into InternalClient as well. There are many changed sample/test files that are affected by these renames, but for the sake of simplifying this PR, those changes will be added later.

old:
```java
public void subscribeToDesiredProperties(...);
public void startTwin(...);
public void getTwin(...);
public void subscribeToDeviceMethod(...); //deviceClient
public void subscribeToMethod(...); //moduleClient
public void registerConnectionStatusChangeCallback(...);
```

new
```java
public void subscribeToDesiredPropertiesAsync(...);
public void startTwinAsync(...);
public void getTwinAsync(...);
public void subscribeToMethodsAsync(...); //moduleClient and deviceClient, "Methods" rather than "Method"
public void setConnectionStatusChangeCallback(...); //"set" instead of "register"
```

With no changes in the parameters or return types