### PR TITLE
release(2022-02-18): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "1.34.1";
+    public static final String CLIENT_VERSION = "1.34.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.34.1') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.34.2') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.34.1</iot-device-client-version>
+        <iot-device-client-version>1.34.2</iot-device-client-version>
         <iot-service-client-version>1.34.1</iot-service-client-version>
         <iot-deps-version>0.15.2</iot-deps-version>
         <provisioning-device-client-version>1.11.1</provisioning-device-client-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.34.2)

 - Reduced log levels of some frequent log statements to avoid flooding logs (#1459)

### Bug fixes
 
 - Removed unnecessary tracking of direct method request Ids that resulted in unnecessary errors logged like #1465 (#1468)
 - Fix bug where deviceClient did not honor keep alive settings if constructed using security provider (#1455)

 
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/1.34.2/jar


old
{
    "device": "1.34.1",
    "service": "1.34.1",
    "deps": "0.15.2",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.1",
    "provisioningService": "1.9.3"
}

new
{
    "device": "1.34.2",
    "service": "1.34.1",
    "deps": "0.15.2",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.1",
    "provisioningService": "1.9.3"
}