### PR TITLE
fix(iot-dev): Fix SDK leaking apache qpid objects after unregistering a device

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsReceiverLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsReceiverLinkHandler.java
@@ -321,5 +321,7 @@ abstract class AmqpsReceiverLinkHandler extends BaseHandler
             childrenIterator.next();
             childrenIterator.remove();
         }
+
+        this.receiverLink.free();
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSasTokenRenewalHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSasTokenRenewalHandler.java
@@ -136,6 +136,7 @@ class AmqpsSasTokenRenewalHandler extends BaseHandler implements AuthenticationM
     {
         if (this.scheduledTask != null)
         {
+            this.scheduledTask.cancel();
             this.scheduledTask.attachments().clear();
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
@@ -335,5 +335,7 @@ abstract class AmqpsSenderLinkHandler extends BaseHandler
             childrenIterator.next();
             childrenIterator.remove();
         }
+
+        this.senderLink.free();
     }
 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -569,5 +569,7 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
             childrenIterator.next();
             childrenIterator.remove();
         }
+
+        this.session.free();
     }
 }


### PR DESCRIPTION
#1478

The reactor instance still held onto the last scheduled SAS token renewal task for an unregistered device when it needed to be cancelled, and the sessions and links needed to be free'd after they were closed.