### PR TITLE
Fix some issues with the build gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,11 @@ package-list
 /iot-e2e-tests/android/.idea/*
 /iothub/device/iot-device-samples/android-sample/app/.idea/*
 /iot-e2e-tests/android/app/.idea/*
+
+**/jquery/*
+**/package-search-index.zip
+**/member-search-index.zip
+**/type-search-index.zip
+**/element-list
+**/x.png
+**/glass.png

--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -204,6 +204,20 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
+                <configuration>
+                    <!--
+                    For some reason, this build will attempt to run the e2e tests as part of the
+                    maven failsafe plugin (which is expected) and then again as part of the maven
+                    surefire plugin (which is not expected). Adding this hardcoded "don't run
+                    tests in this module with the surefire plugin" seems to resolve this issue, though.
+                    -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4</version>
                 <executions>

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ClientToProxyConnection.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ClientToProxyConnection.java
@@ -473,7 +473,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest>
         }
 
         protected Future<?> execute() {
-            log.info("Responding to proxy connect request with successful status code");
+            log.trace("Responding to proxy connect request with successful status code");
             HttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1,
                     CONNECTION_ESTABLISHED);
             response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/RerunFailedTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/RerunFailedTestRule.java
@@ -1,6 +1,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.helpers.rules;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -29,23 +30,33 @@ public class RerunFailedTestRule implements TestRule
         @Override
         public void evaluate() throws Throwable
         {
-            for (int i = 0; i < NUMBER_OF_RETRIES; i++)
+            int attempt = 0;
+            while (true)
             {
                 try
                 {
+                    attempt++;
                     base.evaluate();
                     return; // if the test passes, no need to rerun the test
                 }
+                catch (AssumptionViolatedException e)
+                {
+                    // This exception is thrown when an assumption isn't satisfied (for instance,
+                    // "assumeTrue(protocol == HTTPS)" when protocol is AMQPS). In cases like these,
+                    // there is no need to rerun as the test should be skipped. JUnit understands that
+                    // a thrown AssumptionViolatedException means that the test was successfully skipped.
+                    throw e;
+                }
                 catch (Throwable e)
                 {
-                    if (i == NUMBER_OF_RETRIES - 1)
+                    if (attempt >= NUMBER_OF_RETRIES)
                     {
                         log.info("Test failed on final rerun. Not rerunning this test anymore");
                         throw e;
                     }
                     else
                     {
-                        log.info("Test failed on run {} with error {}. Rerunning the test.", i, e.getMessage());
+                        log.info("Test failed on run {} with error {}. Rerunning the test.", attempt, e.getMessage());
                     }
                 }
             }

--- a/iot-e2e-tests/common/src/test/resources/log4j2.properties
+++ b/iot-e2e-tests/common/src/test/resources/log4j2.properties
@@ -20,7 +20,7 @@ logger.testproxy.level = INFO
 
 # Log test logs at this level
 logger.tests.name = tests.integration.com.microsoft.azure.sdk.iot
-logger.tests.level = TRACE
+logger.tests.level = DEBUG
 
 logger.sdk.name = com.microsoft.azure.sdk.iot
 logger.sdk.level = INFO

--- a/vsts/build_e2e_tests.cmd
+++ b/vsts/build_e2e_tests.cmd
@@ -9,4 +9,4 @@ for %%i in ("%build-root%") do set build-root=%%~fi
 
 @REM -- E2E Test Build --
 cd %build-root%
-mvn -Dmaven.javadoc.skip=true --projects :iot-e2e-common --also-make clean install -DskipTests
+mvn -Dmaven.javadoc.skip=true --projects :iot-e2e-common --also-make clean install -DskipTests --batch-mode -q

--- a/vsts/build_repo.ps1
+++ b/vsts/build_repo.ps1
@@ -21,17 +21,17 @@ if (($env:JAVA_VERSION).equals("8"))
     if ($isPullRequestBuild.equals("true"))
     {
         Write-Host "Skipping e2e tests since only Java 11 runs e2e tests during a pull request build"
-        mvn install -DskipIntegrationTests -DskipTests -T 2C
+        mvn install -DskipIntegrationTests -DskipTests -T 2C --batch-mode -q
     }
     else
     {
-        mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C
+        mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C --batch-mode -q
     }
 }
 elseif (($env:JAVA_VERSION).equals("11"))
 {
     $env:JAVA_HOME=$env:JAVA_HOME_11_X64
-    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C -DskipUnitTests=true
+    mvn -DRUN_PROVISIONING_TESTS="$Env:runProvisioningTests" -DRUN_DIGITAL_TESTS="$Env:runDigitalTwinTests" -DRUN_IOTHUB_TESTS="$Env:runIotHubTests" -DIS_PULL_REQUEST="$isPullRequestBuild" install -T 2C -DskipUnitTests --batch-mode -q
 }
 # Leaving this commented out to make it easy to add Java 17 support later
 #elseif (($env:JAVA_VERSION).equals("17"))

--- a/vsts/release/package-maven-artifacts-for-release.ps1
+++ b/vsts/release/package-maven-artifacts-for-release.ps1
@@ -95,7 +95,7 @@ function PackageArtifacts($Sources, $Tools, $Output) {
 
         Set-Location $Sources
 
-        mvn clean install -DskipTests -T 2C # Attempt to build
+        mvn clean install -DskipTests -T 2C  --batch-mode -q # Attempt to build
         TestLastExitCode
 
         foreach ($job in $jobs) {

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -61,7 +61,7 @@ jobs:
       toolVersion: 'Latest'
       sourceCodeDirectory: '$(Build.SourcesDirectory)'
       language: 'java'
-      buildCommandsString: 'mvn clean install -DskipTests -T 2C'
+      buildCommandsString: 'mvn clean install -DskipTests -T 2C --batch-mode -q'
       querySuite: 'Recommended'
       timeout: '1800'
       ram: '16384'

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -17,7 +17,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: 1
+      maxParallel: 2
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
@@ -118,7 +118,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     displayName: Linux
     strategy:
-      maxParallel: 1
+      maxParallel: 2
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11


### PR DESCRIPTION
- Fix issue where e2e tests were run __twice__ (once by failsafe plugin in parallel, once by surefire plugin in serial)
  - This issue does not repro locally, so I'm not sure why this is happening, but this fix works locally and for the gate 
- Fix issue where rerun test rule didn't account for tests throwing AssumptionViolatedException
- Fix issue where mvn commands were very noisy
- Fix issue where a test proxy log statement that happens a lot was the wrong verbosity
- Allow JDK 11 and 8 builds to run in parallel
  - For PR builds, this is safe because we only run e2e tests on JDK 11. No need to worry about overloading the service
  - For CI/Nightly builds, this may be too much for the service to handle, but I'll keep an eye on that and we can revert this if needed

These changes combined will reduce the gate build time drastically and make it easier to read build logs.