### PR TITLE
release(2021-10-05): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.32.3";
+    private static final String CLIENT_VERSION = "1.33.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.32.3') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.33.0') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.32.3</iot-device-client-version>
+        <iot-device-client-version>1.33.0</iot-device-client-version>
         <iot-service-client-version>1.33.1</iot-service-client-version>
         <iot-deps-version>0.15.0</iot-deps-version>
         <provisioning-device-client-version>1.11.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.9.1</provisioning-service-client-version>
+        <provisioning-service-client-version>1.9.2</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.1";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.33.0)
 - feat(iot-dev): Add support for Plug and Play feature over AMQP, add componentName as optional field for telemetry (#1371)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.9.2)

### Bug fixes
- Remove client side validation of x509 CA references format (#1367)

old
{
    "device": "1.32.3",
    "service": "1.33.1",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.0",
    "provisioningService": "1.9.1"
}

new
{
    "device": "1.33.0",
    "service": "1.33.1",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.0",
    "provisioningService": "1.9.2"
}