### PR TITLE
fix(iot-dev): Remove unnecessary tracking of direct method request Ids

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethod.java
@@ -21,7 +21,6 @@ public class MqttDeviceMethod extends Mqtt
 {
     private final String subscribeTopic;
     private final String responseTopic;
-    private final Map<String, DeviceOperations> requestMap = new HashMap<>();
     private boolean isStarted = false;
 
     private static final String POUND = "#";
@@ -60,11 +59,6 @@ public class MqttDeviceMethod extends Mqtt
     public void stop()
     {
         isStarted = false;
-
-        if (!requestMap.isEmpty())
-        {
-            log.trace("Pending {} responses to be sent to IotHub yet unsubscribed", requestMap.size());
-        }
     }
 
     /**
@@ -103,18 +97,6 @@ public class MqttDeviceMethod extends Mqtt
                 if (message.getRequestId() == null || message.getRequestId().isEmpty())
                 {
                     throw new IllegalArgumentException("Request id cannot be null or empty");
-                }
-
-                if (requestMap.containsKey(message.getRequestId()))
-                {
-                    if (requestMap.remove(message.getRequestId()) != DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST)
-                    {
-                        throwMethodsTransportException("Mismatched request and response operation");
-                    }
-                }
-                else
-                {
-                    throwMethodsTransportException("Sending a response for the method that was never invoked");
                 }
 
                 String topic = this.responseTopic + BACKSLASH +
@@ -180,7 +162,6 @@ public class MqttDeviceMethod extends Mqtt
                                 message.setRequestId(reqId);
 
                                 message.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
-                                requestMap.put(reqId, DeviceOperations.DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
                             }
                             else
                             {

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
@@ -159,9 +159,6 @@ public class MqttDeviceMethodTest
         testMessage.setRequestId("ReqId");
         testMessage.setStatus("testStatus");
         final MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
-        Map<String, DeviceOperations> testRequestMap = new HashMap<>();
-        testRequestMap.put("ReqId", DEVICE_OPERATION_METHOD_RECEIVE_REQUEST);
-        Deencapsulation.setField(testMethod, "requestMap", testRequestMap);
         testMethod.start();
 
         //act
@@ -175,7 +172,6 @@ public class MqttDeviceMethodTest
                 maxTimes = 1;
             }
         };
-        assertTrue(testRequestMap.isEmpty());
     }
 
     @Test (expected = TransportException.class)
@@ -266,26 +262,6 @@ public class MqttDeviceMethodTest
         testMessage.setRequestId("ReqId");
         testMessage.setStatus("testStatus");
         MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
-        testMethod.start();
-
-        //act
-        testMethod.send(testMessage);
-    }
-
-    /*
-    Tests_SRS_MqttDeviceMethod_25_019: [**send method shall throw a TransportException if the getDeviceOperationType() is not of type DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST or DEVICE_OPERATION_METHOD_SEND_RESPONSE .**]**
-     */
-    @Test (expected = TransportException.class)
-    public void sendThrowsOnMismatchedRequestType() throws TransportException
-    {
-        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
-        testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
-        testMessage.setRequestId("ReqId");
-        testMessage.setStatus("testStatus");
-        MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
-        Map<String, DeviceOperations> testRequestMap = new HashMap<>();
-        testRequestMap.put("ReqId", DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST);
         testMethod.start();
 
         //act

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDeviceMethodTest.java
@@ -252,22 +252,6 @@ public class MqttDeviceMethodTest
         testMethod.send(testMessage);
     }
 
-    //Tests_SRS_MqttDeviceMethod_25_023: [send method shall throw an exception if a response is sent without having a method invoke on the request id if the operation is of type DEVICE_OPERATION_METHOD_SEND_RESPONSE.]
-    @Test (expected = TransportException.class)
-    public void sendThrowsOnSendingResponseWithoutReceivingMethodInvoke() throws TransportException
-    {
-        final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
-        final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
-        testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
-        testMessage.setRequestId("ReqId");
-        testMessage.setStatus("testStatus");
-        MqttDeviceMethod testMethod = new MqttDeviceMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
-        testMethod.start();
-
-        //act
-        testMethod.send(testMessage);
-    }
-
     /*
     * Tests_SRS_MQTTDEVICEMETHOD_25_026: [**This method shall call peekMessage to get the message payload from the received Messages queue corresponding to the messaging client's operation.**]**
     * Tests_SRS_MQTTDEVICEMETHOD_25_028: [**If the topic is of type post topic then this method shall parse further for method name and set it for the message by calling setMethodName for the message**]**


### PR DESCRIPTION
method response messages should always be sent. Tracking them like this only allowed issues like #1465 to happen if the state is lost somehow

This state is already not tracked for methods in AMQP