### PR TITLE
release(2023-1-23): bump package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.1.3</iot-device-client-version>
-        <iot-service-client-version>2.1.5</iot-service-client-version>
+        <iot-device-client-version>2.1.4</iot-device-client-version>
+        <iot-service-client-version>2.1.6</iot-service-client-version>
         <provisioning-device-client-version>2.0.3</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.2</provisioning-service-client-version>
         <security-provider-version>2.0.1</security-provider-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.1.4)

### Bug fixes
- Fix bug where correlationCallbacks map was not cleared properly and causing OutOfMemory #1647

## Java IotHub Service Client (com.microsoft.azure.sdk.iot:iot-service-client:2.1.6)

### Bug fixes
- Fix bug where replace method did not work while initiating TwinClient with AzureSasCredential #1658