### PR TITLE
fix(iot-dev): Fix bug where routine MQTT SAS token expired disconnects didn't provide the correct reason

### DIFF
--- a/.github/workflows/github_issues.yml
+++ b/.github/workflows/github_issues.yml
@@ -9,7 +9,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-      - uses: danhellem/github-actions-issue-to-work-item@main
+      - uses: danhellem/github-actions-issue-to-work-item@master
         env:
           ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
           ado_organization: "${{ secrets.ADO_ORGANIZATION }}"

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -88,6 +88,12 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
         return (this.sasToken != null && this.sasToken.isExpired());
     }
 
+    public final boolean isSasTokenExpired()
+    {
+        //similar to isAuthenticationProviderRenewalNecessary, but this won't be overriden by classes that inherit from this class
+        return (this.sasToken != null && this.sasToken.isExpired());
+    }
+
     /**
      * Returns true if the saved token should be refreshed
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -88,9 +88,9 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
         return (this.sasToken != null && this.sasToken.isExpired());
     }
 
-    public final boolean isSasTokenExpired()
+    public boolean isSasTokenExpired()
     {
-        //similar to isAuthenticationProviderRenewalNecessary, but this won't be overriden by classes that inherit from this class
+        //similar to isAuthenticationProviderRenewalNecessary, but this won't be overriden by most classes that inherit from this class
         return (this.sasToken != null && this.sasToken.isExpired());
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -74,4 +74,9 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
         double timeBufferMultiplier = this.timeBufferPercentage / 100.0; //Convert 85 to .85, for example. Percentage multipliers are in decimal
         return (int) (tokenValidSeconds * 1000 * timeBufferMultiplier);
     }
+
+    public boolean isSasTokenExpired()
+    {
+        return (lastSasToken != null && IotHubSasToken.isExpired(new String(lastSasToken)));
+    }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1045,12 +1045,7 @@ public class IotHubTransport implements IotHubListener
         if (e instanceof TransportException)
         {
             TransportException transportException = (TransportException) e;
-            if (transportException.isRetryable())
-            {
-                log.debug("Mapping throwable to NO_NETWORK because it was a retryable exception", e);
-                return IotHubConnectionStatusChangeReason.NO_NETWORK;
-            }
-            else if (isSasTokenExpired())
+            if (isSasTokenExpired())
             {
                 log.debug("Mapping throwable to EXPIRED_SAS_TOKEN because it was a non-retryable exception and the saved sas token has expired", e);
                 return IotHubConnectionStatusChangeReason.EXPIRED_SAS_TOKEN;
@@ -1059,6 +1054,11 @@ public class IotHubTransport implements IotHubListener
             {
                 log.debug("Mapping throwable to BAD_CREDENTIAL because it was a non-retryable exception authorization exception but the saved sas token has not expired yet", e);
                 return IotHubConnectionStatusChangeReason.BAD_CREDENTIAL;
+            }
+            else if (transportException.isRetryable())
+            {
+                log.debug("Mapping throwable to NO_NETWORK because it was a retryable exception", e);
+                return IotHubConnectionStatusChangeReason.NO_NETWORK;
             }
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1665,7 +1665,7 @@ public class IotHubTransport implements IotHubListener
         }
 
         return this.getDefaultConfig().getAuthenticationType() == DeviceClientConfig.AuthType.SAS_TOKEN
-                && this.getDefaultConfig().getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
+                && this.getDefaultConfig().getSasTokenAuthentication().isSasTokenExpired();
     }
 
     /**

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -523,7 +523,7 @@ public class IotHubTransportTest
         //arrange
         new MockUp<IotHubTransport>()
         {
-            @Mock boolean isSasTokenExpired()
+            @Mock boolean isAuthenticationProviderExpired()
             {
                 return true;
             }
@@ -2445,7 +2445,7 @@ public class IotHubTransportTest
                 methodsCalled.append("addToCallbackQueue");
             }
 
-            @Mock boolean isSasTokenExpired()
+            @Mock boolean isAuthenticationProviderExpired()
             {
                 return true;
             }
@@ -2944,7 +2944,7 @@ public class IotHubTransportTest
         //arrange
         new MockUp<IotHubTransport>()
         {
-            @Mock boolean isSasTokenExpired()
+            @Mock boolean isAuthenticationProviderExpired()
             {
                 return true;
             }

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -2690,7 +2690,7 @@ public class IotHubTransportTest
             {
                 mockedConfig.getAuthenticationType();
                 result = DeviceClientConfig.AuthType.SAS_TOKEN;
-                mockedConfig.getSasTokenAuthentication().isAuthenticationProviderRenewalNecessary();
+                mockedConfig.getSasTokenAuthentication().isSasTokenExpired();
                 result = true;
             }
         };

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -786,14 +786,6 @@ public class IotHubTransportTest
         };
         final IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
 
-        new Expectations()
-        {
-            {
-                mockedTransportException.isRetryable();
-                result = false;
-            }
-        };
-
         //act
         IotHubConnectionStatusChangeReason reason = Deencapsulation.invoke(transport, "exceptionToStatusChangeReason", new Class[] {Throwable.class}, mockedTransportException);
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
@@ -150,6 +150,7 @@ public class TokenRenewalTests extends IntegrationTest
         Success[] amqpDisconnectDidNotHappenSuccesses = new Success[clients.size()];
         Success[] mqttDisconnectDidHappenSuccesses = new Success[clients.size()];
         Success[] shutdownWasGracefulSuccesses = new Success[clients.size()];
+        Success[] mqttDisconnectHadTokenExpiredReasonSuccesses = new Success[clients.size()];
         for (int clientIndex = 0; clientIndex < clients.size(); clientIndex++)
         {
             amqpDisconnectDidNotHappenSuccesses[clientIndex] = new Success();
@@ -159,8 +160,16 @@ public class TokenRenewalTests extends IntegrationTest
             amqpDisconnectDidNotHappenSuccesses[clientIndex].setResult(true); //assume success until unexpected DISCONNECTED_RETRYING
             mqttDisconnectDidHappenSuccesses[clientIndex].setResult(false); //assume failure until DISCONNECTED_RETRYING is triggered by token expiring
             shutdownWasGracefulSuccesses[clientIndex].setResult(true); //assume success until DISCONNECTED callback without CLIENT_CLOSE
+            mqttDisconnectHadTokenExpiredReasonSuccesses[clientIndex].setResult(false); //assume failure until first disconnected_retrying executes with reason EXPIRED_SAS_TOKEN
 
-            clients.get(clientIndex).registerConnectionStatusChangeCallback(new IotHubConnectionStatusChangeTokenRenewalCallbackVerifier(clients.get(clientIndex).getConfig().getProtocol(), amqpDisconnectDidNotHappenSuccesses[clientIndex], mqttDisconnectDidHappenSuccesses[clientIndex], shutdownWasGracefulSuccesses[clientIndex]), clients.get(clientIndex));
+            clients.get(clientIndex).registerConnectionStatusChangeCallback(
+                new IotHubConnectionStatusChangeTokenRenewalCallbackVerifier(
+                    clients.get(clientIndex).getConfig().getProtocol(),
+                    amqpDisconnectDidNotHappenSuccesses[clientIndex],
+                    mqttDisconnectDidHappenSuccesses[clientIndex],
+                    shutdownWasGracefulSuccesses[clientIndex],
+                    mqttDisconnectHadTokenExpiredReasonSuccesses[clientIndex]),
+                clients.get(clientIndex));
         }
 
         openEachClient(clients);
@@ -182,7 +191,7 @@ public class TokenRenewalTests extends IntegrationTest
 
         testIdentities.clear();
 
-        verifyClientsConnectivityBehavedCorrectly(clients, amqpDisconnectDidNotHappenSuccesses, mqttDisconnectDidHappenSuccesses, shutdownWasGracefulSuccesses);
+        verifyClientsConnectivityBehavedCorrectly(clients, amqpDisconnectDidNotHappenSuccesses, mqttDisconnectDidHappenSuccesses, shutdownWasGracefulSuccesses, mqttDisconnectHadTokenExpiredReasonSuccesses);
     }
 
     private void closeClients(List<InternalClient> clients) throws IOException
@@ -201,7 +210,12 @@ public class TokenRenewalTests extends IntegrationTest
         }
     }
 
-    private void verifyClientsConnectivityBehavedCorrectly(List<InternalClient> clients, Success[] amqpDisconnectDidNotHappenSuccesses, Success[] mqttDisconnectDidHappenSuccesses, Success[] shutdownWasGracefulSuccesses)
+    private void verifyClientsConnectivityBehavedCorrectly(
+        List<InternalClient> clients,
+        Success[] amqpDisconnectDidNotHappenSuccesses,
+        Success[] mqttDisconnectDidHappenSuccesses,
+        Success[] shutdownWasGracefulSuccesses,
+        Success[] mqttDisconnectHadTokenExpiredReasonSuccesses)
     {
         for (int clientIndex = 0; clientIndex < clients.size(); clientIndex++)
         {
@@ -212,6 +226,7 @@ public class TokenRenewalTests extends IntegrationTest
             {
                 assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("MQTT connection was never lost, token renewal was not tested", client), mqttDisconnectDidHappenSuccesses[clientIndex].result);
                 assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("Connection was lost during test, or shutdown was not graceful", client), shutdownWasGracefulSuccesses[clientIndex].result);
+                assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessage("MQTT connection was lost, but for an unexpected reason", client), mqttDisconnectHadTokenExpiredReasonSuccesses[clientIndex].result);
             }
             else if (protocol == AMQPS || protocol == AMQPS_WS)
             {
@@ -304,13 +319,15 @@ public class TokenRenewalTests extends IntegrationTest
         Success amqpDisconnectDidNotHappen;
         Success mqttDisconnectDidHappen;
         Success shutdownWasGraceful;
+        Success mqttDisconnectHadTokenExpiredReason;
 
-        public IotHubConnectionStatusChangeTokenRenewalCallbackVerifier(IotHubClientProtocol protocol, Success amqpDisconnectDidNotHappen, Success mqttDisconnectDidHappen, Success shutdownWasGraceful)
+        public IotHubConnectionStatusChangeTokenRenewalCallbackVerifier(IotHubClientProtocol protocol, Success amqpDisconnectDidNotHappen, Success mqttDisconnectDidHappen, Success shutdownWasGraceful, Success mqttDisconnectHadTokenExpiredReason)
         {
             this.protocol = protocol;
             this.mqttDisconnectDidHappen = mqttDisconnectDidHappen;
             this.amqpDisconnectDidNotHappen = amqpDisconnectDidNotHappen;
             this.shutdownWasGraceful = shutdownWasGraceful;
+            this.mqttDisconnectHadTokenExpiredReason = mqttDisconnectHadTokenExpiredReason;
         }
 
         @Override
@@ -344,6 +361,12 @@ public class TokenRenewalTests extends IntegrationTest
                 if (protocol == AMQPS || protocol == AMQPS_WS)
                 {
                     amqpDisconnectDidNotHappen.setResult(false);
+                }
+
+                if (protocol == MQTT || protocol == MQTT_WS)
+                {
+                    boolean reasonIsSasTokenExpired = statusChangeReason == IotHubConnectionStatusChangeReason.EXPIRED_SAS_TOKEN;
+                    mqttDisconnectHadTokenExpiredReason.setResult(reasonIsSasTokenExpired);
                 }
             }
         }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
@@ -156,7 +156,8 @@ public class TokenRenewalTests extends IntegrationTest
             amqpDisconnectDidNotHappenSuccesses[clientIndex] = new Success();
             mqttDisconnectDidHappenSuccesses[clientIndex] = new Success();
             shutdownWasGracefulSuccesses[clientIndex] = new Success();
-
+            mqttDisconnectHadTokenExpiredReasonSuccesses[clientIndex] = new Success();
+            
             amqpDisconnectDidNotHappenSuccesses[clientIndex].setResult(true); //assume success until unexpected DISCONNECTED_RETRYING
             mqttDisconnectDidHappenSuccesses[clientIndex].setResult(false); //assume failure until DISCONNECTED_RETRYING is triggered by token expiring
             shutdownWasGracefulSuccesses[clientIndex].setResult(true); //assume success until DISCONNECTED callback without CLIENT_CLOSE


### PR DESCRIPTION
The reason was always "NO_NETWORK" because the exception was retriable. It makes more sense to first check if the SAS token is expired, and then to check if it is retriable

#1405 