### PR TITLE
Make SDK explicitly use UTF-8 for converting strings to bytes

### DIFF
--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/ParserUtility.java
@@ -210,7 +210,7 @@ public class ParserUtility
         }
 
         /* Codes_SRS_PARSER_UTILITY_21_029: [The validateId shall throw IllegalArgumentException if the provided string contains an illegal character.] */
-        byte[] chars = id.getBytes();
+        byte[] chars = id.getBytes(StandardCharsets.UTF_8);
         for (byte c:chars)
         {
             if(!(((c>='A') && (c<='Z')) || ((c>='a') && (c<='z')) || ((c>='0') && (c<='9')) ||

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinParser.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/serializer/TwinParser.java
@@ -21,7 +21,7 @@ public class TwinParser
 
     private TwinChangedCallback onDesiredCallback = null;
     private TwinChangedCallback onReportedCallback = null;
-    private static TwinChangedCallback onTagsCallback = null;
+    private TwinChangedCallback onTagsCallback = null;
 
     private static final String TAGS_TAG = "tags";
     private static final String PROPERTIES_TAG = "properties";
@@ -107,7 +107,7 @@ public class TwinParser
      */
     public void setTagsCallback(TwinChangedCallback onTagsCallback)
     {
-        TwinParser.onTagsCallback = onTagsCallback;
+        this.onTagsCallback = onTagsCallback;
     }
 
     /**

--- a/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
+++ b/deps/src/main/java/com/microsoft/azure/sdk/iot/deps/transport/amqp/AmqpsConnection.java
@@ -21,6 +21,7 @@ import org.apache.qpid.proton.reactor.ReactorOptions;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.*;
 
 @Slf4j
@@ -420,7 +421,7 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
 
             if (length > 0)
             {
-                byte[] tag = String.valueOf(this.nextTag).getBytes();
+                byte[] tag = String.valueOf(this.nextTag).getBytes(StandardCharsets.UTF_8);
 
                 //want to avoid negative delivery tags since -1 is the designated failure value
                 if (this.nextTag == Integer.MAX_VALUE || this.nextTag < 0)

--- a/deps/src/test/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttMessageTest.java
+++ b/deps/src/test/java/com/microsoft/azure/sdk/iot/deps/transport/mqtt/MqttMessageTest.java
@@ -15,6 +15,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.assertEquals;
 
 /** Unit tests for MqttMessage.
@@ -27,7 +29,7 @@ public class MqttMessageTest
 
     private final String mockedtopic = "someTopic";
 
-    private final byte[] mockedPayload = "somePayload".getBytes();
+    private final byte[] mockedPayload = "somePayload".getBytes(StandardCharsets.UTF_8);
 
     @Mocked
     private org.eclipse.paho.client.mqttv3.MqttMessage mockedMqttMessage;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethod.java
@@ -8,6 +8,8 @@ import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
+
 @Slf4j
 public final class DeviceMethod
 {
@@ -76,7 +78,7 @@ public final class DeviceMethod
                                  **Codes_SRS_DEVICEMETHOD_25_015: [**User can provide null response message upon invoking the device method callback which will be serialized as is, before sending it to IotHub.**]**
                                  */
                                 MethodParser methodParserObject = new MethodParser(responseData.getResponseMessage());
-                                IotHubTransportMessage responseMessage = new IotHubTransportMessage(methodParserObject.toJson().getBytes(), MessageType.DEVICE_METHODS);
+                                IotHubTransportMessage responseMessage = new IotHubTransportMessage(methodParserObject.toJson().getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_METHODS);
                                 /*
                                  **Codes_SRS_DEVICEMETHOD_25_012: [**The device method message sent to IotHub shall have same the request id as the invoking message.**]**
                                  */

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwin.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -346,7 +347,7 @@ public class DeviceTwin
             return;
         }
 
-        IotHubTransportMessage updateReportedPropertiesRequest = new IotHubTransportMessage(serializedReportedProperties.getBytes(), MessageType.DEVICE_TWIN);
+        IotHubTransportMessage updateReportedPropertiesRequest = new IotHubTransportMessage(serializedReportedProperties.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         updateReportedPropertiesRequest.setCorrelatingMessageCallback(correlatingMessageCallback);
         updateReportedPropertiesRequest.setCorrelatingMessageCallbackContext(correlatingMessageCallbackContext);
         updateReportedPropertiesRequest.setConnectionDeviceId(this.config.getDeviceId());

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
@@ -14,6 +14,7 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
@@ -142,7 +143,7 @@ public class IotHubSasTokenHardwareAuthenticationProvider extends IotHubSasToken
             }
 
             Long expiryTimeUTC = (System.currentTimeMillis() / 1000) + secondsToLive;
-            byte[] token = this.securityProvider.signWithIdentity(encodedTokenScope.concat("\n" + expiryTimeUTC).getBytes());
+            byte[] token = this.securityProvider.signWithIdentity(encodedTokenScope.concat("\n" + expiryTimeUTC).getBytes(StandardCharsets.UTF_8));
             if (token == null || token.length == 0)
             {
                 //Codes_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_010: [If the call for the saved security provider to sign with identity returns null or empty bytes, this function shall throw an IOException.]

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/SignatureHelper.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/SignatureHelper.java
@@ -56,7 +56,7 @@ public final class SignatureHelper
     public static byte[] decodeDeviceKeyBase64(String deviceKey)
     {
         // Codes_SRS_SIGNATUREHELPER_11_003: [The function shall decode the device key using Base64.]
-        return decodeBase64(deviceKey.getBytes());
+        return decodeBase64(deviceKey.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
@@ -73,7 +73,7 @@ public class HttpsHsmClient
         // <base url>/modules/<url encoded name>/genid/<url encoded gen id>/sign?api-version=<url encoded api version>.]
         String uri = baseUrl != null ? baseUrl.replaceFirst("/*$", "") : "";
 
-        byte[] body = signRequest.toJson().getBytes();
+        byte[] body = signRequest.toJson().getBytes(StandardCharsets.UTF_8);
 
         String pathBuilder = "/modules/" + URLEncoder.encode(moduleName, StandardCharsets.UTF_8.name()) +
                 "/genid/" + URLEncoder.encode(generationId, StandardCharsets.UTF_8.name()) +

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializer.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializer.java
@@ -157,7 +157,7 @@ public class HttpsRequestResponseSerializer
 
         Map<String, List<String>> headerFields = readHeaderFields(bufferedReader);
         byte[] body = readBody(bufferedReader);
-        byte[] errorReason = statusLineParts[2].getBytes();
+        byte[] errorReason = statusLineParts[2].getBytes(StandardCharsets.UTF_8);
 
         bufferedReader.close();
 
@@ -220,6 +220,6 @@ public class HttpsRequestResponseSerializer
             next = bufferedReader.readLine();
         }
 
-        return bodyString.toString().getBytes();
+        return bodyString.toString().getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/parser/SignRequest.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/parser/SignRequest.java
@@ -11,6 +11,8 @@ import com.google.gson.annotations.SerializedName;
 
 import javax.crypto.Mac;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 
 // This suppression below is addressing warnings of fields used for serialization.
@@ -43,7 +45,7 @@ public class SignRequest
     public byte[] getData()
     {
         // Codes_SRS_HTTPHSMSIGNREQUEST_34_002: [This function shall return the saved data.]
-        return data.getBytes();
+        return data.getBytes(StandardCharsets.UTF_8);
     }
 
     public void setData(byte[] data)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
@@ -18,6 +18,7 @@ import org.apache.qpid.proton.message.impl.MessageImpl;
 import org.apache.qpid.proton.reactor.FlowController;
 
 import java.nio.BufferOverflowException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -184,7 +185,7 @@ public abstract class AmqpsSenderLinkHandler extends BaseHandler
             }
         }
 
-        byte[] deliveryTag = String.valueOf(this.nextTag).getBytes();
+        byte[] deliveryTag = String.valueOf(this.nextTag).getBytes(StandardCharsets.UTF_8);
 
         Delivery delivery = this.senderLink.delivery(deliveryTag);
         try

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Socks5SocketFactory.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Socks5SocketFactory.java
@@ -15,6 +15,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 
 import javax.net.SocketFactory;
 
@@ -78,7 +79,7 @@ public class Socks5SocketFactory extends SocketFactory
 
         byte[] getConnectCmd()
         {
-            final byte[] host = mTarget.getHostName().getBytes();
+            final byte[] host = mTarget.getHostName().getBytes(StandardCharsets.UTF_8);
             final byte[] data = new byte[7 + host.length];
             data[0] = (byte) 5;
             data[1] = (byte) CMD_CONNECT;

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceMethodTest.java
@@ -12,6 +12,8 @@ import mockit.NonStrictExpectations;
 import mockit.Verifications;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST;
 import static com.microsoft.azure.sdk.iot.device.DeviceTwin.DeviceOperations.DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
@@ -248,7 +250,7 @@ public class DeviceMethodTest
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);
         testMethod.subscribeToDeviceMethod(mockedDeviceMethodCB, null);
 
-        byte[] testPayload = "TestPayload".getBytes();
+        byte[] testPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(testPayload, MessageType.DEVICE_TWIN);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
 
@@ -287,7 +289,7 @@ public class DeviceMethodTest
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);
         testMethod.subscribeToDeviceMethod(mockedDeviceMethodCB, null);
 
-        byte[] testPayload = "TestPayload".getBytes();
+        byte[] testPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(testPayload, DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
 
@@ -328,7 +330,7 @@ public class DeviceMethodTest
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);
         testMethod.subscribeToDeviceMethod(mockedDeviceMethodCB, null);
 
-        byte[] testPayload = "TestPayload".getBytes();
+        byte[] testPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(testPayload, DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
 
@@ -366,7 +368,7 @@ public class DeviceMethodTest
         DeviceMethod testMethod = new DeviceMethod(mockedDeviceIO, mockedConfig, mockedStatusCB, null);
         testMethod.subscribeToDeviceMethod(mockedDeviceMethodCB, null);
 
-        byte[] testPayload = "TestPayload".getBytes();
+        byte[] testPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(testPayload, DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceTwin/DeviceTwinTest.java
@@ -13,6 +13,7 @@ import mockit.*;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -393,7 +394,7 @@ public class DeviceTwinTest
                 mockedConfig.getDeviceId();
                 result = expectedDeviceId;
 
-                new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+                new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
                 result = mockedDeviceTwinMessage;
             }
         };
@@ -473,7 +474,7 @@ public class DeviceTwinTest
         new NonStrictExpectations()
         {
             {
-                new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+                new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
                 result = mockedDeviceTwinMessage;
             }
         };
@@ -522,7 +523,7 @@ public class DeviceTwinTest
         new NonStrictExpectations()
         {
             {
-                new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+                new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
                 result = mockedDeviceTwinMessage;
             }
         };
@@ -874,7 +875,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -909,7 +910,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -950,7 +951,7 @@ public class DeviceTwinTest
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -985,7 +986,7 @@ public class DeviceTwinTest
         desiredMap.put(new Property(prop1, null), new Pair<>(mockedDesiredCB, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -1017,7 +1018,7 @@ public class DeviceTwinTest
         MessageCallback deviceTwinResponseMessageCallback =
                 Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_RESPONSE);
 
@@ -1061,7 +1062,7 @@ public class DeviceTwinTest
         MessageCallback deviceTwinResponseMessageCallback =
                 Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_RESPONSE);
 
@@ -1112,7 +1113,7 @@ public class DeviceTwinTest
         MessageCallback deviceTwinResponseMessageCallback =
                 Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_RESPONSE);
 
@@ -1197,7 +1198,7 @@ public class DeviceTwinTest
         MessageCallback deviceTwinResponseMessageCallback =
                 Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_GET_RESPONSE);
 
@@ -1243,7 +1244,7 @@ public class DeviceTwinTest
         desiredMap.put(new Property(prop1, null), new Pair<>((PropertyCallBack<String, Object>) null, null));
         testTwin.subscribeDesiredPropertiesNotification(desiredMap);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -1276,7 +1277,7 @@ public class DeviceTwinTest
         desiredMap.put(new Property(prop1, null), new Pair<>((TwinPropertyCallBack) null, null));
         testTwin.subscribeDesiredPropertiesTwinPropertyNotification(desiredMap);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -1305,7 +1306,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -1334,7 +1335,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, mockedGenericTwinPropertyCB, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 
@@ -1363,7 +1364,7 @@ public class DeviceTwinTest
                 mockedStatusCB, null, (TwinPropertyCallBack)null, null);
         MessageCallback deviceTwinResponseMessageCallback = Deencapsulation.newInnerInstance("deviceTwinResponseMessageCallback", testTwin);
 
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(), MessageType.DEVICE_TWIN);
+        final IotHubTransportMessage testMessage = new IotHubTransportMessage(json.getBytes(StandardCharsets.UTF_8), MessageType.DEVICE_TWIN);
         testMessage.setStatus(String.valueOf(200));
         testMessage.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
@@ -57,7 +57,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes = someToken.getBytes();
+        final byte[] tokenBytes = someToken.getBytes(StandardCharsets.UTF_8);
         new Expectations()
         {
             {
@@ -106,7 +106,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {
@@ -137,7 +137,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
 
         //assert
         new Expectations()
@@ -170,7 +170,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
 
         //assert
         new Expectations()
@@ -202,7 +202,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
 
         //assert
         new Expectations()
@@ -254,7 +254,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
                 result = "some token scope";
 
                 mockSecurityProviderTpm.signWithIdentity((byte[]) any);
-                result = "some token".getBytes();
+                result = "some token".getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -309,7 +309,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
                 result = "some token scope";
 
                 mockSecurityProviderTpm.signWithIdentity((byte[]) any);
-                result = "some token".getBytes();
+                result = "some token".getBytes(StandardCharsets.UTF_8);
             }
         };
     }
