### PR TITLE
Fix build pipeline only echoing JDK 8 version

### DIFF
--- a/vsts/echo_versions.ps1
+++ b/vsts/echo_versions.ps1
@@ -1,1 +1,10 @@
-﻿mvn -v
+﻿if (($env:JAVA_VERSION).equals("8"))
+{
+    $env:JAVA_HOME=$env:JAVA_HOME_8_X64
+}
+elseif (($env:JAVA_VERSION).equals("11"))
+{
+    $env:JAVA_HOME=$env:JAVA_HOME_11_X64
+}
+
+mvn -v

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -30,6 +30,7 @@ jobs:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
         env:
+          JAVA_VERSION: $(JAVA_VERSION)
           COMMIT_FROM: $(COMMIT_FROM)
 
       - powershell: ./vsts/start_tpm_windows.ps1
@@ -137,6 +138,7 @@ jobs:
       - powershell: ./vsts/echo_versions.ps1
         displayName: 'Echo Versions'
         env:
+          JAVA_VERSION: $(JAVA_VERSION)
           COMMIT_FROM: $(COMMIT_FROM)
 
       - task: Docker@1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -219,6 +219,7 @@ jobs:
         displayName: 'Echo Versions'
         env:
           COMMIT_FROM: $(COMMIT_FROM)
+          JAVA_VERSION: 8 # Android build doesn't need to run for both JDK 8 and 11
         condition: always()
 
       - powershell: ./vsts/build_e2e_tests.cmd


### PR DESCRIPTION
JDK version is set later in the pipeline, but it would be nice to set here as well so we can get the JDK 11 version instead of whatever default JDK version the build agent has set.