### PR TITLE
Could com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.0 drop off redundant dependencies? 

### DIFF
--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -43,11 +43,12 @@
             <groupId>com.microsoft.azure.sdk.iot.provisioning.security</groupId>
             <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--Test dependencies-->
         <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.0_** introduced **_6_** dependencies. However, among them, **_1_** libraries (**_16%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
commons-codec:commons-codec:jar:1.14:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_commons-codec:commons-codec:jar:1.14:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.0_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/166093471-460b50ac-7093-4abb-8f0d-cb91ad9791a7.png)
