### PR TITLE
Fix unit tests not being run at the gate

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -30,6 +30,11 @@
         <url>https://github.com/Azure/azure-iot-sdk-java.git</url>
     </scm>
     <properties>
+        <!--
+        By default, don't skip unit tests. Can override this behavior by passing in
+        "-DskipUnitTests=true" to your maven command such as "mvn install -DskipUnitTests=true"
+        -->
+        <skipUnitTests>false</skipUnitTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -135,6 +140,7 @@
                 <version>2.22.0</version>
                 <configuration>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipUnitTests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -18,6 +18,11 @@
         </developer>
     </developers>
     <properties>
+        <!--
+        By default, don't skip integration tests. Can override this behavior by passing in
+        "-DskipIntegrationTests=true" to your maven command such as "mvn install -DskipIntegrationTests=true"
+        -->
+        <skipIntegrationTests>false</skipIntegrationTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -165,7 +170,7 @@
                         <include>*Tests.java</include>
                     </includes>
                     <forkCount>1</forkCount>
-
+                    <skipTests>${skipIntegrationTests}</skipTests>
                     <parallel>both</parallel>
 
                     <!--Maven will spawn up as many threads as it wants/can while running tests in parallel-->

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
@@ -26,6 +26,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.digitaltwin.helpers.E2ETest
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.DigitalTwinTest;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
 @DigitalTwinTest
+@IotHubTest
 @Slf4j
 @RunWith(Parameterized.class)
 public class DigitalTwinClientComponentTests extends IntegrationTest

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
@@ -41,6 +41,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.SasTokenTools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.DigitalTwinTest;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.proxy.HttpProxyServer;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.proxy.impl.DefaultHttpProxyServer;
@@ -63,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @DigitalTwinTest
+@IotHubTest
 @Slf4j
 @RunWith(Parameterized.class)
 public class DigitalTwinClientTests extends IntegrationTest

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningServiceClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningServiceClientTests.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.X509CertificateGenerator;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.DeviceProvisioningServiceTest;
 
 import java.util.UUID;
 
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static tests.integration.com.microsoft.azure.sdk.iot.provisioning.setup.ProvisioningCommon.CUSTOM_ALLOCATION_WEBHOOK_URL_VAR_NAME;
 import static tests.integration.com.microsoft.azure.sdk.iot.provisioning.setup.ProvisioningCommon.DPS_CONNECTION_STRING_ENV_VAR_NAME;
 
+@DeviceProvisioningServiceTest
 public class ProvisioningServiceClientTests
 {
     public static final String provisioningServiceConnectionString = Tools.retrieveEnvironmentVariableValue(DPS_CONNECTION_STRING_ENV_VAR_NAME);

--- a/iot-e2e-tests/iot-e2e-jvm-tests/pom.xml
+++ b/iot-e2e-tests/iot-e2e-jvm-tests/pom.xml
@@ -57,6 +57,13 @@
             <version>${tpm-provider-emulator-version}</version>
         </dependency>
     </dependencies>
+    <properties>
+        <!--
+        By default, don't skip integration tests. Can override this behavior by passing in
+        "-DskipIntegrationTests=true" to your maven command such as "mvn install -DskipIntegrationTests=true"
+        -->
+        <skipIntegrationTests>false</skipIntegrationTests>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -84,6 +91,7 @@
                 </executions>
                 <configuration>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipIntegrationTests}</skipTests>
                     <includes>
                         <!--By default, only test files that end in ___Test.java are recognized as tests. This statement extends that to ___Tests.java files-->
                         <include>*Tests.java</include>

