### PR TITLE
fix(iot-serv): Fix serialization of incomplete twin objects

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -92,14 +92,41 @@ public class Twin
         TwinState twinState = new TwinState(json);
 
         Twin twin = new Twin(twinState.getDeviceId());
-        twin.setVersion(twinState.getVersion());
-        twin.setETag(twinState.getETag());
-        twin.setStatus(twinState.getStatus());
-        twin.setStatusUpdateTime(twinState.getStatusUpdatedTime());
-        twin.setConnectionState(twinState.getConnectionState());
-        twin.setLastActivityTime(twinState.getLastActivityTime());
-        twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
 
+        if (twinState.getVersion() != null)
+        {
+            twin.setVersion(twinState.getVersion());
+        }
+
+        if (twinState.getETag() != null)
+        {
+            twin.setETag(twinState.getETag());
+        }
+
+        if (twinState.getStatus() != null)
+        {
+            twin.setStatus(twinState.getStatus());
+        }
+
+        if (twinState.getStatusUpdatedTime() != null)
+        {
+            twin.setStatusUpdateTime(twinState.getStatusUpdatedTime());
+        }
+
+        if (twinState.getConnectionState() != null)
+        {
+            twin.setConnectionState(twinState.getConnectionState());
+        }
+
+        if (twinState.getLastActivityTime() != null)
+        {
+            twin.setLastActivityTime(twinState.getLastActivityTime());
+        }
+
+        if (twinState.getCloudToDeviceMessageCount() != null)
+        {
+            twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
+        }
 
         // Tags
         twin.getTags().setVersion(twinState.getTags().getVersion());
@@ -109,29 +136,35 @@ public class Twin
         }
 
         // Desired properties
-        twin.getDesiredProperties().setVersion(twinState.getDesiredProperties().getVersion());
-        if (twinState.getDesiredProperties().size() > 0)
+        if (twinState.getDesiredProperties() != null)
         {
-            twin.getDesiredProperties().putAll(twinState.getDesiredProperties());
+            twin.getDesiredProperties().setVersion(twinState.getDesiredProperties().getVersion());
+            if (twinState.getDesiredProperties().size() > 0)
+            {
+                twin.getDesiredProperties().putAll(twinState.getDesiredProperties());
+            }
+
+            twin.getDesiredProperties().setTwinMetadata(twinState.getDesiredProperties().getTwinMetadata());
+            if (twinState.getDesiredProperties().getMetadataMap().size() > 0)
+            {
+                twin.getDesiredProperties().getMetadataMap().putAll(twinState.getDesiredProperties().getMetadataMap());
+            }
         }
 
-        twin.getDesiredProperties().setTwinMetadata(twinState.getDesiredProperties().getTwinMetadata());
-        if (twinState.getDesiredProperties().getMetadataMap().size() > 0)
+        if (twinState.getReportedProperties() != null)
         {
-            twin.getDesiredProperties().getMetadataMap().putAll(twinState.getDesiredProperties().getMetadataMap());
-        }
+            // Reported properties
+            twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
+            if (twinState.getReportedProperties().size() > 0)
+            {
+                twin.getReportedProperties().putAll(twinState.getReportedProperties());
+            }
 
-        // Reported properties
-        twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
-        if (twinState.getReportedProperties().size() > 0)
-        {
-            twin.getReportedProperties().putAll(twinState.getReportedProperties());
-        }
-
-        twin.getReportedProperties().setTwinMetadata(twinState.getReportedProperties().getTwinMetadata());
-        if (twinState.getReportedProperties().getMetadataMap().size() > 0)
-        {
-            twin.getReportedProperties().getMetadataMap().putAll(twinState.getReportedProperties().getMetadataMap());
+            twin.getReportedProperties().setTwinMetadata(twinState.getReportedProperties().getTwinMetadata());
+            if (twinState.getReportedProperties().getMetadataMap().size() > 0)
+            {
+                twin.getReportedProperties().getMetadataMap().putAll(twinState.getReportedProperties().getMetadataMap());
+            }
         }
 
         twin.setCapabilities(twinState.getCapabilities());

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -92,41 +92,14 @@ public class Twin
         TwinState twinState = new TwinState(json);
 
         Twin twin = new Twin(twinState.getDeviceId());
+        twin.setVersion(twinState.getVersion());
+        twin.setETag(twinState.getETag());
+        twin.setStatus(twinState.getStatus());
+        twin.setStatusUpdateTime(twinState.getStatusUpdatedTime());
+        twin.setConnectionState(twinState.getConnectionState());
+        twin.setLastActivityTime(twinState.getLastActivityTime());
+        twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
 
