### PR TITLE
fix(iot-dev): Fix bug where connection level issues caused multiplexed device clients to temporarily close

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -317,17 +317,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
                         CountDownLatch deviceSessionOpenedCountDownLatch = this.deviceSessionsOpenedLatches.get(config.getDeviceId());
                         int timeout = config.getAmqpOpenDeviceSessionsTimeout();
 
-                        /*try
-                        {*/
-                            deviceSessionsOpenTimedOut = !deviceSessionOpenedCountDownLatch.await(timeout, TimeUnit.SECONDS);
-                        /*}
-                        catch (NullPointerException e)
-                        {
-                            // indicates that the device session was unregistered while opening the connection, likely due to
-                            // retry logic for both the mux level connection and a particular multiplexed device running
-                            // simultaneously. Safe to ignore.
-                            log.trace("Ignoring null pointer exception from deviceSessionOpenedCountDownLatch");
-                        }*/
+                        deviceSessionsOpenTimedOut = !deviceSessionOpenedCountDownLatch.await(timeout, TimeUnit.SECONDS);
 
                         if (deviceSessionsOpenTimedOut)
                         {

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -958,7 +958,7 @@ public class IotHubTransportTest
                 mockedAmqpsIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedAmqpsIotHubConnection.open();
+                mockedAmqpsIotHubConnection.open((Collection<ClientConfiguration>) any);
                 times = 1;
             }
         };
@@ -998,7 +998,7 @@ public class IotHubTransportTest
                 mockedAmqpsIotHubConnection.setListener(transport);
                 times = 1;
 
-                mockedAmqpsIotHubConnection.open();
+                mockedAmqpsIotHubConnection.open((Collection<ClientConfiguration>) any);
                 times = 1;
             }
         };


### PR DESCRIPTION
The device client would still reconnect after this event, but this temporary close would execute a connection status callback to notify the user that their client has reached a terminal state and their twin/method subscriptions would be erased unnecessarily.

Another symptom that came from this issue was that the IotHubTransport layer's retry logic would be executing both for the multiplexing client and for each of the registered multiplexed clients leading to some race condition caused NPEs. Now the IotHubTransport layer is only notified to start the multiplexing client level retry logic in cases like these.