### PR TITLE
fix(client): Honor keepalive when using security provider

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -302,8 +302,17 @@ public final class DeviceClientConfig
         }
     }
 
+    /**
+     * Constructor for a device client config that retrieves the authentication method from a security provider instance and sets the keep alive interval
+     * @param connectionString The connection string for the iot hub to connect with
+     * @param securityProvider The security provider instance to be used for authentication of this device
+     * @param clientOptions The client options that will be used to set the keep alive
+     * @throws IOException if the provided security provider throws an exception while authenticating
+     */
     DeviceClientConfig(IotHubConnectionString connectionString, SecurityProvider securityProvider, ClientOptions clientOptions) throws IOException
     {
+        // When setting the ClientConfig and a SecurityProvider, the SecurityProvider is responsible for setting the sslContext
+        // we do not need to set the context in this method.
         this(connectionString, securityProvider);
         setKeepAliveInterval(clientOptions);
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -311,7 +311,7 @@ public final class DeviceClientConfig
      */
     DeviceClientConfig(IotHubConnectionString connectionString, SecurityProvider securityProvider, ClientOptions clientOptions) throws IOException
     {
-        // When setting the ClientConfig and a SecurityProvider, the SecurityProvider is responsible for setting the sslContext
+        // When setting the ClientOptions and a SecurityProvider, the SecurityProvider is responsible for setting the sslContext
         // we do not need to set the context in this method.
         this(connectionString, securityProvider);
         setKeepAliveInterval(clientOptions);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -161,8 +161,7 @@ public final class DeviceClientConfig
     public DeviceClientConfig(String hostName, SasTokenProvider sasTokenProvider, ClientOptions clientOptions, String deviceId, String moduleId)
     {
         SSLContext sslContext = clientOptions != null ? clientOptions.sslContext : null;
-        this.keepAliveInterval =
-            clientOptions != null && clientOptions.getKeepAliveInterval() != 0 ? clientOptions.getKeepAliveInterval() : DEFAULT_KEEP_ALIVE_INTERVAL_IN_SECONDS;
+        setKeepAliveInterval(clientOptions);
         this.authenticationProvider =
                 new IotHubSasTokenProvidedAuthenticationProvider(hostName, deviceId, moduleId, sasTokenProvider, sslContext);
 
@@ -208,6 +207,11 @@ public final class DeviceClientConfig
             configSasAuth(iotHubConnectionString);
         }
 
+        setKeepAliveInterval(clientOptions);
+    }
+
+    private void setKeepAliveInterval(ClientOptions clientOptions)
+    {
         this.keepAliveInterval = clientOptions != null && clientOptions.getKeepAliveInterval() != 0 ? clientOptions.getKeepAliveInterval() : DEFAULT_KEEP_ALIVE_INTERVAL_IN_SECONDS;
     }
 
@@ -296,6 +300,12 @@ public final class DeviceClientConfig
             //Codes_SRS_DEVICECLIENTCONFIG_34_084: [If the provided security provider is neither a SecurityProviderX509 instance nor a SecurityProviderTpm instance, this function shall throw an UnsupportedOperationException.]
             throw new UnsupportedOperationException("The provided security provider is not supported.");
         }
+    }
+
+    DeviceClientConfig(IotHubConnectionString connectionString, SecurityProvider securityProvider, ClientOptions clientOptions) throws IOException
+    {
+        this(connectionString, securityProvider);
+        setKeepAliveInterval(clientOptions);
     }
 
     private void commonConstructorSetup(IotHubConnectionString iotHubConnectionString)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClientConfig.java
@@ -312,7 +312,7 @@ public final class DeviceClientConfig
     DeviceClientConfig(IotHubConnectionString connectionString, SecurityProvider securityProvider, ClientOptions clientOptions) throws IOException
     {
         // When setting the ClientOptions and a SecurityProvider, the SecurityProvider is responsible for setting the sslContext
-        // we do not need to set the context in this method.
+        // we do not need to set the context in this constructor.
         this(connectionString, securityProvider);
         setKeepAliveInterval(clientOptions);
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -130,7 +130,7 @@ public class InternalClient
         IotHubConnectionString connectionString = new IotHubConnectionString(uri, deviceId, null, null);
 
         //Codes_SRS_INTERNALCLIENT_34_066: [The provided security provider will be saved in config.]
-        this.config = new DeviceClientConfig(connectionString, securityProvider);
+        this.config = new DeviceClientConfig(connectionString, securityProvider, clientOptions);
         this.config.setProtocol(protocol);
         if (clientOptions != null) {
             this.config.modelId = clientOptions.getModelId();

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -165,12 +165,49 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class}, mockIotHubConnectionString, mockSecurityProvider);
+                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider);
                 times = 1;
 
                 Deencapsulation.newInstance("com.microsoft.azure.sdk.iot.device.DeviceIO",
                         new Class[] {DeviceClientConfig.class, long.class, long.class},
                         any, SEND_PERIOD_MILLIS, RECEIVE_PERIOD_MILLIS_HTTPS);
