### PR TITLE
refactor(iot-dev, iot-serv, dps-dev, dps-serv): Add logs to clients that say what version is being run

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUpload;
 import com.microsoft.azure.sdk.iot.device.fileupload.FileUploadTask;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
+import com.microsoft.azure.sdk.iot.device.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.IoTHubConnectionType;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
@@ -401,6 +402,7 @@ public final class DeviceClient extends InternalClient implements Closeable
     {
         this.ioTHubConnectionType = IoTHubConnectionType.SINGLE_CLIENT;
         this.transportClient = null;
+        log.debug("Initialized a DeviceClient instance using SDK version {}", TransportUtils.CLIENT_VERSION);
     }
 
     private void commonConstructorVerifications() throws UnsupportedOperationException

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.sdk.iot.device.exceptions.TransportException;
 import com.microsoft.azure.sdk.iot.device.hsm.HsmException;
 import com.microsoft.azure.sdk.iot.device.hsm.HttpHsmSignatureProvider;
 import com.microsoft.azure.sdk.iot.device.hsm.IotHubSasTokenHsmAuthenticationProvider;
+import com.microsoft.azure.sdk.iot.device.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsTransportManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -85,6 +86,7 @@ public class ModuleClient extends InternalClient
         //Codes_SRS_MODULECLIENT_34_007: [If the provided protocol is not MQTT, AMQPS, MQTT_WS, or AMQPS_WS, this function shall throw an UnsupportedOperationException.]
         //Codes_SRS_MODULECLIENT_34_004: [If the provided connection string does not contain a module id, this function shall throw an IllegalArgumentException.]
         commonConstructorVerifications(protocol, this.config);
+        commonConstructorSetup();
     }
 
     /**
@@ -109,6 +111,7 @@ public class ModuleClient extends InternalClient
     {
         super(new IotHubConnectionString(connectionString), protocol, SEND_PERIOD_MILLIS, getReceivePeriod(protocol), clientOptions);
         commonConstructorVerifications(protocol, this.config);
+        commonConstructorSetup();
     }
 
     /**
@@ -149,6 +152,7 @@ public class ModuleClient extends InternalClient
         //Codes_SRS_MODULECLIENT_34_008: [If the provided protocol is not MQTT, AMQPS, MQTT_WS, or AMQPS_WS, this function shall throw an UnsupportedOperationException.]
         //Codes_SRS_MODULECLIENT_34_009: [If the provided connection string does not contain a module id, this function shall throw an IllegalArgumentException.]
         commonConstructorVerifications(protocol, this.getConfig());
+        commonConstructorSetup();
     }
 
     /**
@@ -174,6 +178,7 @@ public class ModuleClient extends InternalClient
     {
         super(new IotHubConnectionString(connectionString), protocol, sslContext, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
         commonConstructorVerifications(protocol, this.getConfig());
+        commonConstructorSetup();
     }
 
     /**
@@ -208,6 +213,7 @@ public class ModuleClient extends InternalClient
     {
         super(hostName, deviceId, moduleId, sasTokenProvider, protocol, clientOptions, SEND_PERIOD_MILLIS, getReceivePeriod(protocol));
         commonConstructorVerifications(protocol, this.getConfig());
+        commonConstructorSetup();
     }
 
     /**
@@ -372,6 +378,8 @@ public class ModuleClient extends InternalClient
     private ModuleClient(IotHubAuthenticationProvider iotHubAuthenticationProvider, IotHubClientProtocol protocol, long sendPeriodMillis, long receivePeriodMillis) throws IOException, TransportException
     {
         super(iotHubAuthenticationProvider, protocol, sendPeriodMillis, receivePeriodMillis);
+
+        commonConstructorSetup();
     }
 
     /**
@@ -677,5 +685,10 @@ public class ModuleClient extends InternalClient
         {
             throw new IllegalArgumentException("Connection string must contain field for ModuleId");
         }
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a ModuleClient instance using SDK version {}", TransportUtils.CLIENT_VERSION);
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    private static final String CLIENT_VERSION = "1.33.1";
+    public static final String CLIENT_VERSION = "1.33.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClient.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/ProvisioningDeviceClient.java
@@ -8,6 +8,7 @@
 package com.microsoft.azure.sdk.iot.provisioning.device;
 
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.ProvisioningDeviceClientConfig;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.SDKUtils;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.task.ProvisioningTask;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.contract.ProvisioningDeviceClientContract;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
@@ -80,6 +81,8 @@ public class ProvisioningDeviceClient
         this.provisioningDeviceClientContract = ProvisioningDeviceClientContract.createProvisioningContract(this.provisioningDeviceClientConfig);
         //SRS_ProvisioningDeviceClient_25_007: [ The constructor shall create an executor service with fixed thread pool of size 1. ]
         this.executor = Executors.newFixedThreadPool(MAX_THREADS_TO_RUN);
+
+        log.debug("Initialized a ProvisioningDeviceClient instance using SDK version {}", SDKUtils.PROVISIONING_DEVICE_CLIENT_VERSION);
     }
 
     /**

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -48,6 +48,11 @@
             <version>1.0.4</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.jmockit</groupId>
@@ -66,6 +71,12 @@
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.8</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/ProvisioningServiceClient.java
@@ -6,11 +6,13 @@ package com.microsoft.azure.sdk.iot.provisioning.service;
 import com.microsoft.azure.sdk.iot.provisioning.service.auth.ProvisioningConnectionString;
 import com.microsoft.azure.sdk.iot.provisioning.service.auth.ProvisioningConnectionStringBuilder;
 import com.microsoft.azure.sdk.iot.provisioning.service.contract.ContractApiHttp;
+import com.microsoft.azure.sdk.iot.provisioning.service.contract.SDKUtils;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientException;
 import com.microsoft.azure.sdk.iot.provisioning.service.configs.*;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientExceptionManager;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientNotFoundException;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientTransportException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
 
@@ -73,6 +75,7 @@ import java.util.Collection;
  * @see <a href="https://docs.microsoft.com/en-us/azure/iot-dps">Azure IoT Hub Device Provisioning Service</a>
  * @see <a href="https://docs.microsoft.com/en-us/azure/iot-dps/about-iot-dps">Provisioning devices with Azure IoT Hub Device Provisioning Service</a>
  */
