### PR TITLE
fix(iot-serv): Fix two bugs with file upload notification receiving

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
@@ -146,10 +146,6 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
         // Enables proton-j to automatically mirror the local state of the client with the remote state. For instance,
         // if the service closes a session, this handshaker will automatically close the session locally as well.
         add(new Handshaker());
-
-        // Enables proton-j to automatically give link credit back to the service on all the client side receiver links
-        // after successfully processing a message.
-        add(new FlowController());
     }
 
     @Override

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandler.java
@@ -216,6 +216,11 @@ public class AmqpFeedbackReceivedHandler extends AmqpConnectionHandler
             Source source = new Source();
             source.setAddress(ENDPOINT);
             feedbackReceiverLink.setSource(source);
+
+            // We only want to receive, at most, one feedback message since each receive call the user makes can only return
+            // either a single feedback message or null (no feedback message received). Extend only a single link credit
+            // to the service so that the service can't send more than one message.
+            feedbackReceiverLink.flow(1);
         }
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceive.java
@@ -189,7 +189,12 @@ public class AmqpFileUploadNotificationReceive implements AmqpFeedbackReceivedEv
      */
     public synchronized FileUploadNotification receive(long timeoutMs) throws IOException, InterruptedException
     {
-        if  (isOpen)
+        // This value is set in the reactor thread once we receive the file upload notification from the service over AMQP.
+        // It's important to set this to null since receive may be called multiple times in a row. Otherwise, a single
+        // notification could be returned to the user multiple times if nothing overwrote a previous value.
+        fileUploadNotification = null;
+
+        if (isOpen)
         {
             // instantiating the amqp handler each receive call because each receive call opens a new AMQP connection
             initializeHandler();

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandler.java
@@ -182,6 +182,11 @@ public class AmqpFileUploadNotificationReceivedHandler extends AmqpConnectionHan
             Source source = new Source();
             source.setAddress(FILENOTIFICATION_ENDPOINT);
             fileUploadNotificationReceiverLink.setSource(source);
+
+            // We only want to receive, at most, one file upload notification since each receive call the user makes can
+            // only return either a single file upload notification or null (no file upload notification received).
+            // Extend only a single link credit to the service so that the service can't send more than one message.
+            fileUploadNotificationReceiverLink.flow(1);
         }
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpReceive.java
@@ -188,8 +188,12 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
      */
     public synchronized FeedbackBatch receive(long timeoutMs) throws IOException, InterruptedException
     {
+        // This value is set in the reactor thread once we receive the file upload notification from the service over AMQP.
+        // It's important to set this to null since receive may be called multiple times in a row. Otherwise, a single
+        // notification could be returned to the user multiple times if nothing overwrote a previous value.
         feedbackBatch = null;
-        if  (isOpen)
+        
+        if (isOpen)
         {
             // instantiating the amqp handler each receive call because each receive call opens a new AMQP connection
             initializeHandler();
@@ -206,6 +210,7 @@ public class AmqpReceive implements AmqpFeedbackReceivedEvent
         {
             throw new IOException("receive handler is not initialized. call open before receive");
         }
+
         return feedbackBatch;
     }
 

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandlerTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFeedbackReceivedHandlerTest.java
@@ -84,7 +84,11 @@ public class AmqpFeedbackReceivedHandlerTest
         {
             {
                 handshaker = new Handshaker();
+
+                // We purposefully extend only 1 link credit to the service so that the service only sends,
+                // at most, one message. A flowcontroller here would extend 1024 link credit which we don't want.
                 flowcontroller = new FlowController();
+                times = 0;
             }
         };
         // Act

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandlerTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpFileUploadNotificationReceivedHandlerTest.java
@@ -92,7 +92,11 @@ public class AmqpFileUploadNotificationReceivedHandlerTest
         {
             {
                 handshaker = new Handshaker();
+
+                // We purposefully extend only 1 link credit to the service so that the service only sends,
+                // at most, one message. A flowcontroller here would extend 1024 link credit which we don't want.
                 flowcontroller = new FlowController();
+                times = 0;
             }
         };
         // Act


### PR DESCRIPTION
- Fixed bug where subsequent calls to ```fileUploadNotificationReceiver.receive()``` would return the same notification if no notification was actually received
- Fixed bug where calls to ```fileUploadNotificationReceiver.receive()``` would result in the SDK completing all notifications received instead of just the notification that is returned to the user

Our existing receiver code would get a delivery from the service with 1 to many file upload notifications, but our SDK only returned one of them to the user after acknowledging all of them. To fix this, we will now limit the link credit on these receivers to 1 message. That way the service doesn't send more messages than we are prepared to return to the user.