### PR TITLE
fix(iot-serv): Fix how serviceClient runs openAsync and closeAsync

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -382,7 +382,7 @@ public class ServiceClient
             {
                 future.completeExceptionally(e);
             }
-        });
+        }).run();
 
         return future;
     }
@@ -410,7 +410,7 @@ public class ServiceClient
             {
                 future.completeExceptionally(e);
             }
-        });
+        }).run();
 
         return future;
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -369,7 +369,10 @@ public class ServiceClient
     public CompletableFuture<Void> openAsync()
     {
         final CompletableFuture<Void> future = new CompletableFuture<>();
-        executor.submit(() -> {
+
+        // executor service hasn't been initialized yet, so don't use it to run this thread
+        new Thread(() ->
+        {
             try
             {
                 open();
@@ -380,6 +383,7 @@ public class ServiceClient
                 future.completeExceptionally(e);
             }
         });
+
         return future;
     }
 
@@ -391,9 +395,14 @@ public class ServiceClient
     public CompletableFuture<Void> closeAsync()
     {
         final CompletableFuture<Void> future = new CompletableFuture<>();
-        executor.submit(() -> {
+
+        // executor service will be shut down by this thread, so don't put this logic on the executor service's thread pool
+        new Thread(() ->
+        {
             try
             {
+                // don't shutdown the executor service from within this thread since this thread is in the
+                // executor service's thread pool. Save the executor shutdown for last
                 close();
                 future.complete(null);
             }
@@ -402,6 +411,7 @@ public class ServiceClient
                 future.completeExceptionally(e);
             }
         });
+
         return future;
     }
 


### PR DESCRIPTION
As an addendum to #1344, make it so that openAsync and closeAsync don't run on the same thread pool that they are supposed to create/shutdown

Note that #1344 was not released before this addendum was added, so there is no need to include this "fix" in the next release's release notes