### PR TITLE
fix(iot-service): Fix bug where twin metadata isn't given to user even when it was received from service

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/TwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/TwinClientTests.java
@@ -54,6 +54,9 @@ public class TwinClientTests extends IntegrationTest
         TwinClient twinClient = new TwinClient(iotHubConnectionString, twinClientOptions);
         Twin twin = twinClient.get(testDeviceIdentity.getDeviceId());
 
+        assertNotNull(twin.getTags());
+        assertNull(twin.getTags().getTwinMetadata());
+
         String expectedTagKey = UUID.randomUUID().toString();
         String expectedTagValue = UUID.randomUUID().toString();
 
@@ -92,6 +95,9 @@ public class TwinClientTests extends IntegrationTest
         // assert
         assertTrue(TwinCommon.isPropertyInTwinCollection(twin.getDesiredProperties(), expectedDesiredPropertyKey, expectedDesiredPropertyValue));
         assertNotNull(twin.getDesiredProperties().getVersion());
+        assertNotNull(twin.getDesiredProperties().getTwinMetadata());
+        assertNotNull(twin.getDesiredProperties().getTwinMetadata(expectedDesiredPropertyKey));
+        assertNotNull(twin.getDesiredProperties().getTwinMetadata(expectedDesiredPropertyKey).getLastUpdated());
     }
 
     @Test

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/TwinTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/twin/TwinTests.java
@@ -166,6 +166,14 @@ public class TwinTests extends TwinCommon
         com.microsoft.azure.sdk.iot.service.twin.Twin serviceClientTwin = testInstance.getServiceClientTwin();
         assertTrue(isPropertyInTwinCollection(serviceClientTwin.getReportedProperties(), reportedPropertyKey1, reportedPropertyValue1));
         assertTrue(isPropertyInTwinCollection(serviceClientTwin.getReportedProperties(), reportedPropertyKey2, reportedPropertyValue2));
+
+        // verify that metadata for these new properties is visible to a twin service client
+        com.microsoft.azure.sdk.iot.service.twin.Twin serviceTwin = testInstance.getServiceClientTwin();
+        assertNotNull(serviceTwin.getReportedProperties().getTwinMetadata());
+        assertNotNull(serviceTwin.getReportedProperties().getTwinMetadata(reportedPropertyKey1));
+        assertNotNull(serviceTwin.getReportedProperties().getTwinMetadata(reportedPropertyKey2));
+        assertNotNull(serviceTwin.getReportedProperties().getTwinMetadata(reportedPropertyKey1).getLastUpdated());
+        assertNotNull(serviceTwin.getReportedProperties().getTwinMetadata(reportedPropertyKey2).getLastUpdated());
     }
 
     @Test

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -92,9 +92,23 @@ public class Twin
         }
 
         twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
+        twin.getDesiredProperties().setTwinMetadata(twinState.getDesiredProperties().getTwinMetadata());
+
+        if (twinState.getDesiredProperties().getMetadataMap().size() > 0)
+        {
+            twin.getDesiredProperties().getMetadataMap().putAll(twinState.getDesiredProperties().getMetadataMap());
+        }
+
         if (twinState.getReportedProperties().size() > 0)
         {
             twin.getReportedProperties().putAll(twinState.getReportedProperties());
+        }
+
+        twin.getReportedProperties().setTwinMetadata(twinState.getReportedProperties().getTwinMetadata());
+
+        if (twinState.getReportedProperties().getMetadataMap().size() > 0)
+        {
+            twin.getReportedProperties().getMetadataMap().putAll(twinState.getReportedProperties().getMetadataMap());
         }
 
         twin.setCapabilities(twinState.getCapabilities());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -79,33 +79,34 @@ public class Twin
         twin.setVersion(twinState.getVersion());
         twin.setETag(twinState.getETag());
 
+        // Tags
         twin.getTags().setVersion(twinState.getTags().getVersion());
         if (twinState.getTags().size() > 0)
         {
             twin.getTags().putAll(twinState.getTags());
         }
 
