### PR TITLE
ado: Make component governance run on android build and test

### DIFF
--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -250,6 +250,14 @@ jobs:
           artifactName: 'androidBuildFiles'
           targetPath: 'iot-e2e-tests/android/app/build/outputs/apk'
 
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance Detection
+        inputs:
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
+        condition: always()
+
   - job: AndroidTest
     timeoutInMinutes: 50
     pool:
@@ -321,3 +329,11 @@ jobs:
           filePath: '$(Build.SourcesDirectory)/vsts/RunTestsOnEmulator.sh'
         env:
           TEST_GROUP_ID: $(ANDROID_TEST_GROUP_ID)
+
+      - task : ComponentGovernanceComponentDetection@0
+        displayName : Component Governance Detection
+        inputs :
+          scanType : 'Register'
+          verbosity : 'Verbose'
+          alertWarningLevel : 'Low' # The task will present a warning, but will not cause the build to fail
+        condition : always()


### PR DESCRIPTION
Continuing on #1522 but adding the same logic in the other build steps