### PR TITLE
fix(iot-dev): Fix bug where twin/method subscription wasn't cleared when client is closed

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -168,6 +168,8 @@ public class InternalClient
     public void close()
     {
         this.deviceIO.close();
+        this.method = null;
+        this.twin = null;
     }
 
     /**


### PR DESCRIPTION
As a result, this call would fail:

```java
deviceClient.open();
deviceClient.subscribeToMethods(...);
deviceClient.close();
deviceClient.open();
deviceClient.subscribeToMethods(...); // would always timeout since the callbacks pointed at the previous client's method state
```