### PR TITLE
fix(iot-dev): Fix bug where amqp layer retried sending messages without consulting retry policy

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -267,6 +267,7 @@ public class IotHubTransport implements IotHubListener
             {
                 log.warn("Exception thrown while calling the onUnknownMessageAcknowledged callback in onMessageSent", ex);
             }
+
             log.warn("A message was acknowledged by IoT Hub, but this client has no record of sending it ({})", message);
         }
     }
@@ -1418,7 +1419,7 @@ public class IotHubTransport implements IotHubListener
                 RetryDecision retryDecision = config.getRetryPolicy().getRetryDecision(packet.getCurrentRetryAttempt(), transportException);
                 if (retryDecision.shouldRetry())
                 {
-                    this.taskScheduler.schedule(new MessageRetryRunnable(this.waitingPacketsQueue, packet, this), retryDecision.getDuration(), MILLISECONDS);
+                    this.taskScheduler.schedule(new MessageRetryRunnable(this.waitingPacketsQueue, packet, this.sendThreadLock), retryDecision.getDuration(), MILLISECONDS);
                     return;
                 }
                 else


### PR DESCRIPTION
Instead of requeueing messages locally, send them back up to the IotHubTransport layer so that it can consult the retry policy and be re-sent/cancelled accordingly.

Also clear the local queue of messages when the amqp connection closes so that the unsent messages can be handled by the IotHubTransport layer instead of just carrying them over between retry attempts.