### PR TITLE
break(iot-dev, iot-serv): Allow versions to be null, fix version not …

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinCollection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/TwinCollection.java
@@ -393,7 +393,7 @@ public class TwinCollection extends HashMap<String, Object> {
     /**
      * Setter for the version.
      */
-    public final void setVersion(int version) {
+    public final void setVersion(Integer version) {
         this.version = version;
     }
 

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/TwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/TwinClientTests.java
@@ -91,6 +91,7 @@ public class TwinClientTests extends IntegrationTest
 
         // assert
         assertTrue(TwinCommon.isPropertyInTwinCollection(twin.getDesiredProperties(), expectedDesiredPropertyKey, expectedDesiredPropertyValue));
+        assertNotNull(twin.getDesiredProperties().getVersion());
     }
 
     @Test
@@ -145,5 +146,6 @@ public class TwinClientTests extends IntegrationTest
         // assert
         assertFalse("old twin property was not deleted when twin client replaced it", TwinCommon.isPropertyInTwinCollection(twin.getDesiredProperties(), desiredPropertyToBeReplacedKey, desiredPropertyToBeReplacedValue));
         assertTrue("new twin property was not saved when twin client added it using twinClient.replace", TwinCommon.isPropertyInTwinCollection(twin.getDesiredProperties(), expectedDesiredPropertyKey, expectedDesiredPropertyValue));
+        assertNotNull(twin.getDesiredProperties().getVersion());
     }
 }

--- a/iot-e2e-tests/edge-e2e/src/main/java/io/swagger/server/api/verticle/WrappedTwin.java
+++ b/iot-e2e-tests/edge-e2e/src/main/java/io/swagger/server/api/verticle/WrappedTwin.java
@@ -17,7 +17,7 @@ public class WrappedTwin
 
     private JsonObject mapToJson(TwinCollection map)
     {
-        return new JsonObject(map.toJsonElement().toString());
+        return new JsonObject(map.toJsonObject().toString());
     }
 
     public JsonObject toJsonObject()

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -79,16 +79,19 @@ public class Twin
         twin.setVersion(twinState.getVersion());
         twin.setETag(twinState.getETag());
 
+        twin.getTags().setVersion(twinState.getTags().getVersion());
         if (twinState.getTags().size() > 0)
         {
             twin.getTags().putAll(twinState.getTags());
         }
 
+        twin.getDesiredProperties().setVersion(twinState.getDesiredProperties().getVersion());
         if (twinState.getDesiredProperties().size() > 0)
         {
             twin.getDesiredProperties().putAll(twinState.getDesiredProperties());
         }
 
+        twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
         if (twinState.getReportedProperties().size() > 0)
         {
             twin.getReportedProperties().putAll(twinState.getReportedProperties());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.sdk.iot.service.twin;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.microsoft.azure.sdk.iot.service.ParserUtility;
 
 import java.util.HashMap;
@@ -329,8 +330,13 @@ public class TwinCollection extends HashMap<String, Object> {
      *
      * @return The {@code JsonElement} with the content of this class.
      */
-    public JsonElement toJsonElement() {
-        return ParserUtility.mapToJsonElement(this);
+    public JsonObject toJsonObject() {
+        JsonObject object = ParserUtility.mapToJsonElement(this).getAsJsonObject();
+        if (this.version != null)
+        {
+            object.add(VERSION_TAG, new JsonPrimitive(this.version));
+        }
+        return object;
     }
 
     /**
@@ -394,7 +400,7 @@ public class TwinCollection extends HashMap<String, Object> {
      * Setter for the version of this twin collection.
      * @param version the version.
      */
-    public final void setVersion(int version)
+    public final void setVersion(Integer version)
     {
         this.version = version;
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinProperties.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinProperties.java
@@ -164,12 +164,12 @@ public class TwinProperties
 
         if (this.desired != null)
         {
-            twinJson.add(DESIRED_PROPERTIES_TAG, this.desired.toJsonElement());
+            twinJson.add(DESIRED_PROPERTIES_TAG, this.desired.toJsonObject());
         }
 
         if (this.reported != null)
         {
-            twinJson.add(REPORTED_PROPERTIES_TAG, this.reported.toJsonElement());
+            twinJson.add(REPORTED_PROPERTIES_TAG, this.reported.toJsonObject());
         }
 
         return twinJson;

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollectionTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollectionTest.java
@@ -809,7 +809,7 @@ public class TwinCollectionTest
         };
 
         // act
-        JsonElement jsonElement = twinCollection.toJsonElement();
+        JsonElement jsonElement = twinCollection.toJsonObject();
 
         // assert
         Helpers.assertJson(jsonElement.toString(), JSON_SAMPLE);
@@ -851,7 +851,7 @@ public class TwinCollectionTest
                 "    }\n";
 
         // act
-        JsonElement jsonElement = twinCollection.toJsonElement();
+        JsonElement jsonElement = twinCollection.toJsonObject();
 
         // assert
         Helpers.assertJson(jsonElement.toString(), json);
@@ -867,7 +867,7 @@ public class TwinCollectionTest
         TwinCollection twinCollection = Deencapsulation.invoke(TwinCollection.class, "createFromRawCollection", rawMap);
 
         // act
-        JsonElement jsonElement = twinCollection.toJsonElement();
+        JsonElement jsonElement = twinCollection.toJsonObject();
 
         // assert
         Helpers.assertJson(jsonElement.toString(), JSON_SAMPLE);

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinStateTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinStateTest.java
@@ -392,7 +392,7 @@ public class TwinStateTest
         TwinState twinState = TwinState.createFromDesiredPropertyJson(json);
 
         // assert
-        Helpers.assertJson(twinState.getDesiredProperties().toJsonElement().toString(), json);
+        Helpers.assertJson(twinState.getDesiredProperties().toJsonObject().toString(), json);
     }
 
     /* SRS_TWIN_STATE_21_017: [The factory shall throw IllegalArgumentException if the JSON is null or empty.] */
@@ -448,7 +448,7 @@ public class TwinStateTest
         TwinState twinState = TwinState.createFromReportedPropertyJson(json);
 
         // assert
-        Helpers.assertJson(twinState.getReportedProperties().toJsonElement().toString(), json);
+        Helpers.assertJson(twinState.getReportedProperties().toJsonObject().toString(), json);
     }
 
     /* SRS_TWIN_STATE_21_020: [The factory shall throw IllegalArgumentException if the JSON is null or empty.] */


### PR DESCRIPTION
…showing when service client gets twin

Nullable version means that users can opt out of caring about versions and just send property updates.