### PR TITLE
Add Java 11 testing

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -70,7 +70,7 @@ public class SendMessagesTests extends SendMessagesCommon
             fail("JDK 11 detected!" + version);
         }
 
-        int a = 1;
+        fail("JDK ????? detected!" + version);
     }
 
     @Test

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -58,6 +58,22 @@ public class SendMessagesTests extends SendMessagesCommon
     }
 
     @Test
+    public void test()
+    {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.8."))
+        {
+            fail("JDK 8 detected!" + version);
+        }
+        else if (version.startsWith("1.11."))
+        {
+            fail("JDK 11 detected!" + version);
+        }
+
+        int a = 1;
+    }
+
+    @Test
     public void sendMessages() throws Exception
     {
         this.testInstance.setup();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -58,22 +58,6 @@ public class SendMessagesTests extends SendMessagesCommon
     }
 
     @Test
-    public void test()
-    {
-        String version = System.getProperty("java.version");
-        if (version.startsWith("1.8."))
-        {
-            fail("JDK 8 detected!" + version);
-        }
-        else if (version.startsWith("1.11."))
-        {
-            fail("JDK 11 detected!" + version);
-        }
-
-        fail("JDK ????? detected!" + version);
-    }
-
-    @Test
     public void sendMessages() throws Exception
     {
         this.testInstance.setup();

--- a/supported_platforms.md
+++ b/supported_platforms.md
@@ -30,7 +30,9 @@ Note that, while we only directly test on Ubuntu 18.04, we do generally support 
 
 Nightly test platform details:
 Apache Maven 3.8.1
-Java version: 1.8.0_292, vendor: AdoptOpenJDK
+
+Java 8 version: 1.8.0_332, vendor: Eclipse Temurin
+Java 11 version: 11.0.15_10, vendor: Eclipse Temurin
 
 Default locale: en_US, platform encoding: UTF-8
 

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -12,11 +12,11 @@ else
     Write-Host "Pull request build detected"
 }
 
