### PR TITLE
fix(iot-dev): fix thread-leak issue with IotHubReconnectTask

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -336,7 +336,7 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
     /*
      * IotHubTransport layer will notify this layer when the connection is established and when it is lost. This layer should start/stop
-     * the send/receive threads accordingly
+     * the send/receive/reconnect threads accordingly.
      */
     @Override
     public void onStatusChanged(ConnectionStatusChangeContext connectionStatusChangeContext)
@@ -347,13 +347,13 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
         if (status == this.state)
         {
-            // no change in status, so no need to start/stop worker threads.
+            // No change in status, so no need to start/stop worker threads.
             return;
         }
 
         if (status == IotHubConnectionStatus.DISCONNECTED || status == IotHubConnectionStatus.DISCONNECTED_RETRYING)
         {
-            // No need to keep spawning send/receive tasks during reconnection or when the client is closed
+            // No need to keep spawning send/receive tasks during reconnection or when the client is closed.
             this.stopSendAndReceiveThreads();
 
             if (status == IotHubConnectionStatus.DISCONNECTED)
@@ -363,7 +363,7 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         }
         else if (status == IotHubConnectionStatus.CONNECTED)
         {
-            // Restart the task scheduler so that send/receive/reconnect tasks start spawning again
+            // Restart the task scheduler so that send/receive/reconnect tasks start spawning again.
             this.startWorkerThreads();
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -160,7 +160,6 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         if (this.reconnectTaskScheduler == null)
         {
             this.reconnectTaskScheduler = Executors.newScheduledThreadPool(1);
-
             this.reconnectTaskScheduler.scheduleWithFixedDelay(this.reconnectTask, 0,
                 receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
         }
@@ -357,12 +356,13 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
             if (status == IotHubConnectionStatus.DISCONNECTED)
             {
+                // Stop reconnect task only when the client as a whole has been closed.
                 this.stopReconnectThreads();
             }
         }
         else if (status == IotHubConnectionStatus.CONNECTED)
         {
-            // Restart the task scheduler so that send/receive/reconnect tasks start spawning again.
+            // Restart the task scheduler so that send/receive tasks start spawning again.
             this.startWorkerThreads();
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -152,9 +152,9 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         // Note that this is scheduleWithFixedDelay, not scheduleAtFixedRate. There is no reason to spawn a new
         // send/receive thread until after the previous one has finished.
         this.sendTaskScheduler.scheduleWithFixedDelay(this.sendTask, 0,
-                sendPeriodInMilliseconds, TimeUnit.MILLISECONDS);
+            sendPeriodInMilliseconds, TimeUnit.MILLISECONDS);
         this.receiveTaskScheduler.scheduleWithFixedDelay(this.receiveTask, 0,
-                receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
+            receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
 
         // This is only set to null if the client as a whole has been closed. This thread pool stays active through disconnected_retrying.
         if (this.reconnectTaskScheduler == null)
@@ -162,7 +162,7 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
             this.reconnectTaskScheduler = Executors.newScheduledThreadPool(1);
 
             this.reconnectTaskScheduler.scheduleWithFixedDelay(this.reconnectTask, 0,
-                    receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
+                receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
         }
 
         this.state = IotHubConnectionStatus.CONNECTED;
@@ -271,11 +271,8 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
             // close the old scheduler and start a new one with the new receive period
             this.receiveTaskScheduler.shutdown();
             this.receiveTaskScheduler = Executors.newScheduledThreadPool(1);
-            this.receiveTaskScheduler.scheduleAtFixedRate(
-                this.receiveTask,
-                0,
-                this.receivePeriodInMilliseconds,
-                TimeUnit.MILLISECONDS);
+            this.receiveTaskScheduler.scheduleAtFixedRate(this.receiveTask, 0,
+                this.receivePeriodInMilliseconds, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -299,11 +296,8 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
             // close the old scheduler and start a new one with the new send period
             this.sendTaskScheduler.shutdown();
             this.sendTaskScheduler = Executors.newScheduledThreadPool(1);
-            this.sendTaskScheduler.scheduleAtFixedRate(
-                this.sendTask,
-                0,
-                this.sendPeriodInMilliseconds,
-                TimeUnit.MILLISECONDS);
+            this.sendTaskScheduler.scheduleAtFixedRate(this.sendTask, 0,
+                this.sendPeriodInMilliseconds, TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION
For #1563:

Before this fix, the reconnect thread was not cleared appropriately. As a result, an instance of `IotHubReconnectTask` would be created per connection-status change from "DISCONNECTED_RETRYING" to "CONNECTED", while the previous thread was still waiting until the connection turned into "DISCONNECTED" eventually. 

Thread dump **before** this fix:
![1](https://user-images.githubusercontent.com/94650966/177490517-18476589-a745-4e12-b55c-0f65fffa0b2d.PNG)

Thread dump **after** this fix:
![2](https://user-images.githubusercontent.com/94650966/177490614-6edf93ce-b260-484d-93fb-e95ea50f7095.PNG)
