### PR TITLE
fix(iot-device): change payload type in payload setter from String to Object

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/DirectMethodResponse.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/DirectMethodResponse.java
@@ -31,7 +31,7 @@ public class DirectMethodResponse
         return payload;
     }
 
-    public void setPayload(String payload)
+    public void setPayload(Object payload)
     {
         this.payload = payload;
     }


### PR DESCRIPTION
`DirectMethodResponse` takes the property "payload" in `Object` type, but I missed the setter method before.

Found by customer in #1584
