### PR TITLE
fix(iot-dev): Fix MQTT layer acknowledgement logic

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessage.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessage.java
@@ -6,6 +6,8 @@ package com.microsoft.azure.sdk.iot.device.transport;
 import com.microsoft.azure.sdk.iot.device.twin.DeviceOperations;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsMethod;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Extends Message, adding transport artifacts.
@@ -29,6 +31,10 @@ public class IotHubTransportMessage extends Message
     private DeviceOperations operationType;
     private MessageCallback messageCallback;
     private Object messageCallbackContext;
+
+    @Getter
+    @Setter
+    private int qualityOfService;
 
     /**
      * Constructor with binary data and message type

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -28,11 +28,7 @@ public abstract class Mqtt implements MqttCallback
     private static final int DISCONNECTION_TIMEOUT = 60 * 1000;
 
     //mqtt connection options
-    private static final int MESSAGE_QOS = 1;
-    private static final int SUBSCRIPTION_MESSAGE_QOS = 1;
-
-    // QoS of acknowledgement messages should always be 0 because the service does not send acknowledgements that it received an acknowledgement.
-    private static final int ACKNOWLEDGEMENT_QOS = 0;
+    private static final int QOS = 1;
     private static final int MAX_SUBSCRIBE_ACK_WAIT_TIME = 15 * 1000;
 
     // relatively arbitrary, but only because Paho doesn't have any particular recommendations here. Just a high enough
@@ -223,7 +219,7 @@ public abstract class Mqtt implements MqttCallback
 
             MqttMessage mqttMessage = (payload.length == 0) ? new MqttMessage() : new MqttMessage(payload);
 
-            mqttMessage.setQos(MESSAGE_QOS);
+            mqttMessage.setQos(QOS);
 
             synchronized (this.unacknowledgedSentMessagesLock)
             {
@@ -271,7 +267,7 @@ public abstract class Mqtt implements MqttCallback
 
                 log.debug("Sending MQTT SUBSCRIBE packet for topic {}", topic);
 
-                IMqttToken subToken = this.mqttAsyncClient.subscribe(topic, SUBSCRIPTION_MESSAGE_QOS);
+                IMqttToken subToken = this.mqttAsyncClient.subscribe(topic, QOS);
 
                 subToken.waitForCompletion(MAX_SUBSCRIBE_ACK_WAIT_TIME);
                 log.debug("Sent MQTT SUBSCRIBE packet for topic {} was acknowledged", topic);
@@ -423,7 +419,7 @@ public abstract class Mqtt implements MqttCallback
         log.trace("Sending mqtt ack for received message with mqtt message id {}", messageId);
         try
         {
-            this.mqttAsyncClient.messageArrivedComplete(messageId, ACKNOWLEDGEMENT_QOS);
+            this.mqttAsyncClient.messageArrivedComplete(messageId, QOS);
         }
         catch (MqttException e)
         {
@@ -476,15 +472,6 @@ public abstract class Mqtt implements MqttCallback
             if (propertyString.contains("="))
             {
                 //Expected format is <key>=<value> where both key and value may be encoded
-                String[] keyAndValue = propertyString.split("=");
-
-                if (keyAndValue.length != 2)
-                {
-                    // This case indicates a key/value pair that is missing either the key or the value. Skip it and
-                    // move onto the next pair.
-                    continue;
-                }
-
                 String key = propertyString.split("=")[PROPERTY_KEY_INDEX];
                 String value = propertyString.split("=")[PROPERTY_VALUE_INDEX];
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethod.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethod.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.sdk.iot.device.transport.IotHubTransportMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import java.util.Map;
 import java.util.Queue;
@@ -39,7 +40,7 @@ class MqttDirectMethod extends Mqtt
         String deviceId,
         MqttConnectOptions connectOptions,
         Map<Integer, Message> unacknowledgedSentMessages,
-        Queue<Pair<String, byte[]>> receivedMessages)
+        Queue<Pair<String, MqttMessage>> receivedMessages)
     {
         super(null, deviceId, connectOptions, unacknowledgedSentMessages, receivedMessages);
 
@@ -121,7 +122,7 @@ class MqttDirectMethod extends Mqtt
         {
             IotHubTransportMessage message = null;
 
-            Pair<String, byte[]> messagePair = this.receivedMessages.peek();
+            Pair<String, MqttMessage> messagePair = this.receivedMessages.peek();
 
             if (messagePair != null)
             {
@@ -129,7 +130,8 @@ class MqttDirectMethod extends Mqtt
 
                 if (topic != null && topic.length() > 0)
                 {
-                    byte[] data = messagePair.getValue();
+                    MqttMessage mqttMessage = messagePair.getValue();
+                    byte[] data = mqttMessage.getPayload();
 
                     if (topic.length() > METHOD.length() && topic.startsWith(METHOD))
                     {
@@ -151,6 +153,7 @@ class MqttDirectMethod extends Mqtt
                             }
 
                             message.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_UNKNOWN);
+                            message.setQualityOfService(mqttMessage.getQos());
 
                             String methodName = topicParser.getMethodName(METHOD_TOKEN);
                             message.setMethodName(methodName);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -473,6 +473,8 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
         {
             if (transportMessage.getQualityOfService() == 0)
             {
+                // Direct method messages and Twin messages are always sent with QoS 0, so there is no need for this SDK
+                // to acknowledge them.
                 log.trace("MQTT received message with QoS 0 so it has not been added to the messages to acknowledge list ({})", transportMessage);
             }
             else

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessaging.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.sdk.iot.device.MessageProperty;
 import com.microsoft.azure.sdk.iot.device.transport.TransportException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -30,7 +31,7 @@ class MqttMessaging extends Mqtt
         boolean isEdgeHub,
         MqttConnectOptions connectOptions,
         Map<Integer, Message> unacknowledgedSentMessages,
-        Queue<Pair<String, byte[]>> receivedMessages)
+        Queue<Pair<String, MqttMessage>> receivedMessages)
     {
         super(messageListener, deviceId, connectOptions, unacknowledgedSentMessages, receivedMessages);
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethodTest.java
@@ -61,7 +61,7 @@ public class MqttDirectMethodTest
         String actualResTopic = "$iothub/methods/res";
 
         //act
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //assert
         String testSubscribeTopic = Deencapsulation.getField(testMethod, "subscribeTopic");
@@ -81,7 +81,7 @@ public class MqttDirectMethodTest
     public void startSucceedsCalls(@Mocked final Mqtt mockMqtt) throws TransportException
     {
         //arrange
-        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMethod.start();
@@ -101,7 +101,7 @@ public class MqttDirectMethodTest
     public void startSucceedsDoesNotCallsSubscribeIfStarted(@Mocked final Mqtt mockMqtt) throws TransportException
     {
         //arrange
-        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
         //act
         testMethod.start();
@@ -127,7 +127,7 @@ public class MqttDirectMethodTest
         byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SUBSCRIBE_REQUEST);
-        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -154,7 +154,7 @@ public class MqttDirectMethodTest
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
         testMessage.setRequestId("ReqId");
         testMessage.setStatus("testStatus");
-        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -176,7 +176,7 @@ public class MqttDirectMethodTest
         final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_UNKNOWN);
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -189,7 +189,7 @@ public class MqttDirectMethodTest
     {
         final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMethod.send(testMessage);
@@ -199,7 +199,7 @@ public class MqttDirectMethodTest
     @Test (expected = IllegalArgumentException.class)
     public void sendThrowsOnMessageNull() throws TransportException
     {
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
         //act
         testMethod.send(null);
@@ -214,7 +214,7 @@ public class MqttDirectMethodTest
         final byte[] actualPayload = "TestMessage".getBytes(StandardCharsets.UTF_8);
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setMessageType(MessageType.DEVICE_TWIN);
-        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         testMethod.start();
 
@@ -241,7 +241,7 @@ public class MqttDirectMethodTest
         final IotHubTransportMessage testMessage = new IotHubTransportMessage(actualPayload, MessageType.DEVICE_METHODS);
         testMessage.setMessageType(MessageType.DEVICE_METHODS);
         testMessage.setDeviceOperationType(DEVICE_OPERATION_METHOD_SEND_RESPONSE);
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -260,8 +260,9 @@ public class MqttDirectMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
-        testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessage message = new MqttMessage(actualPayload);
+        testreceivedMessages.add(new MutablePair<>(topic, message));
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);
         testMethod.start();
 
@@ -282,8 +283,8 @@ public class MqttDirectMethodTest
     public void receiveReturnsNullMessageIfTopicNotFound() throws TransportException
     {
         //arrange
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -301,9 +302,10 @@ public class MqttDirectMethodTest
         //arrange
         String topic = "$iothub/methods/Not_POST/testMethod/?$rid=10";
         byte[] actualPayload = "TestPayload".getBytes(StandardCharsets.UTF_8);
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-        testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessage message = new MqttMessage(actualPayload);
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        testreceivedMessages.add(new MutablePair<>(topic, message));
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMethod.start();
 
         //act
@@ -319,8 +321,9 @@ public class MqttDirectMethodTest
         //arrange
         String topic = "$iothub/methods/POST/testMethod/?$rid=10";
         byte[] actualPayload = "".getBytes(StandardCharsets.UTF_8);
-        testreceivedMessages.add(new MutablePair<>(topic, actualPayload));
-        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessage message = new MqttMessage(actualPayload);
+        testreceivedMessages.add(new MutablePair<>(topic, message));
+        MqttDirectMethod testMethod = new MqttDirectMethod("", mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.setField(testMethod, "receivedMessages", testreceivedMessages);
         testMethod.start();
 

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethodTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttDirectMethodTest.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ public class MqttDirectMethodTest
     @Mocked
     MqttConnectOptions mockConnectOptions;
 
-    private ConcurrentLinkedQueue<Pair<String, byte[]>> testreceivedMessages;
+    private ConcurrentLinkedQueue<Pair<String, MqttMessage>> testreceivedMessages;
 
     @Before
     public void baseConstructorExpectation()

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessagingTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttMessagingTest.java
@@ -57,7 +57,7 @@ public class MqttMessagingTest
     public void constructorCallsBaseConstructorWithArguments(@Mocked final Mqtt mockMqtt) throws TransportException
     {
 
-        MqttMessaging testMqttMessaging = new MqttMessaging(CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging(CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         String actualPublishTopic = Deencapsulation.getField(testMqttMessaging, "publishTopic");
         assertNotNull(actualPublishTopic);
@@ -73,7 +73,7 @@ public class MqttMessagingTest
         //arrange
         final String expectedModuleId = "someModule";
         final String expectedDeviceId = "someDevice";
-        MqttMessaging testMqttMessaging = new MqttMessaging(expectedDeviceId, null, expectedModuleId, false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging(expectedDeviceId, null, expectedModuleId, false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         String actualPublishTopic = Deencapsulation.getField(testMqttMessaging, "publishTopic");
         assertEquals("devices/" + expectedDeviceId + "/modules/" + expectedModuleId +"/messages/events/", actualPublishTopic);
@@ -89,13 +89,13 @@ public class MqttMessagingTest
     @Test (expected = IllegalArgumentException.class)
     public void constructorFailsIfDeviceIDIsEmpty() throws TransportException
     {
-        MqttMessaging testMqttMessaging = new MqttMessaging( "", null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( "", null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
     }
 
     @Test (expected = IllegalArgumentException.class)
     public void constructorFailsIfDeviceIDIsNull() throws TransportException
     {
-        MqttMessaging testMqttMessaging = new MqttMessaging( null, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( null, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
     }
 
     /*
@@ -113,7 +113,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         testMqttMessaging.start();
         new Verifications()
@@ -139,7 +139,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.start();
 
         new Verifications()
@@ -167,7 +167,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.start();
 
         new Verifications()
@@ -198,7 +198,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.start();
         testMqttMessaging.stop();
 
@@ -224,7 +224,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.start();
         testMqttMessaging.stop();
 
@@ -253,7 +253,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.send(mockedMessage);
 
         //assert
@@ -282,7 +282,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.send(null);
 
         new Verifications()
@@ -303,7 +303,7 @@ public class MqttMessagingTest
     public void sendShallThrowTransportExceptionIfMessageIsNull(@Mocked final Mqtt mockMqtt) throws TransportException
     {
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testMqttMessaging.send(null);
 
         new Verifications()
@@ -341,7 +341,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         final String publishTopicWithCustomProperties = String.format(
                 "devices/%s/messages/events/%s=%s&%s=%s", CLIENT_ID, propertyName1, propertyValue1, propertyName2, propertyValue2);
 
@@ -378,7 +378,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.send(mockedMessage);
@@ -414,7 +414,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.send(mockedMessage);
@@ -449,7 +449,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.send(mockedMessage);
@@ -485,7 +485,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.send(mockedMessage);
@@ -521,7 +521,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.send(mockedMessage);
@@ -595,7 +595,7 @@ public class MqttMessagingTest
             }
         };
 
-        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttMessaging testMqttMessaging = new MqttMessaging( CLIENT_ID, null, "", false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         final String publishTopicWithAllSystemAndCustomProperties = String.format(
                 "devices/%s/messages/events/$.mid=%s&$.cid=%s&$.uid=%s&$.to=%s&$.on=%s&$.ce=%s&$.ct=%s&$.ctime=%s&%s=%s&%s=%s", CLIENT_ID, messageId, correlationId, userId, to, outputName, contentEncoding, contentTypeEncoded, creationTimeUtcEncoded, propertyName1, propertyValue1, propertyName2, propertyValue2);
 
@@ -620,7 +620,7 @@ public class MqttMessagingTest
         String moduleId = "5678";
         final String inputsSubsriptionChannel = "devices/" + deviceId + "/modules/" + moduleId + "/inputs/#";
         final String eventsSubsriptionChannel = "devices/" + deviceId + "/modules/" + moduleId + "/messages/devicebound/#";
-        final MqttMessaging testMqttMessaging = new MqttMessaging( deviceId, null, moduleId, true, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttMessaging testMqttMessaging = new MqttMessaging( deviceId, null, moduleId, true, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.start();
@@ -647,7 +647,7 @@ public class MqttMessagingTest
         String moduleId = "5678";
         final String inputsSubsriptionChannel = "devices/" + deviceId + "/modules/" + moduleId + "/inputs/#";
         final String eventsSubsriptionChannel = "devices/" + deviceId + "/modules/" + moduleId + "/messages/devicebound/#";
-        final MqttMessaging testMqttMessaging = new MqttMessaging( deviceId, null, moduleId, false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final MqttMessaging testMqttMessaging = new MqttMessaging( deviceId, null, moduleId, false, mockConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testMqttMessaging.start();

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
@@ -623,12 +623,14 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
-       Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+       Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        testreceivedMessages.add(new MutablePair<>(MOCK_PARSE_TOPIC, mockMqttMessage));
        Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-       testreceivedMessages.add(new MutablePair<>(MOCK_PARSE_TOPIC, payload));
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
@@ -666,12 +668,14 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-        testreceivedMessages.add(new MutablePair<>(MOCK_PARSE_TOPIC_WITH_INPUT_NAME, payload));
+        testreceivedMessages.add(new MutablePair<>(MOCK_PARSE_TOPIC_WITH_INPUT_NAME, mockMqttMessage));
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
@@ -735,12 +739,12 @@ public class MqttTest
         mockMqtt.messageArrived(MOCK_PARSE_TOPIC, new MqttMessage(actualPayload));
 
         //assert
-        Queue<Pair<String, byte[]>> actualQueue = Deencapsulation.getField(mockMqtt, "receivedMessages");
-        Pair<String, byte[]> messagePair = actualQueue.poll();
+        Queue<Pair<String, MqttMessage>> actualQueue = Deencapsulation.getField(mockMqtt, "receivedMessages");
+        Pair<String, MqttMessage> messagePair = actualQueue.poll();
         assertNotNull(messagePair);
         assertEquals(messagePair.getKey(), MOCK_PARSE_TOPIC);
 
-        byte[] receivedPayload = messagePair.getValue();
+        byte[] receivedPayload = messagePair.getValue().getPayload();
         assertEquals(actualPayload.length, receivedPayload.length);
         for (int i = 0; i < actualPayload.length; i++)
         {
@@ -827,12 +831,14 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-        testreceivedMessages.add(new MutablePair<>(mockParseTopicInvalidPropertyFormat, payload));
+        testreceivedMessages.add(new MutablePair<>(mockParseTopicInvalidPropertyFormat, mockMqttMessage));
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
@@ -859,12 +865,14 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-        testreceivedMessages.add(new MutablePair<>(mockParseTopicNoCustomProperties, payload));
+        testreceivedMessages.add(new MutablePair<>(mockParseTopicNoCustomProperties, mockMqttMessage));
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
@@ -893,12 +901,14 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-        testreceivedMessages.add(new MutablePair<>(mockParseTopicWithUnusualCharacters, payload));
+        testreceivedMessages.add(new MutablePair<>(mockParseTopicWithUnusualCharacters, mockMqttMessage));
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
@@ -944,14 +954,16 @@ public class MqttTest
             {
                 mockMqttAsyncClient.isConnected();
                 result = true;
+                mockMqttMessage.getPayload();
+                result = payload;
             }
         };
 
         Deencapsulation.invoke(mockMqtt, "connect");
 
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         Deencapsulation.setField(mockMqtt, "receivedMessages", testreceivedMessages);
-        testreceivedMessages.add(new MutablePair<>(mockParseTopicWithUnusualCharacters, payload));
+        testreceivedMessages.add(new MutablePair<>(mockParseTopicWithUnusualCharacters, mockMqttMessage));
 
         //act
         Message receivedMessage = mockMqtt.receive();

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTest.java
@@ -95,14 +95,14 @@ public class MqttTest
     {
         if (withParameters)
         {
-            MqttMessaging mqttMessaging = new MqttMessaging(CLIENT_ID, mockedMessageListener, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttMessaging mqttMessaging = new MqttMessaging(CLIENT_ID, mockedMessageListener, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Deencapsulation.invoke(mqttMessaging, "setListener", new Class[]{IotHubListener.class}, listener);
             Deencapsulation.invoke(mqttMessaging, "setMqttAsyncClient", mockMqttAsyncClient);
             return mqttMessaging;
         }
         else
         {
-            MqttTwin mqttTwin = new MqttTwin(null, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin mqttTwin = new MqttTwin(null, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Deencapsulation.invoke(mqttTwin, "setListener", new Class[]{IotHubListener.class}, listener);
             Deencapsulation.invoke(mqttTwin, "setMqttAsyncClient", mockMqttAsyncClient);
             return mqttTwin;
@@ -616,7 +616,7 @@ public class MqttTest
         final byte[] payload = {0x61, 0x62, 0x63};
         baseConnectExpectation();
 
-       final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+       final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
        Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
        new NonStrictExpectations()
         {
@@ -659,7 +659,7 @@ public class MqttTest
         final byte[] payload = {0x61, 0x62, 0x63};
         baseConnectExpectation();
 
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
         new NonStrictExpectations()
         {
@@ -690,7 +690,7 @@ public class MqttTest
         //arrange
         final byte[] payload = {0x61, 0x62, 0x63};
         baseConnectExpectation();
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID,  null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID,  null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
 
         new NonStrictExpectations()
@@ -795,7 +795,7 @@ public class MqttTest
         try
         {
             //arrange
-            MqttMessaging testMqttClient = new MqttMessaging("deviceId", null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttMessaging testMqttClient = new MqttMessaging("deviceId", null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             Deencapsulation.setField(testMqttClient, "receivedMessages", testreceivedMessages);
 
@@ -820,7 +820,7 @@ public class MqttTest
         final String mockParseTopicInvalidPropertyFormat = "devices/deviceID/messages/devicebound/%24.mid=69ea4caf-d83e-454b-81f2-caafda4c81c8&%24.exp=99999&%24.to=%2Fdevices%2FdeviceID%2Fmessages%2FdeviceBound&%24.cid=169c34b3-99b0-49f9-b0f6-8fa9d2c99345&iothub-ack=full&property1value1";
         baseConnectExpectation();
 
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
         new NonStrictExpectations()
         {
@@ -851,7 +851,7 @@ public class MqttTest
         final String mockParseTopicNoCustomProperties = "devices/deviceID/messages/devicebound/%24.mid=69ea4caf-d83e-454b-81f2-caafda4c81c8&%24.exp=0&%24.to=%2Fdevices%2FdeviceID%2Fmessages%2FdeviceBound&%24.cid=169c34b3-99b0-49f9-b0f6-8fa9d2c99345&iothub-ack=full";
         baseConnectExpectation();
 
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
 
         new NonStrictExpectations()
@@ -886,7 +886,7 @@ public class MqttTest
         final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=69ea4caf-d83e-454b-81f2-caafda4c81c8&%24.exp=0&%24.to=%2Fdevices%2FdeviceID%2Fmessages%2FdeviceBound&%24.cid=169c34b3-99b0-49f9-b0f6-8fa9d2c99345&iothub-ack=full&property1=%24&property2=%26&%25=_&finalProperty=.";
         baseConnectExpectation();
 
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
         new NonStrictExpectations()
         {
@@ -937,7 +937,7 @@ public class MqttTest
         final String mockParseTopicWithUnusualCharacters = "devices/deviceID/messages/devicebound/%24.mid=" + msgId + "&%24.exp=" + expTime + "&%24.to=" + URLEncoder.encode(to, StandardCharsets.UTF_8.name()) + "&%24.cid=" + corId + "&iothub-ack=full&%24.ce=" + contentEncoding + "&%24.ct=" + URLEncoder.encode(contentType, StandardCharsets.UTF_8.name()) + "&%24.on=" + outputName + "&property1=%24&property2=%26&%25=_&finalProperty=.";
         baseConnectExpectation();
 
-        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        final Mqtt mockMqtt = new MqttMessaging(CLIENT_ID, null, "", false, mockMqttConnectionOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Deencapsulation.invoke(mockMqtt, "setMqttAsyncClient", mockMqttAsyncClient);
         new NonStrictExpectations()
         {

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.junit.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +53,7 @@ public class MqttTwinTest
         //arrange
 
         //act
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
         //assert
         String actualSubscribeTopic = Deencapsulation.getField(testTwin, "subscribeTopic");
         assertNotNull(actualSubscribeTopic);
@@ -65,7 +66,7 @@ public class MqttTwinTest
     public void startSubscribesToDeviceTwinResponse(@Mocked final Mqtt mockMqtt) throws TransportException
     {
         //arrange
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
 
         //act
 
@@ -95,7 +96,7 @@ public class MqttTwinTest
             }
         };
 
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
 
         //act
         testTwin.start();
@@ -110,7 +111,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/GET/?$rid="+mockReqId;
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -151,7 +152,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
             testTwin.start();
             new NonStrictExpectations()
             {
@@ -178,7 +179,7 @@ public class MqttTwinTest
                 {
                     mockMessage.getBytes();
                     times = 1;
-                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, actualPayload, mockMessage);
+                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, new MqttMessage(actualPayload), mockMessage);
                     times = 0;
 
                 }
@@ -194,7 +195,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/PATCH/properties/reported/?$rid="+ mockReqId + "&$version=" + mockVersion;
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -237,7 +238,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
             testTwin.start();
             new NonStrictExpectations()
             {
@@ -264,7 +265,7 @@ public class MqttTwinTest
                 {
                     mockMessage.getBytes();
                     times = 1;
-                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, actualPayload, mockMessage);
+                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, new MqttMessage(actualPayload), mockMessage);
                     times = 0;
 
                 }
@@ -280,7 +281,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/#";
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -320,7 +321,7 @@ public class MqttTwinTest
     {
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -421,7 +422,7 @@ public class MqttTwinTest
                 {
                     mockMessage.getBytes();
                     times = 0;
-                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, actualPayload, mockMessage);
+                    Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, new MqttMessage(actualPayload), mockMessage);
                     times = 0;
                 }
             };
@@ -442,8 +443,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
@@ -479,8 +480,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -515,8 +516,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             //act
@@ -547,8 +548,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             //act
@@ -573,8 +574,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Deencapsulation.setField(testTwin, "stateLock", new Object());
 
@@ -601,8 +602,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Deencapsulation.setField(testTwin, "stateLock", new Object());
 
@@ -637,8 +638,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -674,8 +675,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -712,8 +713,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Map<String, DeviceOperations> requestMap = new HashMap<>();
             requestMap.put(mockReqId, DEVICE_OPERATION_TWIN_GET_REQUEST);
@@ -747,8 +748,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Deencapsulation.setField(testTwin, "stateLock", new Object());
 
@@ -797,8 +798,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             Map<String, DeviceOperations> requestMap = new HashMap<>();
@@ -837,8 +838,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             //act
@@ -877,8 +878,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
 
             //act
@@ -916,8 +917,8 @@ public class MqttTwinTest
         {
             //arrange
             MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-            Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-            testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, new MqttMessage(actualPayload)));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
             Deencapsulation.setField(testTwin, "stateLock", new Object());
 
@@ -951,8 +952,8 @@ public class MqttTwinTest
     {
         //arrange
         MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
-        Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
-        testreceivedMessages.add(new MutablePair<String, byte[]>(null, new byte[5]));
+        Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+        testreceivedMessages.add(new MutablePair<>(null, new MqttMessage(new byte[5])));
         Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
         Deencapsulation.setField(testTwin, "stateLock", new Object());
         Deencapsulation.setField(testTwin, "receivedMessagesLock", new Object());

--- a/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
+++ b/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
@@ -52,7 +52,7 @@ public class MqttTwinTest
         //arrange
 
         //act
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         //assert
         String actualSubscribeTopic = Deencapsulation.getField(testTwin, "subscribeTopic");
         assertNotNull(actualSubscribeTopic);
@@ -65,7 +65,7 @@ public class MqttTwinTest
     public void startSubscribesToDeviceTwinResponse(@Mocked final Mqtt mockMqtt) throws TransportException
     {
         //arrange
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
 
@@ -95,7 +95,7 @@ public class MqttTwinTest
             }
         };
 
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
         //act
         testTwin.start();
@@ -110,7 +110,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/GET/?$rid="+mockReqId;
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -151,7 +151,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             testTwin.start();
             new NonStrictExpectations()
             {
@@ -194,7 +194,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/PATCH/properties/reported/?$rid="+ mockReqId + "&$version=" + mockVersion;
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -237,7 +237,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             testTwin.start();
             new NonStrictExpectations()
             {
@@ -280,7 +280,7 @@ public class MqttTwinTest
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/#";
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -320,7 +320,7 @@ public class MqttTwinTest
     {
         //arrange
         final byte[] actualPayload = {0x61, 0x62, 0x63};
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -366,7 +366,7 @@ public class MqttTwinTest
         final byte[] actualPayload = {0x61, 0x62, 0x63};
         final String expectedTopic = "$iothub/twin/PATCH/properties/desired/?$version="+ mockVersion;
         final String expectedSubscribeTopic = "$iothub/twin/PATCH/properties/desired/#";
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         testTwin.start();
         new NonStrictExpectations()
         {
@@ -409,7 +409,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
 
             //act
             testTwin.send(null);
@@ -441,7 +441,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -478,7 +478,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -514,7 +514,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -546,7 +546,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -572,7 +572,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -600,7 +600,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -636,7 +636,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -673,7 +673,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -711,7 +711,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -746,7 +746,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -796,7 +796,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -836,7 +836,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -876,7 +876,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -915,7 +915,7 @@ public class MqttTwinTest
         try
         {
             //arrange
-            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
             Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
             testreceivedMessages.add(new MutablePair<>(expectedTopic, actualPayload));
             Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);
@@ -950,7 +950,7 @@ public class MqttTwinTest
     public void receiveReturnsNullMessageIfTopicNotFound(@Mocked final Mqtt mockMqtt) throws TransportException
     {
         //arrange
-        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<Pair<String, byte[]>>());
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<Integer, Message>(), new ConcurrentLinkedQueue<>());
         Queue<Pair<String, byte[]>> testreceivedMessages = new ConcurrentLinkedQueue<>();
         testreceivedMessages.add(new MutablePair<String, byte[]>(null, new byte[5]));
         Deencapsulation.setField(testTwin, "receivedMessages", testreceivedMessages);


### PR DESCRIPTION
The SDK wasn't checking if the received MQTT messages had QoS of 0 or 1 and attempted to ack all of them because of that.

Received twin/direct method messages are QoS 0 so we will now skip sending ack's for them. 

The previous behavior did cause some bugs when using gwv2 because the received twin/direct method messages could have a messageId of 0. When we tried to ack that message Id, [Paho would override that messageId](https://github.com/eclipse/paho.mqtt.java/blob/f4e0db802a4433645ef011e711646a09ec9fae89/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java#L499) (because it assumed that "messageId == 0" meant that it wasn't assigned a messageId yet) and send an ack for a message that the service never sent. GWv1 seems to handle this bug fine, but GWv2 closes the connection when this happens. All of this is now moot though since we won't be ack'ing twin/direct method messages since they are QoS 0