### PR TITLE
feat(dps-dev): Add missing registration result fields

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1800,7 +1800,7 @@ public class MultiplexingClientTests extends IntegrationTest
     @Test
     public void multiplexedSessionsRecoverSubscriptionsFromDeviceSessionDrops() throws Exception
     {
-        testInstance.setup(DEVICE_MULTIPLEX_COUNT);
+        testInstance.setup(DEVICE_MULTIPLEX_COUNT, MultiplexingClientOptions.builder().build(), true);
         ConnectionStatusChangeTracker multiplexedConnectionStatusChangeTracker = new ConnectionStatusChangeTracker();
         testInstance.multiplexingClient.registerConnectionStatusChangeCallback(multiplexedConnectionStatusChangeTracker, null);
         ConnectionStatusChangeTracker[] connectionStatusChangeTrackers = new ConnectionStatusChangeTracker[DEVICE_MULTIPLEX_COUNT];

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -306,6 +306,14 @@ public class ProvisioningCommon extends IntegrationTest
         Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected status", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), PROVISIONING_DEVICE_STATUS_ASSIGNED, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus());
         testInstance.provisionedDeviceId = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId();
         testInstance.provisionedIotHubUri = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri();
+
+        assertEquals(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
+        assertEquals(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getRegistrationId(), testInstance.registrationId);
+        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getCreatedDateTimeUtc());
+        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getLastUpdatesDateTimeUtc());
+        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getLastUpdatesDateTimeUtc());
+        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getSubstatus());
+
         assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId);
         assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId.isEmpty());
         assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientRegistrationResult.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientRegistrationResult.java
@@ -7,12 +7,33 @@
 
 package com.microsoft.azure.sdk.iot.provisioning.device;
 
