### PR TITLE
fix(iot-dev): Fix issue where multiplexed connections would leak heap memory for unregistered device clients

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -878,6 +878,8 @@ public class IotHubTransport implements IotHubListener
                         throw new MultiplexingClientDeviceRegistrationTimeoutException("Timed out waiting for all device unregistrations to finish.");
                     }
                 }
+
+                this.deviceConnectionStates.remove(newlyUnregisteredConfig.getDeviceId());
             }
         }
     }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -216,6 +216,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         }
 
         clientConfigurations.remove(config);
+        deviceSessionsOpenedLatches.remove(config.getDeviceId());
     }
 
     public void open() throws TransportException
@@ -1197,6 +1198,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         for (ClientConfiguration successfullyUnregisteredConfig : configsUnregisteredSuccessfully)
         {
             this.multiplexingClientsToUnregister.remove(successfullyUnregisteredConfig);
+            this.deviceSessionsOpenedLatches.remove(successfullyUnregisteredConfig.getDeviceId());
         }
 
         this.clientConfigurations.removeAll(configsUnregisteredSuccessfully);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -1198,7 +1198,6 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         for (ClientConfiguration successfullyUnregisteredConfig : configsUnregisteredSuccessfully)
         {
             this.multiplexingClientsToUnregister.remove(successfullyUnregisteredConfig);
-            this.deviceSessionsOpenedLatches.remove(successfullyUnregisteredConfig.getDeviceId());
         }
 
         this.clientConfigurations.removeAll(configsUnregisteredSuccessfully);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
@@ -128,6 +128,7 @@ abstract class AmqpsSenderLinkHandler extends BaseHandler
         {
             log.debug("{} sender link with address {} and link correlation id {} was closed remotely unexpectedly", getLinkInstanceType(), this.senderLinkAddress, this.linkCorrelationId);
             link.close();
+            clearHandlers();
             this.amqpsLinkStateCallback.onLinkClosedUnexpectedly(link.getRemoteCondition());
         }
         else
@@ -164,6 +165,7 @@ abstract class AmqpsSenderLinkHandler extends BaseHandler
         {
             log.debug("Closing {} sender link with address {} and link correlation id {}", getLinkInstanceType(), this.senderLinkAddress, this.linkCorrelationId);
             this.senderLink.close();
+            clearHandlers();
         }
     }
 
@@ -315,5 +317,23 @@ abstract class AmqpsSenderLinkHandler extends BaseHandler
         Section section = new Data(binary);
         outgoingMessage.setBody(section);
         return outgoingMessage;
+    }
+
+    // Removes any children of this handler (such as LoggingFlowController) and disassociates this handler
+    // from the proton reactor. By removing the reference of the proton reactor to this handler, this handler becomes
+    // eligible for garbage collection by the JVM. This is important for multiplexed connections where links come and go
+    // but the reactor stays alive for a long time.
+    private void clearHandlers()
+    {
+        this.senderLink.attachments().clear();
+
+        // a sender link shouldn't have any children, but other handlers may be added as this SDK grows and this protects
+        // against potential memory leaks
+        Iterator<Handler> childrenIterator = this.children();
+        while (childrenIterator.hasNext())
+        {
+            childrenIterator.next();
+            childrenIterator.remove();
+        }
     }
 }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -97,9 +97,6 @@ public class MultiplexingClientTests extends IntegrationTest
     private static final int FAULT_INJECTION_RECOVERY_TIMEOUT_MILLIS = 2 * 60 * 1000;
     private static final int FAULT_INJECTION_TIMEOUT_MILLIS = 60 * 1000;
     private static final int DEVICE_METHOD_SUBSCRIBE_TIMEOUT_MILLISECONDS = 60 * 1000;
-    private static final int TWIN_SUBSCRIBE_TIMEOUT_MILLIS = 60 * 1000;
-    private static final long MAXIMUM_TIME_TO_WAIT_FOR_DESIRED_PROPERTY_SUBSCRIPTION_ACKNOWLEDGEMENT = 500; // .5 seconds
-    private static final long MAXIMUM_TIME_TO_WAIT_FOR_REPORTED_PROPERTY_ACKNOWLEDGEMENT = 1000; // 1 second
     private static final int DESIRED_PROPERTY_CALLBACK_TIMEOUT_MILLIS = 60 * 1000;
     private static final int DEVICE_SESSION_OPEN_TIMEOUT = 60 * 1000;
     private static final int DEVICE_SESSION_CLOSE_TIMEOUT = 60 * 1000;


### PR DESCRIPTION
The proton-j reactor powering the multiplexed connection still had references to the various amqp handler objects used in our SDK even after the client using each of these handlers had been unregistered. By clearing the handlers from the reactor, the JVM is free to garbage collect these handlers

Also fix a few small state maps that weren't kept up to date whenever a client was unregistered from a muxed connection

#1478 