### PR TITLE
fix(iot-service): maxExecutionTimeInSeconds improper serialization

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/serializers/ScheduledJobParser.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/serializers/ScheduledJobParser.java
@@ -71,7 +71,7 @@ public class ScheduledJobParser
     private String startTime;
 
     // Max execution time in seconds (ttl duration)
-    private static final String MAXEXECUTIONTIMEINSECONDS_TAG = "maxExecutionTimeSeconds";
+    private static final String MAXEXECUTIONTIMEINSECONDS_TAG = "maxExecutionTimeInSeconds";
     @Expose(deserialize = false)
     @SerializedName(MAXEXECUTIONTIMEINSECONDS_TAG)
     private long maxExecutionTimeInSeconds;

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/scheduled/ScheduledJobParserTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/jobs/scheduled/ScheduledJobParserTest.java
@@ -44,7 +44,7 @@ public class ScheduledJobParserTest
     }
 
     /* Tests_SRS_JOBSPARSER_21_001: [The constructor shall evaluate and store the commons parameters using the internal function commonFields.] */
-    /* Tests_SRS_JOBSPARSER_21_014: [The commonFields shall store the jobId, queryCondition, and maxExecutionTimeSeconds.] */
+    /* Tests_SRS_JOBSPARSER_21_014: [The commonFields shall store the jobId, queryCondition, and maxExecutionTimeInSeconds.] */
     @Test
     public void constructorMethodCommonParsSucceed()
     {
@@ -131,7 +131,7 @@ public class ScheduledJobParserTest
     }
 
     /* Tests_SRS_JOBSPARSER_21_002: [If any common parameter is invalid, the constructor shall throws IllegalArgumentException.] */
-    /* Tests_SRS_JOBSPARSER_21_017: [If the maxExecutionTimeSeconds is negative, the commonFields shall throws IllegalArgumentException.] */
+    /* Tests_SRS_JOBSPARSER_21_017: [If the maxExecutionTimeInSeconds is negative, the commonFields shall throws IllegalArgumentException.] */
     @Test (expected = IllegalArgumentException.class)
     public void constructorMethodInvalidMaxExecutionTimeInSecondsThrows()
     {
@@ -251,7 +251,7 @@ public class ScheduledJobParserTest
                         "\"updateTwin\":null," +
                         "\"queryCondition\":\"" + queryCondition + "\"," +
                         "\"startTime\":\"" + Helpers.formatUTC(startTime) + "\"," +
-                        "\"maxExecutionTimeSeconds\":" + maxExecutionTimeInSeconds +
+                        "\"maxExecutionTimeInSeconds\":" + maxExecutionTimeInSeconds +
                 "}";
 
         // Act
@@ -265,7 +265,7 @@ public class ScheduledJobParserTest
 
 
     /* Tests_SRS_JOBSPARSER_21_007: [The constructor shall evaluate and store the commons parameters using the internal function commonFields.] */
-    /* Tests_SRS_JOBSPARSER_21_014: [The commonFields shall store the jobId, queryCondition, and maxExecutionTimeSeconds.] */
+    /* Tests_SRS_JOBSPARSER_21_014: [The commonFields shall store the jobId, queryCondition, and maxExecutionTimeInSeconds.] */
     @Test
     public void ConstructorTwinCommonParsSucceed()
     {
@@ -352,7 +352,7 @@ public class ScheduledJobParserTest
     }
 
     /* Tests_SRS_JOBSPARSER_21_008: [If any common parameter is invalid, the constructor shall throws IllegalArgumentException.] */
-    /* Tests_SRS_JOBSPARSER_21_017: [If the maxExecutionTimeSeconds is negative, the commonFields shall throws IllegalArgumentException.] */
+    /* Tests_SRS_JOBSPARSER_21_017: [If the maxExecutionTimeInSeconds is negative, the commonFields shall throws IllegalArgumentException.] */
     @Test (expected = IllegalArgumentException.class)
     public void ConstructorInvalidMaxExecutionTimeInSecondsThrows()
     {
@@ -472,7 +472,7 @@ public class ScheduledJobParserTest
                         "\"updateTwin\":" + twinState.toJsonElement().toString() + "," +
                         "\"queryCondition\":\"" + queryCondition + "\"," +
                         "\"startTime\":\"" + Helpers.formatUTC(startTime) + "\"," +
-                        "\"maxExecutionTimeSeconds\":" + maxExecutionTimeInSeconds +
+                        "\"maxExecutionTimeInSeconds\":" + maxExecutionTimeInSeconds +
                 "}";
 
         // Act


### PR DESCRIPTION
The ScheduledJobsClient class improperly sets maxExecutionTimeInSeconds due to a bug in the ScheduledJobParser class
fix create job maxExecutionTimeInSeconds improper json serialization
Github Issue (fix#1591)

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [ X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [ X] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/1591

# Description of the problem
The ScheduledJobsClient.scheduleDirectMethod() method and other similar methods ignore the maxExecutionTimeInSeconds as the ScheduledJobParser.java class improperly serializes the field as maxExecutionTimeSeconds, missing the "In".
The end result is any created scheduled job is created with the default maxExecutionTimeInSeconds of 3600 or one hour.
The issue further describes and links to a forked repo where a sample exists.

# Description of the solution
The solution is simple in just fixing the improper naming of the json maxExecutionTimeSeconds field in ScheduledJobParser.java.
The test was also changed to ensure the correct expectation.
