### PR TITLE
refactor(security-x509, prov-security, iot-dev): Put commons-codec dependency at appropriate level in pom hierarchy

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -40,11 +40,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
-        </dependency>
-        <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
             <version>1.24</version>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -44,11 +44,6 @@
             <artifactId>${security-provider-artifact-id}</artifactId>
             <version>${security-provider-version}</version>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
-        </dependency>
         <!--Test dependencies-->
         <dependency>
             <groupId>org.jmockit</groupId>


### PR DESCRIPTION
This library is used in the device client package, but is not used in the security provider or the x509 security provider packages.

Since the device client package takes a dependency on the security provider packages, it got this commons-codec package for free previously. Now, it will need to declare an explicit dependency

Builds on #1543 as submitted by @Celebrate-future