### PR TITLE
release(2022-07-07): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.0.3";
+    public static final String CLIENT_VERSION = "2.0.4";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Remote binary dependency
-    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.3') {
+    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.4') {
         exclude module: 'slf4j-api'
         exclude module: 'log4j-slf4j-impl'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,10 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.0.3</iot-device-client-version>
-        <iot-service-client-version>2.0.2</iot-service-client-version>
-        <provisioning-device-client-version>2.0.0</provisioning-device-client-version>
-        <provisioning-service-client-version>2.0.0</provisioning-service-client-version>
+        <iot-device-client-version>2.0.4</iot-device-client-version>
+        <iot-service-client-version>2.1.0</iot-service-client-version>
+        <provisioning-device-client-version>2.0.1</provisioning-device-client-version>
+        <provisioning-service-client-version>2.0.1</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>
         <tpm-provider-emulator-version>2.0.0</tpm-provider-emulator-version>
         <tpm-provider-version>2.0.0</tpm-provider-version>

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/SDKUtils.java
@@ -11,7 +11,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     public static final String PROVISIONING_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.dps.dps-device-client/";
-    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "2.0.0";
+    public static final String PROVISIONING_DEVICE_CLIENT_VERSION = "2.0.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
+++ b/provisioning/provisioning-service-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/service/contract/SDKUtils.java
@@ -10,7 +10,7 @@ public class SDKUtils
 {
     private static final String SERVICE_API_VERSION = "2019-03-31";
     private static final String PROVISIONING_SERVICE_CLIENT = "com.microsoft.azure.sdk.iot.provisioning.service.provisioning-service-client/";
-    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "2.0.0";
+    private static final String PROVISIONING_SERVICE_CLIENT_VERSION = "2.0.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.0.2";
+    public static final String serviceVersion = "2.1.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.0.4)

+ Upgrade Gson dependency version to 2.9.0 (#1557)

### Bug fixes

+ Fix thread-leak issue with IotHubReconnectTask (#1567)


## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.1.0)

+ Upgrade Gson dependency version to 2.9.0 (#1557)
+ Add missing fields with getters and setters to Twin and TwinState classes(#1562)(#1566)


## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:2.0.1)

+ Upgrade Gson dependency version to 2.9.0 (#1557)



## Java Provisioning Service Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-service-client:2.0.1)

+ Upgrade Gson dependency version to 2.9.0 (#1557)