### PR TITLE
fix(iot-serv): fix replace call on TwinClient

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinClient.java
@@ -321,11 +321,11 @@ public final class TwinClient
         URL url;
         if (twin.getModuleId() == null || twin.getModuleId().length() == 0)
         {
-            url = this.iotHubConnectionString.getUrlTwin(twin.getDeviceId());
+            url = IotHubConnectionString.getUrlTwin(this.hostName, twin.getDeviceId());
         }
         else
         {
-            url = this.iotHubConnectionString.getUrlModuleTwin(twin.getDeviceId(), twin.getModuleId());
+            url = IotHubConnectionString.getUrlModuleTwin(this.hostName, twin.getDeviceId(), twin.getModuleId());
         }
 
         TwinState twinState = new TwinState(twin.getTags(), twin.getDesiredProperties(), null);


### PR DESCRIPTION
For issue https://github.com/Azure/azure-iot-sdk-java/issues/1657

Currently, request URL within a "replace" call cannot be created properly while initiating a `TwinClient` with `AzureSasCredential`.