+import lombok.Getter;
+
 public class ProvisioningDeviceClientRegistrationResult
 {
     protected String iothubUri;
     protected String deviceId;
     protected ProvisioningDeviceClientStatus provisioningDeviceClientStatus;
     protected String payload;
+
+    @Getter
+    protected String registrationId;
+
+    @Getter
+    protected String createdDateTimeUtc;
+
+    @Getter
+    protected String status;
+
+    @Getter
+    protected ProvisioningDeviceClientSubstatus substatus;
+
+    @Getter
+    protected String eTag;
+
+    @Getter
+    protected String lastUpdatesDateTimeUtc;
+
     /**
      * Empty constructor to let users gather the data.
      */

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientSubstatus.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientSubstatus.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.provisioning.device;
+
+/**
+ * The possible substatus values of a successful device provisioning.
+ */
+public enum ProvisioningDeviceClientSubstatus
+{
+    /**
+     * Device has been assigned to an IoT hub for the first time
+     */
+    INITIAL_ASSIGNMENT("initialAssignment"),
+
+    /**
+     * Device has been assigned to a different IoT hub and its device data was migrated from the previously assigned
+     * IoT hub. Device data was removed from the previously assigned IoT hub.
+     */
+    DEVICE_DATA_MIGRATED("deviceDataMigrated"),
+
+    /**
+     * Device has been assigned to a different IoT hub and its device data was populated from the initial state stored
+     * in the enrollment. Device data was removed from the previously assigned IoT hub.
+     */
+    DEVICE_DATA_RESET("deviceDataReset"),
+
+    /**
+     * Device has been re-provisioned to a previously assigned IoT hub.
+     */
+    REPROVISIONED_TO_INITIAL_ASSIGNMENT("reprovisionedToInitialAssignment");
+
+    private final String substatus;
+
+    ProvisioningDeviceClientSubstatus(String substatus)
+    {
+        this.substatus = substatus;
+    }
+
+    public String getValue()
+    {
+        return this.substatus;
+    }
+
+    public static ProvisioningDeviceClientSubstatus fromString(String substatus)
+    {
+        for (ProvisioningDeviceClientSubstatus substatusCode : ProvisioningDeviceClientSubstatus.values())
+        {
+            if (substatusCode.substatus.equalsIgnoreCase(substatus))
+            {
+                return substatusCode;
+            }
+        }
+
+        return null;
+    }
+}

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientSubstatus.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClientSubstatus.java
@@ -9,7 +9,7 @@ package com.microsoft.azure.sdk.iot.provisioning.device;
 public enum ProvisioningDeviceClientSubstatus
 {
     /**
-     * Device has been assigned to an IoT hub for the first time
+     * Device has been assigned to an IoT hub for the first time.
      */
     INITIAL_ASSIGNMENT("initialAssignment"),
 

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/exceptions/ProvisioningDeviceHubException.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/exceptions/ProvisioningDeviceHubException.java
@@ -7,6 +7,9 @@
 
 package com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class ProvisioningDeviceHubException extends ProvisioningDeviceClientException
 {
     public ProvisioningDeviceHubException(String message)
@@ -23,4 +26,11 @@ public class ProvisioningDeviceHubException extends ProvisioningDeviceClientExce
     {
         super(cause);
     }
+
+    /**
+     * The error code sent from the service to clarify what exception occurred.
+     */
+    @Getter
+    @Setter
+    private int errorCode;
 }

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/DeviceRegistrationResultParser.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/parser/DeviceRegistrationResultParser.java
@@ -37,6 +37,10 @@ public class DeviceRegistrationResultParser
     @SerializedName(STATUS)
     private String status;
 
+    private static final String SUBSTATUS = "substatus";
+    @SerializedName(SUBSTATUS)
+    private String substatus;
+
     private static final String ETAG = "etag";
     @SerializedName(ETAG)
     private String eTag;
@@ -118,6 +122,15 @@ public class DeviceRegistrationResultParser
     {
         //SRS_DeviceRegistrationResultParser_25_005: [ This method shall return the parsed status. ]
         return status;
+    }
+
+    /**
+     * Getter for Substatus
+     * @return Getter for Substatus
+     */
+    public String getSubstatus()
+    {
+        return substatus;
     }
 
     /**

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
@@ -214,6 +214,13 @@ public class ProvisioningTask implements Callable<Object>
                                                             registrationStatus.getDeviceId(),
                                                             registrationStatus.getPayload(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
 
+                    registrationInfo.setRegistrationId(registrationStatus.getRegistrationId());
+                    registrationInfo.setStatus(registrationStatus.getStatus());
+                    registrationInfo.setSubstatus(ProvisioningDeviceClientSubstatus.fromString(registrationStatus.getSubstatus()));
+                    registrationInfo.setCreatedDateTimeUtc(registrationStatus.getCreatedDateTimeUtc());
+                    registrationInfo.setLastUpdatesDateTimeUtc(registrationStatus.getLastUpdatesDateTimeUtc());
+                    registrationInfo.setETag(registrationStatus.getEtag());
+
                     if (this.securityProvider instanceof SecurityProviderTpm)
                     {
                         if (registrationStatus.getTpm() == null
@@ -236,6 +243,7 @@ public class ProvisioningTask implements Callable<Object>
                     this.dpsStatus = PROVISIONING_DEVICE_STATUS_FAILED;
                     String errorMessage = statusRegistrationOperationStatusParser.getRegistrationState().getErrorMessage();
                     ProvisioningDeviceHubException dpsHubException = new ProvisioningDeviceHubException(errorMessage);
+                    dpsHubException.setErrorCode(registrationOperationStatusParser.getRegistrationState().getErrorCode());
                     registrationInfo = new RegistrationResult(null, null, null, PROVISIONING_DEVICE_STATUS_FAILED);
                     log.error("Device provisioning service failed to provision the device, finished with status FAILED: {}", errorMessage);
                     this.invokeRegistrationCallback(registrationInfo, dpsHubException);
@@ -245,6 +253,7 @@ public class ProvisioningTask implements Callable<Object>
                     this.dpsStatus = PROVISIONING_DEVICE_STATUS_DISABLED;
                     String disabledErrorMessage = statusRegistrationOperationStatusParser.getRegistrationState().getErrorMessage();
                     dpsHubException = new ProvisioningDeviceHubException(disabledErrorMessage);
+                    dpsHubException.setErrorCode(registrationOperationStatusParser.getRegistrationState().getErrorCode());
                     registrationInfo = new RegistrationResult(null, null, null, PROVISIONING_DEVICE_STATUS_DISABLED);
                     log.error("Device provisioning service failed to provision the device, finished with status DISABLED: {}", disabledErrorMessage);
                     this.invokeRegistrationCallback(registrationInfo, dpsHubException);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegistrationResult.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegistrationResult.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.sdk.iot.provisioning.device.internal.task;
 
 import com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientRegistrationResult;
 import com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientStatus;
+import com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientSubstatus;
 
 public class RegistrationResult extends ProvisioningDeviceClientRegistrationResult
 {
@@ -26,5 +27,35 @@ public class RegistrationResult extends ProvisioningDeviceClientRegistrationResu
         this.deviceId = deviceId;
         this.payload = jsonPayload;
         this.provisioningDeviceClientStatus = dpsStatus;
+    }
+
+    void setRegistrationId(String registrationId)
+    {
+        this.registrationId = registrationId;
+    }
+
+    void setCreatedDateTimeUtc(String createdDateTimeUtc)
+    {
+        this.createdDateTimeUtc = createdDateTimeUtc;
+    }
+
+    void setStatus(String status)
+    {
+        this.status = status;
+    }
+
+    void setSubstatus(ProvisioningDeviceClientSubstatus substatus)
+    {
+        this.substatus = substatus;
+    }
+
+    void setETag(String eTag)
+    {
+        this.eTag = eTag;
+    }
+
+    void setLastUpdatesDateTimeUtc(String lastUpdatesDateTimeUtc)
+    {
+        this.lastUpdatesDateTimeUtc = lastUpdatesDateTimeUtc;
     }
 }


### PR DESCRIPTION
The service has sent these fields for a while, but we never exposed them to users for some reason. This brings our registration result class up to par with what the service sends to the SDK