@@ -320,7 +320,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {
@@ -462,7 +462,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {
@@ -501,7 +501,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     {
         //arrange
         final String someToken = "someToken";
-        final byte[] tokenBytes= someToken.getBytes();
+        final byte[] tokenBytes= someToken.getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509Test.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509Test.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -171,13 +172,13 @@ public class IotHubX509Test
                 result = mockedPublicKeyCertPath;
 
                 Files.readAllBytes(mockedPublicKeyCertPath);
-                result = someCert.getBytes();
+                result = someCert.getBytes(StandardCharsets.UTF_8);
 
                 Paths.get(someKeyPath);
                 result = mockedPrivateKeyPath;
 
                 Files.readAllBytes(mockedPrivateKeyPath);
-                result = someKey.getBytes();
+                result = someKey.getBytes(StandardCharsets.UTF_8);
             }
         };
     }

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTaskTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/fileupload/FileUploadTaskTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -125,7 +126,7 @@ public class FileUploadTaskTest
                 mockResponseMessage.getStatus();
                 result = IotHubStatusCode.OK;
                 mockResponseMessage.getBytes();
-                result = responseJson.getBytes();
+                result = responseJson.getBytes(StandardCharsets.UTF_8);
                 new FileUploadSasUriResponse(responseJson);
                 result = mockFileUploadSasUriResponse;
             }
@@ -652,7 +653,7 @@ public class FileUploadTaskTest
                 mockResponseMessage.getStatus();
                 result = IotHubStatusCode.OK;
                 mockResponseMessage.getBytes();
-                result = VALID_RESPONSE_JSON.getBytes();
+                result = VALID_RESPONSE_JSON.getBytes(StandardCharsets.UTF_8);
                 new FileUploadSasUriResponse(VALID_RESPONSE_JSON);
                 result = new IllegalArgumentException();
             }

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClientTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClientTest.java
@@ -24,6 +24,7 @@ import java.io.*;
 import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -127,7 +128,7 @@ public class HttpsHsmClientTest
                 mockedSignRequest.toJson();
                 result = expectedJson;
 
-                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(), anyString);
+                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(StandardCharsets.UTF_8), anyString);
                 result = mockedHttpsRequest;
 
                 mockedHttpsRequest.send();
@@ -137,7 +138,7 @@ public class HttpsHsmClientTest
                 result = 200;
 
                 mockedHttpsResponse.getBody();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -184,7 +185,7 @@ public class HttpsHsmClientTest
                 mockedSignRequest.toJson();
                 result = expectedJson;
 
-                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(), anyString);
+                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(StandardCharsets.UTF_8), anyString);
                 result = mockedHttpsRequest;
 
                 mockedHttpsRequest.sendAsHttpRequest();
@@ -194,7 +195,7 @@ public class HttpsHsmClientTest
                 result = 200;
 
                 mockedHttpsResponse.getBody();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -228,8 +229,8 @@ public class HttpsHsmClientTest
     {
         //arrange
         final String expectedJson = "some json";
-        final byte[] expectedMetaData = "some headers and such".getBytes();
-        final byte[] expectedBody = "http request's body".getBytes();
+        final byte[] expectedMetaData = "some headers and such".getBytes(StandardCharsets.UTF_8);
+        final byte[] expectedBody = "http request's body".getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {
@@ -242,7 +243,7 @@ public class HttpsHsmClientTest
                 mockedSignRequest.toJson();
                 result = expectedJson;
 
-                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(), anyString);
+                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(StandardCharsets.UTF_8), anyString);
                 result = mockedHttpsRequest;
 
                 HttpsRequestResponseSerializer.serializeRequest(mockedHttpsRequest, anyString, anyString, anyString);
@@ -316,7 +317,7 @@ public class HttpsHsmClientTest
                 mockedSignRequest.toJson();
                 result = expectedJson;
 
-                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(), anyString);
+                new HttpsRequest((URL) any, HttpsMethod.POST, expectedJson.getBytes(StandardCharsets.UTF_8), anyString);
                 result = mockedHttpsRequest;
 
                 mockedHttpsRequest.send();
@@ -326,7 +327,7 @@ public class HttpsHsmClientTest
                 result = 401;
 
                 mockedHttpsResponse.getBody();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -414,7 +415,7 @@ public class HttpsHsmClientTest
                 result = 200;
 
                 mockedHttpsResponse.getBody();
-                result = "some trust bundle".getBytes();
+                result = "some trust bundle".getBytes(StandardCharsets.UTF_8);
 
                 TrustBundleResponse.fromJson("some trust bundle");
                 result = mockedTrustBundleResponse;
@@ -458,7 +459,7 @@ public class HttpsHsmClientTest
                 result = expectedStatusCode;
 
                 mockedHttpsResponse.getBody();
-                result = "some trust bundle".getBytes();
+                result = "some trust bundle".getBytes(StandardCharsets.UTF_8);
 
                 ErrorResponse.fromJson("some trust bundle");
                 result = mockedErrorResponse;

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializerTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsRequestResponseSerializerTest.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -90,14 +91,14 @@ public class HttpsRequestResponseSerializerTest
                 result = "Connection: close\r\n" + "Content-Type: application/json\r\n";
 
                 mockedHttpsRequest.getBody();
-                result = "11111".getBytes();
+                result = "11111".getBytes(StandardCharsets.UTF_8);
             }
         };
 
         uriExpectations();
 
         String expected = "POST /modules/testModule/sign?api-version=2018-06-28 HTTP/1.1\r\nHost: localhost:8081\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: 5\r\n\r\n";
-        byte[] body = "11111".getBytes();
+        byte[] body = "11111".getBytes(StandardCharsets.UTF_8);
         HttpsRequest request = new HttpsRequest(new URL("https://localhost:8081/modules/testModule/sign?api-version=2018-06-28"), HttpsMethod.GET, body, null);
         request.setHeaderField("content-type", "application/json");
         request.setHeaderField("content-length", "5");
@@ -131,14 +132,14 @@ public class HttpsRequestResponseSerializerTest
                 result = "Connection: close\r\n" + "Content-Type: application/json\r\n";
 
                 mockedHttpsRequest.getBody();
-                result = "11111".getBytes();
+                result = "11111".getBytes(StandardCharsets.UTF_8);
             }
         };
 
         uriExpectations();
 
         String expected = "POST /modules/testModule/sign HTTP/1.1\r\nHost: localhost:8081\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: 5\r\n\r\n";
-        byte[] body = "11111".getBytes();
+        byte[] body = "11111".getBytes(StandardCharsets.UTF_8);
         HttpsRequest request = new HttpsRequest(new URL("https://localhost:8081/modules/testModule/sign"), HttpsMethod.GET, body, null);
         request.setHeaderField("content-type", "application/json");
         request.setHeaderField("content-length", "5");