-        if (twinState.getVersion() != null)
-        {
-            twin.setVersion(twinState.getVersion());
-        }
-
-        if (twinState.getETag() != null)
-        {
-            twin.setETag(twinState.getETag());
-        }
-
-        if (twinState.getStatus() != null)
-        {
-            twin.setStatus(twinState.getStatus());
-        }
-
-        if (twinState.getStatusUpdatedTime() != null)
-        {
-            twin.setStatusUpdateTime(twinState.getStatusUpdatedTime());
-        }
-
-        if (twinState.getConnectionState() != null)
-        {
-            twin.setConnectionState(twinState.getConnectionState());
-        }
-
-        if (twinState.getLastActivityTime() != null)
-        {
-            twin.setLastActivityTime(twinState.getLastActivityTime());
-        }
-
-        if (twinState.getCloudToDeviceMessageCount() != null)
-        {
-            twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
-        }
 
         // Tags
         twin.getTags().setVersion(twinState.getTags().getVersion());
@@ -199,11 +172,6 @@ public class Twin
     {
         this();
 
-        if (Tools.isNullOrEmpty(deviceId))
-        {
-            throw new IllegalArgumentException("deviceId cannot be null or empty.");
-        }
-
         this.deviceId = deviceId;
     }
 
@@ -217,16 +185,6 @@ public class Twin
     public Twin(String deviceId, String moduleId) throws IllegalArgumentException
     {
         this();
-
-        if (Tools.isNullOrEmpty(deviceId))
-        {
-            throw new IllegalArgumentException("deviceId cannot be null or empty.");
-        }
-
-        if (Tools.isNullOrEmpty(moduleId))
-        {
-            throw new IllegalArgumentException("moduleId cannot be null or empty.");
-        }
 
         this.deviceId = deviceId;
         this.moduleId = moduleId;

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -100,7 +100,6 @@ public class Twin
         twin.setLastActivityTime(twinState.getLastActivityTime());
         twin.setCloudToDeviceMessageCount(twinState.getCloudToDeviceMessageCount());
 
-
         // Tags
         twin.getTags().setVersion(twinState.getTags().getVersion());
         if (twinState.getTags().size() > 0)
@@ -172,6 +171,9 @@ public class Twin
     {
         this();
 
+        // The deviceId field is allowed to be null because users can query twins and filter down to specific fields
+        // such as status. In cases like that, the service doesn't return the deviceId, so we can't throw
+        // an argument exception here if it is null.
         this.deviceId = deviceId;
     }
 
@@ -186,6 +188,9 @@ public class Twin
     {
         this();
 
+        // Both these fields are allowed to be null because users can query twins and filter down to specific fields
+        // such as status. In cases like that, the service doesn't return the deviceId/moduleId, so we can't throw
+        // an argument exception here if they are null.
         this.deviceId = deviceId;
         this.moduleId = moduleId;
     }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/Twin.java
@@ -123,9 +123,9 @@ public class Twin
             }
         }
 
