### PR TITLE
break(all): Fix spelling of "Callback" in various classes and methods

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -10,9 +10,9 @@ import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodCallback;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceTwin;
 import com.microsoft.azure.sdk.iot.device.twin.Pair;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.PropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.PropertyCallback;
 import com.microsoft.azure.sdk.iot.device.twin.TwinPropertiesCallback;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
@@ -260,7 +260,7 @@ public class InternalClient
      *
      * @throws IOException if called when client is not opened or called before starting twin.
      */
-    public void subscribeToDesiredPropertiesAsync(Map<Property, Pair<PropertyCallBack<String, Object>, Object>> onDesiredPropertyChange) throws IOException
+    public void subscribeToDesiredPropertiesAsync(Map<Property, Pair<PropertyCallback<String, Object>, Object>> onDesiredPropertyChange) throws IOException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
@@ -285,7 +285,7 @@ public class InternalClient
      *
      * @throws IOException if called when client is not opened or called before starting twin.
      */
-    public void subscribeToTwinDesiredPropertiesAsync(Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange) throws IOException
+    public void subscribeToTwinDesiredPropertiesAsync(Map<Property, Pair<TwinPropertyCallback, Object>> onDesiredPropertyChange) throws IOException
     {
         verifyRegisteredIfMultiplexing();
         verifyTwinOperationsAreSupported();
@@ -567,8 +567,8 @@ public class InternalClient
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertyCallBack the PropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.
+     * @param genericPropertyCallback the PropertyCallback callback for providing any changes in desired properties. Cannot be {@code null}.
+     * @param genericPropertyCallbackContext the context to be passed to the property callback. Can be {@code null}.
      * @param <Type1> The type of the desired property key. Since the twin is a json object, the key will always be a String.
      * @param <Type2> The type of the desired property value.
      *
@@ -577,7 +577,7 @@ public class InternalClient
      * @throws IOException if called when client is not opened
      */
     public <Type1, Type2> void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
-                                 PropertyCallBack<Type1, Type2> genericPropertyCallBack, Object genericPropertyCallBackContext)
+                                 PropertyCallback<Type1, Type2> genericPropertyCallback, Object genericPropertyCallbackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
         verifyRegisteredIfMultiplexing();
@@ -588,7 +588,7 @@ public class InternalClient
             throw new IOException("Open the client connection before using it.");
         }
 
-        if (twinStatusCallback == null || genericPropertyCallBack == null)
+        if (twinStatusCallback == null || genericPropertyCallback == null)
         {
             throw new IllegalArgumentException("Callback cannot be null");
         }
@@ -599,8 +599,8 @@ public class InternalClient
                     this.config,
                     twinStatusCallback,
                     twinStatusCallbackContext,
-                    genericPropertyCallBack,
-                    genericPropertyCallBackContext);
+                    genericPropertyCallback,
+                    genericPropertyCallbackContext);
 
             twin.getDeviceTwin();
         }
@@ -627,15 +627,15 @@ public class InternalClient
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertyCallBack the TwinPropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.     *
+     * @param genericPropertyCallback the TwinPropertyCallback callback for providing any changes in desired properties. Cannot be {@code null}.
+     * @param genericPropertyCallbackContext the context to be passed to the property callback. Can be {@code null}.     *
      *
      * @throws IllegalArgumentException if the callback is {@code null}
      * @throws UnsupportedOperationException if called more than once on the same device
      * @throws IOException if called when client is not opened
      */
     public void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
-                               TwinPropertyCallBack genericPropertyCallBack, Object genericPropertyCallBackContext)
+                               TwinPropertyCallback genericPropertyCallback, Object genericPropertyCallbackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
         verifyRegisteredIfMultiplexing();
@@ -646,14 +646,14 @@ public class InternalClient
             throw new IOException("Open the client connection before using it.");
         }
 
-        if (twinStatusCallback == null || genericPropertyCallBack == null)
+        if (twinStatusCallback == null || genericPropertyCallback == null)
         {
             throw new IllegalArgumentException("Callback cannot be null");
         }
         if (this.twin == null)
         {
             twin = new DeviceTwin(this.deviceIO, this.config, twinStatusCallback, twinStatusCallbackContext,
-                    genericPropertyCallBack, genericPropertyCallBackContext);
+                    genericPropertyCallback, genericPropertyCallbackContext);
             twin.getDeviceTwin();
         }
         else
@@ -679,15 +679,15 @@ public class InternalClient
      *
      * @param twinStatusCallback the IotHubEventCallback callback for providing the status of Device Twin operations. Cannot be {@code null}.
      * @param twinStatusCallbackContext the context to be passed to the status callback. Can be {@code null}.
-     * @param genericPropertiesCallBack the TwinPropertyCallBack callback for providing any changes in desired properties. Cannot be {@code null}.
-     * @param genericPropertyCallBackContext the context to be passed to the property callback. Can be {@code null}.
+     * @param genericPropertiesCallback the TwinPropertyCallback callback for providing any changes in desired properties. Cannot be {@code null}.
+     * @param genericPropertyCallbackContext the context to be passed to the property callback. Can be {@code null}.
      *
      * @throws IllegalArgumentException if the callback is {@code null}
      * @throws UnsupportedOperationException if called more than once on the same device
      * @throws IOException if called when client is not opened
      */
     public void startTwinAsync(IotHubEventCallback twinStatusCallback, Object twinStatusCallbackContext,
-                           TwinPropertiesCallback genericPropertiesCallBack, Object genericPropertyCallBackContext)
+                           TwinPropertiesCallback genericPropertiesCallback, Object genericPropertyCallbackContext)
             throws IOException, IllegalArgumentException, UnsupportedOperationException
     {
         verifyRegisteredIfMultiplexing();
@@ -698,7 +698,7 @@ public class InternalClient
             throw new IOException("Open the client connection before using it.");
         }
 
-        if (twinStatusCallback == null || genericPropertiesCallBack == null)
+        if (twinStatusCallback == null || genericPropertiesCallback == null)
         {
             throw new IllegalArgumentException("Callback cannot be null");
         }
@@ -710,8 +710,8 @@ public class InternalClient
                     this.config,
                     twinStatusCallback,
                     twinStatusCallbackContext,
-                    genericPropertiesCallBack,
-                    genericPropertyCallBackContext);
+                    genericPropertiesCallback,
+                    genericPropertyCallbackContext);
             twin.getDeviceTwin();
         }
         else
@@ -722,9 +722,9 @@ public class InternalClient
 
     /**
      * Get the twin for this client. This method sends a request for the twin to the service and will asynchronously
-     * provide the retrieved twin to the callback provided in {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallBack, Object)}.
+     * provide the retrieved twin to the callback provided in {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallback, Object)}.
      *
-     * Users must call {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallBack, Object)} before using this method.
+     * Users must call {@link #startTwinAsync(IotHubEventCallback, Object, TwinPropertyCallback, Object)} before using this method.
      * @throws IOException if the iot hub cannot be reached.
      */
     public void getTwinAsync() throws IOException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/Device.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/Device.java
@@ -8,10 +8,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 
-abstract public class Device implements PropertyCallBack<String, Object>
+abstract public class Device implements PropertyCallback<String, Object>
 {
     private final HashSet<Property> reportedProp = new HashSet<>();
-    private final HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredProp = new HashMap<>();
+    private final HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> desiredProp = new HashMap<>();
 
     public HashSet<Property> getReportedProp()
     {
@@ -48,19 +48,19 @@ abstract public class Device implements PropertyCallBack<String, Object>
         this.reportedProp.add(reportedProp);
     }
 
-    public HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> getDesiredProp()
+    public HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> getDesiredProp()
     {
         return this.desiredProp;
     }
 
-    public void setDesiredPropertyCallback(Property desiredProp, PropertyCallBack<String, Object> desiredPropCallBack, Object desiredPropCallBackContext)
+    public void setDesiredPropertyCallback(Property desiredProp, PropertyCallback<String, Object> desiredPropCallback, Object desiredPropCallbackContext)
     {
         if (desiredProp  == null)
         {
             throw new IllegalArgumentException("desired property cannot be null");
         }
 
-        this.desiredProp.put(desiredProp, new Pair<>(desiredPropCallBack, desiredPropCallBackContext));
+        this.desiredProp.put(desiredProp, new Pair<>(desiredPropCallback, desiredPropCallbackContext));
     }
 
     public void clean()
@@ -71,7 +71,7 @@ abstract public class Device implements PropertyCallBack<String, Object>
             repProperty.remove();
         }
 
