### PR TITLE
release(2022-03-04): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -10,7 +10,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "1.34.2";
+    public static final String CLIENT_VERSION = "1.34.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.34.2') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:1.34.3') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,17 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>1.34.2</iot-device-client-version>
-        <iot-service-client-version>1.34.1</iot-service-client-version>
-        <iot-deps-version>0.15.2</iot-deps-version>
-        <provisioning-device-client-version>1.11.1</provisioning-device-client-version>
-        <provisioning-service-client-version>1.9.3</provisioning-service-client-version>
+        <iot-device-client-version>1.34.3</iot-device-client-version>
+        <iot-service-client-version>1.34.2</iot-service-client-version>
+        <iot-deps-version>0.15.3</iot-deps-version>
+        <provisioning-device-client-version>1.11.2</provisioning-device-client-version>
+        <provisioning-service-client-version>1.9.4</provisioning-service-client-version>
         <security-provider-version>1.5.0</security-provider-version>
         <tpm-provider-emulator-version>1.1.2</tpm-provider-emulator-version>
         <tpm-provider-version>1.1.3</tpm-provider-version>
         <dice-provider-emulator-version>1.1.1</dice-provider-emulator-version>
         <dice-provider-version>1.1.1</dice-provider-version>
-        <x509-provider-version>1.1.6</x509-provider-version>
+        <x509-provider-version>1.1.7</x509-provider-version>
 
         <!-- Properties to consolidate slf4j versions -->
         <slf4j-version>1.7.32</slf4j-version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>service</module>
         <module>iot-e2e-tests</module>
         <module>provisioning</module>
+        <module>deps</module>
     </modules>
     <properties>
         <iot-device-client-artifact-id>iot-device-client</iot-device-client-artifact-id>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.11.1";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "1.11.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.3";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "1.9.4";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "1.34.1";
+    public static final String serviceVersion = "1.34.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java Deps (com.microsoft.azure.sdk.iot:iot-deps:0.15.3)

 - Upgrade bouncycastle dependency versions to 1.70 (#1476)
 - Upgrade gson dependency version to 2.8.9 (#1476)
 - Upgrade jackson-databind dependency version to 2.11.3 (#1476)


## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:1.34.3)

 - Upgrade iot-deps package dependency to 0.15.3 (#1476)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:1.34.2)

 - Upgrade iot-deps package dependency to 0.15.3 (#1476)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:1.11.2)

 - Upgrade iot-deps package dependency to 0.15.3 (#1476)

## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:1.9.4)

 - Upgrade iot-deps package dependency to 0.15.3 (#1476)
 - Upgrade com.microsoft.rest:client-runtime dependency to 1.7.14 (#1476)

## Java X509 Provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:1.1.7)

 - Upgrade bouncycastle dependency versions to 1.70 (#1476)


old
{
    "device": "1.34.2",
    "service": "1.34.1",
    "deps": "0.15.2",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.6",
    "provisioningDevice": "1.11.1",
    "provisioningService": "1.9.3"
}

new
{
    "device": "1.34.3",
    "service": "1.34.2",
    "deps": "0.15.3",
    "securityProvider": "1.5.0",
    "tpmHsm": "1.1.3",
    "x509": "1.1.7",
    "provisioningDevice": "1.11.2",
    "provisioningService": "1.9.4"
}