### PR TITLE
fix(iot-dev): Fix bug caused by unclearing correlationCallbacks map

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -33,7 +33,7 @@ public class IotHubTransport implements IotHubListener
 {
     private static final int DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
 
-    private static final int DEFAULT_CORRELATION_ID_LIVE_TIME = 30000;
+    private static final int DEFAULT_CORRELATION_ID_LIVE_TIME = 20000;
 
     // For tracking the state of this layer in particular. If multiplexing, this value may be CONNECTED while a
     // device specific state is DISCONNECTED_RETRYING. If this state is DISCONNECTED_RETRYING, then the multiplexed

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -117,9 +117,6 @@ public class IotHubTransport implements IotHubListener
     private final Map<String, CorrelatingMessageCallback> correlationCallbacks = new ConcurrentHashMap<>();
     private final Map<String, Object> correlationCallbackContexts = new ConcurrentHashMap<>();
 
-    // Used to store the number of milliseconds since epoch that this packet was created for a correlationId
-    private final Map<String, Long> correlationStartTimeMillis = new ConcurrentHashMap<>();
-
     /**
      * Constructor for an IotHubTransport object with default values
      *
@@ -1178,7 +1175,6 @@ public class IotHubTransport implements IotHubListener
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
                         correlationCallbacks.remove(correlationId);
                         correlationCallbackContexts.remove(correlationId);
-                        correlationStartTimeMillis.remove(correlationId);
                     }
                 }
                 catch (Exception ex)
@@ -1820,7 +1816,6 @@ public class IotHubTransport implements IotHubListener
                     if (!correlationId.isEmpty() && correlationCallback != null)
                     {
                         correlationCallbacks.put(correlationId, correlationCallback);
-                        correlationStartTimeMillis.put(correlationId, System.currentTimeMillis());
 
                         Object correlationCallbackContext = message.getCorrelatingMessageCallbackContext();
                         if (correlationCallbackContext != null)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -736,7 +736,7 @@ public class IotHubTransport implements IotHubListener
     public void sendMessages()
     {
         checkForExpiredMessages();
-        checkForOldMessages();
+        //checkForOldMessages();
 
         if (this.connectionStatus == IotHubConnectionStatus.DISCONNECTED
                 || this.connectionStatus == IotHubConnectionStatus.DISCONNECTED_RETRYING)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -727,12 +727,7 @@ public class IotHubTransport implements IotHubListener
     public void sendMessages()
     {
         checkForExpiredMessages();
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                checkForOldMessages();
-            }
-        }).start();
+        new Thread(() -> checkForOldMessages()).start();
 
         if (this.connectionStatus == IotHubConnectionStatus.DISCONNECTED
                 || this.connectionStatus == IotHubConnectionStatus.DISCONNECTED_RETRYING)
@@ -1207,13 +1202,11 @@ public class IotHubTransport implements IotHubListener
 
                         // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
-                        new Thread(new Runnable() {
-                            @Override
-                            public void run() {
-                                correlationCallbacks.remove(correlationId);
-                                correlationCallbackContexts.remove(correlationId);
-                                correlationStartTimeMillis.remove(correlationId);
-                            }
+                        new Thread(() ->
+                        {
+                            correlationCallbacks.remove(correlationId);
+                            correlationCallbackContexts.remove(correlationId);
+                            correlationStartTimeMillis.remove(correlationId);
                         }).start();
                     }
                 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1198,13 +1198,12 @@ public class IotHubTransport implements IotHubListener
                         {
                             Object context = correlationCallbackContexts.get(correlationId);
                             callback.onResponseAcknowledged(receivedMessage, context);
-
-                            correlationCallbackContexts.remove(correlationId);
                         }
 
                         // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
                         correlationCallbacks.remove(correlationId);
+                        correlationCallbackContexts.remove(correlationId);
                         correlationStartTimeMillis.remove(correlationId);
                     }
                 }

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -727,7 +727,7 @@ public class IotHubTransport implements IotHubListener
     public void sendMessages()
     {
         checkForExpiredMessages();
-        //checkForOldMessages();
+        checkForOldMessages();
 
         if (this.connectionStatus == IotHubConnectionStatus.DISCONNECTED
                 || this.connectionStatus == IotHubConnectionStatus.DISCONNECTED_RETRYING)
@@ -1202,9 +1202,9 @@ public class IotHubTransport implements IotHubListener
 
                         // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
-//                        correlationCallbacks.remove(correlationId);
-//                        correlationCallbackContexts.remove(correlationId);
-//                        correlationStartTimeMillis.remove(correlationId);
+                        correlationCallbacks.remove(correlationId);
+                        correlationCallbackContexts.remove(correlationId);
+                        correlationStartTimeMillis.remove(correlationId);
                     }
                 }
                 catch (Exception ex)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1202,9 +1202,9 @@ public class IotHubTransport implements IotHubListener
 
                         // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
-                        correlationCallbacks.remove(correlationId);
-                        correlationCallbackContexts.remove(correlationId);
-                        correlationStartTimeMillis.remove(correlationId);
+//                        correlationCallbacks.remove(correlationId);
+//                        correlationCallbackContexts.remove(correlationId);
+//                        correlationStartTimeMillis.remove(correlationId);
                     }
                 }
                 catch (Exception ex)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -732,7 +732,7 @@ public class IotHubTransport implements IotHubListener
             public void run() {
                 checkForOldMessages();
             }
-        });
+        }).start();
 
         if (this.connectionStatus == IotHubConnectionStatus.DISCONNECTED
                 || this.connectionStatus == IotHubConnectionStatus.DISCONNECTED_RETRYING)
@@ -1214,7 +1214,7 @@ public class IotHubTransport implements IotHubListener
                                 correlationCallbackContexts.remove(correlationId);
                                 correlationStartTimeMillis.remove(correlationId);
                             }
-                        });
+                        }).start();
                     }
                 }
                 catch (Exception ex)

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1166,6 +1166,10 @@ public class IotHubTransport implements IotHubListener
                     {
                         CorrelatingMessageCallback callback = correlationCallbacks.get(correlationId);
 
+                        // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
+                        // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
+                        correlationCallbacks.remove(correlationId);
+
                         if (callback != null)
                         {
                             Object context = correlationCallbackContexts.get(correlationId);

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -33,7 +33,7 @@ public class IotHubTransport implements IotHubListener
 {
     private static final int DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
 
-    private static final int DEFAULT_CORRELATION_ID_LIVE_TIME = 60000;
+    private static final int DEFAULT_CORRELATION_ID_LIVE_TIME = 30000;
 
     // For tracking the state of this layer in particular. If multiplexing, this value may be CONNECTED while a
     // device specific state is DISCONNECTED_RETRYING. If this state is DISCONNECTED_RETRYING, then the multiplexed


### PR DESCRIPTION
Bug fix for issue #1629 

Currently we are never clearing the `correlationCallbacks` map in "IotHubTransport" class, even after the acknowledgement for received cloud to device message has been sent back to the hub. As a result, the size of map will grow endlessly which will result in OutOfMemory Error eventually. 