+@Slf4j
 public final class ProvisioningServiceClient
 {
 
@@ -124,6 +127,8 @@ public final class ProvisioningServiceClient
         this.enrollmentGroupManager = EnrollmentGroupManager.createFromContractApiHttp(contractApiHttp);
         /* SRS_PROVISIONING_SERVICE_CLIENT_21_007: [The constructor shall create a new instance of the RegistrationStatusManager.] */
         this.registrationStatusManager = RegistrationStatusManager.createFromContractApiHttp(contractApiHttp);
+
+        log.debug("Initialized a ProvisioningServiceClient instance using SDK version {}", SDKUtils.getServiceApiVersion());
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/RegistryManager.java
@@ -16,9 +16,11 @@ import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubExceptionManager;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpRequest;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -40,6 +42,7 @@ import java.util.concurrent.Executors;
  * Use the RegistryManager client to manage the identity registry in IoT hubs.
  * To access twins, use the {@link com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwin} client.
  */
+@Slf4j
 public class RegistryManager
 {
     private static final int EXECUTOR_THREAD_POOL_SIZE = 10;
@@ -137,6 +140,7 @@ public class RegistryManager
         this.hostName = iotHubConnectionString.getHostName();
         this.options = options;
         this.executor = Executors.newFixedThreadPool(EXECUTOR_THREAD_POOL_SIZE);
+        commonConstructorSetup();
     }
 
     /**
@@ -172,6 +176,7 @@ public class RegistryManager
         this.options = options;
         this.credentialCache = new TokenCredentialCache(credential);
         this.hostName = hostName;
+        commonConstructorSetup();
     }
 
     /**
@@ -205,6 +210,12 @@ public class RegistryManager
         this.options = options;
         this.azureSasCredential = azureSasCredential;
         this.hostName = hostName;
+        commonConstructorSetup();
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a RegistryManager instance client using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/ServiceClient.java
@@ -9,6 +9,7 @@ import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.service.transport.amqps.AmqpSend;
 import lombok.extern.slf4j.Slf4j;
 
@@ -123,6 +124,8 @@ public class ServiceClient
                         iotHubServiceClientProtocol,
                         options.getProxyOptions(),
                         options.getSslContext());
+
+        commonConstructorSetup();
     }
 
     /**
@@ -190,6 +193,8 @@ public class ServiceClient
                         this.iotHubServiceClientProtocol,
                         options.getProxyOptions(),
                         options.getSslContext());
+
+        commonConstructorSetup();
     }
 
     /**
@@ -238,6 +243,8 @@ public class ServiceClient
                         iotHubServiceClientProtocol,
                         options.getProxyOptions(),
                         options.getSslContext());
+
+        commonConstructorSetup();
     }
 
     /**
@@ -285,6 +292,13 @@ public class ServiceClient
                 this.iotHubServiceClientProtocol,
                 options.getProxyOptions(),
                 options.getSslContext());
+
+        commonConstructorSetup();
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a ServiceClient instance using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceMethod.java
@@ -13,8 +13,10 @@ import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.Proxy;
@@ -26,6 +28,7 @@ import java.util.Objects;
 /**
  * Use the DeviceMethod client to directly invoke methods on devices and modules in IoT hub.
  */
+@Slf4j
 public class DeviceMethod
 {
     private Integer requestId = 0;
@@ -108,6 +111,7 @@ public class DeviceMethod
         this.hostName = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString).getHostName();
         this.options = options;
         this.iotHubConnectionString = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
+        commonConstructorSetup();
     }
 
     /**
@@ -142,6 +146,8 @@ public class DeviceMethod
         this.options = options;
         this.credentialCache = new TokenCredentialCache(credential);
         this.hostName = hostName;
+        commonConstructorSetup();
+
     }
 
     /**
@@ -174,6 +180,12 @@ public class DeviceMethod
         this.options = options;
         this.azureSasCredential = azureSasCredential;
         this.hostName = hostName;
+        commonConstructorSetup();
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a DeviceMethod client instance using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/devicetwin/DeviceTwin.java
@@ -16,8 +16,10 @@ import com.microsoft.azure.sdk.iot.service.Tools;
 import com.microsoft.azure.sdk.iot.service.auth.IotHubServiceSasToken;
 import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -34,6 +36,7 @@ import java.util.Objects;
 /**
  * Use the DeviceTwin class to manage the device twins in IoT hubs.
  */
