### PR TITLE
fix(iot-dev): Fix bug where multiplexed devices didn't persist subscriptions if transport error occurred

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -572,6 +572,13 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         this.savedException = AmqpsExceptionTranslator.convertFromAmqpException(errorCondition);
 
+        if (this.isMultiplexing)
+        {
+            // transport errors involve closing the entire amqp connection, so save all the previous sessions
+            // so that their twin/methods subscriptions can persist
+            this.reconnectingDeviceSessionHandlers.putAll(this.sessionHandlers);
+        }
+
         // In the event that we get a local error and the connection is already in the closed state we need to manually call
         // onConnectionLocalClose. Proton will not queue the CONNECTION_LOCAL_CLOSE event since the Endpoint status is CLOSED
         if (event.getConnection().getLocalState() == EndpointState.CLOSED && isALocalErrorCondition)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -918,7 +918,7 @@ public class MultiplexingClientTests extends IntegrationTest
     private static void testReportedPropertiesFlow(DeviceClient deviceClient, TwinClient twinClientServiceClient, String expectedPropertyKey, String expectedPropertyValue) throws IOException, IotHubException, InterruptedException, TimeoutException, IotHubClientException
     {
         String expectedReportedPropertyValue = expectedPropertyValue + "-reported";
-        TwinCollection reportedProperties = new TwinCollection();
+        TwinCollection reportedProperties = deviceClient.getTwin().getReportedProperties();
         reportedProperties.put(expectedPropertyKey, expectedReportedPropertyValue);
         deviceClient.updateReportedProperties(reportedProperties);
 
@@ -926,7 +926,7 @@ public class MultiplexingClientTests extends IntegrationTest
         Twin serviceClientTwin = twinClientServiceClient.get(deviceClient.getConfig().getDeviceId());
 
         com.microsoft.azure.sdk.iot.service.twin.TwinCollection retrievedReportedProperties = serviceClientTwin.getReportedProperties();
-        assertEquals(1, retrievedReportedProperties.size());
+        assertTrue(retrievedReportedProperties.size() > 1);
         String retrievedReportedPropertyKey = retrievedReportedProperties.keySet().iterator().next();
         assertEquals(expectedPropertyKey, retrievedReportedPropertyKey);
         String actualReportedPropertyValue = (String) retrievedReportedProperties.get(retrievedReportedPropertyKey);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -926,7 +926,7 @@ public class MultiplexingClientTests extends IntegrationTest
         Twin serviceClientTwin = twinClientServiceClient.get(deviceClient.getConfig().getDeviceId());
 
         com.microsoft.azure.sdk.iot.service.twin.TwinCollection retrievedReportedProperties = serviceClientTwin.getReportedProperties();
-        assertTrue(retrievedReportedProperties.size() > 1);
+        assertTrue(retrievedReportedProperties.size() > 0);
         String retrievedReportedPropertyKey = retrievedReportedProperties.keySet().iterator().next();
         assertEquals(expectedPropertyKey, retrievedReportedPropertyKey);
         String actualReportedPropertyValue = (String) retrievedReportedProperties.get(retrievedReportedPropertyKey);


### PR DESCRIPTION
also fix an e2e test not getting the initial twin before sending reported property updates