### PR TITLE
refactor(e2e): Mark a c2d test as standard tier only

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/MessagingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/MessagingClientTests.java
@@ -366,6 +366,7 @@ public class MessagingClientTests extends IntegrationTest
     }
 
     @Test
+    @StandardTierHubOnlyTest
     @ContinuousIntegrationTest
     public void cloudToDeviceTelemetryWithTooLargeMessageThrows() throws IOException, GeneralSecurityException, IotHubException, URISyntaxException, TimeoutException, InterruptedException
     {
@@ -385,8 +386,6 @@ public class MessagingClientTests extends IntegrationTest
                 false);
 
         Device device = testDeviceIdentity.getDevice();
-
-        Device deviceGetBefore = registryClient.getDevice(device.getDeviceId());
 
         MessagingClientOptions messagingClientOptions =
             MessagingClientOptions.builder()


### PR DESCRIPTION
Basic tier hubs do not support cloud to device telemetry, so we can't test it.

The other c2d tests were already marked this way, but this test was not. This test was failing in CI builds of basic tier hubs. The only reason this hasn't been a problem yet is that this test was skipped in PR builds.