@@ -195,8 +196,8 @@ public class HttpsRequestResponseSerializerTest
     public void deserializeSuccess() throws IOException
     {
         //arrange
-        final byte[] expectedBody = ("test").getBytes();
-        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes();
+        final byte[] expectedBody = ("test").getBytes(StandardCharsets.UTF_8);
+        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes(StandardCharsets.UTF_8);
 
         final Map<String, List<String>> expectedHeaders = new HashMap<>();
         List<String> values1 = new ArrayList<>();
@@ -216,7 +217,7 @@ public class HttpsRequestResponseSerializerTest
         new Expectations()
         {
             {
-                new HttpsResponse(203, expectedBody, expectedHeaders, "OK".getBytes());
+                new HttpsResponse(203, expectedBody, expectedHeaders, "OK".getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpsResponse;
 
                 mockedHttpsResponse.getStatus();
@@ -243,7 +244,7 @@ public class HttpsRequestResponseSerializerTest
     public void deserializeThrowsIfTooManyHttpHeadersReceived() throws IOException
     {
         //arrange
-        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes();
+        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes(StandardCharsets.UTF_8);
 
         long MAX_HEADER_COUNT = Deencapsulation.getField(HttpsRequestResponseSerializer.class, "MAXIMUM_HEADER_COUNT");
 
@@ -322,8 +323,8 @@ public class HttpsRequestResponseSerializerTest
     public void deserializeThrowsForHeaderWithoutSeparators() throws IOException
     {
         //arrange
-        final byte[] expectedBody = ("test").getBytes();
-        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes();
+        final byte[] expectedBody = ("test").getBytes(StandardCharsets.UTF_8);
+        final byte[] expectedBodyWithNewLine = ("test\r\n").getBytes(StandardCharsets.UTF_8);
 
         final Map<String, List<String>> expectedHeaders = new HashMap<>();
         List<String> values1 = new ArrayList<>();

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/parser/SignRequestTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/parser/SignRequestTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 
 import javax.crypto.Mac;
 
+import java.nio.charset.StandardCharsets;
+
 import static junit.framework.TestCase.assertEquals;
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 import static org.junit.Assert.assertArrayEquals;
@@ -32,7 +34,7 @@ public class SignRequestTest
         //arrange
         final String expectedAlgoString = "some algorithm";
         final String expectedKeyId = "some key id";
-        final byte[] expectedData = "some data".getBytes();
+        final byte[] expectedData = "some data".getBytes(StandardCharsets.UTF_8);
         final String expectedEncodedData = encodeBase64String(expectedData);
 
         new NonStrictExpectations()
@@ -52,6 +54,6 @@ public class SignRequestTest
         //assert
         assertEquals(mockedMac, Deencapsulation.getField(request, "algo"));
         assertEquals(expectedKeyId, Deencapsulation.getField(request, "keyId"));
-        assertArrayEquals(expectedEncodedData.getBytes(), request.getData());
+        assertArrayEquals(expectedEncodedData.getBytes(StandardCharsets.UTF_8), request.getData());
     }
 }

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendResultTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSendResultTest.java
@@ -8,6 +8,8 @@ import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpsSendResult;
 import mockit.Deencapsulation;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.*;
 
 /**
@@ -21,7 +23,7 @@ public class AmqpsSendResultTest
     public void constructorInitializesAllMembersUnsuccessfulDelivery()
     {
         //arrange
-        byte[] expectedDeliveryTag = "-1".getBytes();
+        byte[] expectedDeliveryTag = "-1".getBytes(StandardCharsets.UTF_8);
 
         //act
         AmqpsSendResult amqpsSendResult = Deencapsulation.newInstance(AmqpsSendResult.class);
@@ -37,7 +39,7 @@ public class AmqpsSendResultTest
     public void constructorInitializesAllMembersSuccessfulDelivery() {
         //arrange
         int expectedDeliveryTag = 56;
-        byte[] deliveryTag = String.valueOf(expectedDeliveryTag).getBytes();
+        byte[] deliveryTag = String.valueOf(expectedDeliveryTag).getBytes(StandardCharsets.UTF_8);
 
         //act
         AmqpsSendResult amqpsSendResult = Deencapsulation.newInstance(AmqpsSendResult.class, (Object) deliveryTag);
@@ -53,7 +55,7 @@ public class AmqpsSendResultTest
     public void getDeliveryTagWorks()
     {
         //arrange
-        byte[] deliveryTag = String.valueOf(24).getBytes();
+        byte[] deliveryTag = String.valueOf(24).getBytes(StandardCharsets.UTF_8);
         int deliveryTagInt = Integer.parseInt(new String(deliveryTag));
         AmqpsSendResult amqpsSendResult = Deencapsulation.newInstance(AmqpsSendResult.class, (Object) deliveryTag);
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsBatchMessageTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsBatchMessageTest.java
@@ -60,7 +60,7 @@ public class HttpsBatchMessageTest
         {
             {
                 mockMsg.getBody();
-                result = msgBody.getBytes();
+                result = msgBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -70,7 +70,7 @@ public class HttpsBatchMessageTest
         String testBatchBody =
                 new String(batchMsg.getBody(), UTF8).replaceAll("\\s", "");
 
-        final String expectedMsgBody = encodeBase64String(msgBody.getBytes());
+        final String expectedMsgBody = encodeBase64String(msgBody.getBytes(StandardCharsets.UTF_8));
         assertThat(testBatchBody, containsString(expectedMsgBody));
     }
 
@@ -84,7 +84,7 @@ public class HttpsBatchMessageTest
         {
             {
                 mockMsg.getBody();
-                result = msgBody.getBytes();
+                result = msgBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -145,7 +145,7 @@ public class HttpsBatchMessageTest
         {
             {
                 mockMsg.getBody();
-                result = msgBody.getBytes();
+                result = msgBody.getBytes(StandardCharsets.UTF_8);
                 mockMsg.getProperties();
                 result = properties;
                 mockProperty.getName();
@@ -280,7 +280,7 @@ public class HttpsBatchMessageTest
         {
             {
                 mockMsg.getBody();
-                result = msgBody.getBytes();
+                result = msgBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsConnectionTest.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -1033,7 +1034,7 @@ public class HttpsConnectionTest
         };
         HttpsConnection conn = new HttpsConnection(mockUrl, httpsMethod);
 
-        byte[] expectedBody = "test".getBytes();
+        byte[] expectedBody = "test".getBytes(StandardCharsets.UTF_8);
         conn.writeOutput(expectedBody);
 
         //act

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsRequestTest.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -478,11 +479,11 @@ public class HttpsRequestTest
     public void gettersWork(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         //arrange
         final URL mockUrl = new URL("https://www.microsoft.com");
-        HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.POST, "some body".getBytes(), "some user agent string");
+        HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.POST, "some body".getBytes(StandardCharsets.UTF_8), "some user agent string");
 
         final String expectedRequestHeaders = "User-Agent: some user agent string\r\nHost: www.microsoft.com\r\n";
         final String expectedMethod = "POST";
-        final byte[] expectedBody = "some body".getBytes();
+        final byte[] expectedBody = "some body".getBytes(StandardCharsets.UTF_8);
         new NonStrictExpectations()
         {
             {
@@ -512,7 +513,7 @@ public class HttpsRequestTest
     public void sendAsHttpRequestWorks(@Mocked final HttpsConnection mockConn) throws TransportException, MalformedURLException {
         //arrange
         final URL mockUrl = new URL("http://www.microsoft.com");
-        HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.GET, "some body".getBytes(), "some user agent string");
+        HttpsRequest request = new HttpsRequest(mockUrl, HttpsMethod.GET, "some body".getBytes(StandardCharsets.UTF_8), "some user agent string");
 
         final String expectedRequestHeaders = "User-Agent: some user agent string\r\nHost: www.microsoft.com\r\n";
         final String expectedMethod = "GET";

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsSingleMessageTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsSingleMessageTest.java
@@ -13,6 +13,7 @@ import mockit.NonStrictExpectations;
 import mockit.Verifications;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -732,7 +733,7 @@ public class HttpsSingleMessageTest
         {
             {
                 httpsResponse.getBody();
-                result = "body".getBytes();
+                result = "body".getBytes(StandardCharsets.UTF_8);
 
                 httpsResponse.getHeaderFields();
                 result = headerFields;

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManagerTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/https/HttpsTransportManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -465,7 +466,7 @@ public class HttpsTransportManagerTest
                 result = IotHubStatusCode.OK_EMPTY;
 
                 mockResponseMessage.getBytes();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
 
                 new MethodResult(expectedResponseBody);
             }
@@ -522,7 +523,7 @@ public class HttpsTransportManagerTest
                 result = IotHubStatusCode.OK_EMPTY;
 
                 mockResponseMessage.getBytes();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
 
                 new MethodResult(expectedResponseBody);
             }
@@ -597,7 +598,7 @@ public class HttpsTransportManagerTest
                 result = IotHubStatusCode.HUB_OR_DEVICE_ID_NOT_FOUND;
 
                 mockResponseMessage.getBytes();
-                result = expectedResponseBody.getBytes();
+                result = expectedResponseBody.getBytes(StandardCharsets.UTF_8);
             }
         };
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -127,7 +128,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         final String actualSubscribeTopic = "$iothub/methods/POST/#";
-        byte[] actualPayload = "TestMessage".getBytes();
+        byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST);
         final MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
@@ -152,7 +153,7 @@ public class MqttDeviceMethodTest
     @Test
     public void sendSucceedsCallsPublish(@Mocked final Mqtt mockMqtt) throws IOException, TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
         testMessage.setRequestId("ReqId");
@@ -180,7 +181,7 @@ public class MqttDeviceMethodTest
     @Test (expected = TransportException.class)
     public void sendThrowsOnInvalidOperation(@Mocked final Mqtt mockMqtt) throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_UNKNOWN);
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
@@ -194,7 +195,7 @@ public class MqttDeviceMethodTest
     @Test (expected = TransportException.class)
     public void sendThrowsIfNotStarted(@Mocked final Mqtt mockMqtt) throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
 
@@ -218,7 +219,7 @@ public class MqttDeviceMethodTest
     @Test
     public void sendDoesNotSendOnDifferentMessageType(@Mocked final Mqtt mockMqtt, final @Mocked IotHubTransportMessage mockedMessage) throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setMessageType(MessageType.DEVICE_TWIN);
         final MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
@@ -244,7 +245,7 @@ public class MqttDeviceMethodTest
     @Test (expected = IllegalArgumentException.class)
     public void sendThrowsOnNullRequestID() throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setMessageType(MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
@@ -259,7 +260,7 @@ public class MqttDeviceMethodTest
     @Test (expected = TransportException.class)
     public void sendThrowsOnSendingResponseWithoutReceivingMethodInvoke() throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
         testMessage.setRequestId("ReqId");
@@ -277,7 +278,7 @@ public class MqttDeviceMethodTest
     @Test (expected = TransportException.class)
     public void sendThrowsOnMismatchedRequestType() throws TransportException
     {
-        final byte[] actualPayload = "TestMessage".getBytes();
+        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
         testMessage.setRequestId("ReqId");
@@ -302,7 +303,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
-        byte[] actualPayload = "TestPayload".getBytes();
+        byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);
@@ -343,7 +344,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         String topic = "$iothub/methods/Not_POST/testMethod/?$rid=10";
-        byte[] actualPayload = "TestPayload".getBytes();
+        byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
@@ -362,7 +363,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         String topic = "$iothub/methods/POST/";
-        byte[] actualPayload = "TestPayload".getBytes();
+        byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);
@@ -380,7 +381,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         String topic = "$iothub/methods/POST/testMethod/";
-        byte[] actualPayload = "TestPayload".getBytes();
+        byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
         testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);
@@ -396,7 +397,7 @@ public class MqttDeviceMethodTest
     {
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
-        byte[] actualPayload = "".getBytes();
+        byte[] actualPayload = "".getBytes(StandardCharsets.UTF_8);
         testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceTwinTest.java
@@ -17,6 +17,7 @@ import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.junit.Test;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -475,7 +476,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveParsesResponseTopicForGetTwinSucceeds() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "200" + "/?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
 
@@ -508,7 +509,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveParsesResponseTopicForUpdateReportedPropertiesSucceeds() throws TransportException
     {
-        final byte[] actualPayload = "".getBytes();
+        final byte[] actualPayload = "".getBytes(StandardCharsets.UTF_8);
         /*
             The following does not work
             final byte[] actualPayload = null;
@@ -548,7 +549,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveParsesPatchTopicForDesiredPropertiesNotificationSucceeds() throws TransportException
     {
-        final byte[] actualPayload = "UpdateDesiredPropertiesNotificationData".getBytes();
+        final byte[] actualPayload = "UpdateDesiredPropertiesNotificationData".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/" + "?$version=" + mockVersion;
         IotHubTransportMessage receivedMessage = null;
 
@@ -580,7 +581,7 @@ public class MqttDeviceTwinTest
     @Test (expected = TransportException.class)
     public void receiveParsesResponseTopicMandatoryStatusNotFoundException() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
 
@@ -607,7 +608,7 @@ public class MqttDeviceTwinTest
     @Test (expected = TransportException.class)
     public void receiveParsesResponseTopicInvalidStatusThrowsException() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "abc/" + "?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -635,7 +636,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveSetsReqIdOnResTopic() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "200" + "/?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -671,7 +672,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveDoesNotSetReqIdOnResTopicIfNotFound() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "200";
         IotHubTransportMessage receivedMessage = null;
         try
@@ -708,7 +709,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveSetsVersionOnResTopic() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "201" + "/?$rid=" + mockReqId + "&$version=" + mockVersion;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -746,7 +747,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveDoesNotSetVersionOnResTopicIfNotFound() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "201" + "/?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -781,7 +782,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveSetsDataForGetTwinResp() throws TransportException
     {
-        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes();
+        final byte[] actualPayload = "GetTwinResponseDataContainingDesiredAndReportedPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/res/" + "200" + "/?$rid=" + mockReqId;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -826,7 +827,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveDoesNotSetDataForUpdateReportedPropResp() throws TransportException
     {
-        final byte[] actualPayload = "".getBytes();
+        final byte[] actualPayload = "".getBytes(StandardCharsets.UTF_8);
         /*
             The following does not work
             final byte[] actualPayload = null;
@@ -871,7 +872,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveSetsDataForDesiredPropNotifResp() throws TransportException
     {
-        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes();
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/";
         IotHubTransportMessage receivedMessage = null;
         try
@@ -911,7 +912,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveDoesNotSetVersionForDesiredPropNotifRespIfNotFound() throws TransportException
     {
-        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes();
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/";
         IotHubTransportMessage receivedMessage = null;
         try
@@ -950,7 +951,7 @@ public class MqttDeviceTwinTest
     @Test
     public void receiveSetVersionForDesiredPropNotifRespIfFound() throws TransportException
     {
-        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes();
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/" + "?$version=" + mockVersion ;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -990,7 +991,7 @@ public class MqttDeviceTwinTest
     @Test (expected = TransportException.class)
     public void receiveThrowsTransportExceptionOnAnythingOtherThenPatchDesiredProp() throws TransportException
     {
-        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes();
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/PATCH/properties/" + "?$version=" + mockVersion ;
         IotHubTransportMessage receivedMessage = null;
         try
@@ -1018,7 +1019,7 @@ public class MqttDeviceTwinTest
     @Test (expected = TransportException.class)
     public void receiveThrowsTransportExceptionOnAnythingOtherThenPatchOrResTopic() throws TransportException
     {
-        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes();
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
         final String expectedTopic = "$iothub/twin/NOTPATCH_NOTRES/properties/" + "?$version=" + mockVersion ;
         IotHubTransportMessage receivedMessage = null;
         try

--- a/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/TemperatureController.java
+++ b/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/TemperatureController.java
@@ -213,7 +213,7 @@ public class TemperatureController {
     }
 
     private static void initializeAndProvisionDevice() throws ProvisioningDeviceClientException, IOException, URISyntaxException, InterruptedException {
-        SecurityProviderSymmetricKey securityClientSymmetricKey = new SecurityProviderSymmetricKey(deviceSymmetricKey.getBytes(), registrationId);
+        SecurityProviderSymmetricKey securityClientSymmetricKey = new SecurityProviderSymmetricKey(deviceSymmetricKey.getBytes(StandardCharsets.UTF_8), registrationId);
         ProvisioningDeviceClient provisioningDeviceClient;
         ProvisioningStatus provisioningStatus = new ProvisioningStatus();
 

--- a/device/iot-device-samples/pnp-device-sample/thermostat-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/Thermostat.java
+++ b/device/iot-device-samples/pnp-device-sample/thermostat-device-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/device/Thermostat.java
@@ -170,7 +170,7 @@ public class Thermostat {
     }
 
     private static void initializeAndProvisionDevice() throws ProvisioningDeviceClientException, IOException, URISyntaxException, InterruptedException {
-        SecurityProviderSymmetricKey securityClientSymmetricKey = new SecurityProviderSymmetricKey(deviceSymmetricKey.getBytes(), registrationId);
+        SecurityProviderSymmetricKey securityClientSymmetricKey = new SecurityProviderSymmetricKey(deviceSymmetricKey.getBytes(StandardCharsets.UTF_8), registrationId);
         ProvisioningDeviceClient provisioningDeviceClient;
         ProvisioningStatus provisioningStatus = new ProvisioningStatus();
 

--- a/device/iot-device-samples/send-event-x509/src/main/java/samples/com/microsoft/azure/sdk/iot/SSLContextBuilder.java
+++ b/device/iot-device-samples/send-event-x509/src/main/java/samples/com/microsoft/azure/sdk/iot/SSLContextBuilder.java
@@ -108,7 +108,7 @@ public class SSLContextBuilder
             throw new GeneralSecurityException("Public key certificate cannot be null or empty");
         }
 
-        InputStream pemInputStream = new ByteArrayInputStream(pemString.getBytes());
+        InputStream pemInputStream = new ByteArrayInputStream(pemString.getBytes(StandardCharsets.UTF_8));
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         Collection<X509Certificate> collection = new ArrayList<>();
         X509Certificate x509Cert;
@@ -155,7 +155,7 @@ public class SSLContextBuilder
 
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
 
-        try (InputStream inputStream = new ByteArrayInputStream(DEFAULT_CERT.getBytes()))
+        try (InputStream inputStream = new ByteArrayInputStream(DEFAULT_CERT.getBytes(StandardCharsets.UTF_8)))
         {
             Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(inputStream);
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SSLContextBuilder.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SSLContextBuilder.java
@@ -113,7 +113,7 @@ public class SSLContextBuilder
             throw new GeneralSecurityException("Public key certificate cannot be null or empty");
         }
 
-        InputStream pemInputStream = new ByteArrayInputStream(pemString.getBytes());
+        InputStream pemInputStream = new ByteArrayInputStream(pemString.getBytes(StandardCharsets.UTF_8));
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         Collection<X509Certificate> collection = new ArrayList<>();
         X509Certificate x509Cert;
@@ -160,7 +160,7 @@ public class SSLContextBuilder
 
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
 
-        try (InputStream inputStream = new ByteArrayInputStream(DEFAULT_CERT.getBytes()))
+        try (InputStream inputStream = new ByteArrayInputStream(DEFAULT_CERT.getBytes(StandardCharsets.UTF_8)))
         {
             Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(inputStream);
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SasTokenGenerator.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/SasTokenGenerator.java
@@ -67,8 +67,8 @@ public class SasTokenGenerator
     {
         try
         {
-            byte[] textToSign = new String(resourceUri + "\n" + expiryTime).getBytes();
-            byte[] decodedDeviceKey = decodeBase64(devicePrimaryKey.getBytes());
+            byte[] textToSign = new String(resourceUri + "\n" + expiryTime).getBytes(StandardCharsets.UTF_8);
+            byte[] decodedDeviceKey = decodeBase64(devicePrimaryKey.getBytes(StandardCharsets.UTF_8));
             byte[] signature = encryptHmacSha256(textToSign, decodedDeviceKey);
             byte[] encryptedSignature = encodeBase64(signature);
             String encryptedSignatureUtf8 = new String(encryptedSignature, StandardCharsets.UTF_8);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/Tools.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/Tools.java
@@ -40,6 +40,7 @@ import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -742,7 +743,7 @@ public class Tools
 
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
 
-        HttpRequest request = new HttpRequest(url, HttpMethod.POST, jsonPayload.getBytes());
+        HttpRequest request = new HttpRequest(url, HttpMethod.POST, jsonPayload.getBytes(StandardCharsets.UTF_8));
         request.setReadTimeoutMillis(IntegrationTest.HTTP_READ_TIMEOUT);
         request.setHeaderField("authorization", sasTokenString);
         request.setHeaderField("Accept", "application/json");

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
@@ -45,6 +45,7 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -234,7 +235,7 @@ public class ServiceClientTests extends IntegrationTest
         Message message;
         if (withPayload)
         {
-            message = new Message(content.getBytes());
+            message = new Message(content.getBytes(StandardCharsets.UTF_8));
         }
         else
         {
@@ -284,7 +285,7 @@ public class ServiceClientTests extends IntegrationTest
         serviceClient = new ServiceClient(iotHubConnectionStringObj.getHostName(), sasCredential, testInstance.protocol);
         serviceClient.open();
 
-        Message message = new Message(content.getBytes());
+        Message message = new Message(content.getBytes(StandardCharsets.UTF_8));
         serviceClient.send(device.getDeviceId(), message);
 
         // deliberately expire the SAS token to provoke a 401 to ensure that the registry manager is using the shared

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -556,7 +556,7 @@ public class ProvisioningCommon extends IntegrationTest
                 createTestIndividualEnrollment(attestation, allocationPolicy, reprovisionPolicy, customAllocationDefinition, iothubs, twinState, deviceCapabilities);
                 assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected symmetric key attestation", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
                 SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) testInstance.individualEnrollment.getAttestation();
-                securityProvider = new SecurityProviderSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(), testInstance.registrationId);
+                securityProvider = new SecurityProviderSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(StandardCharsets.UTF_8), testInstance.registrationId);
             }
 
             Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected device id assigned", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());

--- a/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
+++ b/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -84,7 +85,7 @@ public class TokenCredentialTests
         ServiceClient serviceClient = buildServiceClientWithTokenCredential(IotHubServiceClientProtocol.AMQPS);
         serviceClient.open();
 
-        Message message = new Message("some message".getBytes());
+        Message message = new Message("some message".getBytes(StandardCharsets.UTF_8));
 
         serviceClient.send(device.getDeviceId(), message);
 

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandler.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/AmqpsProvisioningSaslHandler.java
@@ -12,6 +12,8 @@ import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.Provi
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ResponseData;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Implementation of a SaslHandler that is designed to handle Sasl negotiation using TPM authentication against the Device Provisioning Service
  */
@@ -332,7 +334,7 @@ public class AmqpsProvisioningSaslHandler implements SaslHandler
         }
 
         this.challengeState = ChallengeState.WAITING_FOR_FINAL_OUTCOME;
-        return prependByteArrayWithControlByte(INIT_SEGMENT_CONTROL_BYTE, sasToken.getBytes());
+        return prependByteArrayWithControlByte(INIT_SEGMENT_CONTROL_BYTE, sasToken.getBytes(StandardCharsets.UTF_8));
     }
 
     private byte[] buildNonceFromThirdChallenge(byte[] challengeData)
@@ -345,7 +347,7 @@ public class AmqpsProvisioningSaslHandler implements SaslHandler
 
     private static byte[] buildSaslInitPayload(String idScope, String registrationId, byte[] endorsementKey)
     {
-        byte[] bytes = concatBytesWithNullDelimiter(idScope.getBytes(), registrationId.getBytes(), endorsementKey);
+        byte[] bytes = concatBytesWithNullDelimiter(idScope.getBytes(StandardCharsets.UTF_8), registrationId.getBytes(StandardCharsets.UTF_8), endorsementKey);
         return prependByteArrayWithControlByte(INIT_SEGMENT_CONTROL_BYTE, bytes);
     }
 

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqp.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqp.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.RequestData
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ContractAPIAmqp extends ProvisioningDeviceClientContract
@@ -180,7 +181,7 @@ public class ContractAPIAmqp extends ProvisioningDeviceClientContract
             this.amqpSaslHandler.setSasToken(requestData.getSasToken());
         }
 
-        byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes();
+        byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes(StandardCharsets.UTF_8);
 
         // SRS_ContractAPIAmqp_07_005: [This method shall send an AMQP message with the property of iotdps-register.]
         this.provisioningAmqpOperations.sendRegisterMessage(responseCallback, callbackContext, payload);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttp.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttp.java
@@ -201,7 +201,7 @@ public class ContractAPIHttp extends ProvisioningDeviceClientContract
             String base64EncodedEk = new String(encodeBase64(requestData.getEndorsementKey()));
             String base64EncodedSrk = new String(encodeBase64(requestData.getStorageRootKey()));
             //SRS_ContractAPIHttp_25_025: [ This method shall build the required Json input using parser. ]
-            byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload(), base64EncodedEk, base64EncodedSrk).toJson().getBytes();
+            byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload(), base64EncodedEk, base64EncodedSrk).toJson().getBytes(StandardCharsets.UTF_8);
             //SRS_ContractAPIHttp_25_005: [This method shall prepare the PUT request by setting following headers on a HttpRequest 1. User-Agent : User Agent String for the SDK 2. Accept : "application/json" 3. Content-Type: "application/json; charset=utf-8".]
             HttpRequest httpRequest = this.prepareRequest(new URL(url), HttpMethod.PUT, payload, null);
             //SRS_ContractAPIHttp_25_006: [This method shall set the SSLContext for the Http Request.]