+@Slf4j
 public class DeviceTwin
 {
     private int requestId = 0;
@@ -106,6 +109,7 @@ public class DeviceTwin
         this.options = options;
         this.iotHubConnectionString = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
         this.hostName = this.iotHubConnectionString.getHostName();
+        commonConstructorSetup();
     }
 
     /**
@@ -140,6 +144,7 @@ public class DeviceTwin
         this.options = options;
         this.credentialCache = new TokenCredentialCache(credential);
         this.hostName = hostName;
+        commonConstructorSetup();
     }
 
     /**
@@ -172,6 +177,12 @@ public class DeviceTwin
         this.options = options;
         this.azureSasCredential = azureSasCredential;
         this.hostName = hostName;
+        commonConstructorSetup();
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a DeviceTwin client instance using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -29,11 +29,13 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinUpdateR
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DeserializationHelpers;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DigitalTwinStringSerializer;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.rest.RestClient;
 import com.microsoft.rest.ServiceResponse;
 import com.microsoft.rest.ServiceResponseBuilder;
 import com.microsoft.rest.ServiceResponseWithHeaders;
 import com.microsoft.rest.serializer.JacksonAdapter;
+import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
@@ -50,6 +52,7 @@ import static com.microsoft.azure.sdk.iot.service.digitaltwin.helpers.Tools.*;
  * The Digital Twins Service Client contains asynchronous methods to retrieve and update digital twin information, and invoke commands on a digital twin device.
  * </p>
  */
+@Slf4j
 public class DigitalTwinAsyncClient {
     private final DigitalTwinsImpl _protocolLayer;
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -100,6 +103,7 @@ public class DigitalTwinAsyncClient {
 
         IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
         _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        commonConstructorSetup();
     }
 
     /**
@@ -150,6 +154,7 @@ public class DigitalTwinAsyncClient {
 
         IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
         _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        commonConstructorSetup();
     }
 
 
@@ -198,6 +203,7 @@ public class DigitalTwinAsyncClient {
 
         IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
         _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        commonConstructorSetup();
     }
 
     /**
@@ -208,6 +214,10 @@ public class DigitalTwinAsyncClient {
      */
     public static DigitalTwinAsyncClient createFromConnectionString(String connectionString) {
         return new DigitalTwinAsyncClient(connectionString);
+    }
+
+    private static void commonConstructorSetup() {
+        log.debug("Initialized a digital twin client instance using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/JobClient.java
@@ -21,8 +21,10 @@ import com.microsoft.azure.sdk.iot.service.devicetwin.Pair;
 import com.microsoft.azure.sdk.iot.service.devicetwin.Query;
 import com.microsoft.azure.sdk.iot.service.devicetwin.QueryType;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
+import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpMethod;
 import com.microsoft.azure.sdk.iot.service.transport.http.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -37,6 +39,7 @@ import java.util.Set;
 /**
  * Use the JobClient to schedule and cancel jobs for a group of devices using IoT hub.
  */
+@Slf4j
 public class JobClient
 {
     private final static Integer DEFAULT_PAGE_SIZE = 100;
@@ -94,6 +97,7 @@ public class JobClient
         this.iotHubConnectionString = IotHubConnectionStringBuilder.createIotHubConnectionString(connectionString);
         this.hostName = this.iotHubConnectionString.getHostName();
         this.options = options;
+        commonConstructorSetup();
     }
 
     /**
@@ -129,6 +133,7 @@ public class JobClient
         this.hostName = hostName;
         this.credentialCache = new TokenCredentialCache(credential);
         this.options = options;
+        commonConstructorSetup();
     }
 
     /**
@@ -162,6 +167,12 @@ public class JobClient
         this.hostName = hostName;
         this.azureSasCredential = azureSasCredential;
         this.options = options;
+        commonConstructorSetup();
+    }
+
+    private static void commonConstructorSetup()
+    {
+        log.debug("Initialized a JobClient instance using SDK version {}", TransportUtils.serviceVersion);
     }
 
     /**


### PR DESCRIPTION
Making the SDK log this should help us deal with any confusion we get from customer logs where the user claims to use one version of the SDK but the logs don't appear to come from that version