### PR TITLE
refactor(e2e): Remove some flakey checks in a query test

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/QueryClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/serviceclient/QueryClientTests.java
@@ -258,8 +258,6 @@ public class QueryClientTests extends IntegrationTest
 
             assertNotNull(job.getJobId());
             assertNotNull(job.getJobType());
-            assertNotNull(job.getStartTime());
-            assertNotNull(job.getEndTime());
             assertNotNull(job.getCreatedTime());
             assertNotNull(job.getMaxExecutionTimeInSeconds());
             assertNotNull(job.getJobStatus());


### PR DESCRIPTION
The start and end time fields may not be present in the service's response if the job has not finished and/or has not started