@@ -220,7 +220,7 @@ public class ContractAPIHttp extends ProvisioningDeviceClientContract
                 {
                     String tpmRegistrationResultJson = new String(httpResponse.getErrorReason(), StandardCharsets.UTF_8);
                     TpmRegistrationResultParser registerResponseTPMParser = TpmRegistrationResultParser.createFromJson(tpmRegistrationResultJson);
-                    byte[] base64DecodedAuthKey = decodeBase64(registerResponseTPMParser.getAuthenticationKey().getBytes());
+                    byte[] base64DecodedAuthKey = decodeBase64(registerResponseTPMParser.getAuthenticationKey().getBytes(StandardCharsets.UTF_8));
                     responseCallback.run(new ResponseData(base64DecodedAuthKey, ContractState.DPS_REGISTRATION_RECEIVED, 0), dpsAuthorizationCallbackContext);
                     return;
                 }
@@ -283,11 +283,11 @@ public class ContractAPIHttp extends ProvisioningDeviceClientContract
                 //SRS_ContractAPIHttp_25_027: [ This method shall base 64 encoded endorsement key, storage root key. ]
                 String base64EncodedEk = new String(encodeBase64(requestData.getEndorsementKey()));
                 String base64EncodedSrk = new String(encodeBase64(requestData.getStorageRootKey()));
-                payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload(), base64EncodedEk, base64EncodedSrk).toJson().getBytes();
+                payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload(), base64EncodedEk, base64EncodedSrk).toJson().getBytes(StandardCharsets.UTF_8);
             }
             else
             {
-                payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes();
+                payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes(StandardCharsets.UTF_8);
             }
 
             //SRS_ContractAPIHttp_25_013: [This method shall prepare the PUT request by setting following headers on a HttpRequest 1. User-Agent : User Agent String for the SDK 2. Accept : "application/json" 3. Content-Type: "application/json; charset=utf-8" 4. Authorization: specified sas token as authorization if a non null value is given.]

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ResponseDat
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -238,7 +239,7 @@ public class ContractAPIMqtt extends ProvisioningDeviceClientContract implements
             String topic = String.format(MQTT_REGISTER_MESSAGE_FMT, this.packetId++);
 
             //SRS_ContractAPIMqtt_07_026: [ This method shall build the required Json input using parser. ]
-            byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes();
+            byte[] payload = new DeviceRegistrationParser(requestData.getRegistrationId(), requestData.getPayload()).toJson().getBytes(StandardCharsets.UTF_8);
 
             // SRS_ContractAPIMqtt_07_005: [This method shall send an MQTT message with the property of iotdps-register.]
             this.executeProvisioningMessage(topic, payload, responseCallback, callbackContext);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
@@ -22,6 +22,7 @@ import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderX509;
 import com.microsoft.azure.sdk.iot.provisioning.security.exceptions.SecurityProviderException;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.*;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientStatus.*;
@@ -233,7 +234,7 @@ public class ProvisioningTask implements Callable<Object>
 
                         //Codes_SRS_ProvisioningTask_34_016: [Upon reaching the terminal state ASSIGNED, if the saved security client is an instance of SecurityClientTpm, the security client shall decrypt and store the authentication key from the statusResponseParser.]
                         String authenticationKey = registrationStatus.getTpm().getAuthenticationKey();
-                        ((SecurityProviderTpm) this.securityProvider).activateIdentityKey(decodeBase64(authenticationKey.getBytes()));
+                        ((SecurityProviderTpm) this.securityProvider).activateIdentityKey(decodeBase64(authenticationKey.getBytes(StandardCharsets.UTF_8)));
                     }
                     log.info("Device provisioning service assigned the device successfully");
                     this.invokeRegistrationCallback(registrationInfo, null);

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTask.java
@@ -166,7 +166,7 @@ public class RegisterTask implements Callable<RegistrationOperationStatusParser>
         if (securityProvider instanceof SecurityProviderTpm)
         {
             SecurityProviderTpm securityClientTpm = (SecurityProviderTpm) securityProvider;
-            token = securityClientTpm.signWithIdentity(value.getBytes());
+            token = securityClientTpm.signWithIdentity(value.getBytes(StandardCharsets.UTF_8));
         }
         else if (securityProvider instanceof SecurityProviderSymmetricKey)
         {

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import javax.net.ssl.SSLContext;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,8 +46,8 @@ public class ContractAPIAmqpTest
     private static final String TEST_OPERATION_ID = "testOperationId";
     private static final String TEST_SAS_TOKEN = "testSasToken";
     private static final String TEST_PAYLOAD = "testPayload";
-    private static final byte[] TEST_EK = "testEK".getBytes();
-    private static final byte[] TEST_SRK = "testSRK".getBytes();
+    private static final byte[] TEST_EK = "testEK".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TEST_SRK = "testSRK".getBytes(StandardCharsets.UTF_8);
 
     @Mocked
     AmqpDeviceOperations mockedAmqpProvOperations;

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttpTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/http/ContractAPIHttpTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
@@ -45,8 +46,8 @@ public class ContractAPIHttpTest
     private static final String TEST_REGISTRATION_ID = "testRegistrationId";
     private static final String TEST_OPERATION_ID = "testOperationId";
     private static final String TEST_SAS_TOKEN = "testSasToken";
-    private static final byte[] TEST_EK = "testEK".getBytes();
-    private static final byte[] TEST_SRK = "testSRK".getBytes();
+    private static final byte[] TEST_EK = "testEK".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TEST_SRK = "testSRK".getBytes(StandardCharsets.UTF_8);
 
     @Mocked
     DeviceRegistrationParser mockedDeviceRegistrationParser;
@@ -228,7 +229,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMSucceeds() throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -251,7 +252,7 @@ public class ContractAPIHttpTest
                 TpmRegistrationResultParser.createFromJson(new String(mockedHttpResponse.getBody()));
                 result = mockedTpmRegistrationResultParser;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
-                result = encodeBase64String("some auth key".getBytes());
+                result = encodeBase64String("some auth key".getBytes(StandardCharsets.UTF_8));
                 new DeviceRegistrationParser(anyString, anyString, anyString, anyString);
                 result = mockedDeviceRegistrationParser;
                 mockedDeviceRegistrationParser.toJson();
@@ -286,7 +287,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnNullRegistrationId() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -309,7 +310,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnEmptyRegistrationId() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -332,7 +333,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnNullEk() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -355,7 +356,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnNullSRk() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -378,7 +379,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnNullSSLContext() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -401,7 +402,7 @@ public class ContractAPIHttpTest
     public void requestNonceWithDPSTPMThrowsOnNullResponseCallback() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -424,7 +425,7 @@ public class ContractAPIHttpTest
     @Test (expected = ProvisioningDeviceClientException.class)
     public void requestNonceWithDPSTPMThrowsHubExceptionWithStatusOtherThan404Throws() throws IOException, ProvisioningDeviceClientException
     {
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
 
@@ -473,7 +474,7 @@ public class ContractAPIHttpTest
     @Test (expected = ProvisioningDeviceTransportException.class)
     public void requestNonceWithDPSTPMThrowsHubExceptionWithStatusLessThan300Throws() throws IOException, ProvisioningDeviceClientException
     {
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -520,7 +521,7 @@ public class ContractAPIHttpTest
     @Test (expected = ProvisioningDeviceTransportException.class)
     public void requestNonceWithDPSTPMThrowsTransportExceptionIfAnyOfTheTransportCallsFails() throws IOException, ProvisioningDeviceClientException
     {
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -564,7 +565,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSWithOutAuthSucceeds(@Mocked DeviceRegistrationParser mockedDeviceRegistrationParser) throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -616,7 +617,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSForTPMSucceeds() throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -669,7 +670,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSThrowsOnSendFailure() throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -720,7 +721,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSWithAuthSucceeds() throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -773,7 +774,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSWithAuthAndRetryAfterSucceeds() throws IOException, ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         prepareRequestExpectations();
         new NonStrictExpectations()
@@ -833,7 +834,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSThrowsOnNullRegistrationId() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -855,7 +856,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSThrowsOnEmptyRegistrationId() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -876,7 +877,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSThrowsOnNullSSLContext() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -897,7 +898,7 @@ public class ContractAPIHttpTest
     public void authenticateWithDPSThrowsOnNullResponseCallback() throws ProvisioningDeviceClientException
     {
         //arrange
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -918,7 +919,7 @@ public class ContractAPIHttpTest
     @Test (expected = ProvisioningDeviceTransportException.class)
     public void authenticateWithDPSThrowsTransportExceptionIfAnyOfTheTransportCallsFails() throws ProvisioningDeviceClientException
     {
-        final byte[] expectedPayload = "testByte".getBytes();
+        final byte[] expectedPayload = "testByte".getBytes(StandardCharsets.UTF_8);
         ContractAPIHttp contractAPIHttp = createContractClass();
         new NonStrictExpectations()
         {
@@ -1278,7 +1279,7 @@ public class ContractAPIHttpTest
     public void prepareRequestThrowsOnNullUrl() throws Exception
     {
         //arrange
-        final byte[] expectedPayload = "TestBytes".getBytes();
+        final byte[] expectedPayload = "TestBytes".getBytes(StandardCharsets.UTF_8);
         final String expectedUserAgentValue = "TestUserAgent";
         ContractAPIHttp contractAPIHttp = createContractClass();
 
@@ -1291,7 +1292,7 @@ public class ContractAPIHttpTest
     public void prepareRequestThrowsOnNullMethod() throws Exception
     {
         //arrange
-        final byte[] expectedPayload = "TestBytes".getBytes();
+        final byte[] expectedPayload = "TestBytes".getBytes(StandardCharsets.UTF_8);
         final String expectedUserAgentValue = "TestUserAgent";
         ContractAPIHttp contractAPIHttp = createContractClass();
 
@@ -1317,7 +1318,7 @@ public class ContractAPIHttpTest
     public void prepareRequestThrowsOnInvalidTimeout() throws Exception
     {
         //arrange
-        final byte[] expectedPayload = "TestBytes".getBytes();
+        final byte[] expectedPayload = "TestBytes".getBytes(StandardCharsets.UTF_8);
         final String expectedUserAgentValue = "TestUserAgent";
         ContractAPIHttp contractAPIHttp = createContractClass();
 

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTaskTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTaskTest.java
@@ -25,6 +25,7 @@ import mockit.integration.junit4.JMockit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.*;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientStatus.*;
@@ -1470,7 +1471,7 @@ public class ProvisioningTaskTest
                 mockedDeviceRegistrationResultParser.getTpm();
                 result = mockedTpm;
                 mockedTpm.getAuthenticationKey();
-                result = encodeBase64String("some auth key".getBytes());
+                result = encodeBase64String("some auth key".getBytes(StandardCharsets.UTF_8));
                 mockedProvisioningDeviceClientConfig.getSecurityProvider();
                 result = mockedSecurityProviderTpm;
             }

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTaskTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RegisterTaskTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import javax.net.ssl.SSLContext;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState.DPS_REGISTRATION_RECEIVED;
 import static com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState.DPS_REGISTRATION_UNKNOWN;
@@ -167,7 +168,7 @@ public class RegisterTaskTest
                 mockedDpsSecurityProviderX509.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
             }
@@ -362,15 +363,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -378,7 +379,7 @@ public class RegisterTaskTest
                 mockedUrlPathBuilder.generateSasTokenUrl(TEST_REGISTRATION_ID);
                 result = "testUrl";
                 mockedSecurityProviderTpm.signWithIdentity((byte[])any);
-                result = "testToken".getBytes();
+                result = "testToken".getBytes(StandardCharsets.UTF_8);
             }
         };
         //act
@@ -422,7 +423,7 @@ public class RegisterTaskTest
                 mockedSecurityProviderSymmetricKey.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -430,7 +431,7 @@ public class RegisterTaskTest
                 mockedUrlPathBuilder.generateSasTokenUrl(TEST_REGISTRATION_ID);
                 result = "testUrl";
                 mockedSecurityProviderSymmetricKey.HMACSignData((byte[])any, (byte[]) any);
-                result = "testToken".getBytes();
+                result = "testToken".getBytes(StandardCharsets.UTF_8);
             }
         };
         //act
@@ -511,7 +512,7 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
                 result = null;
             }
@@ -535,9 +536,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -563,9 +564,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -594,9 +595,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -622,9 +623,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -651,9 +652,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -679,9 +680,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -711,15 +712,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -751,15 +752,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -787,15 +788,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -822,15 +823,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -857,15 +858,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -899,7 +900,7 @@ public class RegisterTaskTest
                 mockedSecurityProviderSymmetricKey.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -929,15 +930,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -967,15 +968,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -983,7 +984,7 @@ public class RegisterTaskTest
                 mockedUrlPathBuilder.generateSasTokenUrl(TEST_REGISTRATION_ID);
                 result = "testUrl";
                 mockedSecurityProviderTpm.signWithIdentity((byte[])any);
-                result = "".getBytes();
+                result = "".getBytes(StandardCharsets.UTF_8);
             }
         };
         //act
@@ -1006,15 +1007,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 mockedTpmRegistrationResultParser.getAuthenticationKey();
@@ -1022,7 +1023,7 @@ public class RegisterTaskTest
                 mockedUrlPathBuilder.generateSasTokenUrl(TEST_REGISTRATION_ID);
                 result = "testUrl";
                 mockedSecurityProviderTpm.signWithIdentity((byte[])any);
-                result = "testToken".getBytes();
+                result = "testToken".getBytes(StandardCharsets.UTF_8);
                 mockedProvisioningDeviceClientContract.authenticateWithProvisioningService((RequestData) any,
                                                                                            (ResponseCallback)any, any);
                 result = new ProvisioningDeviceTransportException("test transport exception");
@@ -1047,9 +1048,9 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
@@ -1078,7 +1079,7 @@ public class RegisterTaskTest
                 mockedUrlPathBuilder.generateSasTokenUrl(TEST_REGISTRATION_ID);
                 result = "testUrl";
                 mockedSecurityProviderTpm.signWithIdentity((byte[])any);
-                result = "testToken".getBytes();
+                result = "testToken".getBytes(StandardCharsets.UTF_8);
                 mockedProvisioningDeviceClientContract.authenticateWithProvisioningService((RequestData) any,
                                                                                            (ResponseCallback)any, any);
             }