-        for (Iterator<Map.Entry<Property, Pair<PropertyCallBack<String, Object>, Object>>> desiredProperty = desiredProp.entrySet().iterator(); desiredProperty.hasNext();)
+        for (Iterator<Map.Entry<Property, Pair<PropertyCallback<String, Object>, Object>>> desiredProperty = desiredProp.entrySet().iterator(); desiredProperty.hasNext();)
         {
             desiredProperty.next();
             desiredProperty.remove();

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/DeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/DeviceTwin.java
@@ -39,8 +39,8 @@ public class DeviceTwin
         Callbacks to respond to its user on desired property changes
      */
     @SuppressWarnings("rawtypes")
-    private final PropertyCallBack deviceTwinGenericPropertyChangeCallback;
-    private final TwinPropertyCallBack deviceTwinGenericTwinPropertyChangeCallback;
+    private final PropertyCallback deviceTwinGenericPropertyChangeCallback;
+    private final TwinPropertyCallback deviceTwinGenericTwinPropertyChangeCallback;
     private Object deviceTwinGenericPropertyChangeCallbackContext;
 
     // Callback for providing user all of a given desired property update message's contents, rather than providing
@@ -50,8 +50,8 @@ public class DeviceTwin
     /*
         Map of callbacks to call when a particular desired property changed
      */
-    private ConcurrentSkipListMap<String, Pair<PropertyCallBack<String, Object>, Object>> onDesiredPropertyChangeMap;
-    private ConcurrentSkipListMap<String, Pair<TwinPropertyCallBack, Object>> onDesiredTwinPropertyChangeMap;
+    private ConcurrentSkipListMap<String, Pair<PropertyCallback<String, Object>, Object>> onDesiredPropertyChangeMap;
+    private ConcurrentSkipListMap<String, Pair<TwinPropertyCallback, Object>> onDesiredTwinPropertyChangeMap;
 
     /*
         Callback invoked when a response to device twin operation is issued by iothub
@@ -142,7 +142,7 @@ public class DeviceTwin
                 // properties callback, then execute the callback so that they receive the full twin payload.
                 if (!desiredPropertyMap.isEmpty() && this.deviceTwinGenericTwinPropertiesChangeCallback != null)
                 {
-                    deviceTwinGenericTwinPropertiesChangeCallback.TwinPropertiesCallBack(desiredPropertyMap, deviceTwinGenericPropertyChangeCallbackContext);
+                    deviceTwinGenericTwinPropertiesChangeCallback.TwinPropertiesCallback(desiredPropertyMap, deviceTwinGenericPropertyChangeCallbackContext);
                 }
 
                 for (String propertyKey : desiredPropertyMap.keySet())
@@ -176,7 +176,7 @@ public class DeviceTwin
                     Property property = this.getReportedProperty(reportedPropertyMap, propertyKey);
                     if (deviceTwinGenericTwinPropertyChangeCallback != null)
                     {
-                        deviceTwinGenericTwinPropertyChangeCallback.TwinPropertyCallBack(property, deviceTwinGenericPropertyChangeCallbackContext);
+                        deviceTwinGenericTwinPropertyChangeCallback.TwinPropertyCallback(property, deviceTwinGenericPropertyChangeCallbackContext);
                     }
                 }
             }
@@ -253,7 +253,7 @@ public class DeviceTwin
 
     public <Type1, Type2> DeviceTwin(DeviceIO client, DeviceClientConfig config,
                       IotHubEventCallback deviceTwinCallback, Object deviceTwinCallbackContext,
-                      PropertyCallBack<Type1, Type2> genericPropertyCallback, Object genericPropertyCallbackContext)
+                      PropertyCallback<Type1, Type2> genericPropertyCallback, Object genericPropertyCallbackContext)
     {
         deviceTwinInternal(client, config, deviceTwinCallback, deviceTwinCallbackContext, genericPropertyCallbackContext);
 
@@ -264,7 +264,7 @@ public class DeviceTwin
 
     public DeviceTwin(DeviceIO client, DeviceClientConfig config,
                       IotHubEventCallback deviceTwinCallback, Object deviceTwinCallbackContext,
-                      TwinPropertyCallBack genericPropertyCallback, Object genericPropertyCallbackContext)
+                      TwinPropertyCallback genericPropertyCallback, Object genericPropertyCallbackContext)
     {
         deviceTwinInternal(client, config, deviceTwinCallback, deviceTwinCallbackContext, genericPropertyCallbackContext);
 
@@ -367,7 +367,7 @@ public class DeviceTwin
         this.deviceIO.sendEventAsync(updateReportedPropertiesRequest, reportedPropertiesCallback, callbackContext, this.config.getDeviceId());
     }
 
-    public void subscribeDesiredPropertiesNotification(Map<Property, Pair<PropertyCallBack<String, Object>, Object>> onDesiredPropertyChange)
+    public void subscribeDesiredPropertiesNotification(Map<Property, Pair<PropertyCallback<String, Object>, Object>> onDesiredPropertyChange)
     {
         if (onDesiredPropertyChangeMap == null)
         {
@@ -376,7 +376,7 @@ public class DeviceTwin
 
         if (onDesiredPropertyChange != null)
         {
-            for (Map.Entry<Property, Pair<PropertyCallBack<String, Object>, Object>> desired : onDesiredPropertyChange.entrySet())
+            for (Map.Entry<Property, Pair<PropertyCallback<String, Object>, Object>> desired : onDesiredPropertyChange.entrySet())
             {
                 onDesiredPropertyChangeMap.put(desired.getKey().getKey(), desired.getValue());
             }
@@ -385,7 +385,7 @@ public class DeviceTwin
         checkSubscription();
     }
 
-    public void subscribeDesiredPropertiesTwinPropertyNotification(Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange)
+    public void subscribeDesiredPropertiesTwinPropertyNotification(Map<Property, Pair<TwinPropertyCallback, Object>> onDesiredPropertyChange)
     {
         if (onDesiredTwinPropertyChangeMap == null)
         {
@@ -394,7 +394,7 @@ public class DeviceTwin
 
         if (onDesiredPropertyChange != null)
         {
-            for (Map.Entry<Property, Pair<TwinPropertyCallBack, Object>> desired : onDesiredPropertyChange.entrySet())
+            for (Map.Entry<Property, Pair<TwinPropertyCallback, Object>> desired : onDesiredPropertyChange.entrySet())
             {
                 onDesiredTwinPropertyChangeMap.put(desired.getKey().getKey(), desired.getValue());
             }
@@ -419,7 +419,7 @@ public class DeviceTwin
 
         if (onDesiredPropertyChangeMap != null && onDesiredPropertyChangeMap.containsKey(property.getKey()))
         {
-            Pair<PropertyCallBack<String, Object>, Object> callBackObjectPair = onDesiredPropertyChangeMap.get(property.getKey());
+            Pair<PropertyCallback<String, Object>, Object> callBackObjectPair = onDesiredPropertyChangeMap.get(property.getKey());
             if (callBackObjectPair != null && callBackObjectPair.getKey() != null)
             {
                 callBackObjectPair.getKey().PropertyCall(property.getKey(), property.getValue(), callBackObjectPair.getValue());
@@ -429,10 +429,10 @@ public class DeviceTwin
 
         if (onDesiredTwinPropertyChangeMap != null && onDesiredTwinPropertyChangeMap.containsKey(property.getKey()))
         {
-            Pair<TwinPropertyCallBack, Object> callBackObjectPair = onDesiredTwinPropertyChangeMap.get(property.getKey());
+            Pair<TwinPropertyCallback, Object> callBackObjectPair = onDesiredTwinPropertyChangeMap.get(property.getKey());
             if (callBackObjectPair != null && callBackObjectPair.getKey() != null)
             {
-                callBackObjectPair.getKey().TwinPropertyCallBack(property, callBackObjectPair.getValue());
+                callBackObjectPair.getKey().TwinPropertyCallback(property, callBackObjectPair.getValue());
                 reported = true;
             }
         }
@@ -454,7 +454,7 @@ public class DeviceTwin
 
         if (deviceTwinGenericTwinPropertyChangeCallback != null)
         {
-            deviceTwinGenericTwinPropertyChangeCallback.TwinPropertyCallBack(property, deviceTwinGenericPropertyChangeCallbackContext);
+            deviceTwinGenericTwinPropertyChangeCallback.TwinPropertyCallback(property, deviceTwinGenericPropertyChangeCallbackContext);
             return true;
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/PropertyCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/PropertyCallback.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.sdk.iot.device.twin;
  * @param <Type1> The type of the desired property key. Since the twin is a json object, the key will always be a String.
  * @param <Type2> The type of the desired property value.
  */
-public interface PropertyCallBack<Type1, Type2>
+public interface PropertyCallback<Type1, Type2>
 {
     /**
      * The callback that is triggered when there are changes in the client's twin desired properties.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinPropertiesCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinPropertiesCallback.java
@@ -6,10 +6,10 @@ package com.microsoft.azure.sdk.iot.device.twin;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
 
 /**
- * Interface for receiving desired property callbacks all at once. See {@link TwinPropertyCallBack} for the
+ * Interface for receiving desired property callbacks all at once. See {@link TwinPropertyCallback} for the
  * interface for receiving desired property callbacks one at a time.
  */
 public interface TwinPropertiesCallback
 {
-    void TwinPropertiesCallBack(TwinCollection properties, Object context);
+    void TwinPropertiesCallback(TwinCollection properties, Object context);
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinPropertyCallback.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinPropertyCallback.java
@@ -7,8 +7,8 @@ package com.microsoft.azure.sdk.iot.device.twin;
  * Interface for receiving desired property callbacks one property at a time. See {@link TwinPropertiesCallback} for the
  * interface for receiving desired property callbacks all at once.
  */
-public interface TwinPropertyCallBack
+public interface TwinPropertyCallback
 {
     @SuppressWarnings("MethodNameSameAsClassName") //This is a public interface, renaming this method would be a breaking-change
-    void TwinPropertyCallBack(Property property, Object context);
+    void TwinPropertyCallback(Property property, Object context);
 }

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
@@ -90,7 +90,7 @@ public class DeviceMethodTest
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void constructorThrowsIfCallBackNull() throws IllegalArgumentException
+    public void constructorThrowsIfCallbackNull() throws IllegalArgumentException
     {
         //act
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, null, null);
@@ -138,7 +138,7 @@ public class DeviceMethodTest
     **Tests_SRS_DEVICEMETHOD_25_004: [**If deviceMethodCallback parameter is null then this method shall throw IllegalArgumentException**]**
      */
    @Test (expected = IllegalArgumentException.class)
-    public void subscribeToMethodsThrowsIfCallBackNull() throws IllegalArgumentException
+    public void subscribeToMethodsThrowsIfCallbackNull() throws IllegalArgumentException
     {
         //arrange
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);
@@ -359,7 +359,7 @@ public class DeviceMethodTest
     }
 
     @Test
-    public void deviceMethodResponseCallbackDoesNotHangOnUserCallBackHang() throws IllegalArgumentException
+    public void deviceMethodResponseCallbackDoesNotHangOnUserCallbackHang() throws IllegalArgumentException
     {
         //arrange
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTest.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.sdk.iot.device.twin;
 import com.microsoft.azure.sdk.iot.device.twin.Device;
 import com.microsoft.azure.sdk.iot.device.twin.Pair;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.PropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.PropertyCallback;
 import mockit.Deencapsulation;
 import org.junit.Test;
 
@@ -170,7 +170,7 @@ public class DeviceTest
         testDev.setDesiredPropertyCallback(test, testDev, null);
 
         //act
-        HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
+        HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
 
         //assert
         assertNotNull(testDesiredMap);
@@ -199,7 +199,7 @@ public class DeviceTest
         testDev.setDesiredPropertyCallback(test, testDev, null);
 
         //assert
-        HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
+        HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
         assertNotNull(testDesiredMap);
         assertEquals(testDesiredMap.get(test).getKey(), testDev);
     }
@@ -249,7 +249,7 @@ public class DeviceTest
         testDev.setDesiredPropertyCallback(test, null, null);
 
         //assert
-        HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
+        HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
         assertNotNull(testDesiredMap);
         assertNull(testDesiredMap.get(test).getKey());
     }
@@ -274,7 +274,7 @@ public class DeviceTest
         testDev.setDesiredPropertyCallback(test, null, null);
 
         //assert
-        HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
+        HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
         assertNotNull(testDesiredMap);
         assertNull(testDesiredMap.get(test).getKey());
 
@@ -303,7 +303,7 @@ public class DeviceTest
         testDev.clean();
 
         //assert
-        HashMap<Property, Pair<PropertyCallBack<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
+        HashMap<Property, Pair<PropertyCallback<String, Object>, Object>> testDesiredMap = testDev.getDesiredProp();
         HashSet<Property> testRepMap = testDev.getReportedProp();
 
         assertTrue(testDesiredMap.isEmpty());

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
@@ -36,10 +36,10 @@ public class DeviceTwinTest
     IotHubEventCallback mockedStatusCB;
 
     @Mocked
-    PropertyCallBack mockedGenericPropertyCB;
+    PropertyCallback mockedGenericPropertyCB;
 
     @Mocked
-    TwinPropertyCallBack mockedGenericTwinPropertyCB;
+    TwinPropertyCallback mockedGenericTwinPropertyCB;
 
     /*
      **Tests_SRS_DEVICETWIN_25_003: [**The constructor shall save all the parameters specified i.e client, config, deviceTwinCallback.**]**
@@ -641,7 +641,7 @@ public class DeviceTwinTest
      */
     @Test
     public void subscribeToDesiredSetsCorrectOperation(@Mocked final IotHubTransportMessage mockedDeviceTwinMessage,
-                                                       @Mocked final PropertyCallBack<String, Object> mockedDesiredCB)
+                                                       @Mocked final PropertyCallback<String, Object> mockedDesiredCB)
     {
         // arrange
         new NonStrictExpectations()
@@ -653,14 +653,14 @@ public class DeviceTwinTest
         };
         DeviceTwin testTwin = new DeviceTwin(mockedDeviceIO, mockedConfig,
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
-        Map<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<PropertyCallback<String, Object>, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property("DesiredProp", "DesiredValue"), new Pair<>(mockedDesiredCB, null));
 
         // act
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
         // assert
