### PR TITLE
release(2022-10-13): bump package versions

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     public static final String IOTHUB_API_VERSION = "2020-09-30";
 
     private static final String JAVA_DEVICE_CLIENT_IDENTIFIER = "com.microsoft.azure.sdk.iot.iot-device-client";
-    public static final String CLIENT_VERSION = "2.1.1";
+    public static final String CLIENT_VERSION = "2.1.2";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");

--- a/device/iot-device-samples/android-sample/app/build.gradle
+++ b/device/iot-device-samples/android-sample/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     // Remote binary dependency
-    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.1.1') {
+    implementation ('com.microsoft.azure.sdk.iot:iot-device-client:2.1.2') {
         exclude module: 'slf4j-api'
         exclude module: 'log4j-slf4j-impl'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -79,22 +79,22 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.14.0-rc1</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-joda</artifactId>
-                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.14.0-rc1</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.14.0-rc1</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.13.4</version>
+                <version>2.14.0-rc1</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
         <iot-device-client-version>2.1.2</iot-device-client-version>
-        <iot-service-client-version>2.1.3</iot-service-client-version>
+        <iot-service-client-version>2.1.4</iot-service-client-version>
         <provisioning-device-client-version>2.0.2</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.1</provisioning-service-client-version>
         <security-provider-version>2.0.0</security-provider-version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.1.1</iot-device-client-version>
+        <iot-device-client-version>2.1.2</iot-device-client-version>
         <iot-service-client-version>2.1.3</iot-service-client-version>
         <provisioning-device-client-version>2.0.2</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.1</provisioning-service-client-version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,22 +79,22 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.2.1</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-joda</artifactId>
-                <version>2.13.2</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.13.2</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
+                <version>2.13.4</version> <!-- Nested dependency from azure core. Overriding the version to use newer version-->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.13.2</version>
+                <version>2.13.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/TransportUtils.java
@@ -8,7 +8,7 @@ public class TransportUtils
     /** Version identifier key */
     public static final String versionIdentifierKey = "com.microsoft:client-version";
     public static final String javaServiceClientIdentifier = "com.microsoft.azure.sdk.iot.iot-service-client/";
-    public static final String serviceVersion = "2.1.3";
+    public static final String serviceVersion = "2.1.4";
 
     private static final String JAVA_RUNTIME = System.getProperty("java.version");
     private static final String OPERATING_SYSTEM = System.getProperty("java.runtime.name").toLowerCase().contains("android") ? "Android" : System.getProperty("os.name");


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.1.2)

### Bug fixes

- Fix bug where the client sent PUBACK messages even when the service sent messages with QoS of 0
  - Note that this issue caused the bug documented in issue #1590 on some instances of IoT hub, but not all

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.1.4)
- Upgrade Jackson dependency

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.1.2/jar
https://search.maven.org/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.1.4/jar
