### PR TITLE
fix(iot-dev): Fix unnecessary creation of custom symbol instances in amqp layer

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsMethodsReceiverLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsMethodsReceiverLinkHandler.java
@@ -38,7 +38,7 @@ final class AmqpsMethodsReceiverLinkHandler extends AmqpsReceiverLinkHandler
         this.receiverLinkAddress = getAddress(clientConfiguration);
 
         //Note that this correlation id value must be equivalent to the correlation id in the method sender link that it is paired with
-        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId));
+        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId);
         this.amqpProperties.put(Symbol.getSymbol(VERSION_IDENTIFIER_KEY), clientConfiguration.getProductInfo().getUserAgentString());
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsMethodsSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsMethodsSenderLinkHandler.java
@@ -38,7 +38,7 @@ final class AmqpsMethodsSenderLinkHandler extends AmqpsSenderLinkHandler
         this.senderLinkAddress = getAddress(clientConfiguration);
 
         //Note that this correlation id value must be equivalent to the correlation id in the method receiver link that it is paired with
-        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId));
+        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId);
         this.amqpProperties.put(Symbol.getSymbol(VERSION_IDENTIFIER_KEY), clientConfiguration.getProductInfo().getUserAgentString());
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTelemetryReceiverLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTelemetryReceiverLinkHandler.java
@@ -44,11 +44,11 @@ final class AmqpsTelemetryReceiverLinkHandler extends AmqpsReceiverLinkHandler
         String moduleId = this.clientConfiguration.getModuleId();
         if (moduleId != null)
         {
-            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(this.clientConfiguration.getDeviceId() + "/" + moduleId));
+            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), this.clientConfiguration.getDeviceId() + "/" + moduleId);
         }
         else
         {
-            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(this.clientConfiguration.getDeviceId()));
+            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), this.clientConfiguration.getDeviceId());
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTelemetrySenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTelemetrySenderLinkHandler.java
@@ -38,11 +38,11 @@ final class AmqpsTelemetrySenderLinkHandler extends AmqpsSenderLinkHandler
         String moduleId = clientConfiguration.getModuleId();
         if (moduleId != null && !moduleId.isEmpty())
         {
-            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(deviceId + "/" + moduleId));
+            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), deviceId + "/" + moduleId);
         }
         else
         {
-            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(deviceId));
+            this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), deviceId);
         }
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTwinReceiverLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTwinReceiverLinkHandler.java
@@ -56,7 +56,7 @@ final class AmqpsTwinReceiverLinkHandler extends AmqpsReceiverLinkHandler
         this.receiverLinkAddress = getAddress(clientConfiguration);
 
         //Note that this correlation id value must be equivalent to the correlation id in the twin sender link that it is paired with
-        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId));
+        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId);
         this.amqpProperties.put(Symbol.getSymbol(VERSION_IDENTIFIER_KEY), clientConfiguration.getProductInfo().getUserAgentString());
 
         this.twinOperationCorrelationMap = twinOperationCorrelationMap;

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTwinSenderLinkHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsTwinSenderLinkHandler.java
@@ -58,7 +58,7 @@ final class AmqpsTwinSenderLinkHandler extends AmqpsSenderLinkHandler
         this.senderLinkAddress = getAddress(clientConfiguration);
 
         //Note that this correlation id value must be equivalent to the correlation id in the twin receiver link that it is paired with
-        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), Symbol.getSymbol(CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId));
+        this.amqpProperties.put(Symbol.getSymbol(CORRELATION_ID_KEY), CORRELATION_ID_KEY_PREFIX + this.linkCorrelationId);
         this.amqpProperties.put(Symbol.getSymbol(VERSION_IDENTIFIER_KEY), clientConfiguration.getProductInfo().getUserAgentString());
 
         this.twinOperationCorrelationMap = twinOperationCorrelationMap;


### PR DESCRIPTION
Each new symbol instance is saved within proton-j's symbol cache. This cache lives as long as the proton-j reactor itself and cannot be manually cleared. That means that a multiplexed connection that is never closed and that has an infinite number of devices added and removed over time would cause the symbol cache to grow infinitely.

With this change, the only symbols in the symbol cache will be the constants used as property keys when building the amqp connection/sessions/links like the below:

```java
// same value for every device, safe to save in the symbol cache
String CORRELATION_ID_PREFIX = "com.microsoft:channel-correlation-id"; 
Symbol key = Symbol.getSymbol(CORRELATION_ID_PREFIX);

// different value for every device. Cannot create a symbol since it would cause the cache to grow infinitely
String value = deviceId; 

// This map must be of type Map<Symbol, String> as per proton-j interface. Key cannot be a string
this.amqpProperties.put(key, value);
```

#1478