-        final ConcurrentSkipListMap<String, Pair<PropertyCallBack<String, Object>, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredPropertyChangeMap");
+        final ConcurrentSkipListMap<String, Pair<PropertyCallback<String, Object>, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredPropertyChangeMap");
 
         assertNotNull(actualMap);
         assertFalse(actualMap.isEmpty());
@@ -680,7 +680,7 @@ public class DeviceTwinTest
 
     @Test
     public void subscribeToDesiredTwinPropertySetsCorrectOperation(@Mocked final IotHubTransportMessage mockedDeviceTwinMessage,
-                                                                   @Mocked final TwinPropertyCallBack mockedDesiredCB)
+                                                                   @Mocked final TwinPropertyCallback mockedDesiredCB)
     {
         // arrange
         new NonStrictExpectations()
@@ -692,14 +692,14 @@ public class DeviceTwinTest
         };
         DeviceTwin testTwin = new DeviceTwin(mockedDeviceIO, mockedConfig,
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property("DesiredProp", "DesiredValue"), new Pair<>(mockedDesiredCB, null));
 
         // act
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
         // assert
-        final ConcurrentSkipListMap<String, Pair<TwinPropertyCallBack, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredTwinPropertyChangeMap");
+        final ConcurrentSkipListMap<String, Pair<TwinPropertyCallback, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredTwinPropertyChangeMap");
 
         assertNotNull(actualMap);
         assertFalse(actualMap.isEmpty());
@@ -720,7 +720,7 @@ public class DeviceTwinTest
     @Test
     public void subscribeToDesiredDoesNotSubscribeIfAlreadySubscribed(
             @Mocked final IotHubTransportMessage mockedDeviceTwinMessage,
-            @Mocked final PropertyCallBack<String, Object> mockedDesiredCB)
+            @Mocked final PropertyCallback<String, Object> mockedDesiredCB)
     {
         // arrange
         new NonStrictExpectations()
@@ -732,7 +732,7 @@ public class DeviceTwinTest
         };
         DeviceTwin testTwin = new DeviceTwin(mockedDeviceIO, mockedConfig,
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
-        Map<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<PropertyCallback<String, Object>, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property("DesiredProp1", null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
@@ -744,7 +744,7 @@ public class DeviceTwinTest
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
         // assert
-        final ConcurrentSkipListMap<String, Pair<PropertyCallBack<String, Object>, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredPropertyChangeMap");
+        final ConcurrentSkipListMap<String, Pair<PropertyCallback<String, Object>, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredPropertyChangeMap");
 
         assertNotNull(actualMap);
         assertFalse(actualMap.isEmpty());
@@ -766,7 +766,7 @@ public class DeviceTwinTest
     @Test
     public void subscribeToDesiredTwinPropertyDoesNotSubscribeIfAlreadySubscribed(
             @Mocked final IotHubTransportMessage mockedDeviceTwinMessage,
-            @Mocked final TwinPropertyCallBack mockedDesiredCB)
+            @Mocked final TwinPropertyCallback mockedDesiredCB)
     {
         // arrange
         new NonStrictExpectations()
@@ -778,7 +778,7 @@ public class DeviceTwinTest
         };
         DeviceTwin testTwin = new DeviceTwin(mockedDeviceIO, mockedConfig,
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property("DesiredProp1", null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
@@ -790,7 +790,7 @@ public class DeviceTwinTest
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
         // assert
-        final ConcurrentSkipListMap<String, Pair<TwinPropertyCallBack, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredTwinPropertyChangeMap");
+        final ConcurrentSkipListMap<String, Pair<TwinPropertyCallback, Object>> actualMap = Deencapsulation.getField(testTwin, "onDesiredTwinPropertyChangeMap");
 
         assertNotNull(actualMap);
         assertFalse(actualMap.isEmpty());
@@ -861,7 +861,7 @@ public class DeviceTwinTest
      */
     @Test
     public void subscribeToDesiredCallsGenericCBOnDesiredChangeIfNoUserCBFound(
-            @Mocked final PropertyCallBack<String, Object> mockedDesiredCB)
+            @Mocked final PropertyCallback<String, Object> mockedDesiredCB)
     {
         // arrange
         final String prop1 = "DesiredProp1";
@@ -877,7 +877,7 @@ public class DeviceTwinTest
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
-        Map<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<PropertyCallback<String, Object>, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
@@ -896,7 +896,7 @@ public class DeviceTwinTest
 
     @Test
     public void subscribeToDesiredTwinPropertyCallsGenericCBOnDesiredChangeIfNoUserCBFound(
-            @Mocked final TwinPropertyCallBack mockedDesiredCB)
+            @Mocked final TwinPropertyCallback mockedDesiredCB)
     {
         // arrange
         final String prop1 = "DesiredProp1";
@@ -912,7 +912,7 @@ public class DeviceTwinTest
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
@@ -923,7 +923,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack((Property)any, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback((Property)any, null);
                 times = 1;
             }
         };
@@ -934,7 +934,7 @@ public class DeviceTwinTest
      */
     @Test
     public void subscribeToDesiredCallsUserCBOnDesiredChangeIfUserCBFound(
-            @Mocked final PropertyCallBack<String, Object> mockedDesiredCB)
+            @Mocked final PropertyCallback<String, Object> mockedDesiredCB)
     {
         // arrange
         final String prop1 = "DesiredProp1";
@@ -945,7 +945,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        Map<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<PropertyCallback<String, Object>, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
@@ -969,7 +969,7 @@ public class DeviceTwinTest
 
     @Test
     public void subscribeToDesiredTwinPropertyCallsUserCBOnDesiredChangeIfUserCBFound(
-            @Mocked final TwinPropertyCallBack mockedDesiredCB)
+            @Mocked final TwinPropertyCallback mockedDesiredCB)
     {
         // arrange
         final String prop1 = "DesiredProp1";
@@ -980,7 +980,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredMap = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredMap = new HashMap<>();
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
@@ -995,14 +995,14 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedDesiredCB.TwinPropertyCallBack((Property)any, null);
+                mockedDesiredCB.TwinPropertyCallback((Property)any, null);
                 times = 1;
             }
         };
     }
 
     @Test