@@ -1115,7 +1116,7 @@ public class RegisterTaskTest
                 mockedDpsSecurityProviderX509.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 RegistrationOperationStatusParser.createFromJson("NonNullValue");
@@ -1156,15 +1157,15 @@ public class RegisterTaskTest
                 mockedSecurityProviderTpm.getRegistrationId();
                 result = TEST_REGISTRATION_ID;
                 mockedSecurityProviderTpm.getEndorsementKey();
-                result = TEST_EK.getBytes();
+                result = TEST_EK.getBytes(StandardCharsets.UTF_8);
                 mockedSecurityProviderTpm.getStorageRootKey();
-                result = TEST_SRK.getBytes();
+                result = TEST_SRK.getBytes(StandardCharsets.UTF_8);
                 mockedDeviceRegistrationParser.toJson();
                 result = "testJson";
                 mockedSecurityProviderTpm.getSSLContext();
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 RegistrationOperationStatusParser.createFromJson("NonNullValue");

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RequestDataTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/RequestDataTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import javax.net.ssl.SSLContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import static mockit.Deencapsulation.invoke;
@@ -30,8 +31,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(JMockit.class)
 public class RequestDataTest
 {
-    private static final byte[] TEST_EK = "testEk".getBytes();
-    private static final byte[] TEST_SRK = "testSRk".getBytes();
+    private static final byte[] TEST_EK = "testEk".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TEST_SRK = "testSRk".getBytes(StandardCharsets.UTF_8);
     private static final String TEST_REG = "testReg";
     private static final String TEST_OP = "testOp";
     private static final String TEST_SASTOKEN = "testSasToken";

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ResponseDataTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ResponseDataTest.java
@@ -14,6 +14,8 @@ import mockit.integration.junit4.JMockit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
+
 import static com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState.DPS_REGISTRATION_UNKNOWN;
 import static mockit.Deencapsulation.*;
 import static org.junit.Assert.assertEquals;
@@ -58,7 +60,7 @@ public class ResponseDataTest
     public void setAndGetResponseData() throws Exception
     {
         //arrange
-        byte [] testData = "testData".getBytes();
+        byte [] testData = "testData".getBytes(StandardCharsets.UTF_8);
         ResponseData testResponseData = newInstance(ResponseData.class);
 
         //act

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/StatusTaskTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/StatusTaskTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import javax.net.ssl.SSLContext;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ContractState.DPS_REGISTRATION_RECEIVED;
 import static junit.framework.TestCase.assertEquals;
@@ -158,7 +159,7 @@ public class StatusTaskTest
                 Deencapsulation.invoke(mockedAuthorization, "getSslContext");
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 RegistrationOperationStatusParser.createFromJson(anyString);
@@ -339,7 +340,7 @@ public class StatusTaskTest
                 Deencapsulation.invoke(mockedAuthorization, "getSslContext");
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 RegistrationOperationStatusParser.createFromJson(anyString);
@@ -370,7 +371,7 @@ public class StatusTaskTest
                 Deencapsulation.invoke(mockedAuthorization, "getSslContext");
                 result = mockedSslContext;
                 Deencapsulation.invoke(mockedResponseData, "getResponseData");
-                result = "NonNullValue".getBytes();
+                result = "NonNullValue".getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(mockedResponseData, "getContractState");
                 result = DPS_REGISTRATION_RECEIVED;
                 RegistrationOperationStatusParser.createFromJson(anyString);

--- a/provisioning/provisioning-samples/provisioning-symmetrickey-individual-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ProvisioningSymmetricKeyIndividualEnrollmentSample.java
+++ b/provisioning/provisioning-samples/provisioning-symmetrickey-individual-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/ProvisioningSymmetricKeyIndividualEnrollmentSample.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.Provi
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 /**
@@ -87,7 +88,7 @@ public class ProvisioningSymmetricKeyIndividualEnrollmentSample
         Scanner scanner = new Scanner(System.in);
         DeviceClient deviceClient = null;
 
-        securityClientSymmetricKey = new SecurityProviderSymmetricKey(SYMMETRIC_KEY.getBytes(), REGISTRATION_ID);
+        securityClientSymmetricKey = new SecurityProviderSymmetricKey(SYMMETRIC_KEY.getBytes(StandardCharsets.UTF_8), REGISTRATION_ID);
 
         ProvisioningDeviceClient provisioningDeviceClient = null;
         try

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttp.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttp.java
@@ -144,7 +144,7 @@ public class ContractApiHttp
         URL url = getUrlForPath(path);
 
         /* SRS_HTTP_DEVICE_REGISTRATION_CLIENT_21_010: [The request shall create a new HttpRequest.*/
-        HttpRequest request = createRequest(url, httpMethod, headerParameters, payload.getBytes(), sasTokenString);
+        HttpRequest request = createRequest(url, httpMethod, headerParameters, payload.getBytes(StandardCharsets.UTF_8), sasTokenString);
 
         /* SRS_HTTP_DEVICE_REGISTRATION_CLIENT_21_014: [The request shall send the request to the Device Provisioning Service service by using the HttpRequest.send().*/
         /* SRS_HTTP_DEVICE_REGISTRATION_CLIENT_21_015: [If the HttpRequest failed send the message, the request shall throw ProvisioningServiceClientTransportException, threw by the callee.*/

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/EnrollmentGroupManagerTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/EnrollmentGroupManagerTest.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.*;
 import mockit.*;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -108,7 +109,7 @@ public class EnrollmentGroupManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(EnrollmentGroup.class, resultPayload);
                 result = mockedEnrollmentGroupResponse;
@@ -159,7 +160,7 @@ public class EnrollmentGroupManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(EnrollmentGroup.class, resultPayload);
                 result = mockedEnrollmentGroupResponse;
@@ -323,7 +324,7 @@ public class EnrollmentGroupManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(EnrollmentGroup.class, resultPayload);
                 result = mockedEnrollmentGroupResponse;

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/IndividualEnrollmentManagerTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/IndividualEnrollmentManagerTest.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.*;
 import mockit.*;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -110,7 +111,7 @@ public class IndividualEnrollmentManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(IndividualEnrollment.class, resultPayload);
                 result = mockedIndividualEnrollmentResponse;
@@ -159,7 +160,7 @@ public class IndividualEnrollmentManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.newInstance(IndividualEnrollment.class, resultPayload);
                 result = mockedIndividualEnrollmentResponse;
             }
@@ -344,7 +345,7 @@ public class IndividualEnrollmentManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(BulkEnrollmentOperationResult.class, resultPayload);
                 result = mockedBulkEnrollmentOperationResult;
@@ -504,7 +505,7 @@ public class IndividualEnrollmentManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(IndividualEnrollment.class, resultPayload);
                 result = mockedIndividualEnrollmentResponse;

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/QueryTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/QueryTest.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.*;
 import mockit.*;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -210,7 +211,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, (Map)any, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = "result".getBytes();
+                result = "result".getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
             }
@@ -250,7 +251,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, (Map)any, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = "result".getBytes();
+                result = "result".getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
             }
@@ -304,7 +305,7 @@ public class QueryTest
                 times = 1;
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = "result".getBytes();
+                result = "result".getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 times = 1;
@@ -347,7 +348,7 @@ public class QueryTest
                 times = 1;
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = "result".getBytes();
+                result = "result".getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 times = 1;
@@ -423,7 +424,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, headersSend, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = bodyResult.getBytes();
+                result = bodyResult.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 Deencapsulation.newInstance(QueryResult.class, type, bodyResult, continuationToken);
@@ -470,7 +471,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, headersSend, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = bodyResult.getBytes();
+                result = bodyResult.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 Deencapsulation.newInstance(QueryResult.class, new Class[]{String.class, String.class, String.class}, null, bodyResult, continuationToken);
@@ -518,7 +519,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, headersSend, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = bodyResult.getBytes();
+                result = bodyResult.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 Deencapsulation.newInstance(QueryResult.class, new Class[]{String.class, String.class, String.class}, type, bodyResult, null);
@@ -597,7 +598,7 @@ public class QueryTest
                 mockedContractApiHttp.request(HttpMethod.POST, queryPath, headersSend, querySpecificationJson);
                 result = mockedHttpResponse;
                 mockedHttpResponse.getBody();
-                result = bodyResult.getBytes();
+                result = bodyResult.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getHeaderFields();
                 result = headersResult;
                 Deencapsulation.newInstance(QueryResult.class, new Class[]{String.class, String.class, String.class}, type, bodyResult, null);

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/RegistrationStatusManagerTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/RegistrationStatusManagerTest.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.*;
 import mockit.*;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -107,7 +108,7 @@ public class RegistrationStatusManagerTest
                 result = mockedHttpResponse;
                 times = 1;
                 mockedHttpResponse.getBody();
-                result = resultPayload.getBytes();
+                result = resultPayload.getBytes(StandardCharsets.UTF_8);
                 times = 1;
                 Deencapsulation.newInstance(DeviceRegistrationState.class, resultPayload);
                 result = mockedDeviceRegistrationState;

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/auth/ProvisioningServiceSasTokenTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/auth/ProvisioningServiceSasTokenTest.java
@@ -52,7 +52,7 @@ public class ProvisioningServiceSasTokenTest
         String hostName = "HOSTNAME." + deviceProvisioningServiceName;
         String sharedAccessKeyName = "ACCESSKEYNAME";
         String policyName = "SharedAccessKey";
-        String sharedAccessKey = encodeBase64String("key".getBytes());
+        String sharedAccessKey = encodeBase64String("key".getBytes(StandardCharsets.UTF_8));
         String connectionString = "HostName=" + hostName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
 
         ProvisioningConnectionString provisioningConnectionString = ProvisioningConnectionStringBuilder.createConnectionString(connectionString);
