### PR TITLE
release(2021-08-30): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.32.1";
+    private static final String CLIENT_VERSION = "2.0.0-preview-001";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.32.1') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.0-preview-001') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
         <provisioning-device-client-version>2.0.0-preview-001</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.0-preview-001</provisioning-service-client-version>
         <security-provider-version>2.0.0-preview-001</security-provider-version>
-        <tpm-provider-emulator-version>undefined</tpm-provider-emulator-version>
-        <tpm-provider-version>1.1.3</tpm-provider-version>
-        <dice-provider-emulator-version>undefined</dice-provider-emulator-version>
-        <dice-provider-version>undefined</dice-provider-version>
+        <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
+        <tpm-provider-version>2.0.0-preview-001</tpm-provider-version>
+        <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
+        <dice-provider-version>1.1.1</dice-provider-version>
         <x509-provider-version>2.0.0-preview-001</x509-provider-version>
     </properties>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,17 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.32.1</iot-device-client-version>
-        <iot-service-client-version>1.33.0</iot-service-client-version>
-        <iot-deps-version>0.15.0</iot-deps-version>
-        <provisioning-device-client-version>1.10.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.9.0</provisioning-service-client-version>
-        <security-provider-version>1.5.0</security-provider-version>
-        <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
+        <iot-device-client-version>2.0.0-preview-001</iot-device-client-version>
+        <iot-service-client-version>2.0.0-preview-001</iot-service-client-version>
+        <iot-deps-version>2.0.0-preview-001</iot-deps-version>
+        <provisioning-device-client-version>2.0.0-preview-001</provisioning-device-client-version>
+        <provisioning-service-client-version>2.0.0-preview-001</provisioning-service-client-version>
+        <security-provider-version>2.0.0-preview-001</security-provider-version>
+        <tpm-provider-emulator-version>undefined</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>
-        <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
-        <dice-provider-version>1.1.1</dice-provider-version>
-        <x509-provider-version>1.1.6</x509-provider-version>
+        <dice-provider-emulator-version>undefined</dice-provider-emulator-version>
+        <dice-provider-version>undefined</dice-provider-version>
+        <x509-provider-version>2.0.0-preview-001</x509-provider-version>
     </properties>
     <build>
         <plugins>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.10.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "2.0.0-preview-001";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.0";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "2.0.0-preview-001";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.33.0";
+    public static final String serviceVersion = "2.0.0-preview-001";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
This is a special preview release for our upcoming 2.0.0 clients. There are substantial changes made to the SDK in this upcoming version, and the brief summary of them can be seen below:

## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed all deprecated APIs 
- Removed unthrown exceptions from declared exceptions list for all APIs
- Removed support for parsing certificates

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed all deprecated APIs 
- Removed support for parsing certificates
- Renamed several APIs for consistency between Module and Device clients
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed all deprecated APIs 
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed all deprecated APIs 
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed all deprecated APIs 
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java X509 Provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.0-preview-001)
- Removed support for parsing certificates
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java TPM Provider (com.microsoft.azure.sdk.iot.provisioning.security:tpm-provider:2.0.0-preview-001)
- Removed unthrown exceptions from declared exceptions list for all APIs

## Java Security Provider (com.microsoft.azure.sdk.iot.provisioning.security:security-provider:2.0.0-preview-001)
- Trusted certificates are read from the physical device's trusted root certification authorities certificate store rather than from source.
- Removed unthrown exceptions from declared exceptions list for all APIs

**For a more exhaustive list of changes made in the jump from 1.0.0 to 2.0.0, and for a helpful FAQ section to answer common questions you may have, see [this document](https://github.com/Azure/azure-iot-sdk-java/blob/preview/major%20version%20upgrade%20migration%20guide.md).**

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-deps/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-service-client/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/x509-provider/2.0.0-preview-001/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security/security-provider/2.0.0-preview-001/jar

Note that these preview jars have been tested against the same standard tests as our normal jars other than for Edgehub scenarios. Users may encounter bugs in this preview version if used for writing custom Edgehub modules.