### PR TITLE
fix(iot-serv): Fix bug where service client's thread pool wasn't shutdown when the service client is shutdown

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ServiceClient
 {
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private ExecutorService executor;
 
     private final AmqpSend amqpMessageSender;
     private final String hostName;
@@ -298,6 +298,8 @@ public class ServiceClient
             throw new IOException("AMQP sender is not initialized");
         }
 
+        this.executor = Executors.newFixedThreadPool(10);
+
         log.info("Opening service client...");
 
         this.amqpMessageSender.open();
@@ -314,6 +316,8 @@ public class ServiceClient
         {
             throw new IOException("AMQP sender is not initialized");
         }
+
+        this.executor.shutdownNow();
 
         log.info("Closing service client...");
         this.amqpMessageSender.close();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -317,7 +317,10 @@ public class ServiceClient
             throw new IOException("AMQP sender is not initialized");
         }
 
-        this.executor.shutdownNow();
+        if (this.executor != null)
+        {
+            this.executor.shutdownNow();
+        }
 
         log.info("Closing service client...");
         this.amqpMessageSender.close();

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/ServiceClientTest.java
@@ -15,9 +15,9 @@ import org.junit.Test;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class ServiceClientTest
 {
@@ -195,6 +195,8 @@ public class ServiceClientTest
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         ServiceClient serviceClient = ServiceClient.createFromConnectionString(connectionString, iotHubServiceClientProtocol);
+        serviceClient.open();
+
         // Assert
         new Expectations()
         {
@@ -374,20 +376,21 @@ public class ServiceClientTest
         String policyName = "SharedAccessKey";
         String sharedAccessKey = "1234567890abcdefghijklmnopqrstvwxyz=";
         String connectionString = "HostName=" + hostName + "." + iotHubName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
-        IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         ServiceClient serviceClient = ServiceClient.createFromConnectionString(connectionString, iotHubServiceClientProtocol);
+        serviceClient.open();
+        // Act
+        CompletableFuture<Void> completableFuture = serviceClient.closeAsync();
+        completableFuture.get();
+
         // Assert
-        new Expectations()
+        new Verifications()
         {
             {
                 amqpSend.close();
                 serviceClient.close();
             }
         };
-        // Act
-        CompletableFuture<Void> completableFuture = serviceClient.closeAsync();
-        completableFuture.get();
     }
 
     // Tests_SRS_SERVICE_SDK_JAVA_SERVICECLIENT_12_015: [The function shall create an async wrapper around the close() function call, handle the return value or delegate exception]
@@ -433,6 +436,7 @@ public class ServiceClientTest
         Message iotMessage = new Message(content);
         IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
         ServiceClient serviceClient = ServiceClient.createFromConnectionString(connectionString, iotHubServiceClientProtocol);
+        serviceClient.open();
         // Assert
         new Expectations()
         {
@@ -528,5 +532,29 @@ public class ServiceClientTest
         FeedbackReceiver feedbackReceiver = serviceClient.getFeedbackReceiver();
         // Assert
         assertNotEquals(null, feedbackReceiver);
+    }
+
+    // a new executor service should be created when the service client opens, and
+    // closed when the service client is closed
+    @Test
+    public void executorServiceLifespan() throws IOException
+    {
+        String iotHubName = "IOTHUBNAME";
+        String hostName = "HOSTNAME";
+        String sharedAccessKeyName = "ACCESSKEYNAME";
+        String policyName = "SharedAccessKey";
+        String sharedAccessKey = "1234567890abcdefghijklmnopqrstvwxyz=";
+        String connectionString = "HostName=" + hostName + "." + iotHubName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
+        IotHubServiceClientProtocol iotHubServiceClientProtocol = IotHubServiceClientProtocol.AMQPS;
+        ServiceClient serviceClient = ServiceClient.createFromConnectionString(connectionString, iotHubServiceClientProtocol);
+
+        assertNull(Deencapsulation.getField(serviceClient, "executor"));
+
+        serviceClient.open();
+        assertNotNull(Deencapsulation.getField(serviceClient, "executor"));
+
+        serviceClient.close();
+        ExecutorService executorService = Deencapsulation.getField(serviceClient, "executor");
+        assertTrue(executorService.isShutdown());
     }
 }


### PR DESCRIPTION
Previously, async operations may have continued from the service client even after closing it