@@ -91,7 +91,7 @@ public class ProvisioningServiceSasTokenTest
         String hostName = "HOSTNAME." + deviceProvisioningServiceName;
         String sharedAccessKeyName = "ACCESSKEYNAME";
         String policyName = "SharedAccessKey";
-        String sharedAccessKey = encodeBase64String("key".getBytes());
+        String sharedAccessKey = encodeBase64String("key".getBytes(StandardCharsets.UTF_8));
         String connectionString = "HostName=" + hostName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
         ProvisioningConnectionString provisioningConnectionString = ProvisioningConnectionStringBuilder.createConnectionString(connectionString);
 
@@ -114,7 +114,7 @@ public class ProvisioningServiceSasTokenTest
         String hostName = "HOSTNAME." + deviceProvisioningServiceName;
         String sharedAccessKeyName = "ACCESSKEYNAME";
         String policyName = "SharedAccessKey";
-        String sharedAccessKey = encodeBase64String("key".getBytes());
+        String sharedAccessKey = encodeBase64String("key".getBytes(StandardCharsets.UTF_8));
         String connectionString = "HostName=" + hostName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
 
         // Act

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/EnrollmentGroupTest.java
@@ -11,6 +11,7 @@ import mockit.*;
 import org.junit.Test;
 import com.microsoft.azure.sdk.iot.provisioning.service.Helpers;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -31,8 +32,8 @@ public class EnrollmentGroupTest
     private static final String VALID_PARSED_ETAG = "\"00000000-0000-0000-0000-00000000000\"";
     private static final String PRIMARY_KEY_TEXT = "validPrimaryKey";
     private static final String SECONDARY_KEY_TEXT = "validSecondaryKey";
-    private static final String VALID_PRIMARY_KEY = encodeBase64String(PRIMARY_KEY_TEXT.getBytes());
-    private static final String VALID_SECONDARY_KEY = encodeBase64String(SECONDARY_KEY_TEXT.getBytes());
+    private static final String VALID_PRIMARY_KEY = encodeBase64String(PRIMARY_KEY_TEXT.getBytes(StandardCharsets.UTF_8));
+    private static final String VALID_SECONDARY_KEY = encodeBase64String(SECONDARY_KEY_TEXT.getBytes(StandardCharsets.UTF_8));
 
     //PEM encoded representation of the public key certificate
     private static final String PUBLIC_KEY_CERTIFICATE_STRING =

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/SymmetricKeyAttestationTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/configs/SymmetricKeyAttestationTest.java
@@ -7,6 +7,8 @@ import com.microsoft.azure.sdk.iot.provisioning.service.configs.SymmetricKeyAtte
 import mockit.Deencapsulation;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 import static org.junit.Assert.*;
 
@@ -15,8 +17,8 @@ public class SymmetricKeyAttestationTest
     private static final String PRIMARY_KEY_TEXT = "validPrimaryKey";
     private static final String SECONDARY_KEY_TEXT = "validSecondaryKey";
 
-    private static final String VALID_PRIMARY_KEY = encodeBase64String(PRIMARY_KEY_TEXT.getBytes());
-    private static final String VALID_SECONDARY_KEY = encodeBase64String(SECONDARY_KEY_TEXT.getBytes());
+    private static final String VALID_PRIMARY_KEY = encodeBase64String(PRIMARY_KEY_TEXT.getBytes(StandardCharsets.UTF_8));
+    private static final String VALID_SECONDARY_KEY = encodeBase64String(SECONDARY_KEY_TEXT.getBytes(StandardCharsets.UTF_8));
 
     /* SRS_SYMMETRIC_KEY_ATTESTATION_44_001: [The constructor shall store the provided primary key.] */
     /* SRS_SYMMETRIC_KEY_ATTESTATION_44_002: [The constructor shall store the provided secondary key.] */

--- a/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttpTest.java
+++ b/provisioning/provisioning-service-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/ContractApiHttpTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,7 +51,7 @@ public class ContractApiHttpTest
     private final String VALID_PATH = "a/b";
     private final Map<String, String> VALID_HEADER = new HashMap<>();
     private final String VALID_PAYLOAD = "{}";
-    private final byte[] VALID_BODY = VALID_PAYLOAD.getBytes();
+    private final byte[] VALID_BODY = VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8);
     private final int VALID_SUCCESS_STATUS = 200;
     private final String VALID_SUCCESS_MESSAGE = "success";
     private final String VALID_SASTOKEN = "validSas";
@@ -69,14 +70,14 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpRequest;
                 mockedHttpRequest.send();
                 result = mockedHttpResponse;
                 mockedHttpResponse.getStatus();
                 result = VALID_SUCCESS_STATUS;
                 mockedHttpResponse.getErrorReason();
-                result = VALID_SUCCESS_MESSAGE.getBytes();
+                result = VALID_SUCCESS_MESSAGE.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getBody();
                 result = VALID_BODY;
                 mockedHttpResponse.getHeaderFields();
@@ -155,14 +156,14 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpRequest;
                 mockedHttpRequest.send();
                 result = mockedHttpResponse;
                 mockedHttpResponse.getStatus();
                 result = VALID_SUCCESS_STATUS;
                 mockedHttpResponse.getErrorReason();
-                result = VALID_SUCCESS_MESSAGE.getBytes();
+                result = VALID_SUCCESS_MESSAGE.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getBody();
                 result = VALID_BODY;
                 mockedHttpResponse.getHeaderFields();
@@ -342,14 +343,14 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpRequest;
                 mockedHttpRequest.send();
                 result = mockedHttpResponse;
                 mockedHttpResponse.getStatus();
                 result = VALID_SUCCESS_STATUS;
                 mockedHttpResponse.getErrorReason();
-                result = VALID_SUCCESS_MESSAGE.getBytes();
+                result = VALID_SUCCESS_MESSAGE.getBytes(StandardCharsets.UTF_8);
                 mockedHttpResponse.getBody();
                 result = VALID_BODY;
                 mockedHttpResponse.getHeaderFields();
@@ -384,7 +385,7 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = new IOException();
             }
         };
@@ -515,7 +516,7 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpRequest;
                 mockedHttpRequest.send();
                 result = new ProvisioningServiceClientException();
@@ -551,14 +552,14 @@ public class ContractApiHttpTest
                 result = VALID_HOST_NAME;
                 new URL((String)any);
                 result = mockedURL;
-                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes());
+                new HttpRequest(mockedURL, HttpMethod.PUT, VALID_PAYLOAD.getBytes(StandardCharsets.UTF_8));
                 result = mockedHttpRequest;
                 mockedHttpRequest.send();
                 result = mockedHttpResponse;
                 mockedHttpResponse.getStatus();
                 result = 401;
                 mockedHttpResponse.getErrorReason();
-                result = VALID_SUCCESS_MESSAGE.getBytes();
+                result = VALID_SUCCESS_MESSAGE.getBytes(StandardCharsets.UTF_8);
             }
         };
 

--- a/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProvider.java
+++ b/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProvider.java
@@ -13,6 +13,7 @@ import javax.net.ssl.SSLContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -148,7 +149,7 @@ public abstract class SecurityProvider
         //SRS_SecurityClient_25_002: [ This method shall retrieve the default CertificateFactory instance. ]
         CertificateFactory certFactory = CertificateFactory.getInstance(DEFAULT_CERT_INSTANCE);
         Collection<? extends Certificate> trustedCert;
-        try (InputStream certStreamArray = new ByteArrayInputStream(DEFAULT_TRUSTED_CERT.getBytes()))
+        try (InputStream certStreamArray = new ByteArrayInputStream(DEFAULT_TRUSTED_CERT.getBytes(StandardCharsets.UTF_8)))
         {
             trustedCert =  certFactory.generateCertificates(certStreamArray);
         }

--- a/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKey.java
+++ b/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKey.java
@@ -14,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.util.Base64;
@@ -67,8 +68,8 @@ public class SecurityProviderSymmetricKey extends SecurityProvider
             throw new IllegalArgumentException("Registration ID cannot be null");
         }
 
-        this.primaryKey = primaryKey.getBytes();
-        this.secondaryKey = secondaryKey.getBytes();
+        this.primaryKey = primaryKey.getBytes(StandardCharsets.UTF_8);
+        this.secondaryKey = secondaryKey.getBytes(StandardCharsets.UTF_8);
         this.registrationId = registrationId;
     }
 
@@ -188,6 +189,6 @@ public class SecurityProviderSymmetricKey extends SecurityProvider
         SecretKeySpec secretKey = new SecretKeySpec(masterKeyBytes, HMAC_SHA256);
         Mac hMacSha256 = Mac.getInstance(HMAC_SHA256);
         hMacSha256.init(secretKey);
-        return Base64.getEncoder().encode(hMacSha256.doFinal(deviceId.getBytes()));
+        return Base64.getEncoder().encode(hMacSha256.doFinal(deviceId.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKeyTest.java
+++ b/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKeyTest.java
@@ -20,6 +20,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -36,7 +37,7 @@ import static junit.framework.TestCase.assertEquals;
  */
 public class SecurityProviderSymmetricKeyTest
 {
-    private static final byte[] testSymKey = "symmkey".getBytes();
+    private static final byte[] testSymKey = "symmkey".getBytes(StandardCharsets.UTF_8);
     private static final String testRegId = "regId";
 
     private static final String testPrimaryKey = "12345";
@@ -142,14 +143,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(), TEST_BASE64_DECODED_KEY.getBytes());
+        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8), TEST_BASE64_DECODED_KEY.getBytes(StandardCharsets.UTF_8));
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };
@@ -165,14 +166,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(), null);
+        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8), null);
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };
@@ -187,14 +188,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(), "".getBytes());
+        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8), "".getBytes(StandardCharsets.UTF_8));
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };
@@ -209,14 +210,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData(null, TEST_BASE64_DECODED_KEY.getBytes());
+        securityProviderSymmetricKey.HMACSignData(null, TEST_BASE64_DECODED_KEY.getBytes(StandardCharsets.UTF_8));
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };
@@ -231,14 +232,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData("".getBytes(), TEST_BASE64_DECODED_KEY.getBytes());
+        securityProviderSymmetricKey.HMACSignData("".getBytes(StandardCharsets.UTF_8), TEST_BASE64_DECODED_KEY.getBytes(StandardCharsets.UTF_8));
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };
@@ -260,14 +261,14 @@ public class SecurityProviderSymmetricKeyTest
         //arrange
         SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, testRegId);
         //act
-        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(), TEST_BASE64_DECODED_KEY.getBytes());
+        securityProviderSymmetricKey.HMACSignData(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8), TEST_BASE64_DECODED_KEY.getBytes(StandardCharsets.UTF_8));
         //assert
         new Verifications()
         {
             {
                 new SecretKeySpec((byte[]) any, HMAC_SHA_256);
                 times = 1;
-                mockedMac.doFinal(TEST_SIGNATURE.getBytes());
+                mockedMac.doFinal(TEST_SIGNATURE.getBytes(StandardCharsets.UTF_8));
                 times = 0;
             }
         };

--- a/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
+++ b/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderTpmTest.java
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -38,10 +39,10 @@ import static org.junit.Assert.*;
  */
 public class SecurityProviderTpmTest
 {
-    private static final byte[] ENROLLMENT_KEY = "testEk".getBytes();
-    private static final byte[] STORAGE_ROOT_KEY = "testSRK".getBytes();
-    private static final byte[] TEST_SIGN_DATA = "testSignData".getBytes();
-    private static final byte[] TEST_ACTIVATION = "testActivation".getBytes();
+    private static final byte[] ENROLLMENT_KEY = "testEk".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] STORAGE_ROOT_KEY = "testSRK".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TEST_SIGN_DATA = "testSignData".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TEST_ACTIVATION = "testActivation".getBytes(StandardCharsets.UTF_8);
 
     @Mocked
     MessageDigest mockedMessageDigest;

--- a/provisioning/security/tpm-provider-emulator/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMEmulatorTest.java
+++ b/provisioning/security/tpm-provider-emulator/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMEmulatorTest.java
@@ -18,6 +18,8 @@ import tss.TpmFactory;
 import tss.TpmHelpers;
 import tss.tpm.*;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -339,7 +341,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeySucceeds() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -358,7 +360,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -380,7 +382,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -407,7 +409,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnNullIdKeyPub() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -428,7 +430,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnStartAuthSessionFail() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -455,7 +457,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnInnerWrapKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -488,7 +490,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnIdKeyPrivateNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -507,7 +509,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -525,7 +527,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnHIdKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -544,7 +546,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -564,7 +566,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnInvalidLengthOfEncUriData() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -583,7 +585,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -605,7 +607,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "lenGreaterThan10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "lenGreaterThan10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -621,7 +623,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnCreateResponseNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -640,7 +642,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -662,7 +664,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -681,7 +683,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnHSymKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -700,7 +702,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE) any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE) any, (TPM_HANDLE) any, (TPMS_ID_OBJECT) any, (byte[]) any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE) any, (byte[]) any, (TPMT_PUBLIC) any, (TPM2B_PRIVATE) any, (byte[]) any,
                                  (TPMT_SYM_DEF_OBJECT) any);
@@ -731,7 +733,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -759,7 +761,7 @@ public class SecurityProviderTPMEmulatorTest
     public void activateIdentityKeyThrowsOnEncryptDecryptResponseNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -778,7 +780,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -800,7 +802,7 @@ public class SecurityProviderTPMEmulatorTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -829,7 +831,7 @@ public class SecurityProviderTPMEmulatorTest
                                          @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -866,7 +868,7 @@ public class SecurityProviderTPMEmulatorTest
     public void signWithIdentityThrowsOnNullIdKeyPub() throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -903,7 +905,7 @@ public class SecurityProviderTPMEmulatorTest
                                                    @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "less<10".getBytes();
+        final byte[] deviceIdData = "less<10".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();
@@ -938,7 +940,7 @@ public class SecurityProviderTPMEmulatorTest
                                                    @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMEmulator securityProviderTPMEmulator = new SecurityProviderTPMEmulator();

--- a/provisioning/security/tpm-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMHsmTest.java
+++ b/provisioning/security/tpm-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderTPMHsmTest.java
@@ -17,6 +17,8 @@ import tss.TpmFactory;
 import tss.TpmHelpers;
 import tss.tpm.*;
 
