### PR TITLE
fix(iot-dev): fix bug where reconnection events wouldn't fully close the send/receive thread pools before creating new thread pools

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -219,6 +219,11 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     private void startWorkerThreads()
     {
+        // while startWorkerThreads should never be called when threads are already active, it doesn't hurt to double
+        // check that any previous thread pools have been shut down.
+        stopWorkerThreads();
+
+        log.info("Starting worker threads");
         this.sendTask = new IotHubSendTask(this.transport);
         this.receiveTask = new IotHubReceiveTask(this.transport);
 
@@ -247,12 +252,16 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
     {
         if (this.sendTaskScheduler != null)
         {
-            this.sendTaskScheduler.shutdown();
+            log.trace("Shutting down sendTaskScheduler");
+            this.sendTaskScheduler.shutdownNow();
+            this.sendTaskScheduler = null;
         }
 
         if (this.receiveTaskScheduler != null)
         {
-            this.receiveTaskScheduler.shutdown();
+            log.trace("Shutting down receiveTaskScheduler");
+            this.receiveTaskScheduler.shutdownNow();
+            this.receiveTaskScheduler = null;
         }
     }
 
@@ -462,6 +471,14 @@ public final class DeviceIO implements IotHubConnectionStatusChangeCallback
     @Override
     public void execute(IotHubConnectionStatus status, IotHubConnectionStatusChangeReason statusChangeReason, Throwable throwable, Object callbackContext)
     {
+        log.trace("DeviceIO notified of status {} with reason {}", status, statusChangeReason);
+
+        if (status == this.state)
+        {
+            // no change in status, so no need to start/stop worker threads.
+            return;
+        }
+
         if (status == IotHubConnectionStatus.DISCONNECTED || status == IotHubConnectionStatus.DISCONNECTED_RETRYING)
         {
             // No need to keep spawning send/receive tasks during reconnection or when the client is closed

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -59,6 +59,12 @@ public final class IotHubReceiveTask implements Runnable
             this.transport.handleMessage();
 
         }
+        catch (InterruptedException e)
+        {
+            // Typically happens if a disconnection event occurs and the DeviceIO layer cancels the send/receive threads
+            // while the reconnection takes place.
+            log.trace("Interrupted while waiting for work. Thread is now ending.");
+        }
         catch (Throwable e)
         {
             log.warn("Receive task thread encountered exception while processing received messages", e);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -54,6 +54,12 @@ public final class IotHubSendTask implements Runnable
             this.transport.sendMessages();
             this.transport.invokeCallbacks();
         }
+        catch (InterruptedException e)
+        {
+            // Typically happens if a disconnection event occurs and the DeviceIO layer cancels the send/receive threads
+            // while the reconnection takes place.
+            log.trace("Interrupted while waiting for work. Thread is now ending.");
+        }
         catch (Throwable e)
         {
             log.warn("Send task encountered exception while sending messages", e);

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/DeviceIOTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -666,5 +667,89 @@ public class DeviceIOTest
 
         // assert
         assertTrue(isOpen);
+    }
+
+    @Test
+    public void receiverThreadPoolsIsClosedOnDisconnection() throws IOException
+    {
+        // arrange
+        final DeviceIO deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "state", IotHubConnectionStatus.CONNECTED);
+        Deencapsulation.setField(deviceIO, "receiveTaskScheduler", mockScheduler);
+
+        // act
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.DISCONNECTED_RETRYING, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockScheduler.shutdownNow();
+            }
+        };
+    }
+
+    @Test
+    public void senderThreadPoolsIsClosedOnDisconnection() throws IOException
+    {
+        // arrange
+        final DeviceIO deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "state", IotHubConnectionStatus.CONNECTED);
+        Deencapsulation.setField(deviceIO, "sendTaskScheduler", mockScheduler);
+
+        // act
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.DISCONNECTED_RETRYING, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockScheduler.shutdownNow();
+            }
+        };
+    }
+
+    @Test
+    public void receiverThreadPoolsIsClosedBeforeOpeningIfAlreadyOpen() throws IOException
+    {
+        // arrange
+        final DeviceIO deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "state", IotHubConnectionStatus.DISCONNECTED);
+        Deencapsulation.setField(deviceIO, "receiveTaskScheduler", mockScheduler);
+
+        // act
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.CONNECTED, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockScheduler.shutdownNow();
+
+                mockScheduler.scheduleWithFixedDelay((Runnable) any, anyLong, anyLong, (TimeUnit) any);
+            }
+        };
+    }
+
+    @Test
+    public void senderThreadPoolsIsClosedBeforeOpeningIfAlreadyOpen() throws IOException
+    {
+        // arrange
+        final DeviceIO deviceIO = newDeviceIO();
+        Deencapsulation.setField(deviceIO, "state", IotHubConnectionStatus.DISCONNECTED);
+        Deencapsulation.setField(deviceIO, "sendTaskScheduler", mockScheduler);
+
+        // act
+        Deencapsulation.invoke(deviceIO, "execute", IotHubConnectionStatus.CONNECTED, IotHubConnectionStatusChangeReason.CONNECTION_OK, new Exception(), new Object());
+
+        // assert
+        new Verifications()
+        {
+            {
+                mockScheduler.shutdownNow();
+
+                mockScheduler.scheduleWithFixedDelay((Runnable) any, anyLong, anyLong, (TimeUnit) any);
+            }
+        };
     }
 }


### PR DESCRIPTION
As a result, there would be lingering threads that would build up over time.

#1412