### PR TITLE
doc(iot-dev): Add notes in javadocs about when subscriptions are preserved

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceClient.java
@@ -146,7 +146,13 @@ public final class DeviceClient extends InternalClient
 
     /**
      * Sets the message callback.
-     *
+     * <p>
+     * This should be set before opening the client. If it is set after opening the client, any messages sent by the
+     * service may be missed.
+     * </p>
+     * <p>
+     * This callback is preserved between reconnection attempts and preserved after re-opening a previously closed client.
+     * </p>
      * @param callback the message callback. Can be {@code null}.
      * @param context the context to be passed to the callback. Can be {@code null}.
      *

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -315,6 +315,9 @@ public class InternalClient
      * Start receiving desired property updates for this client. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
      * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
+     * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry
      * policy was exhausted.
@@ -335,6 +338,9 @@ public class InternalClient
     /**
      * Start receiving desired property updates for this client. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
+     * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
      * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry
@@ -530,6 +536,9 @@ public class InternalClient
     /**
      * Subscribes to direct methods.
      * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
+     * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry
      * policy was exhausted.
@@ -549,6 +558,9 @@ public class InternalClient
 
     /**
      * Subscribes to direct methods.
+     * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
      * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry
@@ -668,6 +680,9 @@ public class InternalClient
     /**
      * Start receiving desired property updates for this client asynchronously. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
+     * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
      * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry
@@ -867,6 +882,9 @@ public class InternalClient
 
     /**
      * Subscribes to direct methods.
+     * <p>
+     * This call can only be made after the client has been successfully opened.
+     * </p>
      * <p>
      * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
      * been closed because the user called {@link #close()} or because this client lost its connection and its retry

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/InternalClient.java
@@ -314,7 +314,11 @@ public class InternalClient
     /**
      * Start receiving desired property updates for this client. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
-     *
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param desiredPropertiesCallback The callback to execute each time a desired property update message is received
      * from the service. This will contain one or many properties updated at once.
      * @param desiredPropertiesCallbackContext The context that will be included in the callback of desiredPropertiesCallback. May be null.
@@ -331,7 +335,11 @@ public class InternalClient
     /**
      * Start receiving desired property updates for this client. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
-     *
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param desiredPropertiesCallback The callback to execute each time a desired property update message is received
      * from the service. This will contain one or many properties updated at once.
      * @param desiredPropertiesCallbackContext The context that will be included in the callback of desiredPropertiesCallback. May be null.
@@ -520,8 +528,12 @@ public class InternalClient
     }
 
     /**
-     * Subscribes to direct methods
-     *
+     * Subscribes to direct methods.
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param methodCallback Callback on which direct methods shall be invoked. Cannot be {@code null}.
      * @param methodCallbackContext Context for device method callback. Can be {@code null}.
      *
@@ -536,8 +548,12 @@ public class InternalClient
     }
 
     /**
-     * Subscribes to direct methods
-     *
+     * Subscribes to direct methods.
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param methodCallback Callback on which direct methods shall be invoked. Cannot be {@code null}.
      * @param methodCallbackContext Context for device method callback. Can be {@code null}.
      * @param timeoutMilliseconds The maximum number of milliseconds this call will wait for the service to return the twin.
@@ -652,7 +668,11 @@ public class InternalClient
     /**
      * Start receiving desired property updates for this client asynchronously. After subscribing to desired properties, this client can
      * freely send reported property updates and make getTwin calls.
-     *
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param subscriptionAcknowledgedCallback The callback to execute once the service has acknowledged the subscription request.
      * @param desiredPropertiesSubscriptionCallbackContext The context that will be included in the callback of desiredPropertiesSubscriptionCallback. May be null.
      * @param desiredPropertiesCallback The callback to execute each time a desired property update message is received
@@ -846,8 +866,12 @@ public class InternalClient
     }
 
     /**
-     * Subscribes to direct methods
-     *
+     * Subscribes to direct methods.
+     * <p>
+     * This subscription is preserved between reconnect attempts. However, it is not preserved after a client has
+     * been closed because the user called {@link #close()} or because this client lost its connection and its retry
+     * policy was exhausted.
+     * </p>
      * @param methodCallback Callback on which direct methods shall be invoked. Cannot be {@code null}.
      * @param methodCallbackContext Context for device method callback. Can be {@code null}.
      * @param methodStatusCallback Callback for providing IotHub status for direct methods. Cannot be {@code null}.

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -495,7 +495,13 @@ public class ModuleClient extends InternalClient
 
     /**
      * Sets the message callback.
-     *
+     * <p>
+     * This should be set before opening the client. If it is set after opening the client, any messages sent by the
+     * service may be missed.
+     * </p>
+     * <p>
+     * This callback is preserved between reconnection attempts and preserved after re-opening a previously closed client.
+     * </p>
      * @param callback the message callback. Can be {@code null}.
      * @param context the context to be passed to the callback. Can be {@code null}.
      *


### PR DESCRIPTION
twin and methods subscriptions are preserved only through retry whereas c2d callback is preserved even when the client is closed.