### PR TITLE
Upgrade netty-codec version to 4.1.86.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.77.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.86.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,16 +195,16 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.1.2</iot-device-client-version>
-        <iot-service-client-version>2.1.4</iot-service-client-version>
-        <provisioning-device-client-version>2.0.2</provisioning-device-client-version>
-        <provisioning-service-client-version>2.0.1</provisioning-service-client-version>
-        <security-provider-version>2.0.0</security-provider-version>
-        <tpm-provider-emulator-version>2.0.0</tpm-provider-emulator-version>
-        <tpm-provider-version>2.0.0</tpm-provider-version>
-        <dice-provider-emulator-version>2.0.0</dice-provider-emulator-version>
-        <dice-provider-version>2.0.0</dice-provider-version>
-        <x509-provider-version>2.0.1</x509-provider-version>
+        <iot-device-client-version>2.1.3</iot-device-client-version>
+        <iot-service-client-version>2.1.5</iot-service-client-version>
+        <provisioning-device-client-version>2.0.3</provisioning-device-client-version>
+        <provisioning-service-client-version>2.0.2</provisioning-service-client-version>
+        <security-provider-version>2.0.1</security-provider-version>
+        <tpm-provider-emulator-version>2.0.1</tpm-provider-emulator-version>
+        <tpm-provider-version>2.0.1</tpm-provider-version>
+        <dice-provider-emulator-version>2.0.1</dice-provider-emulator-version>
+        <dice-provider-version>2.0.1</dice-provider-version>
+        <x509-provider-version>2.0.2</x509-provider-version>
     </properties>
     <reporting>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.77.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.86.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.0.24</version> <!--e2e tests and samples only-->
+                <version>1.0.26</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.77.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.86.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/vsts/release/package-maven-artifacts-for-release.ps1
+++ b/vsts/release/package-maven-artifacts-for-release.ps1
@@ -106,10 +106,13 @@ function PackageArtifacts($Sources, $Tools, $Output) {
 
             # copy notice file to temp folder
 
-            Copy-Item "LICENSE.txt" $job.Resources
-            Copy-Item "thirdpartynotice.txt" $job.Resources
-
             Set-Location $job.Source  # set current directory to the folder mvn expects for build and package
+
+            $licensePath = Join-Path $Sources "LICENSE.txt"
+            $thirdPartyNoticePath = Join-Path $Sources "thirdpartynotice.txt"
+
+            Copy-Item $licensePath $job.Resources
+            Copy-Item $thirdPartyNoticePath $job.Resources
 
             mvn package -DskipTests -T 2C # Attempt to package
             TestLastExitCode


### PR DESCRIPTION
netty-codec (v.4.1.77.Final) doesn't have ValueValidator in DefaultHeaders class, so the version needs to be upgraded to 4.1.86.Final.

error message from PR (https://github.com/Azure/azure-iot-sdk-java/pull/1645)
![image](https://user-images.githubusercontent.com/113465132/210643823-c8c9dc70-7df1-4b73-84e0-7f35626a52fc.png)