-    public void getDeviceTwinResponseWithDesiredPropertiesCallsTwinPropertyCallBack(
+    public void getDeviceTwinResponseWithDesiredPropertiesCallsTwinPropertyCallback(
             @Mocked final Property mockedProperty)
     {
         // arrange
@@ -1039,14 +1039,14 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack(mockedProperty, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback(mockedProperty, null);
                 times = 1;
             }
         };
     }
 
     @Test
-    public void getDeviceTwinResponseWithReportedPropertiesCallsTwinPropertyCallBack(
+    public void getDeviceTwinResponseWithReportedPropertiesCallsTwinPropertyCallback(
             @Mocked final Property mockedProperty)
     {
         // arrange
@@ -1083,14 +1083,14 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack(mockedProperty, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback(mockedProperty, null);
                 times = 1;
             }
         };
     }
 
     @Test
-    public void getDeviceTwinResponseWithPropertiesCallsTwinPropertyCallBack(
+    public void getDeviceTwinResponseWithPropertiesCallsTwinPropertyCallback(
             @Mocked final Property mockedProperty)
     {
         // arrange
@@ -1132,14 +1132,14 @@ public class DeviceTwinTest
                         new Class[]{String.class, Object.class, Integer.class, boolean.class, Date.class, Integer.class},
                         reportedProp1, reportedVal2, reportedVersion, true, null, null);
                 times = 1;
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack((Property)any, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback((Property)any, null);
                 times = 2;
             }
         };
     }
 
     @Test
-    public void getDeviceTwinResponseWithPropertiesWithMetadataCallsTwinPropertyCallBack(
+    public void getDeviceTwinResponseWithPropertiesWithMetadataCallsTwinPropertyCallback(
             @Mocked final Property mockedProperty, @Mocked final ParserUtility mockedParserUtility, @Mocked final Date mockedData)
     {
         // arrange
@@ -1217,7 +1217,7 @@ public class DeviceTwinTest
                         new Class[]{String.class, Object.class, Integer.class, boolean.class, Date.class, Integer.class},
                         reportedProp1, reportedVal2, reportedVersion, true, (Date) any, lastUpdatedVersion);
                 times = 1;
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack((Property)any, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback((Property)any, null);
                 times = 2;
             }
         };
