### PR TITLE
standardize on command-line arguments and environment variable

### DIFF
--- a/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManagerSample.java
+++ b/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManagerSample.java
@@ -8,19 +8,22 @@ import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.device.Message;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 public class DeviceClientManagerSample {
-    private static final String deviceConnectionString = System.getenv("DEVICE_CONNECTION_STRING");
+
+    private static int _NUM_REQUESTS = 3;
+    private static int _SLEEP_DURATION_IN_SECONDS = 10;
+    private static int _TIMEOUT_IN_MINUTES = 1;
+    private static String _CMD_LINE = "Expected 1 or 2 arguments but received: %d.\n"
+        + "The program should be called with the following args: \n"
+        + "1. [Device connection string] - String containing Hostname, Device Id & Device Key in one of the following formats: HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key> or HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>;GatewayHostName=<gateway> \n"
+        + "2. (optional, default = mqtt) [mqtt | https | amqps | amqps_ws | mqtt_ws]\n";
     // Can be configured to use any protocol from HTTPS, AMQPS, MQTT, AMQPS_WS, MQTT_WS. Note: HTTPS does not support status callback, device methods and device twins.
-    private static final IotHubClientProtocol protocol = IotHubClientProtocol.AMQPS;
-    private static final int DEVICE_OPERATION_TIMEOUT_IN_MINUTES = 2;
-    private static final int NUM_REQUESTS = 20;
-    private static final int SLEEP_DURATION_IN_SECS = 60;
 
     final static List<String> failedMessageListOnClose = new ArrayList<>(); // List of messages that failed on close
     private static DeviceClientManager deviceClientManager;
@@ -30,38 +33,65 @@ public class DeviceClientManagerSample {
      */
     public static void main(String[] args)
             throws URISyntaxException, IOException {
-        log.debug("Starting the sample...");
-        log.debug("Using communication protocol: {}", protocol.name());
 
-        DeviceClient client = new DeviceClient(deviceConnectionString, protocol);
-        log.debug("Successfully created an IoT Hub client.");
+        System.out.println("Starting...");
+        System.out.println("Beginning setup.");
+        
+        if (args.length < 1 || args.length > 2)
+        {
+            System.out.format(_CMD_LINE, args.length);
+            return;
+        }
+
+        String argDeviceConnectionString = args[0];
+
+        IotHubClientProtocol argProtocol;
+        String strProtocol = (args.length >1)?args[1]:"mqtt";
+
+        if (strProtocol.equals("https"))
+            argProtocol = IotHubClientProtocol.HTTPS;
+        else if (strProtocol.equals("amqps"))
+            argProtocol = IotHubClientProtocol.AMQPS;
+        else if (strProtocol.equals("amqps_ws"))
+            argProtocol = IotHubClientProtocol.AMQPS_WS;
+        else if (strProtocol.equals("mqtt_ws"))
+            argProtocol = IotHubClientProtocol.MQTT_WS;
+        else
+            argProtocol = IotHubClientProtocol.MQTT;        
+        
+        System.out.println("Successfully read input parameters.");
+        System.out.format("Using communication protocol %s.\n", argProtocol.name());
+        
+        DeviceClient client = new DeviceClient(argDeviceConnectionString, argProtocol);
+        System.out.println("Successfully created an IoT Hub client.");
 
         deviceClientManager = new DeviceClientManager(client);
-        deviceClientManager.setOperationTimeout(DEVICE_OPERATION_TIMEOUT_IN_MINUTES);
+        deviceClientManager.setOperationTimeout(_TIMEOUT_IN_MINUTES);
 
         deviceClientManager.open();
-        log.debug("Opened connection to IoT Hub.");
+        System.out.println("Opened connection to IoT Hub.");
 
-        log.debug("Setting C2D message handler...");
+        System.out.println("Setting C2D message handler...");
         deviceClientManager.setMessageCallback(new SampleMessageReceiveCallback(), new Object());
 
-        log.debug("Start sending telemetry ...");
+        System.out.println("Start sending telemetry ...");
         startSendingTelemetry();
 
         // close the connection
-        log.debug("Closing");
+        System.out.println("Closing");
         deviceClientManager.closeNow();
 
         if (! failedMessageListOnClose.isEmpty()) {
-            log.debug("List of messages that were cancelled on close: {}", failedMessageListOnClose.toString());
+            System.out.println("List of messages that were cancelled on close:");
+            System.out.println(failedMessageListOnClose.toString());
         }
 
-        log.debug("Shutting down...");
+        System.out.println("Shutting down...");
     }
 
     private static void startSendingTelemetry() {
         log.debug("Sending the following event messages:");
-        for (int i = 0; i < NUM_REQUESTS; ++i) {
+        for (int i = 0; i < _NUM_REQUESTS; ++i) {
             Message msg = composeMessage(i);
             SampleMessageSendCallback callback = new SampleMessageSendCallback();
             try {
@@ -71,8 +101,8 @@ public class DeviceClientManagerSample {
                 log.error("Exception thrown while sending telemetry: ", e);
             }
             try {
-                log.debug("Sleeping for {} secs before sending next message.", SLEEP_DURATION_IN_SECS);
-                Thread.sleep(SLEEP_DURATION_IN_SECS * 1000);
+                log.debug("Sleeping for {} secs before sending next message.", _SLEEP_DURATION_IN_SECONDS);
+                Thread.sleep(_SLEEP_DURATION_IN_SECONDS * 1000);
             } catch (InterruptedException e) {
                 log.error("Exception thrown while sleeping: ", e);
             }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
This sample uses environmental variables while all the other samples uses command line arguments. Changing this sample to use command line arguments for consistency.

# Description of the solution
Reimplement setup logic for using either environmental variables or command line arguments to setup the sample run.
