### PR TITLE
release(2022-08-25): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.0.5";
+    public static final String CLIENT_VERSION = "2.1.0";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Remote binary dependency
-    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.0.5') {
+    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.1.0') {
         exclude module: 'slf4j-api'
         exclude module: 'log4j-slf4j-impl'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.0.5</iot-device-client-version>
-        <iot-service-client-version>2.1.0</iot-service-client-version>
+        <iot-device-client-version>2.1.0</iot-device-client-version>
+        <iot-service-client-version>2.1.1</iot-service-client-version>
         <provisioning-device-client-version>2.0.1</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.1</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.1.0";
+    public static final String serviceVersion = "2.1.1";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.1.0)

- Allow users to set direct method response payload as any object instead of just as a string (#1586)

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.1.1)

### Bug fixes
- Fixed a bug where the maxExecutionTimeInSeconds property was not sent to the service correctly and causing the service to ignore it (#1592)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.1.0/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/2.1.1/jar

old
{
    "device": "2.0.5",
    "service": "2.1.0",
}

new
{
    "device": "2.1.0",
    "service": "2.1.1",
}