### PR TITLE
release(2021-12-15): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "1.33.1";
+    public static final String CLIENT_VERSION = "1.34.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.33.1') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.34.0') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.33.1</iot-device-client-version>
-        <iot-service-client-version>1.33.2</iot-service-client-version>
-        <iot-deps-version>0.15.1</iot-deps-version>
-        <provisioning-device-client-version>1.11.0</provisioning-device-client-version>
-        <provisioning-service-client-version>1.9.2</provisioning-service-client-version>
+        <iot-device-client-version>1.34.0</iot-device-client-version>
+        <iot-service-client-version>1.34.0</iot-service-client-version>
+        <iot-deps-version>0.15.2</iot-deps-version>
+        <provisioning-device-client-version>1.11.1</provisioning-device-client-version>
+        <provisioning-service-client-version>1.9.3</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.11.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.11.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.2";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.33.2";
+    public static final String serviceVersion = "1.34.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.15.2)
 - Make thread names more identifiable (#1395)

## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.34.0)
 - Make thread names more identifiable (#1395)
 - Added additional logging to amqp layer (#1406, #1435)
 - Add support for configuring keep-alive interval for amqps and mqtt (#1408)
 - Add logs to client that says what version is being run (#1430)
 
### Bug fixes
 - Fix potential deadlock when closing while reconnecting (#1393)
 - Fix bug where routine MQTT SAS token expired disconnects didn't provide the correct reason (#1407)
 - Fix bug where reconnection events wouldn't fully close the send/receive thread pools before creating new thread pools (#1413)
 - Fix bug where a retry scheduled message wouldn't wake up worker thread (#1439)
 - Fix amqp message acknowledgements being sent from outside the reactor thread which may cause a race condition (#1442)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.34.0)
 - Add missing moduleContent field to ConfigurationContent class (#1394)
 - Make thread names more identifiable (#1395)
 - Add logs to client that says what version is being run (#1430)
 
## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.11.1)
 - Make thread names more identifiable (#1395)
 - Add logs to client that says what version is being run (#1430)
  
## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.9.3)
 - Add logs to client that says what version is being run (#1430)

old
{
    "device": "1.33.1",
    "service": "1.33.2",
    "deps": "0.15.1",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.0",
    "provisioningService": "1.9.2"
}

new
{
    "device": "1.34.0",
    "service": "1.34.0",
    "deps": "0.15.2",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.1",
    "provisioningService": "1.9.3"
}