### PR TITLE
Added getter/setter for missing Twin fields

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/QueryClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/QueryClientTests.java
@@ -121,6 +121,15 @@ public class QueryClientTests extends IntegrationTest
             assertEquals(2, twinList.size());
             assertTrue(twinList.get(0).getDeviceId().equals(deviceId1) || twinList.get(0).getDeviceId().equals(deviceId2));
             assertTrue(twinList.get(1).getDeviceId().equals(deviceId1) || twinList.get(1).getDeviceId().equals(deviceId2));
+
+            assertNotNull(twinList.get(0).getStatus());
+            assertNotNull(twinList.get(0).getConnectionState());
+            assertNotNull(twinList.get(0).getLastActivityTime());
+
+            assertNotNull(twinList.get(1).getStatus());
+            assertNotNull(twinList.get(1).getConnectionState());
+            assertNotNull(twinList.get(1).getLastActivityTime());
+
         }
         finally
         {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -29,6 +29,22 @@ public class Twin
     private String eTag;
 
     @Getter
+    @Setter
+    private TwinStatus status;
+
+    @Getter
+    @Setter
+    private String statusUpdateTime;
+
+    @Getter
+    @Setter
+    private String lastActivityTime;
+
+    @Getter
+    @Setter
+    private String cloudToDeviceMessageCount;
+
+    @Getter
     @Setter(AccessLevel.PACKAGE)
     private Integer version;
 
@@ -78,6 +94,12 @@ public class Twin
         Twin twin = new Twin(twinState.getDeviceId());
         twin.setVersion(twinState.getVersion());
         twin.setETag(twinState.getETag());
+        twin.setStatus(twinState.getStatus());
+        twin.setStatusUpdateTime(twinState.getStatusUpdatedTime());
+        twin.setConnectionState(twinState.getConnectionState());
+        twin.setLastActivityTime(twinState.getLastActivityTime());
+        twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
+
 
         // Tags
         twin.getTags().setVersion(twinState.getTags().getVersion());
@@ -255,6 +277,12 @@ public class Twin
                     .append(String.join(",", this.parentScopes))
                     .append("\n");
         }
+
+        thisDevice.append("Status: ").append(this.status.toString()).append("\n");
+        thisDevice.append("StatusUpdateTime: ").append(this.statusUpdateTime).append("\n");
+        thisDevice.append("ConnectionState: ").append(this.connectionState).append("\n");
+        thisDevice.append("LastActivityTime: ").append(this.lastActivityTime).append("\n");
+        thisDevice.append("CloudToDeviceMessageCount:").append(this.cloudToDeviceMessageCount).append("\n");
 
         thisDevice.append(tagsToString());
         thisDevice.append(reportedPropertiesToString());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinState.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinState.java
@@ -211,6 +211,16 @@ public class TwinState
     private String connectionStateUpdatedTime = null;
 
     /**
+     * Cloud to device message count.
+     */
+    private static final String CLOUD_TO_DEVICE_MESSAGE_COUNT = "cloudToDeviceMessageCount";
+    @Expose
+    @SerializedName(CLOUD_TO_DEVICE_MESSAGE_COUNT)
+    @Getter
+    @Setter
+    private String cloudToDeviceMessageCount = null;
+
+    /**
      * Datetime of last time the device authenticated, received, or sent a message.
      */
     private static final String LAST_ACTIVITY_TIME_TAG = "lastActivityTime";
@@ -453,6 +463,7 @@ public class TwinState
         this.setStatusReason(result.getStatusReason());
         this.setStatusUpdatedTime(result.getStatusUpdatedTime());
         this.setVersion(result.getVersion());
+        this.setCloudToDeviceMessageCount(result.cloudToDeviceMessageCount);
     }
 
     /**


### PR DESCRIPTION
Added getter/setter for missing Twin fields reported by customer (reported using Ava: 2206170060000042)
Following are the fields: status, statusUpdateTime,. connectionState, LastActivityTime, cloudToDeviceMessageCount.
Also updated unit test::  testQueryTwins() to validate the fields.

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 