### PR TITLE
refactor(iot-serv): deprecate async service client and registry manager APIs

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -265,7 +265,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #addDevice(Device)}.
      */
+    @Deprecated
     public CompletableFuture<Device> addDeviceAsync(Device device) throws IOException, IotHubException
     {
         if (device == null)
@@ -324,7 +326,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #getDevice(String)}.
      */
+    @Deprecated
     public CompletableFuture<Device> getDeviceAsync(String deviceId) throws IOException, IotHubException
     {
         if (Tools.isNullOrEmpty(deviceId))
@@ -519,7 +523,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #updateDevice(Device)}.
      */
+    @Deprecated
     public CompletableFuture<Device> updateDeviceAsync(Device device) throws IOException, IotHubException
     {
         if (device == null)
@@ -642,7 +648,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #removeDevice(Device)}.
      */
+    @Deprecated
     public CompletableFuture<Boolean> removeDeviceAsync(String deviceId) throws IOException, IotHubException
     {
 
@@ -694,7 +702,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #getStatistics()}.
      */
+    @Deprecated
     public CompletableFuture<RegistryStatistics> getStatisticsAsync() throws IOException, IotHubException
     {
         final CompletableFuture<RegistryStatistics> future = new CompletableFuture<>();
@@ -752,7 +762,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #exportDevices(String, Boolean)}.
      */
+    @Deprecated
     public CompletableFuture<JobProperties> exportDevicesAsync(String exportBlobContainerUri, Boolean excludeKeys)
             throws IllegalArgumentException, IOException, IotHubException, JsonSyntaxException
     {
@@ -815,7 +827,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #exportDevices(JobProperties)}.
      */
+    @Deprecated
     public CompletableFuture<JobProperties> exportDevicesAsync(JobProperties exportDevicesParameters)
             throws IllegalArgumentException, IOException, IotHubException, JsonSyntaxException
     {
@@ -875,7 +889,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #importDevices(String, String)}.
      */
+    @Deprecated
     public CompletableFuture<JobProperties> importDevicesAsync(String importBlobContainerUri, String outputBlobContainerUri)
             throws IllegalArgumentException, IOException, IotHubException, JsonSyntaxException
     {
@@ -939,7 +955,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #importDevices(JobProperties)}.
      */
+    @Deprecated
     public CompletableFuture<JobProperties> importDevicesAsync(JobProperties importParameters)
             throws IllegalArgumentException, IOException, IotHubException, JsonSyntaxException
     {
@@ -995,7 +1013,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the jobId parameter is null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
+     * @deprecated Use the synchronous version of this API {@link #getJob(String)}.
      */
+    @Deprecated
     public CompletableFuture<JobProperties> getJobAsync(String jobId)
             throws IllegalArgumentException, IOException, IotHubException
     {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -265,7 +265,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #addDevice(Device)}.
+     * @deprecated Use the synchronous version of this API {@link #addDevice(Device)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Device> addDeviceAsync(Device device) throws IOException, IotHubException
@@ -326,7 +328,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #getDevice(String)}.
+     * @deprecated Use the synchronous version of this API {@link #getDevice(String)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Device> getDeviceAsync(String deviceId) throws IOException, IotHubException
@@ -523,7 +527,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #updateDevice(Device)}.
+     * @deprecated Use the synchronous version of this API {@link #updateDevice(Device)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Device> updateDeviceAsync(Device device) throws IOException, IotHubException
@@ -648,7 +654,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #removeDevice(Device)}.
+     * @deprecated Use the synchronous version of this API {@link #removeDevice(Device)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Boolean> removeDeviceAsync(String deviceId) throws IOException, IotHubException
@@ -702,7 +710,9 @@ public class RegistryManager
      * @return The future object for the requested operation
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #getStatistics()}.
+     * @deprecated Use the synchronous version of this API {@link #getStatistics()}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<RegistryStatistics> getStatisticsAsync() throws IOException, IotHubException
@@ -762,7 +772,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #exportDevices(String, Boolean)}.
+     * @deprecated Use the synchronous version of this API {@link #exportDevices(String, Boolean)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<JobProperties> exportDevicesAsync(String exportBlobContainerUri, Boolean excludeKeys)
@@ -827,7 +839,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #exportDevices(JobProperties)}.
+     * @deprecated Use the synchronous version of this API {@link #exportDevices(JobProperties)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<JobProperties> exportDevicesAsync(JobProperties exportDevicesParameters)
@@ -889,7 +903,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #importDevices(String, String)}.
+     * @deprecated Use the synchronous version of this API {@link #importDevices(String, String)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<JobProperties> importDevicesAsync(String importBlobContainerUri, String outputBlobContainerUri)
@@ -955,7 +971,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the exportBlobContainerUri or excludeKeys parameters are null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #importDevices(JobProperties)}.
+     * @deprecated Use the synchronous version of this API {@link #importDevices(JobProperties)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<JobProperties> importDevicesAsync(JobProperties importParameters)
@@ -1013,7 +1031,9 @@ public class RegistryManager
      * @throws IllegalArgumentException This exception is thrown if the jobId parameter is null
      * @throws IOException This exception is thrown if the IO operation failed
      * @throws IotHubException This exception is thrown if the response verification failed
-     * @deprecated Use the synchronous version of this API {@link #getJob(String)}.
+     * @deprecated Use the synchronous version of this API {@link #getJob(String)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<JobProperties> getJobAsync(String jobId)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -358,7 +358,9 @@ public class ServiceClient
      * Provide asynchronous access to open()
      *
      * @return The future object for the requested operation
+     * @deprecated Use the synchronous version of this API {@link #open()}.
      */
+    @Deprecated
     public CompletableFuture<Void> openAsync()
     {
         final CompletableFuture<Void> future = new CompletableFuture<>();
@@ -380,7 +382,9 @@ public class ServiceClient
      * Provide asynchronous access to close()
      *
      * @return The future object for the requested operation
+     * @deprecated Use the synchronous version of this API {@link #close()}.
      */
+    @Deprecated
     public CompletableFuture<Void> closeAsync()
     {
         final CompletableFuture<Void> future = new CompletableFuture<>();
@@ -404,7 +408,9 @@ public class ServiceClient
      * @param deviceId The device identifier for the target device
      * @param message The message for the device
      * @return The future object for the requested operation
+     * @deprecated Use the synchronous version of this API {@link #send(String, Message)}.
      */
+    @Deprecated
     public CompletableFuture<Void> sendAsync(String deviceId, Message message)
     {
         final CompletableFuture<Void> future = new CompletableFuture<>();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -358,7 +358,9 @@ public class ServiceClient
      * Provide asynchronous access to open()
      *
      * @return The future object for the requested operation
-     * @deprecated Use the synchronous version of this API {@link #open()}.
+     * @deprecated Use the synchronous version of this API {@link #open()}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Void> openAsync()
@@ -382,7 +384,9 @@ public class ServiceClient
      * Provide asynchronous access to close()
      *
      * @return The future object for the requested operation
-     * @deprecated Use the synchronous version of this API {@link #close()}.
+     * @deprecated Use the synchronous version of this API {@link #close()}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Void> closeAsync()
@@ -408,7 +412,9 @@ public class ServiceClient
      * @param deviceId The device identifier for the target device
      * @param message The message for the device
      * @return The future object for the requested operation
-     * @deprecated Use the synchronous version of this API {@link #send(String, Message)}.
+     * @deprecated Use the synchronous version of this API {@link #send(String, Message)}. This asynchronous
+     * API only spawned a thread to run the synchronous API, so users are advised to do this themselves
+     * in order to have control over the spawned threads.
      */
     @Deprecated
     public CompletableFuture<Void> sendAsync(String deviceId, Message message)


### PR DESCRIPTION
There are no usages of these methods in our e2e tests that we need to update. They do still have some unit tests, though