### PR TITLE
fix(e2e): fix some CI tests

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1369,6 +1369,8 @@ public class MultiplexingClientTests extends IntegrationTest
         boolean expectedExceptionThrown = false;
         try
         {
+            // Note that we are opting to not retry on open because the first attempt should result in the caught
+            // exception below.
             testInstance.multiplexingClient.open(false);
         }
         catch (MultiplexingClientRegistrationException e)
@@ -1479,6 +1481,8 @@ public class MultiplexingClientTests extends IntegrationTest
         boolean expectedExceptionThrown = false;
         try
         {
+            // Note that we are opting to not retry on open because the first attempt should result in the caught
+            // exception below.
             testInstance.multiplexingClient.open(false);
         }
         catch (MultiplexingClientRegistrationException e)

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -1369,7 +1369,7 @@ public class MultiplexingClientTests extends IntegrationTest
         boolean expectedExceptionThrown = false;
         try
         {
-            testInstance.multiplexingClient.open(true);
+            testInstance.multiplexingClient.open(false);
         }
         catch (MultiplexingClientRegistrationException e)
         {
@@ -1469,7 +1469,7 @@ public class MultiplexingClientTests extends IntegrationTest
             else
             {
                 incorrectConnectionString = Tools.getDeviceConnectionString(iotHubConnectionString, testInstance.deviceIdentityArray.get(i+1));
-                incorrectConnectionString =incorrectConnectionString.replace(testInstance.deviceIdentityArray.get(i+1).getDeviceId(), testInstance.deviceIdentityArray.get(i).getDeviceId());
+                incorrectConnectionString = incorrectConnectionString.replace(testInstance.deviceIdentityArray.get(i+1).getDeviceId(), testInstance.deviceIdentityArray.get(i).getDeviceId());
             }
             DeviceClient clientWithIncorrectCredentials = new DeviceClient(incorrectConnectionString, testInstance.protocol);
             clientsWithIncorrectCredentials.add(clientWithIncorrectCredentials);
@@ -1479,7 +1479,7 @@ public class MultiplexingClientTests extends IntegrationTest
         boolean expectedExceptionThrown = false;
         try
         {
-            testInstance.multiplexingClient.open(true);
+            testInstance.multiplexingClient.open(false);
         }
         catch (MultiplexingClientRegistrationException e)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/telemetry/SendMessagesTests.java
@@ -142,20 +142,9 @@ public class SendMessagesTests extends SendMessagesCommon
     @ContinuousIntegrationTest
     public void sendLargestMessages() throws Exception
     {
-        // Only HTTP supports batching messages
-        assumeTrue(this.testInstance.protocol == HTTPS);
-
-        this.testInstance.setup();
-
-        int count = 5;
-        List<Message> messages = new ArrayList<>(count);
-        for (int i = 0; i < count; i++)
-        {
-            messages.add(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE]));
-        }
-
+        testInstance.setup();
         testInstance.identity.getClient().open(true);
-        testInstance.identity.getClient().sendEvents(messages);
+        testInstance.identity.getClient().sendEvent(new Message(new byte[MAX_MESSAGE_PAYLOAD_SIZE]));
         testInstance.identity.getClient().close();
     }
 


### PR DESCRIPTION
SendLargestMessage was never supposed to build a batch message of multiple max-sized messages. It was just supposed to be one max sized message

The mux tests here should not retry on open because they expect to throw an exception