### PR TITLE
fix(prov-dev): Fix bug in failed and disabled statuses during device provisioning

### DIFF
--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTaskTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTaskTest.java
@@ -254,6 +254,8 @@ public class ProvisioningTaskTest
                 result = mockedDeviceRegistrationResultParser;
                 mockedDeviceRegistrationResultParser.getErrorMessage();
                 result = "Test Error Message";
+                mockedDeviceRegistrationResultParser.getErrorCode();
+                result = null;
                 Deencapsulation.newInstance(RegistrationResult.class, new Class[] {String.class, String.class, String.class, ProvisioningDeviceClientStatus.class},
                         any, any, any, PROVISIONING_DEVICE_STATUS_DISABLED);
                 result = mockedRegistrationData;


### PR DESCRIPTION
If the provisioning ended with status DISABLED or FAILED, the SDK previously attempted to to assign a null Integer value (registrationOperationStatusParser.getRegistrationState().getErrorCode()) to the primitive int type used by dpsHubException.setErrorCode(...)

Assigning a null Integer value to the primitive int type caused the ProvisioningTask thread to throw an NPE. As a result, the provisioning state machine stayed locked in ASSIGNING perpetually even though the SDK received the terminal DISABLED/FAILED state from the service.

Co-authored by @sokolowski-daniel 

Thanks to #1640 for pointing out this bug and for providing the fix