+        // Reported properties
         if (twinState.getReportedProperties() != null)
         {
-            // Reported properties
             twin.getReportedProperties().setVersion(twinState.getReportedProperties().getVersion());
             if (twinState.getReportedProperties().size() > 0)
             {
@@ -312,12 +312,7 @@ public class Twin
      */
     private String tagsToString()
     {
-        StringBuilder thisDeviceTags = new StringBuilder();
-        if (tags != null)
-        {
-            thisDeviceTags.append("Tags: ").append(this.tags.toString()).append("\n");
-        }
-        return thisDeviceTags.toString();
+        return "Tags: " + this.tags.toString() + "\n";
     }
 
     /**
@@ -327,12 +322,7 @@ public class Twin
      */
     private String desiredPropertiesToString()
     {
-        StringBuilder thisDeviceRepProp = new StringBuilder();
-        if (this.desiredProperties != null)
-        {
-            thisDeviceRepProp.append("Desired properties: ").append(this.desiredProperties.toString()).append("\n");
-        }
-        return thisDeviceRepProp.toString();
+        return "Desired properties: " + this.desiredProperties.toString() + "\n";
     }
 
     /**
@@ -342,13 +332,6 @@ public class Twin
      */
     private String reportedPropertiesToString()
     {
-        StringBuilder thisDeviceDesProp = new StringBuilder();
-        if (this.reportedProperties != null)
-        {
-            thisDeviceDesProp.append("Reported properties: ")
-                    .append(this.reportedProperties.toString())
-                    .append("\n");
-        }
-        return thisDeviceDesProp.toString();
+        return "Reported properties: " + this.reportedProperties.toString() + "\n";
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinState.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinState.java
@@ -535,6 +535,11 @@ public class TwinState
      */
     public String getConnectionState()
     {
+        if (this.connectionState == null)
+        {
+            return null;
+        }
+
         return this.connectionState.toString();
     }
 

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinTest.java
@@ -66,29 +66,6 @@ public class TwinTest
     }
 
     /*
-     **Tests_SRS_DEVICETWINDEVICE_25_002: [** The constructor shall throw IllegalArgumentException if the input string is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceEmptyDeviceId()
-    {
-        //arrange
-        final String deviceId = "";
-
-        //act
-        new Twin(deviceId);
-    }
-
-    /*
-     **Tests_SRS_DEVICETWINDEVICE_25_002: [** The constructor shall throw IllegalArgumentException if the input string is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceNullDeviceId()
-    {
-        //act
-        new Twin(null);
-    }
-
-    /*
      **Tests_SRS_DEVICETWINDEVICE_25_003: [** The constructor shall create a new instance of twin object for this device and store the device id.**]**
      */
     @Test
@@ -111,60 +88,6 @@ public class TwinTest
         assertEquals(0, repPropMap.size());
         TwinCollection desPropMap = Deencapsulation.getField(testDevice, "reportedProperties");
         assertEquals(0, desPropMap.size());
-    }
-
-    /*
-     **Tests_SRS_DEVICETWINDEVICE_28__005: [** The constructor shall throw IllegalArgumentException if the deviceId is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceForModuleEmptyDeviceId()
-    {
-        //arrange
-        final String deviceId = "";
-        final String moduleId = "somemodule";
-
-        //act
-        new Twin(deviceId, moduleId);
-    }
-
-    /*
-     **Tests_SRS_DEVICETWINDEVICE_28_005: [** The constructor shall throw IllegalArgumentException if the deviceId is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceForModuleNullDeviceId()
-    {
-        //arrange
-        final String moduleId = "somemodule";
-
-        //act
-        new Twin(null, moduleId);
-    }
-
-    /*
-     **Tests_SRS_DEVICETWINDEVICE_28__006: [** The constructor shall throw IllegalArgumentException if the moduleId is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceForModuleEmptyModuleId()
-    {
-        //arrange
-        final String deviceId = "somedevice";
-        final String moduleId = "";
-
-        //act
-        new Twin(deviceId, moduleId);
-    }
-
-    /*
-     **Tests_SRS_DEVICETWINDEVICE_28_006: [** The constructor shall throw IllegalArgumentException if the moduleId is empty or null.**]**
-     */
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorCreatesNewDeviceForModuleNullModuleId()
-    {
-        //arrange
-        final String deviceId = "somedevice";
-
-        //act
-        new Twin(deviceId, null);
     }
 
     /*

--- a/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinTest.java
+++ b/service/iot-service-client/src/test/java/com/microsoft/azure/sdk/iot/service/twin/TwinTest.java
@@ -660,4 +660,32 @@ public class TwinTest
         //assert
         assertEquals(expectedModuleId, Deencapsulation.getField(testTwin, "moduleId"));
     }
+
+
+    // Twins returned by the service as query results won't necessarily have any particular field since a query
+    // can filter on any field like status. This checks that we can still deserialize a twin even when it has no
+    // device Id or when it only has a device Id
+    @Test
+    public void nullValueParsingWorks()
+    {
+        Twin twin = Twin.fromJson("{\"deviceId\":\"someDeviceId\"}");
+        assertNull(twin.getETag());
+        assertNull(twin.getConnectionState());
+        assertNull(twin.getModuleId());
+        assertNull(twin.getCloudToDeviceMessageCount());
+        assertNull(twin.getLastActivityTime());
+        assertNull(twin.getStatus());
+        assertNull(twin.getVersion());
+        assertNotNull(twin.getDeviceId());
+
+        twin = Twin.fromJson("{\"status\":\"enabled\"}");
+        assertNull(twin.getETag());
+        assertNull(twin.getConnectionState());
+        assertNull(twin.getModuleId());
+        assertNull(twin.getCloudToDeviceMessageCount());
+        assertNull(twin.getLastActivityTime());
+        assertNull(twin.getVersion());
+        assertNull(twin.getDeviceId());
+        assertNotNull(twin.getStatus());
+    }
 }


### PR DESCRIPTION
There were some missing null checks and some unnecessary argument-not-null assertions in our twin parsing logic that breaks the ability to query twins with fields filtered down to just one or two fields.

#1611 