### PR TITLE
Feature Request: Enable to set tags, desiredProperties and reportedProperties of a `Twin`

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -51,13 +51,7 @@ public class Twin
     @Getter
     @Setter
     private TwinCollection tags = new TwinCollection();
-
-    @Getter
-    @Setter
     private TwinCollection reportedProperties  = new TwinCollection();
-
-    @Getter
-    @Setter
     private TwinCollection desiredProperties = new TwinCollection();
 
     @Getter

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -48,9 +48,17 @@ public class Twin
     @Setter(AccessLevel.PACKAGE)
     private Integer version;
 
-    private final TwinCollection tags = new TwinCollection();
-    private final TwinCollection reportedProperties = new TwinCollection();
-    private final TwinCollection desiredProperties = new TwinCollection();
+    @Getter
+    @Setter
+    private TwinCollection tags = new TwinCollection();
+
+    @Getter
+    @Setter
+    private TwinCollection reportedProperties  = new TwinCollection();
+
+    @Getter
+    @Setter
+    private TwinCollection desiredProperties = new TwinCollection();
 
     @Getter
     @Setter(AccessLevel.PACKAGE)


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 

# Description of the problem
Editing/setting the `tags` of a Twin via the SDK is not possible. This feature is already active in [Azure IoTHub Web UI](https://github.com/yilmaznaslan/azure-iot-dev-guide/blob/bugfix/addSetterForTwin/docs/TwinIssue.png) 

# Code Sample
https://github.com/yilmaznaslan/azure-iot-dev-guide/blob/bugfix/addSetterForTwin/src/main/java/org/example/azure/MainApplication.java
```
package org.example.azure;

import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
import com.microsoft.azure.sdk.iot.service.twin.Twin;
import com.microsoft.azure.sdk.iot.service.twin.TwinClient;
import com.microsoft.azure.sdk.iot.service.twin.TwinCollection;

import java.io.IOException;

public class MainApplication {

    public static String iotHubConnectionString = "REPLACE_ME";

    public static void main(String[] args) throws Exception {
        patchDeviceTwin("dishwasher_2");
    }
    public static void patchDeviceTwin(String deviceId) throws IOException, IotHubException {
        TwinClient twinClient = new TwinClient(iotHubConnectionString);
        Twin twin = twinClient.get(deviceId);
        TwinCollection twinCollection = new TwinCollection();
        twinCollection.put("customerId", "null");
        twinCollection.put("country", "germany");
        twinCollection.put("SoftwareId", "xe123");
        //twin.setTags(twinCollection);
        twinClient.patch(twin);
    }
}
```

# Description of the solution
 Add a setter to `com.microsoft.azure.sdk.iot.service.twin.Twin#tags`