@@ -1238,8 +1238,8 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        Map<Property, Pair<PropertyCallBack<String, Object>, Object>> desiredMap = new HashMap<>();
-        desiredMap.put(new Property(prop1, null), new Pair<>((PropertyCallBack<String, Object>) null, null));
+        Map<Property, Pair<PropertyCallback<String, Object>, Object>> desiredMap = new HashMap<>();
+        desiredMap.put(new Property(prop1, null), new Pair<>((PropertyCallback<String, Object>) null, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
@@ -1271,8 +1271,8 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredMap = new HashMap<>();
-        desiredMap.put(new Property(prop1, null), new Pair<>((TwinPropertyCallBack) null, null));
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredMap = new HashMap<>();
+        desiredMap.put(new Property(prop1, null), new Pair<>((TwinPropertyCallback) null, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
@@ -1286,7 +1286,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack((Property)any, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback((Property)any, null);
                 times = 1;
             }
         };
@@ -1344,7 +1344,7 @@ public class DeviceTwinTest
         new Verifications()
         {
             {
-                mockedGenericTwinPropertyCB.TwinPropertyCallBack((Property)any, null);
+                mockedGenericTwinPropertyCB.TwinPropertyCallback((Property)any, null);
                 times = 1;
             }
         };
@@ -1359,7 +1359,7 @@ public class DeviceTwinTest
         final String json = "{\"" + prop1 + "\":\"" + val2 + "\"}";
 
         DeviceTwin testTwin = new DeviceTwin(mockedDeviceIO, mockedConfig,
-                mockedStatusCB, null, (TwinPropertyCallBack)null, null);
+                mockedStatusCB, null, (TwinPropertyCallback)null, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -38,7 +38,7 @@ public class InternalClientTest
     IotHubEventCallback mockedIotHubEventCallback;
 
     @Mocked
-    TwinPropertyCallBack mockedTwinPropertyCallback;
+    TwinPropertyCallback mockedTwinPropertyCallback;
 
     @Mocked
     DeviceClientConfig mockConfig;
@@ -559,7 +559,7 @@ public class InternalClientTest
     @Test
     public void startDeviceTwinSucceeds(@Mocked final DeviceTwin mockedDeviceTwin,
                                         @Mocked final IotHubEventCallback mockedStatusCB,
-                                        @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                        @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
     {
         //arrange
         
@@ -576,7 +576,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //assert
         new Verifications()
@@ -589,11 +589,11 @@ public class InternalClientTest
     }
 
     /*
-     **Tests_SRS_INTERNALCLIENT_25_026: [**If the deviceTwinStatusCallback or genericPropertyCallBack is null, the function shall throw an InvalidParameterException.**]**
+     **Tests_SRS_INTERNALCLIENT_25_026: [**If the deviceTwinStatusCallback or genericPropertyCallback is null, the function shall throw an InvalidParameterException.**]**
      */
     @Test (expected = IllegalArgumentException.class)
     public void startDeviceTwinThrowsIfStatusCBisNull(@Mocked final DeviceTwin mockedDeviceTwin,
-                                                      @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                      @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -611,7 +611,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, null, null, mockedPropertyCB, null);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, null, null, mockedPropertyCB, null);
 
         //assert
         new Verifications()
@@ -625,7 +625,7 @@ public class InternalClientTest
     }
 
     /*
-     **Tests_SRS_INTERNALCLIENT_25_026: [**If the deviceTwinStatusCallback or genericPropertyCallBack is null, the function shall throw an InvalidParameterException.**]**
+     **Tests_SRS_INTERNALCLIENT_25_026: [**If the deviceTwinStatusCallback or genericPropertyCallback is null, the function shall throw an InvalidParameterException.**]**
      */
     @Test (expected = IllegalArgumentException.class)
     public void startDeviceTwinThrowsIfPropCBisNull(@Mocked final DeviceTwin mockedDeviceTwin,
@@ -647,7 +647,7 @@ public class InternalClientTest
         Deencapsulation.invoke(client, "open");
 
         //act
-        Deencapsulation.invoke(client, "startTwinAsync", mockedStatusCB, null, (PropertyCallBack) null, null);
+        Deencapsulation.invoke(client, "startTwinAsync", mockedStatusCB, null, (PropertyCallback) null, null);
 
     }
 
@@ -657,7 +657,7 @@ public class InternalClientTest
     @Test
     public void startDeviceTwinThrowsIfCalledTwice(@Mocked final DeviceTwin mockedDeviceTwin,
                                                    @Mocked final IotHubEventCallback mockedStatusCB,
-                                                   @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                   @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -673,12 +673,12 @@ public class InternalClientTest
 
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
         {
-            Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+            Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
         }
         catch (UnsupportedOperationException expected)
         {
@@ -700,7 +700,7 @@ public class InternalClientTest
      */
     @Test (expected = IOException.class)
     public void startDeviceTwinThrowsIfCalledWhenClientNotOpen(@Mocked final IotHubEventCallback mockedStatusCB,
-                                                               @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                               @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -717,7 +717,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
 
         //act
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
     }
 
     /*
@@ -726,8 +726,8 @@ public class InternalClientTest
     @Test
     public void subscribeToDPSucceeds(@Mocked final DeviceTwin mockedDeviceTwin,
                                       @Mocked final IotHubEventCallback mockedStatusCB,
-                                      @Mocked final PropertyCallBack mockedPropertyCB,
-                                      @Mocked final Map<Property, Pair<PropertyCallBack<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
+                                      @Mocked final PropertyCallback mockedPropertyCB,
+                                      @Mocked final Map<Property, Pair<PropertyCallback<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -742,7 +742,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", mockMap);
@@ -761,7 +761,7 @@ public class InternalClientTest
     @Test
     public void subscribeToDPWorksWhenMapIsNull(@Mocked final DeviceTwin mockedDeviceTwin,
                                                 @Mocked final IotHubEventCallback mockedStatusCB,
-                                                @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -776,7 +776,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         Deencapsulation.invoke(client, "subscribeToDesiredPropertiesAsync", new Class[] {Map.class}, NULL_OBJECT);
@@ -798,8 +798,8 @@ public class InternalClientTest
     @Test
     public void subscribeToDPThrowsIfCalledWhenClientNotOpen(@Mocked final DeviceTwin mockedDeviceTwin,
                                                              @Mocked final IotHubEventCallback mockedStatusCB,
-                                                             @Mocked final PropertyCallBack mockedPropertyCB,
-                                                             @Mocked final Map<Property, Pair<PropertyCallBack<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
+                                                             @Mocked final PropertyCallback mockedPropertyCB,
+                                                             @Mocked final Map<Property, Pair<PropertyCallback<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -813,7 +813,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
@@ -840,7 +840,7 @@ public class InternalClientTest
      */
     @Test
     public void subscribeToDPThrowsIfCalledBeforeStartingTwin(@Mocked final DeviceTwin mockedDeviceTwin,
-                                                              @Mocked final Map<Property, Pair<PropertyCallBack<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
+                                                              @Mocked final Map<Property, Pair<PropertyCallback<String, Object>, Object>> mockMap) throws IOException, URISyntaxException
 
     {
         //arrange
@@ -881,7 +881,7 @@ public class InternalClientTest
     @Test
     public void sendRPSucceeds(@Mocked final DeviceTwin mockedDeviceTwin,
                                @Mocked final IotHubEventCallback mockedStatusCB,
-                               @Mocked final PropertyCallBack mockedPropertyCB,
+                               @Mocked final PropertyCallback mockedPropertyCB,
                                @Mocked final Set<Property> mockSet) throws IOException, URISyntaxException
     {
         //arrange
@@ -896,7 +896,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet);
@@ -914,7 +914,7 @@ public class InternalClientTest
     @Test
     public void sendRPWithVersionSucceeds(@Mocked final DeviceTwin mockedDeviceTwin,
                                           @Mocked final IotHubEventCallback mockedStatusCB,
-                                          @Mocked final PropertyCallBack mockedPropertyCB,
+                                          @Mocked final PropertyCallback mockedPropertyCB,
                                           @Mocked final Set<Property> mockSet) throws IOException, URISyntaxException
     {
         //arrange
@@ -929,7 +929,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         Deencapsulation.invoke(client, "sendReportedPropertiesAsync", mockSet, 10);
@@ -1106,7 +1106,7 @@ public class InternalClientTest
     @Test
     public void sendRPThrowsIfCalledWhenRPNullOrEmpty(@Mocked final DeviceTwin mockedDeviceTwin,
                                                       @Mocked final IotHubEventCallback mockedStatusCB,
-                                                      @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                      @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
     {
         //arrange
         
@@ -1120,7 +1120,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
@@ -1145,7 +1145,7 @@ public class InternalClientTest
     @Test
     public void sendRPWithVersionThrowsIfCalledWhenRPNullOrEmpty(@Mocked final DeviceTwin mockedDeviceTwin,
                                                                  @Mocked final IotHubEventCallback mockedStatusCB,
-                                                                 @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                                 @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
     {
         //arrange
         
@@ -1159,7 +1159,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
@@ -1187,7 +1187,7 @@ public class InternalClientTest
     @Test
     public void sendRPThrowsIfCalledWhenVersionIsNegative(@Mocked final DeviceTwin mockedDeviceTwin,
                                                           @Mocked final IotHubEventCallback mockedStatusCB,
-                                                          @Mocked final PropertyCallBack mockedPropertyCB,
+                                                          @Mocked final PropertyCallback mockedPropertyCB,
                                                           @Mocked final Set<Property> mockSet) throws IOException, URISyntaxException
     {
         //arrange
@@ -1202,7 +1202,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.invoke(client, "open");
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, NULL_OBJECT, mockedPropertyCB, NULL_OBJECT);
 
         //act
         try
@@ -1485,7 +1485,7 @@ public class InternalClientTest
     @Test
     public void subscribeToDPSucceedsEvenWhenUserCBIsNull(@Mocked final DeviceTwin mockedDeviceTwin,
                                                           @Mocked final IotHubEventCallback mockedStatusCB,
-                                                          @Mocked final PropertyCallBack mockedPropertyCB) throws IOException, URISyntaxException
+                                                          @Mocked final PropertyCallback mockedPropertyCB) throws IOException, URISyntaxException
     {
         //arrange
         final Device mockDevice = new Device()
@@ -1508,7 +1508,7 @@ public class InternalClientTest
         };
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         client.open();
-        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallBack.class, Object.class}, mockedStatusCB, null, mockedPropertyCB, null);
+        Deencapsulation.invoke(client, "startTwinAsync", new Class[] {IotHubEventCallback.class, Object.class, PropertyCallback.class, Object.class}, mockedStatusCB, null, mockedPropertyCB, null);
         mockDevice.setDesiredPropertyCallback(new Property("Desired", null), null, null);
 
         //act
@@ -1685,7 +1685,7 @@ public class InternalClientTest
         InternalClient client = Deencapsulation.newInstance(InternalClient.class, new Class[] {IotHubConnectionString.class, IotHubClientProtocol.class, long.class, long.class, ClientOptions.class}, mockIotHubConnectionString, protocol, SEND_PERIOD, RECEIVE_PERIOD, null);
         Deencapsulation.setField(client, "twin", null);
 
-        Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
         client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);
@@ -1708,7 +1708,7 @@ public class InternalClientTest
             }
         };
 
-        Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
         client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);
@@ -1731,7 +1731,7 @@ public class InternalClientTest
             }
         };
 
-        final Map<Property, Pair<TwinPropertyCallBack, Object>> onDesiredPropertyChange = new HashMap<>();
+        final Map<Property, Pair<TwinPropertyCallback, Object>> onDesiredPropertyChange = new HashMap<>();
 
         // act
         client.subscribeToTwinDesiredPropertiesAsync(onDesiredPropertyChange);

--- a/device/iot-device-samples/android-sample/app/src/main/java/com/iothub/azure/microsoft/com/androidsample/MainActivity.java
+++ b/device/iot-device-samples/android-sample/app/src/main/java/com/iothub/azure/microsoft/com/androidsample/MainActivity.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.twin.Pair;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubMessageResult;
@@ -85,7 +85,7 @@ public class MainActivity extends AppCompatActivity {
         return METHOD_NOT_DEFINED;
     }
 
-    protected static class DeviceMethodStatusCallBack implements IotHubEventCallback
+    protected static class DeviceMethodStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -121,7 +121,7 @@ public class MainActivity extends AppCompatActivity {
 
     private static AtomicBoolean Succeed = new AtomicBoolean(false);
 
-    protected static class DeviceTwinStatusCallBack implements IotHubEventCallback
+    protected static class DeviceTwinStatusCallback implements IotHubEventCallback
     {
         @Override
         public void execute(IotHubStatusCode status, Object context)
@@ -138,10 +138,10 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    protected static class onProperty implements TwinPropertyCallBack
+    protected static class onProperty implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onProperty callback for " + (property.getIsReported()?"reported": "desired") +
@@ -170,9 +170,9 @@ public class MainActivity extends AppCompatActivity {
                 Counter counter = new Counter(0);
                 client.setMessageCallback(callback, counter);
             }
-            client.subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            client.subscribeToDeviceMethod(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallback(), null);
             Succeed.set(false);
-            client.startDeviceTwin(new DeviceTwinStatusCallBack(), null, new onProperty(), null);
+            client.startDeviceTwin(new DeviceTwinStatusCallback(), null, new onProperty(), null);
 
             do
             {
@@ -180,13 +180,13 @@ public class MainActivity extends AppCompatActivity {
             }
             while(!Succeed.get());
 
-            Map<Property, Pair<TwinPropertyCallBack, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallBack, Object>>()
+            Map<Property, Pair<TwinPropertyCallback, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallback, Object>>()
             {
                 {
-                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
+                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
                 }
             };
 
@@ -281,7 +281,7 @@ public class MainActivity extends AppCompatActivity {
             }
             else
             {
-                client.uploadToBlobAsync(file.getName(), new FileInputStream(file), file.length(), new FileUploadStatusCallBack(), null);
+                client.uploadToBlobAsync(file.getName(), new FileInputStream(file), file.length(), new FileUploadStatusCallback(), null);
             }
 
             System.out.println("File upload started with success");
@@ -294,7 +294,7 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    protected static class FileUploadStatusCallBack implements IotHubEventCallback
+    protected static class FileUploadStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {

--- a/device/iot-device-samples/device-method-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceMethodSample.java
+++ b/device/iot-device-samples/device-method-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceMethodSample.java
@@ -38,7 +38,7 @@ public class DeviceMethodSample
         return METHOD_NOT_DEFINED;
     }
 
-    protected static class DeviceMethodStatusCallBack implements IotHubEventCallback
+    protected static class DeviceMethodStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -177,7 +177,7 @@ public class DeviceMethodSample
 
             System.out.println("Opened connection to IoT Hub.");
 
-            client.subscribeToMethodsAsync(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            client.subscribeToMethodsAsync(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallback(), null);
 
             System.out.println("Subscribed to device method");
 

--- a/device/iot-device-samples/device-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceTwinSample.java
+++ b/device/iot-device-samples/device-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceTwinSample.java
@@ -109,7 +109,7 @@ public class DeviceTwinSample
     }
 
 
-    protected static class DeviceTwinStatusCallBack implements IotHubEventCallback
+    protected static class DeviceTwinStatusCallback implements IotHubEventCallback
     {
         @Override
         public void execute(IotHubStatusCode status, Object context)
@@ -159,12 +159,12 @@ public class DeviceTwinSample
     }
 
     /*
-     * If you don't care about version, you can use the PropertyCallBack.
+     * If you don't care about version, you can use the PropertyCallback.
      */
-    protected static class onHomeTempChange implements TwinPropertyCallBack
+    protected static class onHomeTempChange implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onHomeTempChange change " + property.getKey() +
@@ -173,10 +173,10 @@ public class DeviceTwinSample
         }
     }
 
-    protected static class onCameraActivity implements TwinPropertyCallBack
+    protected static class onCameraActivity implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onCameraActivity change " + property.getKey() +
@@ -185,10 +185,10 @@ public class DeviceTwinSample
         }
     }
 