--- a/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
+++ b/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
@@ -53,8 +53,6 @@ public class TokenCredentialTests
 {
     private static final String THERMOSTAT_MODEL_ID = "dtmi:com:example:Thermostat;1";
 
-    private static final int METHOD_SUBSCRIPTION_TIMEOUT_MILLISECONDS = 60 * 1000;
-
     @Test (timeout = 10000)
     public void cloudToDeviceTelemetryWithTokenCredential() throws Exception
     {

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -34,6 +34,11 @@
         <url>https://github.com/Azure/azure-iot-sdk-java.git</url>
     </scm>
     <properties>
+        <!--
+        By default, don't skip unit tests. Can override this behavior by passing in
+        "-DskipUnitTests=true" to your maven command such as "mvn install -DskipUnitTests=true"
+        -->
+        <skipUnitTests>false</skipUnitTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -130,6 +135,7 @@
                 <version>2.22.0</version>
                 <configuration>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipUnitTests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -34,7 +34,11 @@
         <url>https://github.com/Azure/azure-iot-sdk-java.git</url>
     </scm>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+        By default, don't skip unit tests. Can override this behavior by passing in
+        "-DskipUnitTests=true" to your maven command such as "mvn install -DskipUnitTests=true"
+        -->
+        <skipUnitTests>false</skipUnitTests>
     </properties>
     <dependencies>
         <dependency>
@@ -122,6 +126,7 @@
                 <version>2.22.0</version>
                 <configuration>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipUnitTests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/provisioning/security/pom.xml
+++ b/provisioning/security/pom.xml
@@ -25,4 +25,24 @@
         <module>tpm-provider-emulator</module>
         <module>security-provider</module>
     </modules>
+    <properties>
+        <!--
+        By default, don't skip unit tests. Can override this behavior by passing in
+        "-DskipUnitTests=true" to your maven command such as "mvn install -DskipUnitTests=true"
+        -->
+        <skipUnitTests>false</skipUnitTests>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipUnitTests}</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -30,6 +30,11 @@
         <url>https://github.com/Azure/azure-iot-sdk-java.git</url>
     </scm>
     <properties>
+        <!--
+        By default, don't skip unit tests. Can override this behavior by passing in
+        "-DskipUnitTests=true" to your maven command such as "mvn install -DskipUnitTests=true"
+        -->
+        <skipUnitTests>false</skipUnitTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
@@ -198,6 +203,7 @@
                 <version>2.22.0</version>
                 <configuration>
                     <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <skipTests>${skipUnitTests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -278,11 +278,30 @@ public class Twin
                     .append("\n");
         }
 
-        thisDevice.append("Status: ").append(this.status.toString()).append("\n");
-        thisDevice.append("StatusUpdateTime: ").append(this.statusUpdateTime).append("\n");
-        thisDevice.append("ConnectionState: ").append(this.connectionState).append("\n");
-        thisDevice.append("LastActivityTime: ").append(this.lastActivityTime).append("\n");
-        thisDevice.append("CloudToDeviceMessageCount:").append(this.cloudToDeviceMessageCount).append("\n");
+        if (this.status != null)
+        {
+            thisDevice.append("Status: ").append(this.status.toString()).append("\n");
+        }
+
+        if (this.statusUpdateTime != null)
+        {
+            thisDevice.append("StatusUpdateTime: ").append(this.statusUpdateTime).append("\n");
+        }
+
+        if (this.connectionState != null)
+        {
+            thisDevice.append("ConnectionState: ").append(this.connectionState).append("\n");
+        }
+
+        if (this.lastActivityTime != null)
+        {
+            thisDevice.append("LastActivityTime: ").append(this.lastActivityTime).append("\n");
+        }
+
+        if (this.cloudToDeviceMessageCount != null)
+        {
+            thisDevice.append("CloudToDeviceMessageCount:").append(this.cloudToDeviceMessageCount).append("\n");
+        }
 
         thisDevice.append(tagsToString());
         thisDevice.append(reportedPropertiesToString());

--- a/vsts/build_e2e_tests.cmd
+++ b/vsts/build_e2e_tests.cmd
@@ -9,4 +9,4 @@ for %%i in ("%build-root%") do set build-root=%%~fi
 
 @REM -- E2E Test Build --
 cd %build-root%
-mvn -DskipTests=true -Dmaven.javadoc.skip=true --projects :iot-e2e-common --also-make clean install
+mvn -Dmaven.javadoc.skip=true --projects :iot-e2e-common --also-make clean install -DskipIntegrationTests=true -DskipUnitTests

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -13,7 +13,7 @@ else
 }
 
 # This repo can only run unit tests when using Java 8 currently due to outdated unit test code packages. Because of that,