-if ($env:JAVA_VERSION == 8)
+if (($env:JAVA_VERSION).equals(("8"))
 {
     mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
 }
-elseif ($env:JAVA_VERSION == 11)
+elseif (($env:JAVA_VERSION).equals(("11"))
 {
     mvn install -DskipTests -T 2C
 

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -20,7 +20,7 @@ elseif (($env:JAVA_VERSION).equals("11"))
 {
     mvn install -DskipTests -T 2C
 
-    cd "./azure-iot-sdk-java/iot-e2e-tests"
+    cd "./iot-e2e-tests"
 
     $env:JAVA_HOME=$env:JAVA_HOME_11_X64
 

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -33,10 +33,11 @@ elseif (($env:JAVA_VERSION).equals("11"))
 {
     $env:JAVA_HOME=$env:JAVA_HOME_11_X64
 }
-elseif (($env:JAVA_VERSION).equals("17"))
-{
-    $env:JAVA_HOME=$env:JAVA_HOME_17_X64
-}
+# Leaving this commented out to make it easy to add Java 17 support later
+#elseif (($env:JAVA_VERSION).equals("17"))
+#{
+#    $env:JAVA_HOME=$env:JAVA_HOME_17_X64
+#}
 else
 {
     Write-Host "Unrecognized or unsupported JDK version: " $env:JAVA_VERSION

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -12,4 +12,22 @@ else
     Write-Host "Pull request build detected"
 }
 
-mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+if ($env:JAVA_VERSION == 8)
+{
+    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+}
+else if ($env:JAVA_VERSION == 11)
+{
+    mvn install -DskipTests -T 2C
+
+    cd "azure-iot-sdk-java/iot-e2e-tests"
+
+    $env:JAVA_HOME=$env:JAVA_HOME_11_X64
+
+    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+}
+else
+{
+    Write-Host "Unrecognized or unsupported JDK version: " $env:JAVA_VERSION
+    exit -1
+}

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -12,11 +12,11 @@ else
     Write-Host "Pull request build detected"
 }
 
-if (($env:JAVA_VERSION).equals(("8"))
+if (($env:JAVA_VERSION).equals("8"))
 {
     mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
 }
-elseif (($env:JAVA_VERSION).equals(("11"))
+elseif (($env:JAVA_VERSION).equals("11"))
 {
     mvn install -DskipTests -T 2C
 

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -16,7 +16,7 @@ if ($env:JAVA_VERSION == 8)
 {
     mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
 }
-else if ($env:JAVA_VERSION == 11)
+elseif ($env:JAVA_VERSION == 11)
 {
     mvn install -DskipTests -T 2C
 

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -23,7 +23,7 @@ if (!($env:JAVA_VERSION).equals("8"))
     cd "./iot-e2e-tests"
 }
 
-# Set the Java home equal to the Java version under test. Currently, Azure Devops hosted agents only support Java 8, 11 and 17 currently
+# Set the Java home equal to the Java version under test. Currently, Azure Devops hosted agents only support Java 8, 11 and 17
 # Since they are the current Java LTS versions
 if (($env:JAVA_VERSION).equals("8"))
 {

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -12,22 +12,37 @@ else
     Write-Host "Pull request build detected"
 }
 
+# This repo can only run unit tests when using Java 8 currently due to outdated unit test code packages. Because of that,
+# we can only run e2e tests for Java versions other than Java 8.
+if (!($env:JAVA_VERSION).equals("8"))
+{
+    #Build the repo with Java 8 as configured in the project itself
+    mvn install -DskipTests -T 2C
+
+    # go into the e2e tests folder so the next mvn install only runs the e2e tests instead of running e2e tests + unit tests.
+    cd "./iot-e2e-tests"
+}
+
+# Set the Java home equal to the Java version under test. Currently, Azure Devops hosted agents only support Java 8, 11 and 17 currently
+# Since they are the current Java LTS versions
 if (($env:JAVA_VERSION).equals("8"))
 {
-    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+    $env:JAVA_HOME=$env:JAVA_HOME_8_X64
 }
 elseif (($env:JAVA_VERSION).equals("11"))
 {
-    mvn install -DskipTests -T 2C
-
-    cd "./iot-e2e-tests"
-
     $env:JAVA_HOME=$env:JAVA_HOME_11_X64
-
-    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+}
+elseif (($env:JAVA_VERSION).equals("17"))
+{
+    $env:JAVA_HOME=$env:JAVA_HOME_17_X64
 }
 else
 {
     Write-Host "Unrecognized or unsupported JDK version: " $env:JAVA_VERSION
     exit -1
 }
+
+# Run the e2e tests with the Java version under test
+mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -20,7 +20,7 @@ elseif (($env:JAVA_VERSION).equals("11"))
 {
     mvn install -DskipTests -T 2C
 
-    cd "azure-iot-sdk-java/iot-e2e-tests"
+    cd "./azure-iot-sdk-java/iot-e2e-tests"
 
     $env:JAVA_HOME=$env:JAVA_HOME_11_X64
 

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        JDK 8:
-          JAVA_VERSION: 8
+        ${{ if or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest'))) }}:
+          JDK 8:
+            JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
     pool:

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -37,7 +37,7 @@ jobs:
         displayName: 'Start TPM Simulator'
         env:
           COMMIT_FROM: $(COMMIT_FROM)
-        condition: always()
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
@@ -59,7 +59,7 @@ jobs:
           IOTHUB_CLIENT_SECRET: $(IOTHUB-CLIENT-SECRET)
           IOTHUB_CLIENT_ID: $(IOTHUB-CLIENT-ID)
           MSFT_TENANT_ID: $(MSFT-TENANT-ID)
-        condition: always()
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -21,27 +21,27 @@ jobs:
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
-        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}: # Only run Java 8 if doing a nightly build
-          JDK 8:
-            JAVA_VERSION: 8
+        JDK 8: # only run Java 8 in nightly or CI builds.
+          JAVA_VERSION: 8
     pool:
       vmImage: windows-latest
     displayName: Windows
     steps:
       - powershell: ./vsts/echo_versions.ps1
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         displayName: 'Echo Versions'
         env:
           COMMIT_FROM: $(COMMIT_FROM)
-        condition: always()
 
       - powershell: ./vsts/start_tpm_windows.ps1
         displayName: 'Start TPM Simulator'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
-        condition: always()
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
@@ -60,10 +60,10 @@ jobs:
           IOTHUB_CLIENT_SECRET: $(IOTHUB-CLIENT-SECRET)
           IOTHUB_CLIENT_ID: $(IOTHUB-CLIENT-ID)
           MSFT_TENANT_ID: $(MSFT-TENANT-ID)
-        condition: always()
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
           Contents: |
@@ -71,10 +71,10 @@ jobs:
             **/*.xml
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
         continueOnError: true
-        condition: always()
-      
+
       - task: CopyFiles@2
         displayName: 'Copy Build Results to Artifact Staging Directory'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           flattenFolders: true
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -90,33 +90,33 @@ jobs:
             !**/*test*/**/target/**
           TargetFolder: '$(Build.ArtifactStagingDirectory)/buildOutput'
         continueOnError: true
-        condition: always()
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate SBOM for Build Artifacts'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)/buildOutput'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         continueOnError: true
-        condition: always()
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           mergeTestResults: true
           testRunTitle: "Windows JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
         continueOnError: true
-        condition: always()
-        
+
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
           alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
-        condition: always()
 
   ### Linux ###
   - job: Linux
@@ -130,23 +130,24 @@ jobs:
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
-        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}: # Only run Java 8 if doing a nightly build
-          JDK 8:
-            JAVA_VERSION: 8
+        JDK 8: # only run Java 8 in nightly or CI builds.
+          JAVA_VERSION: 8
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           script: 'cat /etc/*release'
 
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
-        condition: always()
 
       - task: Docker@1
         displayName: 'Start TPM Simulator'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           containerregistrytype: 'Container Registry'
           command: 'Run an image'
@@ -159,6 +160,7 @@ jobs:
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
@@ -178,9 +180,9 @@ jobs:
           IOTHUB_CLIENT_ID: $(IOTHUB-CLIENT-ID)
           MSFT_TENANT_ID: $(MSFT-TENANT-ID)
           RECYCLE_TEST_IDENTITIES: true
-        condition: always()
 
       - task: CopyFiles@2
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         displayName: 'Copy Test Results to Artifact Staging Directory'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -189,28 +191,27 @@ jobs:
             **/*.xml
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
         continueOnError: true
-        condition: always()
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         continueOnError: true
-        condition: always()
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           mergeTestResults: true
           testRunTitle: "Linux JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
         continueOnError: true
-        condition: always()
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
           alertWarningLevel: 'Low' # The task will present a warning, but will not cause the build to fail
-        condition: always()
 
   ### Android, Multi configuration build (Multiple different test groups to cover) ###
   - job: AndroidBuild

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -16,6 +16,8 @@ jobs:
   ### Windows ###
   - job: Windows
     timeoutInMinutes: 180
+    variables:
+      shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       maxParallel: 1
       matrix:
@@ -28,7 +30,7 @@ jobs:
     displayName: Windows
     steps:
       - powershell: ./vsts/echo_versions.ps1
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         displayName: 'Echo Versions'
         env:
           COMMIT_FROM: $(COMMIT_FROM)

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        ${{ if ne(variables['Build.Reason'], 'PullRequest')) }}:
+        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
           JDK 8:
             JAVA_VERSION: 8
         JDK 11:

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -220,7 +220,6 @@ jobs:
     pool:
       vmImage: windows-latest
     displayName: Android Build
-    condition: eq(variables.testEmpty, 'asdf')
 
     steps:
       - powershell: ./vsts/echo_versions.ps1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -17,12 +17,14 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: 100
+      maxParallel: 1
       matrix:
         JDK 8:
           JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
+        JDK 17:
+          JAVA_VERSION: 17
     pool:
       vmImage: windows-latest
     displayName: Windows
@@ -125,12 +127,14 @@ jobs:
       vmImage: 'ubuntu-18.04'
     displayName: Linux
     strategy:
-      maxParallel: 100
+      maxParallel: 1
       matrix:
         JDK 8:
           JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
+        JDK 17:
+          JAVA_VERSION: 17
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -16,10 +16,16 @@ jobs:
   ### Windows ###
   - job: Windows
     timeoutInMinutes: 180
+    strategy:
+      maxParallel: 100
+      matrix:
+        JDK 8:
+          JAVA_VERSION: 8
+        JDK 11:
+          JAVA_VERSION: 11
     pool:
       vmImage: windows-latest
-    displayName: Windows
-    condition: succeeded()
+    displayName: Windows JDK
     steps:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
@@ -36,6 +42,7 @@ jobs:
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
         env:
+          JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
           IOT_DPS_ID_SCOPE: $(WINDOWS-IOT-DPS-ID-SCOPE)
           IOTHUB_CONNECTION_STRING: $(WINDOWS-IOTHUB-CONNECTION-STRING)
@@ -98,7 +105,7 @@ jobs:
         displayName: 'Publish Test Results'
         inputs:
           mergeTestResults: true
-          testRunTitle: "Windows (Attempt $(System.JobAttempt))"
+          testRunTitle: "Windows JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
         continueOnError: true
         condition: always()
         
@@ -116,8 +123,14 @@ jobs:
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: 'ubuntu-18.04'
-    displayName: Linux
-    condition: succeeded()
+    displayName: Linux JDK
+    strategy:
+      maxParallel: 100
+      matrix:
+        JDK 8:
+          JAVA_VERSION: 8
+        JDK 11:
+          JAVA_VERSION: 11
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'
@@ -145,6 +158,7 @@ jobs:
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
         env:
+          JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
           IOT_DPS_ID_SCOPE: $(LINUX-IOT-DPS-ID-SCOPE)
           IOTHUB_CONNECTION_STRING: $(LINUX-IOTHUB-CONNECTION-STRING)
@@ -184,7 +198,7 @@ jobs:
         displayName: 'Publish Test Results'
         inputs:
           mergeTestResults: true
-          testRunTitle: "Linux (Attempt $(System.JobAttempt))"
+          testRunTitle: "Linux JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
         continueOnError: true
         condition: always()
 
@@ -202,6 +216,7 @@ jobs:
     pool:
       vmImage: windows-latest
     displayName: Android Build
+    condition: eq(variables.testEmpty, 'asdf')
 
     steps:
       - powershell: ./vsts/echo_versions.ps1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -27,7 +27,6 @@ jobs:
     pool:
       vmImage: windows-latest
     displayName: Windows
-    condition: or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest')) # only run this job if this is Java 11 or if this isn't a pull request
     steps:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
@@ -134,7 +133,6 @@ jobs:
         ${{ if ne(variables['Build.Reason'], 'PullRequest') }}: # Only run Java 8 if doing a nightly build
           JDK 8:
             JAVA_VERSION: 8
-    condition: or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest')) # only run this job if this is Java 11 or if this isn't a pull request
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        ${{ if or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest'))) }}:
+        ${{ if ne(variables['Build.Reason'], 'PullRequest')) }}:
           JDK 8:
             JAVA_VERSION: 8
         JDK 11:

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -16,8 +16,6 @@ jobs:
   ### Windows ###
   - job: Windows
     timeoutInMinutes: 180
-    variables:
-      shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       maxParallel: 1
       matrix:
@@ -30,7 +28,7 @@ jobs:
     displayName: Windows
     steps:
       - powershell: ./vsts/echo_versions.ps1
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         displayName: 'Echo Versions'
         env:
           COMMIT_FROM: $(COMMIT_FROM)

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -25,7 +25,7 @@ jobs:
           JAVA_VERSION: 11
     pool:
       vmImage: windows-latest
-    displayName: Windows JDK
+    displayName: Windows
     steps:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
@@ -123,7 +123,7 @@ jobs:
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: 'ubuntu-18.04'
-    displayName: Linux JDK
+    displayName: Linux
     strategy:
       maxParallel: 100
       matrix:

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -26,6 +26,7 @@ jobs:
     pool:
       vmImage: windows-latest
     displayName: Windows
+    condition: or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest')) # only run this job if this is Java 11 or if this isn't a pull request
     steps:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
@@ -37,7 +38,7 @@ jobs:
         displayName: 'Start TPM Simulator'
         env:
           COMMIT_FROM: $(COMMIT_FROM)
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
@@ -59,7 +60,7 @@ jobs:
           IOTHUB_CLIENT_SECRET: $(IOTHUB-CLIENT-SECRET)
           IOTHUB_CLIENT_ID: $(IOTHUB-CLIENT-ID)
           MSFT_TENANT_ID: $(MSFT-TENANT-ID)
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'
@@ -131,6 +132,7 @@ jobs:
           JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
+    condition: or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest')) # only run this job if this is Java 11 or if this isn't a pull request
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        JDK 11: # always run Java 11
+          JAVA_VERSION: 11
+        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}: # Only run Java 8 if doing a nightly build
           JDK 8:
             JAVA_VERSION: 8
-        JDK 11:
-          JAVA_VERSION: 11
     pool:
       vmImage: windows-latest
     displayName: Windows
@@ -129,10 +129,11 @@ jobs:
     strategy:
       maxParallel: 1
       matrix:
-        JDK 8:
-          JAVA_VERSION: 8
-        JDK 11:
+        JDK 11: # always run Java 11
           JAVA_VERSION: 11
+        ${{ if ne(variables['Build.Reason'], 'PullRequest') }}: # Only run Java 8 if doing a nightly build
+          JDK 8:
+            JAVA_VERSION: 8
     condition: or(eq(variables['JAVA_VERSION'], 11), ne(variables['Build.Reason'], 'PullRequest')) # only run this job if this is Java 11 or if this isn't a pull request
     steps:
       - task: CmdLine@2

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -17,7 +17,6 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     variables:
-      # defines if a step should be run or if it can be skipped. We skip running Java 8 e2e tests in pull request builds.
       shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       maxParallel: 1
@@ -38,13 +37,13 @@ jobs:
 
       - powershell: ./vsts/start_tpm_windows.ps1
         displayName: 'Start TPM Simulator'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
@@ -66,7 +65,7 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
           Contents: |
@@ -77,7 +76,7 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Build Results to Artifact Staging Directory'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           flattenFolders: true
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -96,18 +95,18 @@ jobs:
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate SBOM for Build Artifacts'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)/buildOutput'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           mergeTestResults: true
           testRunTitle: "Windows JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -115,7 +114,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
@@ -124,9 +123,6 @@ jobs:
   ### Linux ###
   - job: Linux
     timeoutInMinutes: 180
-    variables:
-      # defines if a step should be run or if it can be skipped. We skip running Java 8 e2e tests in pull request builds.
-      shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: 'ubuntu-18.04'
@@ -141,19 +137,19 @@ jobs:
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           script: 'cat /etc/*release'
 
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - task: Docker@1
         displayName: 'Start TPM Simulator'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           containerregistrytype: 'Container Registry'
           command: 'Run an image'
@@ -166,7 +162,7 @@ jobs:
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
@@ -188,7 +184,7 @@ jobs:
           RECYCLE_TEST_IDENTITIES: true
 
       - task: CopyFiles@2
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         displayName: 'Copy Test Results to Artifact Staging Directory'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -200,12 +196,12 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           mergeTestResults: true
           testRunTitle: "Linux JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -213,7 +209,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: shouldRun
+        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -17,6 +17,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     variables:
+      # defines if a step should be run or if it can be skipped. We skip running Java 8 e2e tests in pull request builds.
       shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       maxParallel: 1
@@ -37,13 +38,13 @@ jobs:
 
       - powershell: ./vsts/start_tpm_windows.ps1
         displayName: 'Start TPM Simulator'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
@@ -65,7 +66,7 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
           Contents: |
@@ -76,7 +77,7 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Build Results to Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           flattenFolders: true
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -95,18 +96,18 @@ jobs:
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate SBOM for Build Artifacts'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)/buildOutput'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           mergeTestResults: true
           testRunTitle: "Windows JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -114,7 +115,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
@@ -123,6 +124,9 @@ jobs:
   ### Linux ###
   - job: Linux
     timeoutInMinutes: 180
+    variables:
+      # defines if a step should be run or if it can be skipped. We skip running Java 8 e2e tests in pull request builds.
+      shouldRun: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
       vmImage: 'ubuntu-18.04'
@@ -137,19 +141,19 @@ jobs:
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           script: 'cat /etc/*release'
 
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - task: Docker@1
         displayName: 'Start TPM Simulator'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           containerregistrytype: 'Container Registry'
           command: 'Run an image'
@@ -162,7 +166,7 @@ jobs:
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
@@ -184,7 +188,7 @@ jobs:
           RECYCLE_TEST_IDENTITIES: true
 
       - task: CopyFiles@2
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         displayName: 'Copy Test Results to Artifact Staging Directory'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -196,12 +200,12 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           mergeTestResults: true
           testRunTitle: "Linux JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -209,7 +213,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: shouldRun
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -23,8 +23,6 @@ jobs:
           JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
-        JDK 17:
-          JAVA_VERSION: 17
     pool:
       vmImage: windows-latest
     displayName: Windows
@@ -133,8 +131,6 @@ jobs:
           JAVA_VERSION: 8
         JDK 11:
           JAVA_VERSION: 11
-        JDK 17:
-          JAVA_VERSION: 17
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'


### PR DESCRIPTION
[Java releases for reference](https://whichjdk.com/#releases)

The majority of our non-android users use Java 11 currently, so this PR adds PR and nightly testing of Java 11 to our gates. This PR also relegates Java 8 testing to nightly only in order to save time at the gate.