+        // Desired properties
         twin.getDesiredProperties().setVersion(twinState.getDesiredProperties().getVersion());
         if (twinState.getDesiredProperties().size() > 0)
         {
             twin.getDesiredProperties().putAll(twinState.getDesiredProperties());
         }
 
-        twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
         twin.getDesiredProperties().setTwinMetadata(twinState.getDesiredProperties().getTwinMetadata());
-
         if (twinState.getDesiredProperties().getMetadataMap().size() > 0)
         {
             twin.getDesiredProperties().getMetadataMap().putAll(twinState.getDesiredProperties().getMetadataMap());
         }
 
+        // Reported properties
+        twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
         if (twinState.getReportedProperties().size() > 0)
         {
             twin.getReportedProperties().putAll(twinState.getReportedProperties());
         }
 
         twin.getReportedProperties().setTwinMetadata(twinState.getReportedProperties().getTwinMetadata());
-
         if (twinState.getReportedProperties().getMetadataMap().size() > 0)
         {
             twin.getReportedProperties().getMetadataMap().putAll(twinState.getReportedProperties().getMetadataMap());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
@@ -151,6 +151,11 @@ public class TwinCollection extends HashMap<String, Object> {
         }
     }
 
+    final Map<String, TwinMetadata> getMetadataMap()
+    {
+        return metadataMap;
+    }
+
     /**
      * Add all information in the provided Map to the TwinCollection.
      *
@@ -411,6 +416,10 @@ public class TwinCollection extends HashMap<String, Object> {
      */
     public final TwinMetadata getTwinMetadata() {
         return this.twinMetadata;
+    }
+
+    final void setTwinMetadata(TwinMetadata twinMetadata) {
+        this.twinMetadata = twinMetadata;
     }
 
     /**

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinCollection.java
@@ -151,6 +151,11 @@ public class TwinCollection extends HashMap<String, Object> {
         }
     }
 
+    /**
+     * Getter for the TwinCollection metadata map.
+     *
+     * @return The metadata map for this TwinCollection.
+     */
     final Map<String, TwinMetadata> getMetadataMap()
     {
         return metadataMap;
@@ -418,6 +423,11 @@ public class TwinCollection extends HashMap<String, Object> {
         return this.twinMetadata;
     }
 
+    /**
+     * Setter for the TwinCollection metadata
+     *
+     * @param twinMetadata the metadata to assign to this TwinCollection.
+     */
     final void setTwinMetadata(TwinMetadata twinMetadata) {
         this.twinMetadata = twinMetadata;
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinProperties.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinProperties.java
@@ -130,18 +130,10 @@ public class TwinProperties
         if (desired != null)
         {
             this.desired = TwinCollection.createFromRawCollection(desired);
-            if (desired.getVersion() != null)
-            {
-                this.desired.setVersion(desired.getVersion());
-            }
         }
         if (reported != null)
         {
             this.reported = TwinCollection.createFromRawCollection(reported);
-            if (reported.getVersion() != null)
-            {
-                this.reported.setVersion(reported.getVersion());
-            }
         }
     }
 


### PR DESCRIPTION
Example twin:
```
{
    "deviceId": "devA",
    "etag": "AAAAAAAAAAc=", 
    "status": "enabled",
    "statusReason": "provisioned",
    "statusUpdateTime": "0001-01-01T00:00:00",
    "connectionState": "connected",
    "lastActivityTime": "2015-02-30T16:24:48.789Z",
    "cloudToDeviceMessageCount": 0, 
    "authenticationType": "sas",
    "x509Thumbprint": {     
        "primaryThumbprint": null, 
        "secondaryThumbprint": null 
    }, 
    "version": 2, 
    "tags": {
        "$etag": "123",
        "deploymentLocation": {
            "building": "43",
            "floor": "1"
        }
    },
    "properties": {
        "desired": {
            "telemetryConfig": {
                "sendFrequency": "5m"
            },
            "$metadata" : {...}, // <----- was missing
            "$version": 1
        },
        "reported": {
            "telemetryConfig": {
                "sendFrequency": "5m",
                "status": "success"
            },
            "batteryLevel": 55,
            "$metadata" : {...}, // <----- was missing
            "$version": 4
        }
    }
}
```