-# we will run unit tests on Java 8 regardless of what Jave version this run of the pipeline is configured for.
+# we will run unit tests on Java 8 regardless of what Java version this run of the pipeline is configured for.
 if (!($env:JAVA_VERSION).equals("8"))
 {
     # Build the repo with Java 8 as configured in the project itself. Run unit tests, but skip e2e tests. The e2e tests will run later

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -13,11 +13,12 @@ else
 }
 
 # This repo can only run unit tests when using Java 8 currently due to outdated unit test code packages. Because of that,
-# we can only run e2e tests for Java versions other than Java 8.
+# we will run unit tests on Java 8 regardless of what Jave version this run of the pipeline is configured for.
 if (!($env:JAVA_VERSION).equals("8"))
 {
-    #Build the repo with Java 8 as configured in the project itself
-    mvn install -DskipTests -T 2C
+    # Build the repo with Java 8 as configured in the project itself. Run unit tests, but skip e2e tests. The e2e tests will run later
+    # with the appropriate JDK
+    mvn install -DRUN_PROVISIONING_TESTS="false" -DRUN_IOTHUB_TESTS="false" -T 2C
 
     # go into the e2e tests folder so the next mvn install only runs the e2e tests instead of running e2e tests + unit tests.
     cd "./iot-e2e-tests"

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -28,20 +28,17 @@ jobs:
     displayName: Windows
     steps:
       - powershell: ./vsts/echo_versions.ps1
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         displayName: 'Echo Versions'
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - powershell: ./vsts/start_tpm_windows.ps1
         displayName: 'Start TPM Simulator'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(WINDOWS-IOT-DPS-CONNECTION-STRING)
@@ -63,7 +60,6 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Test Results to Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
           Contents: |
@@ -74,7 +70,7 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Build Results to Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           flattenFolders: true
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -93,18 +89,18 @@ jobs:
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate SBOM for Build Artifacts'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)/buildOutput'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           mergeTestResults: true
           testRunTitle: "Windows JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -112,7 +108,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
@@ -135,19 +131,16 @@ jobs:
     steps:
       - task: CmdLine@2
         displayName: 'Print Linux version'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           script: 'cat /etc/*release'
 
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           COMMIT_FROM: $(COMMIT_FROM)
 
       - task: Docker@1
         displayName: 'Start TPM Simulator'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           containerregistrytype: 'Container Registry'
           command: 'Run an image'
@@ -160,7 +153,6 @@ jobs:
 
       - powershell: ./vsts/build_repo.ps1
         displayName: 'Build and Test'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
         env:
           JAVA_VERSION: $(JAVA_VERSION)
           IOT_DPS_CONNECTION_STRING: $(LINUX-IOT-DPS-CONNECTION-STRING)
@@ -182,7 +174,7 @@ jobs:
           RECYCLE_TEST_IDENTITIES: true
 
       - task: CopyFiles@2
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         displayName: 'Copy Test Results to Artifact Staging Directory'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
@@ -194,12 +186,12 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact Staging Directory'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         continueOnError: true
 
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           mergeTestResults: true
           testRunTitle: "Linux JDK $(JAVA_VERSION) (Attempt $(System.JobAttempt))"
@@ -207,7 +199,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Governance Detection
-        condition: or(eq(variables['JAVA_VERSION'], 11) , ne(variables['Build.Reason'], 'PullRequest'))
+        condition: always()
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'


### PR DESCRIPTION
-DskipTests skipped both the unit tests and the e2e tests, but we only want to skip e2e tests at this step.

Also tag a few e2e test classes that were missing tags