-    protected static class onProperty implements TwinPropertyCallBack
+    protected static class onProperty implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onProperty callback for " + (property.getIsReported()?"reported": "desired") +
@@ -312,7 +312,7 @@ public class DeviceTwinSample
             System.out.println("Start device Twin and get remaining properties...");
             // Properties already set in the Service will shows up in the generic onProperty callback, with value and version.
             Succeed.set(false);
-            client.startTwinAsync(new DeviceTwinStatusCallBack(), null, new onProperty(), null);
+            client.startTwinAsync(new DeviceTwinStatusCallback(), null, new onProperty(), null);
             do
             {
                 Thread.sleep(1000);
@@ -321,13 +321,13 @@ public class DeviceTwinSample
 
 
             System.out.println("Subscribe to Desired properties on device Twin...");
-            Map<Property, Pair<TwinPropertyCallBack, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallBack, Object>>()
+            Map<Property, Pair<TwinPropertyCallback, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallback, Object>>()
             {
                 {
-                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallBack, Object>(new onHomeTempChange(), null));
-                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallBack, Object>(new onCameraActivity(), null));
+                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallback, Object>(new onHomeTempChange(), null));
+                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallback, Object>(new onCameraActivity(), null));
                 }
             };
             client.subscribeToTwinDesiredPropertiesAsync(desiredProperties);

--- a/device/iot-device-samples/module-method-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ModuleMethodSample.java
+++ b/device/iot-device-samples/module-method-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ModuleMethodSample.java
@@ -39,7 +39,7 @@ public class ModuleMethodSample
         return METHOD_NOT_DEFINED;
     }
 
-    protected static class DeviceMethodStatusCallBack implements IotHubEventCallback
+    protected static class DeviceMethodStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -166,7 +166,7 @@ public class ModuleMethodSample
 
             System.out.println("Opened connection to IoT Hub.");
 
-            client.subscribeToMethodsAsync(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+            client.subscribeToMethodsAsync(new SampleDeviceMethodCallback(), null, new DeviceMethodStatusCallback(), null);
 
             System.out.println("Subscribed to device method");
 

--- a/device/iot-device-samples/module-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ModuleTwinSample.java
+++ b/device/iot-device-samples/module-twin-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ModuleTwinSample.java
@@ -32,7 +32,7 @@ public class ModuleTwinSample
 
     private static final AtomicBoolean Succeed = new AtomicBoolean(false);
 
-    protected static class DeviceTwinStatusCallBack implements IotHubEventCallback
+    protected static class DeviceTwinStatusCallback implements IotHubEventCallback
     {
         @Override
         public void execute(IotHubStatusCode status, Object context)
@@ -43,12 +43,12 @@ public class ModuleTwinSample
     }
 
     /*
-     * If you don't care about version, you can use the PropertyCallBack.
+     * If you don't care about version, you can use the PropertyCallback.
      */
-    protected static class onHomeTempChange implements TwinPropertyCallBack
+    protected static class onHomeTempChange implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onHomeTempChange change " + property.getKey() +
@@ -57,10 +57,10 @@ public class ModuleTwinSample
         }
     }
 
-    protected static class onCameraActivity implements TwinPropertyCallBack
+    protected static class onCameraActivity implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onCameraActivity change " + property.getKey() +
@@ -69,10 +69,10 @@ public class ModuleTwinSample
         }
     }
 
-    protected static class onProperty implements TwinPropertyCallBack
+    protected static class onProperty implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onProperty callback for " + (property.getIsReported()?"reported": "desired") +
@@ -185,7 +185,7 @@ public class ModuleTwinSample
             System.out.println("Start device Twin and get remaining properties...");
             // Properties already set in the Service will shows up in the generic onProperty callback, with value and version.
             Succeed.set(false);
-            client.startTwinAsync(new DeviceTwinStatusCallBack(), null, new onProperty(), null);
+            client.startTwinAsync(new DeviceTwinStatusCallback(), null, new onProperty(), null);
             do
             {
                 Thread.sleep(1000);
@@ -194,13 +194,13 @@ public class ModuleTwinSample
 
 
             System.out.println("Subscribe to Desired properties on device Twin...");
-            Map<Property, Pair<TwinPropertyCallBack, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallBack, Object>>()
+            Map<Property, Pair<TwinPropertyCallback, Object>> desiredProperties = new HashMap<Property, Pair<TwinPropertyCallback, Object>>()
             {
                 {
-                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallBack, Object>(new onHomeTempChange(), null));
-                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallBack, Object>(new onProperty(), null));
-                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallBack, Object>(new onCameraActivity(), null));
+                    put(new Property("HomeTemp(F)", null), new Pair<TwinPropertyCallback, Object>(new onHomeTempChange(), null));
+                    put(new Property("LivingRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("BedroomRoomLights", null), new Pair<TwinPropertyCallback, Object>(new onProperty(), null));
+                    put(new Property("HomeSecurityCamera", null), new Pair<TwinPropertyCallback, Object>(new onCameraActivity(), null));
                 }
             };
             client.subscribeToTwinDesiredPropertiesAsync(desiredProperties);

