### PR TITLE
release(2022-04-18): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.0.1";
+    public static final String CLIENT_VERSION = "2.0.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Remote binary dependency
-    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.1') {
+    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.2') {
         exclude module: 'slf4j-api'
         exclude module: 'log4j-slf4j-impl'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.0.1</iot-device-client-version>
-        <iot-service-client-version>2.0.1</iot-service-client-version>
+        <iot-device-client-version>2.0.2</iot-device-client-version>
+        <iot-service-client-version>2.0.2</iot-service-client-version>
         <provisioning-device-client-version>2.0.0</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.0</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.0.1";
+    public static final String serviceVersion = "2.0.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.0.2)

- Remove accidentally added dependency on a logging binding library (#1524)

### Bug fixes

- Fix bug where twin/method subscription wasn't cleared when client is closed (#1536)
- Fix IO errors and time outs not being classified as retryable (#1534)
- Fix bug where multiplexed devices didn't persist subscriptions if transport error occurred (#1525)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.0.2)

- Upgrade Guava and Jackson dependencies (#1529)


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.0.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/2.0.2/jar

old
{
    "device": "2.0.1",
    "service": "2.0.1",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.0",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}

new
{
    "device": "2.0.2",
    "service": "2.0.2",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.0",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}