### PR TITLE
fix(iot-dev): Fix race condition where reconnection logic could carry on after client was closed

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -493,6 +493,10 @@ public class IotHubTransport implements IotHubListener
             throw new IllegalArgumentException("reason cannot be null");
         }
 
+        // Set the flag outside of the synchronized block so that any currently
+        // running reconnection logic knows to give up when this flag is set to true.
+        // Then the rest of the close() code is in the synchronization block so that
+        // it waits for the reconnection logic to end before it starts.
         this.isClosing = true;
 
         // Wait until no reconnection logic is taking place

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1232,7 +1232,7 @@ public class IotHubTransport implements IotHubListener
         {
             if (this.isClosing)
             {
-                log.trace("Abandoning reconnection logic since this client has started closing. Releasing reconnectionLock");
+                log.trace("Abandoning reconnection logic since this client has started closing");
                 return;
             }
 


### PR DESCRIPTION
If close is called during reconnection, it will block until the current reconnection attempt completes (successfully or not) before closing the connection and marking the local state as closed

If reconnection is initiated during a close, it will block until the close call has finished tearing down the connection and marking the local state as closed. After the close call has finished, the reconnection logic will immediately give up since the client was closed

#1343