### PR TITLE
refactor(iot-dev): Fix javadocs for SAS token expiry time, fix reconnection sample

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -82,8 +82,8 @@ public final class ClientOptions
     private final int httpsConnectTimeout = DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLISECONDS;
 
     /**
-     * This option is applicable for HTTP/AMQP/MQTT. This option specifies the time to live for all generated
-     * SAS tokens. By default, this value is 1 hour.
+     * This option specifies the time to live (in seconds) for all SAS tokens generated for this client. By default,
+     * this value is 1 hour.
      */
     @Getter
     @Builder.Default

--- a/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
+++ b/device/iot-device-samples/device-reconnection-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceClientManager.java
@@ -53,7 +53,7 @@ public class DeviceClientManager implements DesiredPropertiesCallback, MethodCal
                             System.exit(-1);
                         }
 
-                        if (newStatusReason == IotHubConnectionStatusChangeReason.EXPIRED_SAS_TOKEN)
+                        if (newStatus == IotHubConnectionStatus.DISCONNECTED && newStatusReason == IotHubConnectionStatusChangeReason.EXPIRED_SAS_TOKEN)
                         {
                             // should only happen if the user provides a shared access signature instead of a connection string.
                             // indicates that the device client is now unusable because there is no way to renew the shared


### PR DESCRIPTION
expiry time javadocs didn't mention the time unit and reconnection sample was missing a check on the status