+                times = 1;
+            }
+        };
+    }
+
+    //Tests_SRS_INTERNALCLIENT_34_065: [The provided uri and device id will be used to create an iotHubConnectionString that will be saved in config.]
+    //Tests_SRS_INTERNALCLIENT_34_066: [The provided security provider will be saved in config.]
+    //Tests_SRS_INTERNALCLIENT_34_067: [The constructor shall initialize the IoT Hub transport for the protocol specified, creating a instance of the deviceIO.]
+    @Test
+    public void createFromSecurityProviderWithKeepAliveUsesUriAndDeviceIdAndSavesSecurityProviderAndCreatesDeviceIO() throws URISyntaxException, SecurityProviderException, IOException
+    {
+        //arrange
+        final String expectedUri = "some uri";
+        final String expectedDeviceId = "some device id";
+        final IotHubClientProtocol expectedProtocol = IotHubClientProtocol.HTTPS;
+        new StrictExpectations()
+        {
+            {
+                new IotHubConnectionString(expectedUri, expectedDeviceId, null, null);
+                result = mockIotHubConnectionString;
+            }
+        };
+
+        // Test the keep alive interval
+        ClientOptions options = new ClientOptions();
+        options.setKeepAliveInterval(60);
+
+        //act
+        final DeviceClient dc = DeviceClient.createFromSecurityProvider(expectedUri, expectedDeviceId, mockSecurityProvider, expectedProtocol, options);
+
+        //assert
+        assertEquals("Keep alive value is not correct, ClientOptions not being honored.", 60, dc.config.getKeepAliveInterval());
+
+        new Verifications()
+        {
+            {
+                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider);
                 times = 1;
             }
         };

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/InternalClientTest.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.sdk.iot.device;
 
-import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.DeviceTwin.*;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubAuthenticationProvider;
 import com.microsoft.azure.sdk.iot.device.auth.IotHubSasTokenAuthenticationProvider;
@@ -165,7 +164,7 @@ public class InternalClientTest
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider);
+                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider, null);
                 times = 1;
 
                 Deencapsulation.newInstance("com.microsoft.azure.sdk.iot.device.DeviceIO",
@@ -180,7 +179,7 @@ public class InternalClientTest
     //Tests_SRS_INTERNALCLIENT_34_066: [The provided security provider will be saved in config.]
     //Tests_SRS_INTERNALCLIENT_34_067: [The constructor shall initialize the IoT Hub transport for the protocol specified, creating a instance of the deviceIO.]
     @Test
-    public void createFromSecurityProviderWithKeepAliveUsesUriAndDeviceIdAndSavesSecurityProviderAndCreatesDeviceIO() throws URISyntaxException, SecurityProviderException, IOException
+    public void createFromSecurityProviderWithClientOptionsUsesUriAndDeviceIdAndSavesSecurityProviderAndCreatesDeviceIO() throws URISyntaxException, SecurityProviderException, IOException
     {
         //arrange
         final String expectedUri = "some uri";
@@ -194,20 +193,14 @@ public class InternalClientTest
             }
         };
 
-        // Test the keep alive interval
-        ClientOptions options = new ClientOptions();
-        options.setKeepAliveInterval(60);
-
+        final ClientOptions clientOptions = new ClientOptions();
         //act
-        final DeviceClient dc = DeviceClient.createFromSecurityProvider(expectedUri, expectedDeviceId, mockSecurityProvider, expectedProtocol, options);
-
-        //assert
-        assertEquals("Keep alive value is not correct, ClientOptions not being honored.", 60, dc.config.getKeepAliveInterval());
+        final DeviceClient dc = DeviceClient.createFromSecurityProvider(expectedUri, expectedDeviceId, mockSecurityProvider, expectedProtocol, clientOptions);
 
         new Verifications()
         {
             {
-                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider);
+                Deencapsulation.newInstance(DeviceClientConfig.class, new Class[] {IotHubConnectionString.class, SecurityProvider.class, ClientOptions.class}, mockIotHubConnectionString, mockSecurityProvider, clientOptions);
                 times = 1;
             }
         };


### PR DESCRIPTION
When using a security provider the keep alive defined in the ClientOptions is not set.