### PR TITLE
fix(iot-dev): Fix bug where configuration content was not serialized correctly

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ConfigurationsClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/ConfigurationsClientTests.java
@@ -114,14 +114,20 @@ public class ConfigurationsClientTests extends IntegrationTest
     {
         // Arrange
         ConfigurationsClientTestInstance testInstance = new ConfigurationsClientTestInstance();
+
+        // testing such that one configuration uses a floating point value and the other an integer so that
+        // the value is maintained as an int/float through serialization and deserialization
+        int expectedTemperatureValue = 66;
+        double expectedPressureValue = 28.02;
+
         final HashMap<String, Object> testDeviceContent = new HashMap<String, Object>()
         {
             {
                 put("properties.desired.chiller-water", new HashMap<String, Object>()
                     {
                         {
-                            put("temperature", 66);
-                            put("pressure", 28);
+                            put("temperature", expectedTemperatureValue);
+                            put("pressure", expectedPressureValue);
                         }
                     }
                 );
@@ -163,8 +169,8 @@ public class ConfigurationsClientTests extends IntegrationTest
             String[] entry = pair.split("=");
             actualMap.put(entry[0].trim(), entry[1].trim());
         }
-        assertEquals(buildExceptionMessage("", hostName), "66.0", actualMap.get("temperature"));
-        assertEquals(buildExceptionMessage("", hostName), "28.0", actualMap.get("pressure"));
+        assertEquals(buildExceptionMessage("", hostName), expectedTemperatureValue, Integer.valueOf(actualMap.get("temperature")).intValue());
+        assertEquals(buildExceptionMessage("", hostName), expectedPressureValue, Double.valueOf(actualMap.get("pressure")).doubleValue(), 0);
         assertEquals(buildExceptionMessage("", hostName), "SELECT deviceId FROM devices WHERE properties.reported.chillerWaterSettings.status=\'pending\'",
             configRetrieved.getMetrics().getQueries().get("waterSettingsPending"));
         assertEquals(buildExceptionMessage("", hostName), "properties.reported.chillerProperties.model=\'4000x\'",

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationContent.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationContent.java
@@ -43,6 +43,7 @@ public class ConfigurationContent
         ConfigurationContentParser parser = new ConfigurationContentParser();
         parser.setModulesContent(this.modulesContent);
         parser.setDeviceContent(this.deviceContent);
+        parser.setModuleContent(this.moduleContent);
         return parser;
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClient.java
@@ -341,7 +341,7 @@ public class ConfigurationsClient
 
         URL url = IotHubConnectionString.getUrlApplyConfigurationContent(this.hostName, deviceId);
 
-        HttpRequest request = createRequest(url, HttpMethod.POST, content.toConfigurationContentParser().toJson().getBytes(StandardCharsets.UTF_8));
+        HttpRequest request = createRequest(url, HttpMethod.POST, content.toConfigurationContentParser().toJsonElement().toString().getBytes(StandardCharsets.UTF_8));
 
         request.send();
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/serializers/ConfigurationContentParser.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/serializers/ConfigurationContentParser.java
@@ -1,9 +1,6 @@
 package com.microsoft.azure.sdk.iot.service.configurations.serializers;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.azure.sdk.iot.service.ParserUtility;
@@ -36,7 +33,7 @@ public class ConfigurationContentParser
     @Setter
     private Map<String, Object> deviceContent;
 
-    private final transient static Gson gson = new Gson();
+    private final transient static Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
 
     /**
      * Empty constructor: Used only to keep GSON happy.
@@ -51,7 +48,6 @@ public class ConfigurationContentParser
      */
     public ConfigurationContentParser(String json)
     {
-        //Codes_SRS_CONFIGURATION_CONTENT_PARSER_28_001: [If the provided json is null, empty an IllegalArgumentException shall be thrown.]
         if (json == null || json.isEmpty())
         {
             throw new IllegalArgumentException("The provided json cannot be null or empty");
@@ -60,14 +56,10 @@ public class ConfigurationContentParser
         ConfigurationContentParser configurationContentParser;
         try
         {
-            //Codes_SRS_CONFIGURATION_CONTENT_PARSER_28_002: [The constructor shall take the provided json and convert
-            // it into a new ConfigurationContentParser and return it.]
             configurationContentParser = gson.fromJson(json, ConfigurationContentParser.class);
         }
         catch (JsonSyntaxException e)
         {
-            //Codes_SRS_CONFIGURATION_CONTENT_PARSER_28_003: [If the provided json cannot be parsed into a Configuration
-            // ContentParser object, an IllegalArgumentException shall be thrown.]
             throw new IllegalArgumentException("The provided json could not be parsed");
         }
 
@@ -76,30 +68,23 @@ public class ConfigurationContentParser
         this.deviceContent = configurationContentParser.deviceContent;
     }
 
-    public String toJson()
-    {
-        return gson.toJson(this);
-    }
-
     public JsonElement toJsonElement()
     {
         JsonObject contentJson = new JsonObject();
 
-        /* Codes_SRS_CONFIGURATION_METRICS_PARSER_28_009: [If the modulesContent is null, the toJsonElement shall not include the `modulesContent` in the final JSON.] */
-        if (this.modulesContent != null)
+        if (this.modulesContent != null && this.modulesContent.size() > 0)
         {
             Map<String, Object> map = new HashMap<>();
             map.putAll(this.modulesContent);
             contentJson.add(MODULES_CONTENT_NAME, ParserUtility.mapToJsonElement(map));
         }
 
-        /* Codes_SRS_CONFIGURATION_METRICS_PARSER_28_010: [If the deviceContent is null, the toJsonElement shall not include the `deviceContent` in the final JSON.]*/
-        if (this.deviceContent != null)
+        if (this.deviceContent != null && this.deviceContent.size() > 0)
         {
             contentJson.add(DEVICE_CONTENT_NAME, ParserUtility.mapToJsonElement(this.deviceContent));
         }
 
-        if (this.moduleContent != null)
+        if (this.moduleContent != null && this.moduleContent.size() > 0)
         {
             contentJson.add(MODULE_CONTENT_NAME, ParserUtility.mapToJsonElement(this.moduleContent));
         }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/serializers/ConfigurationParser.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/serializers/ConfigurationParser.java
@@ -1,9 +1,6 @@
 package com.microsoft.azure.sdk.iot.service.configurations.serializers;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.azure.sdk.iot.service.ParserUtility;
@@ -99,7 +96,12 @@ public class ConfigurationParser
     @Setter
     private String eTag;
 
-    private final transient static Gson gson = new GsonBuilder().enableComplexMapKeySerialization().serializeNulls().create();
+    private final transient static Gson gson =
+            new GsonBuilder()
+                .enableComplexMapKeySerialization()
+                .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .serializeNulls()
+                .create();
 
     /**
      * Empty constructor: Used only to keep GSON happy.

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationContentParserTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationContentParserTest.java
@@ -37,7 +37,7 @@ public class ConfigurationContentParserTest
     {
         //arrange
         String json = "{\"modulesContent\":{\"properties\":{\"c\":\"abc\",\"d\":\"def\"}}, " +
-                "\"deviceContent\":{\"properties.desired.settings1\": {\"c\":3,\"d\":4}}}";
+                "\"deviceContent\":{\"properties.desired.settings1\": {\"c\":3,\"d\":4.1}}}";
 
         //act
         ConfigurationContentParser parser = new ConfigurationContentParser(json);
@@ -48,8 +48,8 @@ public class ConfigurationContentParserTest
         assertEquals("abc", moduleContentMap.get("c"));
         assertEquals("def", moduleContentMap.get("d"));
         Map<String, Object> deviceContentMap = ((Map<String,Object>)(parser.getDeviceContent().get("properties.desired.settings1")));
-        assertEquals((double)3, deviceContentMap.get("c"));
-        assertEquals((double)4, deviceContentMap.get("d"));
+        assertEquals(3l, deviceContentMap.get("c"));
+        assertEquals(4.1, deviceContentMap.get("d"));
     }
 
     //Tests_SRS_CONFIGURATION_CONTENT_PARSER_28_003: [If the provided json cannot be parsed into a ConfigurationContentParser

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClientTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClientTest.java
@@ -506,7 +506,7 @@ public class ConfigurationsClientTest
                 mockedConfigurationContent.toConfigurationContentParser();
                 result = mockedConfigurationContentParser;
 
-                mockedConfigurationContentParser.toJson();
+                mockedConfigurationContentParser.toJsonElement().toString();
                 result = expectedJson;
             }
         };


### PR DESCRIPTION
It always sent empty json objects for ModuleContent, ModulesContent, and DeviceContent even if the user provided one or more key-value pairs for it

Also fix a bug where numeric configuration values were always serialized and deserialized as floats even if they were integers