+import java.nio.charset.StandardCharsets;
+
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -339,7 +341,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeySucceeds() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -358,7 +360,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -380,7 +382,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -407,7 +409,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnNullIdKeyPub() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -428,7 +430,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnStartAuthSessionFail() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -455,7 +457,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnInnerWrapKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -488,7 +490,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnIdKeyPrivateNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -507,7 +509,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -525,7 +527,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnHIdKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -544,7 +546,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -564,7 +566,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnInvalidLengthOfEncUriData() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -583,7 +585,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -605,7 +607,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "lenGreaterThan10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "lenGreaterThan10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -621,7 +623,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnCreateResponseNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -640,7 +642,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -662,7 +664,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -681,7 +683,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnHSymKeyNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -700,7 +702,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE) any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE) any, (TPM_HANDLE) any, (TPMS_ID_OBJECT) any, (byte[]) any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE) any, (byte[]) any, (TPMT_PUBLIC) any, (TPM2B_PRIVATE) any, (byte[]) any,
                                  (TPMT_SYM_DEF_OBJECT) any);
@@ -731,7 +733,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -759,7 +761,7 @@ public class SecurityProviderTPMHsmTest
     public void activateIdentityKeyThrowsOnEncryptDecryptResponseNull() throws Exception
     {
         //arrange
-        final byte[] testKey = "testKey".getBytes();
+        final byte[] testKey = "testKey".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -778,7 +780,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm._withSessions((TPM_HANDLE)any, mockedStartAuthSessionResponse.handle);
                 mockedTpm.ActivateCredential((TPM_HANDLE)any, (TPM_HANDLE)any, (TPMS_ID_OBJECT)any, (byte[])any);
-                result = "innerWrapKey".getBytes();
+                result = "innerWrapKey".getBytes(StandardCharsets.UTF_8);
 
                 mockedTpm.Import((TPM_HANDLE )any, (byte[] )any, (TPMT_PUBLIC )any, (TPM2B_PRIVATE )any, (byte[])any,
                                  (TPMT_SYM_DEF_OBJECT)any);
@@ -800,7 +802,7 @@ public class SecurityProviderTPMHsmTest
 
                 mockedTpm.FlushContext((TPM_HANDLE) any);
 
-                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes());
+                Deencapsulation.setField(mockedTpm2BData, "buffer", "len<10".getBytes(StandardCharsets.UTF_8));
 
                 TpmHelpers.getTpmProperty(mockedTpm, TPM_PT.INPUT_BUFFER);
                 result = 10;
@@ -829,7 +831,7 @@ public class SecurityProviderTPMHsmTest
                                          @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -866,7 +868,7 @@ public class SecurityProviderTPMHsmTest
     public void signWithIdentityThrowsOnNullIdKeyPub() throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -903,7 +905,7 @@ public class SecurityProviderTPMHsmTest
                                                    @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "less<10".getBytes();
+        final byte[] deviceIdData = "less<10".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();
@@ -938,7 +940,7 @@ public class SecurityProviderTPMHsmTest
                                                    @Mocked TPMS_KEYEDHASH_PARMS mockedTpmsKeyedhashParms) throws Exception
     {
         //arrange
-        final byte[] deviceIdData = "deviceIdData".getBytes();
+        final byte[] deviceIdData = "deviceIdData".getBytes(StandardCharsets.UTF_8);
         createPersistentPrimaryExpectations();
         createPersistentPrimaryExpectations();
         SecurityProviderTPMHsm securityProviderTPMEmulator = new SecurityProviderTPMHsm();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/Message.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/Message.java
@@ -145,7 +145,7 @@ public class Message
         this();
         if (stream != null)
         {
-            this.body = stream.toString().getBytes();
+            this.body = stream.toString().getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -247,7 +247,7 @@ public class RegistryManager
         String deviceJson = device.toDeviceParser().toJson();
 
         URL url = IotHubConnectionString.getUrlDevice(this.hostName, device.getDeviceId());
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, deviceJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, deviceJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -507,7 +507,7 @@ public class RegistryManager
         device.setForceUpdate(forceUpdate);
 
         URL url = IotHubConnectionString.getUrlDevice(this.hostName, device.getDeviceId());
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, device.toDeviceParser().toJson().getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, device.toDeviceParser().toJson().getBytes(StandardCharsets.UTF_8));
 
         request.setHeaderField("If-Match", "*");
 
@@ -756,7 +756,7 @@ public class RegistryManager
         URL url = IotHubConnectionString.getUrlCreateExportImportJob(this.hostName);
 
         String jobPropertiesJson = CreateExportJobPropertiesJson(exportBlobContainerUri, excludeKeys);
-        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -819,7 +819,7 @@ public class RegistryManager
 
         exportDevicesParameters.setType(JobProperties.JobType.EXPORT);
         String jobPropertiesJson = exportDevicesParameters.toJobPropertiesParser().toJson();
-        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -886,7 +886,7 @@ public class RegistryManager
         URL url = IotHubConnectionString.getUrlCreateExportImportJob(this.hostName);
 
         String jobPropertiesJson = CreateImportJobPropertiesJson(importBlobContainerUri, outputBlobContainerUri);
-        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -950,7 +950,7 @@ public class RegistryManager
 
         importDevicesParameters.setType(JobProperties.JobType.IMPORT);
         String jobPropertiesJson = importDevicesParameters.toJobPropertiesParser().toJson();
-        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.POST, jobPropertiesJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -1075,7 +1075,7 @@ public class RegistryManager
 
         URL url = IotHubConnectionString.getUrlModule(this.hostName, module.getDeviceId(), module.getId());
 
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, moduleJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, moduleJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -1199,7 +1199,7 @@ public class RegistryManager
 
         URL url = IotHubConnectionString.getUrlModule(this.hostName, module.getDeviceId(), module.getId());
 
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, module.toDeviceParser().toJson().getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, module.toDeviceParser().toJson().getBytes(StandardCharsets.UTF_8));
         request.setHeaderField("If-Match", "*");
 
         HttpResponse response = request.send();
@@ -1300,7 +1300,7 @@ public class RegistryManager
 
         URL url = IotHubConnectionString.getUrlConfiguration(this.hostName, configuration.getId());
 
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, configurationJson.getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, configurationJson.getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 
@@ -1420,7 +1420,7 @@ public class RegistryManager
 
         URL url = IotHubConnectionString.getUrlConfiguration(this.hostName, configuration.getId());
 
-        HttpRequest request = CreateRequest(url, HttpMethod.PUT, configuration.toConfigurationParser().toJson().getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.PUT, configuration.toConfigurationParser().toJson().getBytes(StandardCharsets.UTF_8));
 
         request.setHeaderField("If-Match", "*");
 
@@ -1510,7 +1510,7 @@ public class RegistryManager
 
         URL url = IotHubConnectionString.getUrlApplyConfigurationContent(this.hostName, deviceId);
 
-        HttpRequest request = CreateRequest(url, HttpMethod.POST, content.toConfigurationContentParser().toJson().getBytes());
+        HttpRequest request = CreateRequest(url, HttpMethod.POST, content.toConfigurationContentParser().toJson().getBytes(StandardCharsets.UTF_8));
 
         HttpResponse response = request.send();
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/Query.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -183,7 +184,7 @@ public class Query
         if (isSqlQuery)
         {
             QueryRequestParser requestParser = new QueryRequestParser(this.query);
-            payload = requestParser.toJson().getBytes();
+            payload = requestParser.toJson().getBytes(StandardCharsets.UTF_8);
         }
         else
         {
@@ -281,7 +282,7 @@ public class Query
         if (isSqlQuery)
         {
             QueryRequestParser requestParser = new QueryRequestParser(this.query);
-            payload = requestParser.toJson().getBytes();
+            payload = requestParser.toJson().getBytes(StandardCharsets.UTF_8);
         }
         else
         {
@@ -381,7 +382,7 @@ public class Query
         if (isSqlQuery)
         {
             QueryRequestParser requestParser = new QueryRequestParser(this.query);
-            payload = requestParser.toJson().getBytes();
+            payload = requestParser.toJson().getBytes(StandardCharsets.UTF_8);
         }
         else
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollection.java
@@ -287,7 +287,7 @@ public class QueryCollection
         if (isSqlQuery)
         {
             QueryRequestParser requestParser = new QueryRequestParser(this.query);
-            payload = requestParser.toJson().getBytes();
+            payload = requestParser.toJson().getBytes(StandardCharsets.UTF_8);
         }
         else
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -41,7 +41,7 @@ public class JobClient
 {
     private final static Integer DEFAULT_PAGE_SIZE = 100;
 
-    private final static byte[] EMPTY_JSON = "{}".getBytes();
+    private final static byte[] EMPTY_JSON = "{}".getBytes(StandardCharsets.UTF_8);
 
     private String hostName;
     private TokenCredentialCache credentialCache;
@@ -560,7 +560,7 @@ public class JobClient
         if (nextObject instanceof String)
         {
             String deviceJobJson = (String) nextObject;
-            return new JobResult(deviceJobJson.getBytes());
+            return new JobResult(deviceJobJson.getBytes(StandardCharsets.UTF_8));
         }
         else
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandler.java
@@ -22,6 +22,7 @@ import org.apache.qpid.proton.engine.*;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -161,7 +162,7 @@ public class AmqpSendHandler extends AmqpConnectionHandler
         properties.setCorrelationId(message.getCorrelationId());
         if (message.getUserId() != null)
         {
-            properties.setUserId(new Binary(message.getUserId().getBytes()));
+            properties.setUserId(new Binary(message.getUserId().getBytes(StandardCharsets.UTF_8)));
         }
         protonMessage.setProperties(properties);
 
@@ -177,7 +178,7 @@ public class AmqpSendHandler extends AmqpConnectionHandler
         }
 
         Binary binary;
-        //Messages may have no payload, so check that the message has a payload before giving message.getBytes() as the payload
+        //Messages may have no payload, so check that the message has a payload before giving message.getBytes(StandardCharsets.UTF_8) as the payload
         if (message.getBytes() != null)
         {
             binary = new Binary(message.getBytes());
@@ -221,7 +222,7 @@ public class AmqpSendHandler extends AmqpConnectionHandler
                     }
                 }
 
-                byte[] tag = String.valueOf(nextTag).getBytes();
+                byte[] tag = String.valueOf(nextTag).getBytes(StandardCharsets.UTF_8);
 
                 //want to avoid negative delivery tags since -1 is the designated failure value
                 if (this.nextTag == Integer.MAX_VALUE || this.nextTag < 0)

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/SenderLinkHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/SenderLinkHandler.java
@@ -19,6 +19,7 @@ import org.apache.qpid.proton.reactor.FlowController;
 
 import java.io.IOException;
 import java.nio.BufferOverflowException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -156,7 +157,7 @@ public abstract class SenderLinkHandler extends BaseHandler
             }
         }
 
-        byte[] deliveryTag = String.valueOf(this.nextTag).getBytes();
+        byte[] deliveryTag = String.valueOf(this.nextTag).getBytes(StandardCharsets.UTF_8);
 
         Delivery delivery = this.senderLink.delivery(deliveryTag);
         try

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/RegistryManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -1104,7 +1105,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = jobPropertiesJson.getBytes();
+                result = jobPropertiesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -1201,7 +1202,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = jobPropertiesJson.getBytes();
+                result = jobPropertiesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -1295,7 +1296,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = jobPropertiesJson.getBytes();
+                result = jobPropertiesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -1360,7 +1361,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = jobPropertiesJson.getBytes();
+                result = jobPropertiesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -1445,7 +1446,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = jobPropertiesJson.getBytes();
+                result = jobPropertiesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
 
@@ -2292,7 +2293,7 @@ public class RegistryManagerTest
                 IotHubConnectionString.getUrlApplyConfigurationContent(anyString, expectedDeviceId);
                 times = 1;
 
-                new HttpRequest(mockUrl, HttpMethod.POST, expectedJson.getBytes(), (Proxy) any);
+                new HttpRequest(mockUrl, HttpMethod.POST, expectedJson.getBytes(StandardCharsets.UTF_8), (Proxy) any);
                 times = 1;
 
                 mockHttpRequest.send();
@@ -2371,7 +2372,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = deviceJson.getBytes();
+                result = deviceJson.getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(device, "toDeviceParser");
                 result = new DeviceParser();
             }
@@ -2413,7 +2414,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = devicesJson.getBytes();
+                result = devicesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
     }
@@ -2454,7 +2455,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = moduleJson.getBytes();
+                result = moduleJson.getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(module, "toDeviceParser");
                 result = new DeviceParser();
             }
@@ -2496,7 +2497,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = modulesJson.getBytes();
+                result = modulesJson.getBytes(StandardCharsets.UTF_8);
             }
         };
     }
@@ -2537,7 +2538,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = configJson.getBytes();
+                result = configJson.getBytes(StandardCharsets.UTF_8);
                 Deencapsulation.invoke(config, "toConfigurationParser");
                 result = new ConfigurationParser();
             }
@@ -2579,7 +2580,7 @@ public class RegistryManagerTest
                 result = mockHttpResponse;
                 IotHubExceptionManager.httpResponseVerification((HttpResponse) any);
                 mockHttpResponse.getBody();
-                result = configsJson.getBytes();
+                result = configsJson.getBytes(StandardCharsets.UTF_8);
             }
         };
     }

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/auth/IotHubServiceSasTokenTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/auth/IotHubServiceSasTokenTest.java
@@ -52,7 +52,7 @@ public class IotHubServiceSasTokenTest
         String hostName = "HOSTNAME." + iotHubName;
         String sharedAccessKeyName = "ACCESSKEYNAME";
         String policyName = "SharedAccessKey";
-        String sharedAccessKey = encodeBase64String("1234567890abcdefghijklmnopqrstvwxyz=".getBytes());
+        String sharedAccessKey = encodeBase64String("1234567890abcdefghijklmnopqrstvwxyz=".getBytes(StandardCharsets.UTF_8));
         String connectionString = "HostName=" + hostName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
 
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
@@ -90,7 +90,7 @@ public class IotHubServiceSasTokenTest
         String hostName = "HOSTNAME." + iotHubName;
         String sharedAccessKeyName = "ACCESSKEYNAME";
         String policyName = "SharedAccessKey";