--- a/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/TemperatureController.java
+++ b/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/TemperatureController.java
@@ -159,11 +159,11 @@ public class TemperatureController {
 
         log.debug("Set handler to receive \"targetTemperature\" updates.");
         deviceClient.startTwinAsync(new TwinIotHubEventCallback(), null, new GenericPropertyUpdateCallback(), null);
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertyUpdateCallback = Stream.of(
-                new AbstractMap.SimpleEntry<Property, Pair<TwinPropertyCallBack, Object>>(
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredPropertyUpdateCallback = Stream.of(
+                new AbstractMap.SimpleEntry<Property, Pair<TwinPropertyCallback, Object>>(
                         new Property(THERMOSTAT_1, null),
                         new Pair<>(new TargetTemperatureUpdateCallback(), THERMOSTAT_1)),
-                new AbstractMap.SimpleEntry<Property, Pair<TwinPropertyCallBack, Object>>(
+                new AbstractMap.SimpleEntry<Property, Pair<TwinPropertyCallback, Object>>(
                         new Property(THERMOSTAT_2, null),
                         new Pair<>(new TargetTemperatureUpdateCallback(), THERMOSTAT_2))
         ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
@@ -363,14 +363,14 @@ public class TemperatureController {
      * The desired property update callback, which receives the target temperature as a desired property update,
      * and updates the current temperature value over telemetry and reported property update.
      */
-    private static class TargetTemperatureUpdateCallback implements TwinPropertyCallBack
+    private static class TargetTemperatureUpdateCallback implements TwinPropertyCallback
     {
 
         final String propertyName = "targetTemperature";
 
         @SneakyThrows({IOException.class, InterruptedException.class})
         @Override
-        public void TwinPropertyCallBack(Property property, Object context) {
+        public void TwinPropertyCallback(Property property, Object context) {
             String componentName = (String) context;
 
             if (property.getKey().equalsIgnoreCase(componentName)) {
@@ -524,11 +524,11 @@ public class TemperatureController {
     /**
      * The callback to be invoked for a property change that is not explicitly monitored by the device.
      */
-    private static class GenericPropertyUpdateCallback implements TwinPropertyCallBack
+    private static class GenericPropertyUpdateCallback implements TwinPropertyCallback
     {
 
         @Override
-        public void TwinPropertyCallBack(Property property, Object context) {
+        public void TwinPropertyCallback(Property property, Object context) {
             log.debug("Property - Received property unhandled by device, key={}, value={}", property.getKey(), property.getValue());
         }
     }

--- a/device/iot-device-samples/pnp-device-sample/thermostat-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/Thermostat.java
+++ b/device/iot-device-samples/pnp-device-sample/thermostat-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/Thermostat.java
@@ -141,7 +141,7 @@ public class Thermostat {
 
         log.debug("Start twin and set handler to receive \"targetTemperature\" updates.");
         deviceClient.startTwinAsync(new TwinIotHubEventCallback(), null, new TargetTemperatureUpdateCallback(), null);
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertyUpdateCallback =
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredPropertyUpdateCallback =
                 Collections.singletonMap(
                         new Property("targetTemperature", null),
                         new Pair<>(new TargetTemperatureUpdateCallback(), null));
@@ -249,14 +249,14 @@ public class Thermostat {
      * The desired property update callback, which receives the target temperature as a desired property update,
      * and updates the current temperature value over telemetry and reported property update.
      */
-    private static class TargetTemperatureUpdateCallback implements TwinPropertyCallBack
+    private static class TargetTemperatureUpdateCallback implements TwinPropertyCallback
     {
 
         final String propertyName = "targetTemperature";
 
         @SneakyThrows({InterruptedException.class, IOException.class})
         @Override
-        public void TwinPropertyCallBack(Property property, Object context) {
+        public void TwinPropertyCallback(Property property, Object context) {
             if (property.getKey().equalsIgnoreCase(propertyName)) {
                 double targetTemperature = ((Number)property.getValue()).doubleValue();
                 log.debug("Property: Received - {\"{}\": {}°C}.", propertyName, targetTemperature);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
@@ -10,7 +10,7 @@ import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodCallback;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.twin.Pair;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.service.Device;
@@ -311,7 +311,7 @@ public class DigitalTwinClientTests extends IntegrationTest
         Integer newPropertyValue = 35;
 
         // Property update callback
-        TwinPropertyCallBack twinPropertyCallBack = (property, context) -> {
+        TwinPropertyCallback twinPropertyCallback = (property, context) -> {
             Set<Property> properties = new HashSet<>();
             properties.add(property);
             try {
@@ -324,11 +324,11 @@ public class DigitalTwinClientTests extends IntegrationTest
         IotHubEventCallback iotHubEventCallback = (responseStatus, callbackContext) -> {};
 
         // start device twin and setup handler for property updates in device
-        deviceClient.startTwinAsync(iotHubEventCallback, null, twinPropertyCallBack, null);
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertyUpdateCallback =
+        deviceClient.startTwinAsync(iotHubEventCallback, null, twinPropertyCallback, null);
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredPropertyUpdateCallback =
                 Collections.singletonMap(
                         new Property(newProperty, null),
-                        new Pair<>(twinPropertyCallBack, null));
+                        new Pair<>(twinPropertyCallback, null));
         deviceClient.subscribeToTwinDesiredPropertiesAsync(desiredPropertyUpdateCallback);
 
         DigitalTwinUpdateRequestOptions optionsWithoutEtag = new DigitalTwinUpdateRequestOptions();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/DeviceEmulator.java
@@ -143,21 +143,21 @@ public class DeviceEmulator
     /**
      * Enable device twin on the emulated device.
      *
-     * @param deviceTwinStatusCallBack callback to twin status. If {@code null}, use the local status callback.
-     * @param deviceTwinStatusCallbackContext context for status callback. Used only if deviceTwinStatusCallBack is not {@code null}.
+     * @param deviceTwinStatusCallback callback to twin status. If {@code null}, use the local status callback.
+     * @param deviceTwinStatusCallbackContext context for status callback. Used only if deviceTwinStatusCallback is not {@code null}.
      * @param deviceTwin is the device twin including the properties callback. If {@code null}, use the local device with standard properties.
-     * @param propertyCallBackContext context for the properties callback. Used only if deviceTwin is not {@code null}.
+     * @param propertyCallbackContext context for the properties callback. Used only if deviceTwin is not {@code null}.
      * @param mustSubscribeToDesiredProperties is a boolean to define if it should or not subscribe to the desired properties.
      * @throws IOException if failed to start the Device twin.
      */
     @SuppressWarnings("SameParameterValue") // DeviceEmulator will subscribe to default callback in case the supplied callback is null
-    void subscribeToDeviceTwin(IotHubEventCallback deviceTwinStatusCallBack, Object deviceTwinStatusCallbackContext,
-                               Device deviceTwin, Object propertyCallBackContext, boolean mustSubscribeToDesiredProperties) throws IOException
+    void subscribeToDeviceTwin(IotHubEventCallback deviceTwinStatusCallback, Object deviceTwinStatusCallbackContext,
+                               Device deviceTwin, Object propertyCallbackContext, boolean mustSubscribeToDesiredProperties) throws IOException
     {
         // If user do not provide any status callback, use the local one.
-        if(deviceTwinStatusCallBack == null)
+        if(deviceTwinStatusCallback == null)
         {
-            deviceTwinStatusCallBack = new DeviceStatusCallback();
+            deviceTwinStatusCallback = new DeviceStatusCallback();
             deviceTwinStatusCallbackContext = deviceStatus;
         }
 
@@ -165,10 +165,10 @@ public class DeviceEmulator
         if(deviceTwin == null)
         {
             deviceTwin = new DeviceTwinProperty();
-            propertyCallBackContext = twinChanges;
+            propertyCallbackContext = twinChanges;
         }
 
-        client.startTwinAsync(deviceTwinStatusCallBack, deviceTwinStatusCallbackContext, deviceTwin, propertyCallBackContext);
+        client.startTwinAsync(deviceTwinStatusCallback, deviceTwinStatusCallbackContext, deviceTwin, propertyCallbackContext);
 
         if(mustSubscribeToDesiredProperties)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -135,7 +135,7 @@ public class FileUploadTests extends IntegrationTest
         String blobName;
         InputStream fileInputStream;
         long fileLength;
-        boolean isCallBackTriggered;
+        boolean isCallbackTriggered;
         STATUS fileUploadStatus;
         STATUS fileUploadNotificationReceived;
     }
@@ -156,7 +156,7 @@ public class FileUploadTests extends IntegrationTest
             if (context instanceof FileUploadState)
             {
                 FileUploadState fileUploadState = (FileUploadState) context;
-                fileUploadState.isCallBackTriggered = true;
+                fileUploadState.isCallbackTriggered = true;
 
                 // On failure, Don't update fileUploadStatus any further
                 if ((responseStatus == OK || responseStatus == OK_EMPTY) && fileUploadState.fileUploadStatus != FAILURE)
@@ -199,7 +199,7 @@ public class FileUploadTests extends IntegrationTest
             testInstance.fileUploadState[i].fileLength = buf.length;
             testInstance.fileUploadState[i].fileUploadStatus = SUCCESS;
             testInstance.fileUploadState[i].fileUploadNotificationReceived = FAILURE;
-            testInstance.fileUploadState[i].isCallBackTriggered = false;
+            testInstance.fileUploadState[i].isCallbackTriggered = false;
 
             testInstance.messageStates[i] = new MessageState();
             testInstance.messageStates[i].messageBody = new String(buf);
@@ -285,16 +285,16 @@ public class FileUploadTests extends IntegrationTest
 
     private void waitForFileUploadStatusCallbackTriggered(int fileUploadStateIndex, DeviceClient deviceClient) throws InterruptedException
     {
-        if (!testInstance.fileUploadState[fileUploadStateIndex].isCallBackTriggered)
+        if (!testInstance.fileUploadState[fileUploadStateIndex].isCallbackTriggered)
         {
             //wait until file upload callback is triggered
             long startTime = System.currentTimeMillis();
-            while (!testInstance.fileUploadState[fileUploadStateIndex].isCallBackTriggered)
+            while (!testInstance.fileUploadState[fileUploadStateIndex].isCallbackTriggered)
             {
                 Thread.sleep(300);
                 if (System.currentTimeMillis() - startTime > MAXIMUM_TIME_TO_WAIT_FOR_CALLBACK_MILLISECONDS)
                 {
-                    assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), testInstance.fileUploadState[fileUploadStateIndex].isCallBackTriggered);
+                    assertTrue(buildExceptionMessage("File upload callback was not triggered", deviceClient), testInstance.fileUploadState[fileUploadStateIndex].isCallbackTriggered);
                 }
             }
         }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
@@ -174,7 +174,7 @@ public class HubTierConnectionTests extends IntegrationTest
         }
     }
 
-    protected static class DeviceMethodStatusCallBack implements IotHubEventCallback
+    protected static class DeviceMethodStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -193,7 +193,7 @@ public class HubTierConnectionTests extends IntegrationTest
         testInstance.client.open();
 
         //act
-        testInstance.client.subscribeToMethodsAsync(new DeviceMethodCallback(), null, new DeviceMethodStatusCallBack(), null);
+        testInstance.client.subscribeToMethodsAsync(new DeviceMethodCallback(), null, new DeviceMethodStatusCallback(), null);
 
         //assert
         waitForDisconnect(connectionStatusUpdates, WAIT_FOR_DISCONNECT_TIMEOUT_MILLISECONDS, testInstance.client);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DesiredPropertiesErrInjTests.java
@@ -541,7 +541,7 @@ public class DesiredPropertiesErrInjTests extends DeviceTwinCommon
     {
         // Arrange
         List<com.microsoft.azure.sdk.iot.device.twin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
-        setConnectionStatusCallBack(actualStatusUpdates);
+        setConnectionStatusCallback(actualStatusUpdates);
         subscribeToDesiredPropertiesAndVerify(1, propertyValue, updatePropertyValue, update1Prefix);
 
         // Act

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/DeviceMethodErrInjTests.java
@@ -245,7 +245,7 @@ public class DeviceMethodErrInjTests extends DeviceMethodCommon
     {
         // Arrange
         List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
-        setConnectionStatusCallBack(actualStatusUpdates);
+        setConnectionStatusCallback(actualStatusUpdates);
         invokeMethodSucceed();
 
         // Act

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/GetTwinErrInjTests.java
@@ -246,7 +246,7 @@ public class GetTwinErrInjTests extends DeviceTwinCommon
     {
         // Arrange
         List<com.microsoft.azure.sdk.iot.device.twin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
-        setConnectionStatusCallBack(actualStatusUpdates);
+        setConnectionStatusCallback(actualStatusUpdates);
         testGetDeviceTwin();
 
         // Act

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/errorinjection/ReportedPropertiesErrInjTests.java
@@ -216,7 +216,7 @@ public class ReportedPropertiesErrInjTests extends DeviceTwinCommon
     {
         // Arrange
         List<com.microsoft.azure.sdk.iot.device.twin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates = new ArrayList<>();
-        setConnectionStatusCallBack(actualStatusUpdates);
+        setConnectionStatusCallback(actualStatusUpdates);
         sendReportedPropertiesAndVerify(1);
 
         // Act

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceMethodCommon.java
@@ -279,7 +279,7 @@ public class DeviceMethodCommon extends IntegrationTest
         }
     }
 
-    protected void setConnectionStatusCallBack(final List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
+    protected void setConnectionStatusCallback(final List<Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
     {
 
         IotHubConnectionStatusChangeCallback connectionStatusUpdateCallback = (status, statusChangeReason, throwable, callbackContext) -> actualStatusUpdates.add(new Pair<>(status, throwable));

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/DeviceTwinCommon.java
@@ -10,7 +10,7 @@ import com.google.gson.JsonParser;
 import com.microsoft.azure.sdk.iot.deps.twin.TwinConnectionState;
 import com.microsoft.azure.sdk.iot.device.twin.Device;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.InternalClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeCallback;
@@ -161,7 +161,7 @@ public class DeviceTwinCommon extends IntegrationTest
     // How much to wait until a message makes it to the server, in milliseconds
     protected static final Integer SEND_TIMEOUT_MILLISECONDS = 60000;
 
-    public class DeviceTwinStatusCallBack implements IotHubEventCallback
+    public class DeviceTwinStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -197,10 +197,10 @@ public class DeviceTwinCommon extends IntegrationTest
         public Integer propertyNewVersion;
     }
 
-    public class OnProperty implements TwinPropertyCallBack
+    public class OnProperty implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             PropertyState propertyState = (PropertyState) context;
             if (property.getKey().equals(propertyState.property.getKey()))
@@ -326,7 +326,7 @@ public class DeviceTwinCommon extends IntegrationTest
         if (openDeviceClient)
         {
             client.open();
-            client.startTwinAsync(new DeviceTwinStatusCallBack(), deviceState, deviceState.dCDeviceForTwin, deviceState);
+            client.startTwinAsync(new DeviceTwinStatusCallback(), deviceState, deviceState.dCDeviceForTwin, deviceState);
         }
 
         deviceState.deviceTwinStatus = IotHubStatusCode.ERROR;
@@ -641,7 +641,7 @@ public class DeviceTwinCommon extends IntegrationTest
         waitAndVerifyDesiredPropertyCallback(propertyNewValuePrefix, false);
     }
 
-    protected void setConnectionStatusCallBack(final List<com.microsoft.azure.sdk.iot.device.twin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
+    protected void setConnectionStatusCallback(final List<com.microsoft.azure.sdk.iot.device.twin.Pair<IotHubConnectionStatus, Throwable>> actualStatusUpdates)
     {
         IotHubConnectionStatusChangeCallback connectionStatusUpdateCallback = (status, statusChangeReason, throwable, callbackContext) -> actualStatusUpdates.add(new com.microsoft.azure.sdk.iot.device.twin.Pair<>(status, throwable));
 
@@ -651,7 +651,7 @@ public class DeviceTwinCommon extends IntegrationTest
     protected void testGetDeviceTwin() throws IOException, InterruptedException, IotHubException
     {
         // arrange
-        Map<Property, com.microsoft.azure.sdk.iot.device.twin.Pair<TwinPropertyCallBack, Object>> desiredPropertiesCB = new HashMap<>();
+        Map<Property, com.microsoft.azure.sdk.iot.device.twin.Pair<TwinPropertyCallback, Object>> desiredPropertiesCB = new HashMap<>();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             PropertyState propertyState = new PropertyState();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DesiredPropertiesTests.java
@@ -10,7 +10,7 @@ import com.microsoft.azure.sdk.iot.deps.twin.TwinCollection;
 import com.microsoft.azure.sdk.iot.device.twin.Pair;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
 import com.microsoft.azure.sdk.iot.device.twin.TwinPropertiesCallback;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -180,7 +180,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         // arrange
         testInstance.deviceUnderTest.sCDeviceForTwin.clearTwin();
         testInstance.deviceUnderTest.dCDeviceForTwin.getDesiredProp().clear();
-        Map<Property, Pair<TwinPropertyCallBack, Object>> desiredPropertiesCB = new HashMap<>();
+        Map<Property, Pair<TwinPropertyCallback, Object>> desiredPropertiesCB = new HashMap<>();
         for (int i = 0; i < MAX_PROPERTIES_TO_TEST; i++)
         {
             PropertyState propertyState = new PropertyState();
@@ -327,7 +327,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         TwinCollection expectedProperties;
 
         @Override
-        public void TwinPropertiesCallBack(TwinCollection actualProperties, Object context) {
+        public void TwinPropertiesCallback(TwinCollection actualProperties, Object context) {
             Success desiredPropertiesCallbackState = (Success) context;
             desiredPropertiesCallbackState.callbackWasFired();
 
@@ -382,7 +382,7 @@ public class DesiredPropertiesTests extends DeviceTwinCommon
         Success desiredPropertiesCallbackState = new Success();
 
         testInstance.testIdentity.getClient().open();
-        testInstance.testIdentity.getClient().startTwinAsync(new DeviceTwinStatusCallBack(), testInstance.deviceUnderTest, twinPropertiesCallback, desiredPropertiesCallbackState);
+        testInstance.testIdentity.getClient().startTwinAsync(new DeviceTwinStatusCallback(), testInstance.deviceUnderTest, twinPropertiesCallback, desiredPropertiesCallbackState);
 
         long startTime = System.currentTimeMillis();
         while (testInstance.deviceUnderTest.deviceTwinStatus != IotHubStatusCode.OK)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/DeviceTwinWithVersionTests.java
@@ -8,7 +8,7 @@ package tests.integration.com.microsoft.azure.sdk.iot.iothub.twin;
 
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
@@ -129,10 +129,10 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         return null;
     }
 
-    private static class DeviceTwinPropertyCallback implements TwinPropertyCallBack
+    private static class DeviceTwinPropertyCallback implements TwinPropertyCallback
     {
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             DeviceTwinWithVersionTestDevice state = (DeviceTwinWithVersionTestDevice) context;
             state.receivedProperties.add(property);
@@ -161,7 +161,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
         }
     }
 
-    protected static class DeviceTwinStatusCallBack implements IotHubEventCallback
+    protected static class DeviceTwinStatusCallback implements IotHubEventCallback
     {
         public void execute(IotHubStatusCode status, Object context)
         {
@@ -210,7 +210,7 @@ public class DeviceTwinWithVersionTests extends IntegrationTest
     {
         testInstance.deviceTwinWithVersionTestDevice.deviceClient = new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, testInstance.deviceForRegistryManager), protocol);
         testInstance.deviceTwinWithVersionTestDevice.deviceClient.open();
-        testInstance.deviceTwinWithVersionTestDevice.deviceClient.startTwinAsync(new DeviceTwinStatusCallBack(), testInstance.deviceTwinWithVersionTestDevice, new DeviceTwinPropertyCallback(), testInstance.deviceTwinWithVersionTestDevice);
+        testInstance.deviceTwinWithVersionTestDevice.deviceClient.startTwinAsync(new DeviceTwinStatusCallback(), testInstance.deviceTwinWithVersionTestDevice, new DeviceTwinPropertyCallback(), testInstance.deviceTwinWithVersionTestDevice);
     }
 
     @Before

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
@@ -9,7 +9,7 @@ package tests.integration.com.microsoft.azure.sdk.iot.provisioning;
 import com.microsoft.azure.sdk.iot.deps.twin.DeviceCapabilities;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.PropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.PropertyCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.IotHubEventCallback;
 import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
@@ -299,7 +299,7 @@ public class ProvisioningTests extends ProvisioningCommon
         assertTwinIsCorrect(reprovisionPolicy, expectedReportedPropertyName, expectedReportedPropertyValue, !reprovisionPolicy.getUpdateHubAssignment());
     }
 
-    private static class StubTwinCallback implements IotHubEventCallback, PropertyCallBack
+    private static class StubTwinCallback implements IotHubEventCallback, PropertyCallback
     {
         private final CountDownLatch twinLock;
 

--- a/iot-e2e-tests/edge-e2e/src/main/java/glue/ModuleGlue.java
+++ b/iot-e2e-tests/edge-e2e/src/main/java/glue/ModuleGlue.java
@@ -4,7 +4,7 @@ import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodCallback;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceMethodData;
 import com.microsoft.azure.sdk.iot.device.twin.Property;
-import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallBack;
+import com.microsoft.azure.sdk.iot.device.twin.TwinPropertyCallback;
 import com.microsoft.azure.sdk.iot.device.edge.MethodRequest;
 import com.microsoft.azure.sdk.iot.device.edge.MethodResult;
 import com.microsoft.azure.sdk.iot.device.exceptions.ModuleClientException;
@@ -235,7 +235,7 @@ public class ModuleGlue
         }
     }
 
-    private static class ModuleTwinPropertyCallBack implements TwinPropertyCallBack
+    private static class ModuleTwinPropertyCallback implements TwinPropertyCallback
     {
         private JsonObject _props = null;
         private Handler<AsyncResult<Object>> _handler;
@@ -261,7 +261,7 @@ public class ModuleGlue
         }
 
         @Override
-        public void TwinPropertyCallBack(Property property, Object context)
+        public void TwinPropertyCallback(Property property, Object context)
         {
             System.out.println(
                     "onProperty callback for " + (property.getIsReported() ? "reported" : "desired") +
@@ -325,7 +325,7 @@ public class ModuleGlue
         }
     }
 
-    private final ModuleTwinPropertyCallBack _deviceTwinPropertyCallback = new ModuleTwinPropertyCallBack();
+    private final ModuleTwinPropertyCallback _deviceTwinPropertyCallback = new ModuleTwinPropertyCallback();
 
     private static class IotHubEventCallbackImpl implements IotHubEventCallback
     {


### PR DESCRIPTION
Callback is one word, so no need to uppercase the "B"