### PR TITLE
refactor(all): update Gson dependency in main pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.9</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Not exactly for Gson-related [dependabot alerts](https://github.com/Azure/azure-iot-sdk-java/security/dependabot) here, as we are using patched version 2.8.9 already. The security alerts were triggered as dependabot could not determine the currently installed version. 