### PR TITLE
release(2022-05-03): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.0.2";
+    public static final String CLIENT_VERSION = "2.0.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_METHODS;
 import static com.microsoft.azure.sdk.iot.device.MessageType.DEVICE_TWIN;
 import static com.microsoft.azure.sdk.iot.device.transport.mqtt.Mqtt.MAX_IN_FLIGHT_COUNT;
+import static org.eclipse.paho.client.mqttv3.MqttConnectOptions.MQTT_VERSION_3_1_1;
 
 @Slf4j
 public class MqttIotHubConnection implements IotHubTransportConnection, MqttMessageListener
@@ -42,7 +43,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
     private static final String SSL_PREFIX = "ssl://";
     private static final String SSL_PORT_SUFFIX = ":8883";
 
-    private static final int MQTT_VERSION = 4;
+    private static final int MQTT_VERSION = MQTT_VERSION_3_1_1;
     private static final boolean SET_CLEAN_SESSION = false;
 
     private static final String MODEL_ID = "model-id";

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Remote binary dependency
-    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.2') {
+    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.3') {
         exclude module: 'slf4j-api'
         exclude module: 'log4j-slf4j-impl'
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -322,6 +322,7 @@ public class MultiplexingClientTests extends IntegrationTest
         testInstance.multiplexingClient.close();
     }
 
+    @Ignore // This test passes, but is intensive enough on the service to disrupt other tests since it requires creating hundreds of devices
     @ContinuousIntegrationTest
     @Test
     public void sendMessagesMaxDevicesAllowed() throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.0.2</iot-device-client-version>
+        <iot-device-client-version>2.0.3</iot-device-client-version>
         <iot-service-client-version>2.0.2</iot-service-client-version>
         <provisioning-device-client-version>2.0.0</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.0</provisioning-service-client-version>
@@ -194,7 +194,7 @@
         <tpm-provider-version>2.0.0</tpm-provider-version>
         <dice-provider-emulator-version>2.0.0</dice-provider-emulator-version>
         <dice-provider-version>2.0.0</dice-provider-version>
-        <x509-provider-version>2.0.0</x509-provider-version>
+        <x509-provider-version>2.0.1</x509-provider-version>
     </properties>
     <reporting>
         <plugins>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.0.3)

### Bug fixes

 - Fixed bug where subsequent calls to subscribe to twin/methods times out (#1545)
 - Handle an issue with proton-j reactor's internal state during cleanup (#1542)
 - Remove unnecessary creation of custom symbol instances in amqp layer (#1541)


## Java Provisioning x509 provider (com.microsoft.azure.sdk.iot.provisioning.security:x509-provider:2.0.1)

 - Removed unused apache commons-codec dependency (#1543) 


https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.0.3/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning.security:x509-provider/2.01/jar


before
{
    "device": "2.0.2",
    "service": "2.0.2",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.0",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}

after
{
    "device": "2.0.3",
    "service": "2.0.2",
    "securityProvider": "2.0.0",
    "tpmHsm": "2.0.0",
    "x509": "2.0.1",
    "provisioningDevice": "2.0.0",
    "provisioningService": "2.0.0"
}