### PR TITLE
release(2021-10-13): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.33.0";
+    private static final String CLIENT_VERSION = "1.33.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.33.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.33.1') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.33.0</iot-device-client-version>
-        <iot-service-client-version>1.33.1</iot-service-client-version>
-        <iot-deps-version>0.15.0</iot-deps-version>
+        <iot-device-client-version>1.33.1</iot-device-client-version>
+        <iot-service-client-version>1.33.2</iot-service-client-version>
+        <iot-deps-version>0.15.1</iot-deps-version>
         <provisioning-device-client-version>1.11.0</provisioning-device-client-version>
         <provisioning-service-client-version>1.9.2</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.33.1";
+    public static final String serviceVersion = "1.33.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.15.1)

### Bug fixes
 - Remove metadata validation for null metadata (#1381)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.33.1)

### Bug fixes

 - Fix bug where AMQP layer would block a while on closing if the proton reactor thread crashed (#1383)
 - Fix issue where amqp layer would requeue messages that failed to send regardless of if the device session is still around (#1380)
 - Fix bug where client failed to handle AMQP partial deliveries correctly (#1389)


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.33.2)


### Bug fixes

 - Fix bug where subsequent calls to fileUploadNotificationReceiver.receive() returns the same notification if no new notification available to consume (#1384)
 - Fix bug where file upload notification receiver would acknowledge multiple notifications from the service, but only return one to the user (#1384)

old
{
    "device": "1.33.0",
    "service": "1.33.1",
    "deps": "0.15.0",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.0",
    "provisioningService": "1.9.2"
}

new
{
    "device": "1.33.1",
    "service": "1.33.2",
    "deps": "0.15.1",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.0",
    "provisioningService": "1.9.2"
}