### PR TITLE
fix(e2e): Fix test bug where x509 authentication certs were given to SAS  authenticated devices

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/HubTierConnectionTests.java
@@ -94,10 +94,9 @@ public class HubTierConnectionTests extends IntegrationTest
         hostName = IotHubConnectionStringBuilder.createIotHubConnectionString(iotHubConnectionString).getHostName();
         SSLContext sslContext = SSLContextBuilder.buildSSLContext(x509CertificateGenerator.getX509Certificate(), x509CertificateGenerator.getPrivateKey());
 
-        ClientOptions options = ClientOptions.builder().sslContext(sslContext).build();
+        ClientOptions x509ClientOptions = ClientOptions.builder().sslContext(sslContext).build();
 
         Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-        ClientOptions optionsWithProxy = ClientOptions.builder().proxySettings((new ProxySettings(testProxy, testProxyUser, testProxyPass))).build();
 
         return new ArrayList(Arrays.asList(
                 new Object[][]
@@ -107,10 +106,10 @@ public class HubTierConnectionTests extends IntegrationTest
                                 {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS), AMQPS_WS, device, SAS, false},
 
                                 //x509 device client
-                                {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, options), AMQPS, deviceX509, SELF_SIGNED, false},
+                                {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, deviceX509), AMQPS, x509ClientOptions), AMQPS, deviceX509, SELF_SIGNED, false},
 
                                 //sas token device client, with proxy
-                                {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS, options), AMQPS_WS, device, SAS, true}
+                                {new DeviceClient(DeviceConnectionString.get(iotHubConnectionString, device), AMQPS_WS, x509ClientOptions), AMQPS_WS, device, SAS, true}
                         }
         ));
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/setup/SendMessagesCommon.java
@@ -208,7 +208,16 @@ public class SendMessagesCommon extends IntegrationTest
 
         public void setup() throws Exception
         {
-            SSLContext sslContext = SSLContextBuilder.buildSSLContext(x509CertificateGenerator.getX509Certificate(), x509CertificateGenerator.getPrivateKey());
+            // Builds an SSL context instance that trusts the certs on the device's certificate store
+            // and has no private keys
+            SSLContext sslContext = SSLContextBuilder.buildSSLContext();
+            if (testInstance.authenticationType == SELF_SIGNED)
+            {
+                // Builds an SSL context instance that trusts the certs on the device's certifiate store
+                // and also has a private key + public cert specific to this device identity
+                sslContext = SSLContextBuilder.buildSSLContext(x509CertificateGenerator.getX509Certificate(), x509CertificateGenerator.getPrivateKey());
+            }
+
             setup(sslContext);
         }
 


### PR DESCRIPTION
This didn't cause any issues as far as I can tell, but we shouldn't be including private keys on device identities who don't use x509 authentication