### PR TITLE
fix(iot-device): fix issue with direct method after reconnect from temporary network disconnect - AMQP

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -583,12 +583,10 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         this.savedException = AmqpsExceptionTranslator.convertFromAmqpException(errorCondition);
 
-        if (this.isMultiplexing)
-        {
-            // transport errors involve closing the entire amqp connection, so save all the previous sessions
-            // so that their twin/methods subscriptions can persist
-            this.reconnectingDeviceSessionHandlers.putAll(this.sessionHandlers);
-        }
+
+        // transport errors involve closing the entire amqp connection, so save all the previous sessions
+        // so that their twin/methods subscriptions can persist
+        this.reconnectingDeviceSessionHandlers.putAll(this.sessionHandlers);
 
         // In the event that we get a local error and the connection is already in the closed state we need to manually call
         // onConnectionLocalClose. Proton will not queue the CONNECTION_LOCAL_CLOSE event since the Endpoint status is CLOSED

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -35,6 +35,9 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
     private IotHubTransportMessage explicitInProgressTwinSubscriptionMessage;
     private IotHubTransportMessage explicitInProgressMethodsSubscriptionMessage;
 
+    //Carries over state between reconnections
+    private boolean subscribeToMethodsOnReconnection = false;
+    private boolean subscribeToTwinOnReconnection = false;
     private final AmqpsSessionStateCallback amqpsSessionStateCallback;
 
     //Should not carry over state between reconnects
@@ -333,12 +336,12 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
             createTelemetryLinksAsync();
         }
 
-        if (!alreadyCreatedTwinLinks)
+        if (subscribeToTwinOnReconnection && !alreadyCreatedTwinLinks)
         {
             createTwinLinksAsync();
         }
 
-        if (!alreadyCreatedMethodLinks)
+        if (subscribeToMethodsOnReconnection && !alreadyCreatedMethodLinks)
         {
             createMethodLinksAsync();
         }
@@ -525,6 +528,7 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
         Receiver receiver = session.receiver(AmqpsMethodsReceiverLinkHandler.getTag(clientConfiguration, methodsLinkCorrelationId));
         this.receiverLinkHandlers.put(DEVICE_METHODS, new AmqpsMethodsReceiverLinkHandler(receiver, this, this.clientConfiguration, methodsLinkCorrelationId));
 
+        this.subscribeToMethodsOnReconnection = true;
         this.alreadyCreatedMethodLinks = true;
     }
 
@@ -545,6 +549,7 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
         Receiver receiver = session.receiver(AmqpsTwinReceiverLinkHandler.getTag(clientConfiguration, twinLinkCorrelationId));
         this.receiverLinkHandlers.put(DEVICE_TWIN, new AmqpsTwinReceiverLinkHandler(receiver, this, this.clientConfiguration, twinLinkCorrelationId, twinOperationCorrelationMap));
 
+        this.subscribeToTwinOnReconnection = true;
         this.alreadyCreatedTwinLinks = true;
     }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSessionHandler.java
@@ -35,9 +35,6 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
     private IotHubTransportMessage explicitInProgressTwinSubscriptionMessage;
     private IotHubTransportMessage explicitInProgressMethodsSubscriptionMessage;
 
-    //Carries over state between reconnections
-    private boolean subscribeToMethodsOnReconnection = false;
-    private boolean subscribeToTwinOnReconnection = false;
     private final AmqpsSessionStateCallback amqpsSessionStateCallback;
 
     //Should not carry over state between reconnects
@@ -336,12 +333,12 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
             createTelemetryLinksAsync();
         }
 
-        if (subscribeToTwinOnReconnection && !alreadyCreatedTwinLinks)
+        if (!alreadyCreatedTwinLinks)
         {
             createTwinLinksAsync();
         }
 
-        if (subscribeToMethodsOnReconnection && !alreadyCreatedMethodLinks)
+        if (!alreadyCreatedMethodLinks)
         {
             createMethodLinksAsync();
         }
@@ -528,7 +525,6 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
         Receiver receiver = session.receiver(AmqpsMethodsReceiverLinkHandler.getTag(clientConfiguration, methodsLinkCorrelationId));
         this.receiverLinkHandlers.put(DEVICE_METHODS, new AmqpsMethodsReceiverLinkHandler(receiver, this, this.clientConfiguration, methodsLinkCorrelationId));
 
-        this.subscribeToMethodsOnReconnection = true;
         this.alreadyCreatedMethodLinks = true;
     }
 
@@ -549,7 +545,6 @@ class AmqpsSessionHandler extends BaseHandler implements AmqpsLinkStateCallback
         Receiver receiver = session.receiver(AmqpsTwinReceiverLinkHandler.getTag(clientConfiguration, twinLinkCorrelationId));
         this.receiverLinkHandlers.put(DEVICE_TWIN, new AmqpsTwinReceiverLinkHandler(receiver, this, this.clientConfiguration, twinLinkCorrelationId, twinOperationCorrelationMap));
 
-        this.subscribeToTwinOnReconnection = true;
         this.alreadyCreatedTwinLinks = true;
     }
 


### PR DESCRIPTION
DeviceClient doesn't fully reconnect after temporary network disconnect (AMQP), attempts to invoke direct method fails.
Removed unnecessary boolean which were intended to carry over state between reconnection.

With each reconnection, we instantiate new SessionHandler but only set the boolean to true (and create method/twin links) when sending first message during initial connection, thus during reconnection we never create method/twin links.

github issue: https://github.com/Azure/azure-iot-sdk-java/issues/1571

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 