-        String sharedAccessKey = encodeBase64String("1234567890abcdefghijklmnopqrstvwxyz=".getBytes());
+        String sharedAccessKey = encodeBase64String("1234567890abcdefghijklmnopqrstvwxyz=".getBytes(StandardCharsets.UTF_8));
         String connectionString = "HostName=" + hostName + ";SharedAccessKeyName=" + sharedAccessKeyName + ";" + policyName + "=" + sharedAccessKey;
         IotHubConnectionString iotHubConnectionString = IotHubConnectionStringBuilder.createConnectionString(connectionString);
 

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceOperationsTest.java
@@ -36,7 +36,7 @@ public class DeviceOperationsTest
 {
     private static final String STANDARD_HOSTNAME = "testHostName.azure.net";
     private static final String STANDARD_SHAREDACCESSKEYNAME = "testKeyName";
-    private static final String STANDARD_SHAREDACCESSKEY = encodeBase64String("1234567890ABCDEFGHIJKLMNOPQRESTUVWXYZab=".getBytes());
+    private static final String STANDARD_SHAREDACCESSKEY = encodeBase64String("1234567890ABCDEFGHIJKLMNOPQRESTUVWXYZab=".getBytes(StandardCharsets.UTF_8));
     private static final String STANDARD_CONNECTIONSTRING =
             "HostName=" + STANDARD_HOSTNAME +
                     ";SharedAccessKeyName=" + STANDARD_SHAREDACCESSKEYNAME +
@@ -480,7 +480,7 @@ public class DeviceOperationsTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes();
+        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes(StandardCharsets.UTF_8);
         HttpResponse sendResponse = new HttpResponse(status, body, headerFields, errorReason);
 
         new NonStrictExpectations()
@@ -528,7 +528,7 @@ public class DeviceOperationsTest
         final int status = 200;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "succeed".getBytes();
+        final byte[] errorReason = "succeed".getBytes(StandardCharsets.UTF_8);
         HttpResponse sendResponse = new HttpResponse(status, body, headerFields, errorReason);
 
         new NonStrictExpectations()
@@ -599,7 +599,7 @@ public class DeviceOperationsTest
         final int status = 200;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "succeed".getBytes();
+        final byte[] errorReason = "succeed".getBytes(StandardCharsets.UTF_8);
         HttpResponse sendResponse = new HttpResponse(status, body, headerFields, errorReason);
 
         new NonStrictExpectations()

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/devicetwin/QueryCollectionTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import static junit.framework.TestCase.assertEquals;
@@ -393,7 +394,7 @@ public class QueryCollectionTest
         //arrange
         String expectedQueryString = "some query";
         String expectedQueryStringJson = "some query json";
-        byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes();
+        byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes(StandardCharsets.UTF_8);
         QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
 
         new NonStrictExpectations()
@@ -408,7 +409,7 @@ public class QueryCollectionTest
                 mockQueryRequestParser.toJson();
                 result = expectedQueryStringJson;
 
-                expectedQueryStringJson.getBytes();
+                expectedQueryStringJson.getBytes(StandardCharsets.UTF_8);
                 result = expectedQueryStringBytes;
 
                 DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);
@@ -431,7 +432,7 @@ public class QueryCollectionTest
         //arrange
         String expectedQueryString = "some query";
         String expectedQueryStringJson = "some query json";
-        byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes();
+        byte[] expectedQueryStringBytes = expectedQueryStringJson.getBytes(StandardCharsets.UTF_8);
         QueryCollection queryCollection = Deencapsulation.newInstance(QueryCollection.class, new Class[] {String.class, int.class, QueryType.class, IotHubConnectionString.class, URL.class, HttpMethod.class, long.class}, expectedQueryString, expectedPageSize, QueryType.RAW, mockConnectionString, mockUrl, mockHttpMethod, expectedTimeout);
 
         new NonStrictExpectations()
@@ -446,7 +447,7 @@ public class QueryCollectionTest
                 mockQueryRequestParser.toJson();
                 result = expectedQueryStringJson;
 
-                expectedQueryStringJson.getBytes();
+                expectedQueryStringJson.getBytes(StandardCharsets.UTF_8);
                 result = expectedQueryStringBytes;
 
                 DeviceOperations.request((IotHubConnectionString) any, (URL) any, (HttpMethod) any, expectedQueryStringBytes, null, anyLong);

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/exceptions/IotHubExceptionManagerTest.java
@@ -11,6 +11,7 @@ import mockit.integration.junit4.JMockit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -264,7 +265,7 @@ public class IotHubExceptionManagerTest
         final int status = 301;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes();
+        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try
@@ -293,7 +294,7 @@ public class IotHubExceptionManagerTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes();
+        final byte[] errorReason = "{\"ExceptionMessage\":\"This is the error message\"}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try
@@ -317,7 +318,7 @@ public class IotHubExceptionManagerTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"ExceptionMessage\":null}".getBytes();
+        final byte[] errorReason = "{\"ExceptionMessage\":null}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try
@@ -341,7 +342,7 @@ public class IotHubExceptionManagerTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"ExceptionMessage\":}".getBytes();
+        final byte[] errorReason = "{\"ExceptionMessage\":}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try
@@ -365,7 +366,7 @@ public class IotHubExceptionManagerTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"Message\":\"ErrorCode:IotHubUnauthorizedAccess;Unauthorized\",\"ExceptionMessage\":\"Tracking ID:(tracking id)-TimeStamp:12/14/2016 03:15:17\"}".getBytes();
+        final byte[] errorReason = "{\"Message\":\"ErrorCode:IotHubUnauthorizedAccess;Unauthorized\",\"ExceptionMessage\":\"Tracking ID:(tracking id)-TimeStamp:12/14/2016 03:15:17\"}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try
@@ -389,7 +390,7 @@ public class IotHubExceptionManagerTest
         final int status = 400;
         final byte[] body = { 1 };
         final Map<String, List<String>> headerFields = new HashMap<>();
-        final byte[] errorReason = "{\"Message\":\"ErrorCode:ArgumentInvalid;Error: BadRequest {\\\"Message\\\":\\\"ErrorCode:ArgumentInvalid;Missing or invalid etag for job type ScheduleUpdateTwin. ScheduleUpdateTwin job type is a force update, which only accepts '*' as the Etag.\\\",\\\"ExceptionMessage\\\":\\\"Tracking ID:1234-TimeStamp:06/26/2017 20:56:33\\\"}\",\"ExceptionMessage\":\"Tracking ID:5678-G:10-TimeStamp:06/26/2017 20:56:33\"}".getBytes();
+        final byte[] errorReason = "{\"Message\":\"ErrorCode:ArgumentInvalid;Error: BadRequest {\\\"Message\\\":\\\"ErrorCode:ArgumentInvalid;Missing or invalid etag for job type ScheduleUpdateTwin. ScheduleUpdateTwin job type is a force update, which only accepts '*' as the Etag.\\\",\\\"ExceptionMessage\\\":\\\"Tracking ID:1234-TimeStamp:06/26/2017 20:56:33\\\"}\",\"ExceptionMessage\":\"Tracking ID:5678-G:10-TimeStamp:06/26/2017 20:56:33\"}".getBytes(StandardCharsets.UTF_8);
         HttpResponse response = new HttpResponse(status, body, headerFields, errorReason);
         // Act
         try

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/JobClientTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
@@ -212,7 +213,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -276,7 +277,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -344,7 +345,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -597,7 +598,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -670,7 +671,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -687,7 +688,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -744,7 +745,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = new IOException();
             }
         };
@@ -805,7 +806,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1094,7 +1095,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1140,7 +1141,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1195,7 +1196,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -1212,7 +1213,7 @@ public class JobClientTest
         new Verifications()
         {
             {
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 times = 1;
             }
         };
@@ -1251,7 +1252,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = new IOException();
             }
         };
@@ -1294,7 +1295,7 @@ public class JobClientTest
                 IotHubConnectionString.getUrlJobs(anyString, jobId);
                 result = mockedURL;
 
-                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(), (String)any, anyInt, anyInt, (Proxy) any);
+                DeviceOperations.request(anyString, mockedURL, HttpMethod.PUT, json.getBytes(StandardCharsets.UTF_8), (String)any, anyInt, anyInt, (Proxy) any);
                 result = mockedHttpResponse;
 
                 Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, (byte[])any);
@@ -2053,7 +2054,7 @@ public class JobClientTest
             {
                 mockedQuery.sendQueryRequest((TokenCredentialCache) any, (AzureSasCredential) any, (IotHubConnectionString) any, (URL) any, HttpMethod.POST, anyInt, anyInt, (Proxy) any);
                 times = 1;
-                Deencapsulation.newInstance(JobResult.class, new Class [] {byte[].class}, expectedString.getBytes());
+                Deencapsulation.newInstance(JobResult.class, new Class [] {byte[].class}, expectedString.getBytes(StandardCharsets.UTF_8));
                 times = 1;
             }
         };

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/JobResultTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -178,7 +179,7 @@ public class JobResultTest
         JobsResponseParserExpectations(json, twinState, null, new Date(), null, "scheduleUpdateTwin");
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         new Verifications()
@@ -206,7 +207,7 @@ public class JobResultTest
         };
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
     }
 
     /* Tests_SRS_JOBRESULT_21_004: [The constructor shall locally store all results information in the provided body.] */
@@ -227,7 +228,7 @@ public class JobResultTest
         JobsResponseParserExpectations(json, twinState, null, now, null, "scheduleUpdateTwin");
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertEquals(JOB_ID, Deencapsulation.getField(jobResult, "jobId"));
@@ -265,7 +266,7 @@ public class JobResultTest
         JobsResponseParserExpectations(json, twinState, null, now, null, "scheduleUpdateTwin");
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertNotNull(Deencapsulation.getField(jobResult, "updateTwin"));
@@ -302,7 +303,7 @@ public class JobResultTest
         JobsResponseParserExpectations(json, twinState, null, now, null, "scheduleUpdateTwin");
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertEquals(JOB_ID, jobResult.getJobId());
@@ -339,7 +340,7 @@ public class JobResultTest
         jobsResponseParserWithNullDeviceIdExpectations(json, twinState, null, now, null, "scheduleUpdateTwin");
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertEquals(JOB_ID, jobResult.getJobId());
@@ -405,7 +406,7 @@ public class JobResultTest
         };
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertEquals(JOB_ID, jobResult.getJobId());
@@ -458,7 +459,7 @@ public class JobResultTest
         };
 
         //act
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //assert
         assertNull(jobResult.getOutcomeResult());
@@ -514,7 +515,7 @@ public class JobResultTest
         twinState.setETag(ETAG);
 
         JobsResponseParserExpectations(json, twinState, null, now, null, "scheduleUpdateTwin");
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //act
         String prettyPrint = jobResult.toString();
@@ -577,7 +578,7 @@ public class JobResultTest
         twinState.setETag(ETAG);
 
         JobsResponseParserExpectations(json, twinState, null, now, null, "unknown");
-        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes());
+        JobResult jobResult = Deencapsulation.newInstance(JobResult.class, new Class[] {byte[].class}, json.getBytes(StandardCharsets.UTF_8));
 
         //act
         String prettyPrint = jobResult.toString();

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandlerTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpSendHandlerTest.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.BufferOverflowException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -199,7 +200,7 @@ public class AmqpSendHandlerTest
                 new Properties();
                 result = properties;
                 message.setProperties(properties);
-                binary = new Binary(content.getBytes());
+                binary = new Binary(content.getBytes(StandardCharsets.UTF_8));
                 section = new Data(binary);
                 message.setApplicationProperties((ApplicationProperties) any);
                 message.setBody(section);
@@ -253,7 +254,7 @@ public class AmqpSendHandlerTest
                 new Properties();
                 result = properties;
                 message.setProperties(properties);
-                binary = new Binary(content.getBytes());
+                binary = new Binary(content.getBytes(StandardCharsets.UTF_8));
                 section = new Data(binary);
                 message.setApplicationProperties((ApplicationProperties) any);
                 message.setBody(section);

--- a/service/iot-service-samples/azure-sas-credential-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/AzureSasCredentialSample.java
+++ b/service/iot-service-samples/azure-sas-credential-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/AzureSasCredentialSample.java
@@ -34,6 +34,7 @@ import com.microsoft.azure.sdk.iot.service.jobs.JobResult;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -159,7 +160,7 @@ public class AzureSasCredentialSample
                 options);
 
         String cloudToDeviceMessagePayload = "This is a message sent by an RBAC authenticated service client!";
-        Message cloudToDeviceMessage = new Message(cloudToDeviceMessagePayload.getBytes());
+        Message cloudToDeviceMessage = new Message(cloudToDeviceMessagePayload.getBytes(StandardCharsets.UTF_8));
         try
         {
             System.out.println("Sending cloud to device message to the new device");

--- a/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
+++ b/service/iot-service-samples/role-based-authorization-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/RoleBasedAuthenticationSample.java
@@ -35,6 +35,7 @@ import com.microsoft.azure.sdk.iot.service.jobs.JobClientOptions;
 import com.microsoft.azure.sdk.iot.service.jobs.JobResult;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -150,7 +151,7 @@ public class RoleBasedAuthenticationSample
                 options);
 
         String cloudToDeviceMessagePayload = "This is a message sent by an RBAC authenticated service client!";
-        Message cloudToDeviceMessage = new Message(cloudToDeviceMessagePayload.getBytes());
+        Message cloudToDeviceMessage = new Message(cloudToDeviceMessagePayload.getBytes(StandardCharsets.UTF_8));
         try
         {
             System.out.println("Sending cloud to device message to the new device");


### PR DESCRIPTION
IoT device client, IoT service client, deps, DPS device client, DPS service client, tpm security provider, and symmetric key security provider

This shouldn't impact most users since this is the default encoding anyways, but this is flagged as an issue in Spotbugs