### PR TITLE
release(2022-04-06): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.0.0";
+    public static final String CLIENT_VERSION = "2.0.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Remote binary dependency
-    api ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.0') {
+    api ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.1') {
         exclude module: 'slf4j-api'
     }
     implementation 'org.slf4j:slf4j-android:1.7.29'

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.0.0</iot-device-client-version>
-        <iot-service-client-version>2.0.0</iot-service-client-version>
+        <iot-device-client-version>2.0.1</iot-device-client-version>
+        <iot-service-client-version>2.0.1</iot-service-client-version>
         <provisioning-device-client-version>2.0.0</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.0</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.0.0";
+    public static final String serviceVersion = "2.0.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.0.1)

### Bug fixes

- Fix bug where synchronous operations did not throw an exception if it received an unsuccessful status code (#1512)
- Fix bug where AMQP connections did not map AmqpLinkMessageSizeExceededException to REQUEST_ENTITY_TOO_LARGE (#1512)
- Fix stack traces for synchronous methods not including the synchronous method call itself (#1512)
- Fix bug where multiplexing client did not cancel queued or sent packets for a device when it is unregistered (#1503)


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.0.1)

### Bug fixes

- Fix a bug where numeric configuration values were always serialized and deserialized as floats even if they were integers (#1510)
- Fix bug where configuration content was not serialized correctly (#1510)
- Fix bug where SDK rejected deserialized registry device instances with no authentication details (#1508)
- Fix bug where twin metadata isn't given to user even when it was received from service (#1516)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.0.1/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/2.0.1/jar

old
{
    "device": "2.0.0",
    "service": "2.0.0",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.0",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}

new
{
    "device": "2.0.1",
    "service": "2.0.1",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.0",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}