### PR TITLE
fix(prov-dev): Fix bug in failed and disabled statuses during device provisioning

### DIFF
--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
@@ -249,7 +249,7 @@ public class ProvisioningTask implements Callable<Object>
                     this.dpsStatus = PROVISIONING_DEVICE_STATUS_FAILED;
                     String errorMessage = statusRegistrationOperationStatusParser.getRegistrationState().getErrorMessage();
                     ProvisioningDeviceHubException dpsHubException = new ProvisioningDeviceHubException(errorMessage);
-                    dpsHubException.setErrorCode(registrationOperationStatusParser.getRegistrationState().getErrorCode());
+                    dpsHubException.setErrorCode(statusRegistrationOperationStatusParser.getRegistrationState().getErrorCode());
                     registrationInfo = new RegistrationResult(null, null, null, PROVISIONING_DEVICE_STATUS_FAILED);
                     log.error("Device provisioning service failed to provision the device, finished with status FAILED: {}", errorMessage);
                     this.invokeRegistrationCallback(registrationInfo, dpsHubException);
@@ -259,7 +259,7 @@ public class ProvisioningTask implements Callable<Object>
                     this.dpsStatus = PROVISIONING_DEVICE_STATUS_DISABLED;
                     String disabledErrorMessage = statusRegistrationOperationStatusParser.getRegistrationState().getErrorMessage();
                     dpsHubException = new ProvisioningDeviceHubException(disabledErrorMessage);
-                    dpsHubException.setErrorCode(registrationOperationStatusParser.getRegistrationState().getErrorCode());
+                    dpsHubException.setErrorCode(statusRegistrationOperationStatusParser.getRegistrationState().getErrorCode());
                     registrationInfo = new RegistrationResult(null, null, null, PROVISIONING_DEVICE_STATUS_DISABLED);
                     log.error("Device provisioning service failed to provision the device, finished with status DISABLED: {}", disabledErrorMessage);
                     this.invokeRegistrationCallback(registrationInfo, dpsHubException);


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
ProvisioningTask.executeStateMachineForStatus() method doesn't handle switch from Assigning to Failed/Disabled status during device registration.
registrationOperationStatusParser.getRegistrationState() object is used to read error code while this object is null and causes NPE, as the result registration stuck in Assigning status.

# Description of the solution
statusRegistrationOperationStatusParser object is updated in Assigning status and contains required information.
After changing registrationOperationStatusParser.getRegistrationState() to statusRegistrationOperationStatusParser.getRegistrationState(), failed and disabled statuses are reported correctly and ProvisioningTask invokes registration callback with expected exception.