### PR TITLE
Added Automatic-Module-Name to jar manifests for Modular Java 

### DIFF
--- a/device/iot-device-client/pom.xml
+++ b/device/iot-device-client/pom.xml
@@ -131,6 +131,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.iot.device.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/provisioning-device-client/pom.xml
+++ b/provisioning/provisioning-device-client/pom.xml
@@ -125,6 +125,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.device.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/provisioning-service-client/pom.xml
+++ b/provisioning/provisioning-service-client/pom.xml
@@ -117,6 +117,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.service.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
+++ b/provisioning/provisioning-tools/provisioning-x509-cert-generator/pom.xml
@@ -51,6 +51,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.x509.cert.generator</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4</version>
                 <executions>

--- a/provisioning/security/dice-provider-emulator/pom.xml
+++ b/provisioning/security/dice-provider-emulator/pom.xml
@@ -111,6 +111,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.dice.provider.emulator</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/security/dice-provider/pom.xml
+++ b/provisioning/security/dice-provider/pom.xml
@@ -80,6 +80,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.dice.provider</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/security/security-provider/pom.xml
+++ b/provisioning/security/security-provider/pom.xml
@@ -101,6 +101,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.security.provider</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/security/tpm-provider-emulator/pom.xml
+++ b/provisioning/security/tpm-provider-emulator/pom.xml
@@ -124,6 +124,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.tpm.provider.emulator</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/security/tpm-provider/pom.xml
+++ b/provisioning/security/tpm-provider/pom.xml
@@ -125,6 +125,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.tpm.provider</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/provisioning/security/x509-provider/pom.xml
+++ b/provisioning/security/x509-provider/pom.xml
@@ -108,6 +108,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.provisioning.x509.provider</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -155,6 +155,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.microsoft.iot.service.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [✓] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [*] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [✓] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
I am building Modular Java 18 apps. When I add one or more of these libraries, it breaks my build because the library does not have a module that I can import. 

# Description of the solution
By adding the Automatic-Module-Name to the jar Manifest, people writing modular Java will still be able to use the libraries without preventing those still on Java 8 from using them.  I have made [this change in other Azure projects](https://github.com/microsoft/ApplicationInsights-Java/pull/2503/files) to allow Modular support. 

*No tests changes were made, because the changes to the build file should not affect the code, only adding a line to the manifests that will allow them to work with Modular Java.