### PR TITLE
break(iot-serv, iot-dev): Remove unnecessary synchronization from public methods

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -315,7 +315,7 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      * @throws IllegalArgumentException if the message provided is {@code null}.
      * @throws IllegalStateException if the client has not been opened yet or is already closed.
      */
-    public synchronized void sendEventAsync(Message message,
+    public void sendEventAsync(Message message,
                                IotHubEventCallback callback,
                                Object callbackContext,
                                String deviceId)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -143,7 +143,7 @@ public class DeviceMethod
      * @throws IotHubException This exception is thrown if the response verification failed.
      * @throws IOException This exception is thrown if the IO operation failed.
      */
-    public synchronized MethodResult invoke(
+    public MethodResult invoke(
         String deviceId,
         String methodName,
         Long responseTimeoutInSeconds,
@@ -177,7 +177,7 @@ public class DeviceMethod
      * @throws IotHubException This exception is thrown if the response verification failed.
      * @throws IOException This exception is thrown if the IO operation failed.
      */
-    public synchronized MethodResult invoke(
+    public MethodResult invoke(
         String deviceId,
         String moduleId,
         String methodName,
@@ -217,7 +217,7 @@ public class DeviceMethod
      * @throws IotHubException This exception is thrown if the response verification failed.
      * @throws IOException This exception is thrown if the IO operation failed.
      */
-    private synchronized MethodResult invokeMethod(
+    private MethodResult invokeMethod(
         URL url,
         String methodName,
         Long responseTimeoutInSeconds,

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -207,7 +207,7 @@ public class DeviceTwin
      * @throws IOException This exception is thrown if the IO operation failed.
      * @throws IotHubException This exception is thrown if the response verification failed.
      */
-    public synchronized void updateTwin(DeviceTwinDevice device) throws IotHubException, IOException
+    public void updateTwin(DeviceTwinDevice device) throws IotHubException, IOException
     {
         if (device == null || device.getDeviceId() == null || device.getDeviceId().length() == 0)
         {
@@ -244,34 +244,6 @@ public class DeviceTwin
                 options.getHttpConnectTimeout(),
                 options.getHttpReadTimeout(),
                 proxy);
-    }
-
-    /**
-     * This method replaces desired properties for the specified device. desired properties can be input
-     * via device's
-     * {@link com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice#setDesiredProperties(TwinCollection)}
-     * method.
-     *
-     * @param device The device with a valid id for which device twin is to be updated.
-     * @throws UnsupportedOperationException This exception is always thrown.
-     */
-    public void replaceDesiredProperties(DeviceTwinDevice device) throws UnsupportedOperationException
-    {
-        // Currently this is not supported by service
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * This method replaces tags for the specified device. Tags can be input via device's
-     * {@link com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice#setTags(TwinCollection)} method.
-     *
-     * @param device The device with a valid Id for which device twin is to be updated.
-     * @throws UnsupportedOperationException This exception is always thrown.
-     */
-    public void replaceTags(DeviceTwinDevice device) throws UnsupportedOperationException
-    {
-        // Currently this is not supported by service
-        throw new UnsupportedOperationException();
     }
 
     /**
@@ -352,7 +324,7 @@ public class DeviceTwin
      * @throws IotHubException If query request was not successful at the Iot hub.
      * @throws IOException If input parameters are invalid.
      */
-    public synchronized Query queryTwin(String sqlQuery, Integer pageSize) throws IotHubException, IOException
+    public Query queryTwin(String sqlQuery, Integer pageSize) throws IotHubException, IOException
     {
         if (sqlQuery == null || sqlQuery.length() == 0)
         {
@@ -390,7 +362,7 @@ public class DeviceTwin
      * @throws IotHubException If query request was not successful at the Iot hub.
      * @throws IOException If input parameters are invalid.
      */
-    public synchronized Query queryTwin(String sqlQuery) throws IotHubException, IOException
+    public Query queryTwin(String sqlQuery) throws IotHubException, IOException
     {
         return this.queryTwin(sqlQuery, DEFAULT_PAGE_SIZE);
     }
@@ -403,7 +375,7 @@ public class DeviceTwin
      * @return The created {@link QueryCollection} object that can be used to query the service.
      * @throws MalformedURLException If twin query URL is not correct.
      */
-    public synchronized QueryCollection queryTwinCollection(String sqlQuery) throws MalformedURLException
+    public QueryCollection queryTwinCollection(String sqlQuery) throws MalformedURLException
     {
         return this.queryTwinCollection(sqlQuery, DEFAULT_PAGE_SIZE);
     }
@@ -417,7 +389,7 @@ public class DeviceTwin
      * @return The created QueryCollection object that can be used to query the service.
      * @throws MalformedURLException If twin query URL is not correct.
      */
-    public synchronized QueryCollection queryTwinCollection(String sqlQuery, Integer pageSize) throws MalformedURLException
+    public QueryCollection queryTwinCollection(String sqlQuery, Integer pageSize) throws MalformedURLException
     {
         ProxyOptions proxyOptions = options.getProxyOptions();
         Proxy proxy = proxyOptions != null ? proxyOptions.getProxy() : null;
@@ -473,7 +445,7 @@ public class DeviceTwin
      * @throws IotHubException If Iot hub could not respond back to the query successfully.
      * @throws IOException If input parameter is incorrect.
      */
-    public synchronized boolean hasNextDeviceTwin(Query deviceTwinQuery) throws IotHubException, IOException
+    public boolean hasNextDeviceTwin(Query deviceTwinQuery) throws IotHubException, IOException
     {
         if (deviceTwinQuery == null)
         {
@@ -492,7 +464,7 @@ public class DeviceTwin
      * @throws IotHubException If an unsuccessful response from IoT Hub is received.
      * @throws NoSuchElementException If no additional element was found.
      */
-    public synchronized DeviceTwinDevice getNextDeviceTwin(Query deviceTwinQuery)
+    public DeviceTwinDevice getNextDeviceTwin(Query deviceTwinQuery)
             throws IOException, IotHubException, NoSuchElementException
     {
         if (deviceTwinQuery == null)
@@ -519,7 +491,7 @@ public class DeviceTwin
      * @return {@code True} if the provided deviceTwinQueryCollection has a next page to query, {@code false} otherwise.
      * @throws IllegalArgumentException if the provided deviceTwinQueryCollection is null.
      */
-    public synchronized boolean hasNext(QueryCollection deviceTwinQueryCollection)
+    public boolean hasNext(QueryCollection deviceTwinQueryCollection)
     {
         if (deviceTwinQueryCollection == null)
         {
@@ -542,7 +514,7 @@ public class DeviceTwin
      * @throws IOException If an {@link IotHubException} occurs when querying the service or if the results of that
      * query doesn't match expectations.
      */
-    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(
+    public QueryCollectionResponse<DeviceTwinDevice> next(
             QueryCollection deviceTwinQueryCollection) throws IOException, IotHubException
     {
         QueryOptions options = new QueryOptions();
@@ -568,7 +540,7 @@ public class DeviceTwin
      * @throws IOException If an {@link IotHubException} occurs when querying the service or if the results of that
      * query doesn't match expectations.
      */
-    public synchronized QueryCollectionResponse<DeviceTwinDevice> next(
+    public QueryCollectionResponse<DeviceTwinDevice> next(
             QueryCollection deviceTwinQueryCollection,
             QueryOptions options) throws IOException, IotHubException
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/RawTwinQuery.java
@@ -99,7 +99,7 @@ public class RawTwinQuery
      * @throws IotHubException If IotHub did not respond successfully to the query
      * @throws IOException If any of the input parameters are incorrect
      */
-    public synchronized Query query(String sqlQuery, Integer pageSize) throws IotHubException, IOException
+    public Query query(String sqlQuery, Integer pageSize) throws IotHubException, IOException
     {
         if (sqlQuery == null || sqlQuery.length() == 0)
         {
@@ -133,7 +133,7 @@ public class RawTwinQuery
      * @throws IotHubException If IotHub did not respond successfully to the query
      * @throws IOException If any of the input parameters are incorrect
      */
-    public synchronized Query query(String sqlQuery) throws IotHubException, IOException
+    public Query query(String sqlQuery) throws IotHubException, IOException
     {
         return this.query(sqlQuery, DEFAULT_PAGE_SIZE);
     }
@@ -146,7 +146,7 @@ public class RawTwinQuery
      * @throws IotHubException If IotHub could not respond successfully to the query request
      * @throws IOException If any of the input parameters are incorrect
      */
-    public synchronized boolean hasNext(Query query) throws IotHubException, IOException
+    public boolean hasNext(Query query) throws IotHubException, IOException
     {
         if (query == null)
         {
@@ -164,7 +164,7 @@ public class RawTwinQuery
      * @throws IotHubException If IotHub could not respond successfully to the query request
      * @throws NoSuchElementException If no other element is found
      */
-    public synchronized String next(Query query) throws IOException, IotHubException, NoSuchElementException
+    public String next(Query query) throws IOException, IotHubException, NoSuchElementException
     {
         if (query == null)
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -159,7 +159,7 @@ public class JobClient
      * @throws IOException if the function cannot create a URL for the job
      * @throws IotHubException if the http request failed
      */
-    public synchronized JobResult scheduleUpdateTwin(
+    public JobResult scheduleUpdateTwin(
         String jobId,
         String queryCondition,
         DeviceTwinDevice updateTwin,
@@ -239,7 +239,7 @@ public class JobClient
      * @throws IOException if the function cannot create a URL for the job, or the IO failed on request
      * @throws IotHubException if the http request failed
      */
-    public synchronized JobResult scheduleDeviceMethod(
+    public JobResult scheduleDeviceMethod(
         String jobId,
         String queryCondition,
         String methodName,
@@ -322,7 +322,7 @@ public class JobClient
      * @throws IOException if the function cannot create a URL for the job, or the IO failed on request
      * @throws IotHubException if the http request failed
      */
-    public synchronized JobResult getJob(String jobId)
+    public JobResult getJob(String jobId)
         throws IllegalArgumentException, IOException, IotHubException
     {
         URL url;
@@ -365,7 +365,7 @@ public class JobClient
      * @throws IOException if the function cannot create a URL for the job, or the IO failed on request
      * @throws IotHubException if the http request failed
      */
-    public synchronized JobResult cancelJob(String jobId)
+    public JobResult cancelJob(String jobId)
         throws IllegalArgumentException, IOException, IotHubException
     {
         URL url;
@@ -461,7 +461,7 @@ public class JobClient
      * @throws IotHubException When IotHub fails to respond
      * @throws IOException When any of the parameters are incorrect
      */
-    public synchronized Query queryDeviceJob(String sqlQuery, Integer pageSize) throws IotHubException, IOException
+    public Query queryDeviceJob(String sqlQuery, Integer pageSize) throws IotHubException, IOException
     {
         if (sqlQuery == null || sqlQuery.length() == 0)
         {
@@ -499,7 +499,7 @@ public class JobClient
      * @throws IotHubException When IotHub fails to respond
      * @throws IOException When any of the parameters are incorrect
      */
-    public synchronized Query queryDeviceJob(String sqlQuery) throws IotHubException, IOException
+    public Query queryDeviceJob(String sqlQuery) throws IotHubException, IOException
     {
         return queryDeviceJob(sqlQuery, DEFAULT_PAGE_SIZE);
     }
@@ -512,7 +512,7 @@ public class JobClient
      * @throws IotHubException When IotHub fails to respond
      * @throws IOException if any of the input parameters are incorrect
      */
-    public synchronized boolean hasNextJob(Query query) throws IotHubException, IOException
+    public boolean hasNextJob(Query query) throws IotHubException, IOException
     {
         if (query == null)
         {
@@ -531,7 +531,7 @@ public class JobClient
      * @throws IOException if any of the input parameters are incorrect
      * @throws NoSuchElementException if called when no further responses are left
      */
-    public synchronized JobResult getNextJob(Query query) throws IOException, IotHubException, NoSuchElementException
+    public JobResult getNextJob(Query query) throws IOException, IotHubException, NoSuchElementException
     {
         if (query == null)
         {
@@ -560,7 +560,7 @@ public class JobClient
      * @throws IOException If any of the input parameters are incorrect
      * @throws IotHubException If IotHub failed to respond
      */
-    public synchronized Query queryJobResponse(JobType jobType, JobStatus jobStatus, Integer pageSize)
+    public Query queryJobResponse(JobType jobType, JobStatus jobStatus, Integer pageSize)
         throws IOException, IotHubException
     {
         if (pageSize <= 0)
@@ -597,7 +597,7 @@ public class JobClient
      * @throws IOException If any of the input parameters are incorrect
      * @throws IotHubException If IotHub failed to respond
      */
-    public synchronized Query queryJobResponse(JobType jobType, JobStatus jobStatus)
+    public Query queryJobResponse(JobType jobType, JobStatus jobStatus)
         throws IotHubException, IOException
     {
         return queryJobResponse(jobType, jobStatus, DEFAULT_PAGE_SIZE);


### PR DESCRIPTION
The ```synchronized``` keyword on a method simply means that a given instance of the class that contains that method cannot invoke the method or any other synchronized method at the same time. It makes them behave like atomic operations.

A given device method client should be allowed to invoke a method on device "a" while already invoking a method on device "b". The service will protect users from trying to invoke multiple methods on the same device simultaneously.

These APIs do not share any local resources that we needed to synchronize on. They are just simple HTTP requests to the service that are constructed locally within the method call itself. 