### PR TITLE
release(2022-09-28): bump package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
         <iot-device-client-version>2.1.1</iot-device-client-version>
-        <iot-service-client-version>2.1.2</iot-service-client-version>
+        <iot-service-client-version>2.1.3</iot-service-client-version>
         <provisioning-device-client-version>2.0.2</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.1</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.1.2";
+    public static final String serviceVersion = "2.1.3";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.1.3)


### Bug fixes
- Fix the authenticationType enum serialization keys (#1600)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-service-client/2.1.3/jar
