### PR TITLE
fix(iot-serv): Fix service client limiting amqps_ws messages to 16 kb

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ServiceClientTests.java
@@ -65,7 +65,8 @@ public class ServiceClientTests extends IntegrationTest
 {
     protected static String iotHubConnectionString = "";
     protected static String invalidCertificateServerConnectionString = "";
-    private static final String content = "abcdefghijklmnopqrstuvwxyz1234567890";
+    private static final byte[] SMALL_PAYLOAD = new byte[1024];
+    private static final byte[] LARGEST_PAYLOAD = new byte[65000]; // IoT Hub allows a max of 65 kb per message
     private static String hostName;
 
     protected static HttpProxyServer proxyServer;
@@ -125,14 +126,14 @@ public class ServiceClientTests extends IntegrationTest
     @StandardTierHubOnlyTest
     public void cloudToDeviceTelemetry() throws Exception
     {
-        cloudToDeviceTelemetry(false, true, false, false);
+        cloudToDeviceTelemetry(false, true, false, false, false);
     }
 
     @Test
     @StandardTierHubOnlyTest
     public void cloudToDeviceTelemetryWithCustomSSLContext() throws Exception
     {
-        cloudToDeviceTelemetry(false, true, true, false);
+        cloudToDeviceTelemetry(false, true, false, true, false);
     }
 
     @Test
@@ -145,7 +146,7 @@ public class ServiceClientTests extends IntegrationTest
             return;
         }
 
-        cloudToDeviceTelemetry(true, true, false, false);
+        cloudToDeviceTelemetry(true, true, false, false, false);
     }
 
     @Test
@@ -158,7 +159,7 @@ public class ServiceClientTests extends IntegrationTest
             return;
         }
 
-        cloudToDeviceTelemetry(true, true, true, false);
+        cloudToDeviceTelemetry(true, true, false, true, false);
     }
 
     @Test
@@ -166,19 +167,42 @@ public class ServiceClientTests extends IntegrationTest
     @ContinuousIntegrationTest
     public void cloudToDeviceTelemetryWithNoPayload() throws Exception
     {
-        cloudToDeviceTelemetry(false, false, false, false);
+        cloudToDeviceTelemetry(false, false, false, false, false);
     }
 
     @Test
     @StandardTierHubOnlyTest
     public void cloudToDeviceTelemetryWithAzureSasCredential() throws Exception
     {
-        cloudToDeviceTelemetry(false, true, false, true);
+        cloudToDeviceTelemetry(false, true, false, false, true);
+    }
+
+    @Test
+    @ContinuousIntegrationTest
+    @StandardTierHubOnlyTest
+    public void cloudToDeviceTelemetryWithMaxPayloadSize() throws Exception
+    {
+        cloudToDeviceTelemetry(false, true, true, false, false);
+    }
+
+    @Test
+    @ContinuousIntegrationTest
+    @StandardTierHubOnlyTest
+    public void cloudToDeviceTelemetryWithMaxPayloadSizeAndProxy() throws Exception
+    {
+        if (testInstance.protocol != IotHubServiceClientProtocol.AMQPS_WS)
+        {
+            //Proxy support only exists for AMQPS_WS currently
+            return;
+        }
+
+        cloudToDeviceTelemetry(true, true, true, false, false);
     }
 
     public void cloudToDeviceTelemetry(
             boolean withProxy,
             boolean withPayload,
+            boolean withLargestPayload,
             boolean withCustomSSLContext,
             boolean withAzureSasCredential) throws Exception
     {
@@ -236,7 +260,14 @@ public class ServiceClientTests extends IntegrationTest
         Message message;
         if (withPayload)
         {
-            message = new Message(content.getBytes(StandardCharsets.UTF_8));
+            if (withLargestPayload)
+            {
+                message = new Message(LARGEST_PAYLOAD);
+            }
+            else
+            {
+                message = new Message(SMALL_PAYLOAD);
+            }
         }
         else
         {
@@ -286,7 +317,7 @@ public class ServiceClientTests extends IntegrationTest
         serviceClient = new ServiceClient(iotHubConnectionStringObj.getHostName(), sasCredential, testInstance.protocol);
         serviceClient.open();
 
-        Message message = new Message(content.getBytes(StandardCharsets.UTF_8));
+        Message message = new Message(SMALL_PAYLOAD);
         serviceClient.send(device.getDeviceId(), message);
 
         // deliberately expire the SAS token to provoke a 401 to ensure that the registry manager is using the shared

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/AmqpConnectionHandler.java
@@ -42,7 +42,7 @@ public abstract class AmqpConnectionHandler extends ErrorLoggingBaseHandlerWithC
     private static final String WEB_SOCKET_PATH = "/$iothub/websocket";
     private static final String WEB_SOCKET_SUB_PROTOCOL = "AMQPWSB10";
     private static final String WEB_SOCKET_QUERY = "iothub-no-client-cert=true";
-    private static final int MAX_MESSAGE_PAYLOAD_SIZE = 256 * 1024; //max IoT Hub message size is 256 kb, so amqp websocket layer should buffer at most that much space
+    private static final int MAX_MESSAGE_PAYLOAD_SIZE = 65 * 1024; //max IoT Hub cloud to device message size is 65 kb, so amqp websocket layer should buffer at most that much space
 
     private Exception savedException;
     private boolean connectionOpenedRemotely;

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
@@ -10,6 +10,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.HandlerException;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.reactor.ReactorOptions;
 
 import java.io.IOException;
 
@@ -21,10 +22,19 @@ public class ReactorRunner
     private final Reactor reactor;
     public static final int REACTOR_TIMEOUT = 3141; // reactor timeout in milliseconds
     public static final int CLOSE_REACTOR_GRACEFULLY_TIMEOUT = 10 * 1000;
+    private static final int MAX_FRAME_SIZE = 4 * 1024;
 
     public ReactorRunner(BaseHandler baseHandler, String threadNamePrefix, String threadNamePostfix) throws IOException
     {
-        this.reactor = Proton.reactor(baseHandler);
+        ReactorOptions options = new ReactorOptions();
+
+        // If this option isn't set, proton defaults to 16 * 1024 max frame size. This used to default to 4 * 1024,
+        // and this change to 16 * 1024 broke the websocket implementation that we layer on top of proton-j.
+        // By setting this frame size back to 4 * 1024, AMQPS_WS clients can send messages with payloads up to the
+        // expected 256 * 1024 bytes. For more context, see https://github.com/Azure/azure-iot-sdk-java/issues/742
+        options.setMaxFrameSize(MAX_FRAME_SIZE);
+
+        this.reactor = Proton.reactor(options, baseHandler);
         this.threadName = threadNamePrefix + "-" + THREAD_NAME + "-" + threadNamePostfix;
     }
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
@@ -31,7 +31,7 @@ public class ReactorRunner
         // If this option isn't set, proton defaults to 16 * 1024 max frame size. This used to default to 4 * 1024,
         // and this change to 16 * 1024 broke the websocket implementation that we layer on top of proton-j.
         // By setting this frame size back to 4 * 1024, AMQPS_WS clients can send messages with payloads up to the
-        // expected 256 * 1024 bytes. For more context, see https://github.com/Azure/azure-iot-sdk-java/issues/742
+        // expected 64 * 1024 bytes. For more context, see https://github.com/Azure/azure-iot-sdk-java/issues/742
         options.setMaxFrameSize(MAX_FRAME_SIZE);
 
         this.reactor = Proton.reactor(options, baseHandler);


### PR DESCRIPTION
Service allows up to 65 kb so this fix brings the SDK in line with the service's advertised limits

#1420