### PR TITLE
Revert "fix(iot-serv): Fix bug where service client's thread pool was…

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ServiceClient
 {
-    private ExecutorService executor;
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     private final AmqpSend amqpMessageSender;
     private final String hostName;
@@ -298,8 +298,6 @@ public class ServiceClient
             throw new IOException("AMQP sender is not initialized");
         }
 
-        this.executor = Executors.newFixedThreadPool(10);
-
         log.info("Opening service client...");
 
         this.amqpMessageSender.open();
@@ -315,11 +313,6 @@ public class ServiceClient
         if (this.amqpMessageSender == null)
         {
             throw new IOException("AMQP sender is not initialized");
-        }
-
-        if (this.executor != null)
-        {
-            this.executor.shutdownNow();
         }
 
         log.info("Closing service client...");


### PR DESCRIPTION
…n't shutdown when the service client is shutdown (#1344)"

This reverts commit a6a70590677001790c11163e74c469008319f35a.

Reverting this commit while we work out a better fix that doesn't break how openAsync and closeAsync work