### PR TITLE
Refactor/Simplify some device provisioning tests

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/ProvisioningTests.java
@@ -45,7 +45,8 @@ public class ProvisioningTests extends ProvisioningCommon
     @ContinuousIntegrationTest
     public void individualEnrollmentRegistration() throws Exception
     {
-        basicRegistrationFlow(EnrollmentType.INDIVIDUAL);
+        testInstance.securityProvider = getSecurityProviderInstance(EnrollmentType.INDIVIDUAL);
+        registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpoint);
     }
 
     @Test
@@ -56,14 +57,15 @@ public class ProvisioningTests extends ProvisioningCommon
         assumeTrue("Skipping this test because only Symmetric Key attestion can be tested for enrollment groups",
             this.testInstance.attestationType == AttestationType.SYMMETRIC_KEY);
 
-        basicRegistrationFlow(EnrollmentType.GROUP);
+        testInstance.securityProvider = getSecurityProviderInstance(EnrollmentType.GROUP);
+        registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpoint);
     }
 
     @Test
     @ContinuousIntegrationTest
     public void individualEnrollmentWithInvalidRemoteServerCertificateFails() throws Exception
     {
-        Assume.assumeTrue(Tools.isLinux());
+        Assume.assumeTrue("Test infrastructure is only setup to run this test on Linux", Tools.isLinux());
         enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType.INDIVIDUAL);
     }
 
@@ -71,7 +73,7 @@ public class ProvisioningTests extends ProvisioningCommon
     @ContinuousIntegrationTest
     public void groupEnrollmentWithInvalidRemoteServerCertificateFails() throws Exception
     {
-        Assume.assumeTrue(Tools.isLinux());
+        Assume.assumeTrue("Test infrastructure is only setup to run this test on Linux", Tools.isLinux());
         enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType.GROUP);
     }
 
@@ -107,13 +109,8 @@ public class ProvisioningTests extends ProvisioningCommon
         assumeFalse("Skipping test because it is being run on Android", Tools.isAndroid());
 
         testInstance.certificateAlgorithm = X509CertificateGenerator.CertificateAlgorithm.ECC;
-        basicRegistrationFlow(EnrollmentType.INDIVIDUAL);
-    }
-
-    private void basicRegistrationFlow(EnrollmentType enrollmentType) throws Exception
-    {
-        testInstance.securityProvider = getSecurityProviderInstance(enrollmentType);
-        registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpoint, false, null, null, null);
+        testInstance.securityProvider = getSecurityProviderInstance(EnrollmentType.INDIVIDUAL);
+        registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpoint);
     }
 
     private void enrollmentWithInvalidRemoteServerCertificateFails(EnrollmentType enrollmentType) throws Exception
@@ -128,7 +125,7 @@ public class ProvisioningTests extends ProvisioningCommon
         // Register identity
         try
         {
-            registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpointWithInvalidCert, false, null, null, null);
+            registerDevice(testInstance.protocol, testInstance.securityProvider, provisioningServiceGlobalEndpointWithInvalidCert);
         }
         catch (Exception | AssertionError e)
         {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -20,8 +20,6 @@ import com.microsoft.azure.sdk.iot.provisioning.security.hsm.SecurityProviderX50
 import com.microsoft.azure.sdk.iot.provisioning.service.ProvisioningServiceClient;
 import com.microsoft.azure.sdk.iot.provisioning.service.configs.*;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientException;
-import com.microsoft.azure.sdk.iot.service.registry.RegistryClient;
-import com.microsoft.azure.sdk.iot.service.registry.RegistryClientOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
@@ -138,8 +136,6 @@ public class ProvisioningCommon extends IntegrationTest
 
     public static final int MAX_TPM_CONNECT_RETRY_ATTEMPTS = 10;
 
-    public RegistryClient registryClient = null;
-
     public ProvisioningCommon(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
     {
         this.testInstance = new ProvisioningTestInstance(protocol, attestationType);
@@ -177,16 +173,12 @@ public class ProvisioningCommon extends IntegrationTest
     @Before
     public void setUp() throws Exception
     {
-        registryClient = new RegistryClient(iotHubConnectionString, RegistryClientOptions.builder().httpReadTimeoutSeconds(HTTP_READ_TIMEOUT).build());
-
         this.testInstance = new ProvisioningTestInstance(this.testInstance.protocol, this.testInstance.attestationType);
     }
 
     @After
     public void tearDown()
     {
-        registryClient = null;
-
         if (testInstance != null && testInstance.securityProvider != null && testInstance.securityProvider instanceof SecurityProviderTPMEmulator)
         {
             try

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/provisioning/setup/ProvisioningCommon.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import com.microsoft.azure.sdk.iot.provisioning.device.*;
 import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceClientException;
+import com.microsoft.azure.sdk.iot.provisioning.device.internal.exceptions.ProvisioningDeviceHubException;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderTpm;
@@ -21,33 +22,22 @@ import com.microsoft.azure.sdk.iot.provisioning.service.configs.*;
 import com.microsoft.azure.sdk.iot.provisioning.service.exceptions.ProvisioningServiceClientException;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClient;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClientOptions;
-import junit.framework.AssertionFailedError;
 import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.bouncycastle.util.io.pem.PemObject;
-import org.bouncycastle.util.io.pem.PemReader;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.*;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.security.Key;
-import java.security.Security;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
+import java.security.*;
 import java.security.cert.X509Certificate;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.microsoft.azure.sdk.iot.provisioning.device.ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_ASSIGNED;
 import static junit.framework.TestCase.fail;
@@ -62,7 +52,45 @@ public class ProvisioningCommon extends IntegrationTest
     public static Collection inputs()
     {
         getEnvironmentVariables();
-        return inputsCommon();
+
+        // Intentionally not doing TPM tests here. There is a separate class for running those
+        // tests in serial
+        return Arrays.asList(
+            new Object[][]
+                {
+                    {ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.X509},
+                    {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.X509},
+                    {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.X509},
+
+                    {ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.SYMMETRIC_KEY},
+                    {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.SYMMETRIC_KEY},
+                    {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.SYMMETRIC_KEY},
+                });
+    }
+
+    // Called from android runner to only run this test suite for a particular attestation type
+    public static Collection inputs(AttestationType attestationType)
+    {
+        getEnvironmentVariables();
+
+        if (attestationType == AttestationType.SYMMETRIC_KEY || attestationType == AttestationType.X509)
+        {
+            return Arrays.asList(
+                new Object[][]
+                    {
+                        {ProvisioningDeviceClientTransportProtocol.HTTPS, attestationType},
+                        {ProvisioningDeviceClientTransportProtocol.AMQPS, attestationType},
+                        {ProvisioningDeviceClientTransportProtocol.MQTT, attestationType},
+                    });
+        }
+        else if (attestationType == AttestationType.TPM)
+        {
+            return Collections.emptyList(); // TPM tests are run in the ProvisioningTPMTests file so they can be run in serial
+        }
+        else
+        {
+            throw new IllegalArgumentException("Unknown attestation type provided");
+        }
     }
 
     private static void getEnvironmentVariables()
@@ -74,13 +102,6 @@ public class ProvisioningCommon extends IntegrationTest
         provisioningServiceGlobalEndpointWithInvalidCert = Tools.retrieveEnvironmentVariableValue(DPS_GLOBAL_ENDPOINT_WITH_INVALID_CERT_ENV_VAR_NAME);
         provisioningServiceWithInvalidCertConnectionString = Tools.retrieveEnvironmentVariableValue(DPS_CONNECTION_STRING_WITH_INVALID_CERT_ENV_VAR_NAME);
         isPullRequest = Boolean.parseBoolean(Tools.retrieveEnvironmentVariableValue(TestConstants.IS_PULL_REQUEST));
-    }
-
-    // Called from android runner to only run this test suite for a particular attestation type
-    public static Collection inputs(AttestationType attestationType)
-    {
-        getEnvironmentVariables();
-        return inputsCommon(attestationType);
     }
 
     public enum AttestationType
@@ -113,54 +134,11 @@ public class ProvisioningCommon extends IntegrationTest
     public static final String DPS_ID_SCOPE_ENV_VAR_NAME = "IOT_DPS_ID_SCOPE";
     public static String provisioningServiceIdScope = "";
 
-    public static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION_MILLISECONDS = 60 * 1000;
-    public static final int QUERY_TIMEOUT_MILLISECONDS = 4 * 60 * 1000; // 4 minutes
+    public static final long MAX_TIME_TO_WAIT_FOR_REGISTRATION_SECONDS = 60;
 
     public static final int MAX_TPM_CONNECT_RETRY_ATTEMPTS = 10;
 
     public RegistryClient registryClient = null;
-
-    //sending reported properties for twin operations takes some time to get the appropriate callback
-    public static final int MAX_TWIN_PROPAGATION_WAIT_SECONDS = 60;
-
-    public static Collection inputsCommon(AttestationType attestationType)
-    {
-        if (attestationType == AttestationType.SYMMETRIC_KEY || attestationType == AttestationType.X509)
-        {
-            return Arrays.asList(
-                    new Object[][]
-                            {
-                                    {ProvisioningDeviceClientTransportProtocol.HTTPS, attestationType},
-                                    {ProvisioningDeviceClientTransportProtocol.AMQPS, attestationType},
-                                    {ProvisioningDeviceClientTransportProtocol.MQTT, attestationType},
-                            });
-        }
-        else if (attestationType == AttestationType.TPM)
-        {
-            return Collections.emptyList(); // TPM tests are run in the ProvisioningTPMTests file so they can be run in serial
-        }
-        else
-        {
-            throw new IllegalArgumentException("Unknown attestation type provided");
-        }
-    }
-
-    public static Collection inputsCommon()
-    {
-        // Intentionally not doing TPM tests here. There is a separate class for running those
-        // tests in serial
-        return Arrays.asList(
-                new Object[][]
-                        {
-                                {ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.X509},
-                                {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.X509},
-                                {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.X509},
-
-                                {ProvisioningDeviceClientTransportProtocol.HTTPS, AttestationType.SYMMETRIC_KEY},
-                                {ProvisioningDeviceClientTransportProtocol.AMQPS, AttestationType.SYMMETRIC_KEY},
-                                {ProvisioningDeviceClientTransportProtocol.MQTT, AttestationType.SYMMETRIC_KEY},
-                        });
-    }
 
     public ProvisioningCommon(ProvisioningDeviceClientTransportProtocol protocol, AttestationType attestationType)
     {
@@ -225,13 +203,13 @@ public class ProvisioningCommon extends IntegrationTest
 
         try
         {
-            if (testInstance.groupId != null && !testInstance.groupId.isEmpty())
+            if (testInstance != null && testInstance.groupId != null && !testInstance.groupId.isEmpty())
             {
                 log.debug("Deleting enrollment group with group Id {}", testInstance.groupId);
                 testInstance.provisioningServiceClient.deleteEnrollmentGroup(testInstance.groupId);
             }
 
-            if (testInstance.individualEnrollment != null)
+            if (testInstance != null && testInstance.individualEnrollment != null)
             {
                 log.debug("Deleting individual enrollment with registration Id {}", testInstance.individualEnrollment.getRegistrationId());
                 testInstance.provisioningServiceClient.deleteIndividualEnrollment(testInstance.individualEnrollment.getRegistrationId());
@@ -243,153 +221,75 @@ public class ProvisioningCommon extends IntegrationTest
         }
     }
 
-    public static class ProvisioningStatus
+    public void registerDevice(ProvisioningDeviceClientTransportProtocol protocol, SecurityProvider securityProvider, String globalEndpoint) throws Exception
     {
-        public ProvisioningDeviceClientRegistrationResult provisioningDeviceClientRegistrationInfoClient = new ProvisioningDeviceClientRegistrationResult();
-        public Exception exception;
-        public ProvisioningDeviceClient provisioningDeviceClient;
-    }
+        ProvisioningDeviceClient provisioningDeviceClient = ProvisioningDeviceClient.create(globalEndpoint, provisioningServiceIdScope,
+            protocol,
+            securityProvider);
 
-    public static class ProvisioningDeviceClientRegistrationCallbackImpl implements ProvisioningDeviceClientRegistrationCallback
-    {
-        @Override
-        public void run(ProvisioningDeviceClientRegistrationResult provisioningDeviceClientRegistrationResult, Exception exception, Object context)
+        try
         {
-            if (context instanceof ProvisioningStatus)
-            {
-                ProvisioningStatus status = (ProvisioningStatus) context;
-                status.provisioningDeviceClientRegistrationInfoClient = provisioningDeviceClientRegistrationResult;
-                status.exception = exception;
-            }
-            else
-            {
-                System.out.println("Received unknown context");
-            }
-        }
-    }
 
-    public void waitForRegistrationCallback(ProvisioningStatus provisioningStatus) throws Exception
-    {
-        long startTime = System.currentTimeMillis();
-        while (provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() != PROVISIONING_DEVICE_STATUS_ASSIGNED)
+            final CountDownLatch registrationLatch = new CountDownLatch(1);
+            AtomicReference<ProvisioningDeviceClientRegistrationResult> registrationResultReference = new AtomicReference<>();
+            AtomicReference<Exception> registrationExceptionReference = new AtomicReference<>();
+            provisioningDeviceClient.registerDevice(
+                (provisioningDeviceClientRegistrationResult, e, context) ->
+                {
+                    registrationResultReference.set(provisioningDeviceClientRegistrationResult);
+                    registrationExceptionReference.set(e);
+                    registrationLatch.countDown();
+                },
+                null);
+
+            // Wait until registration finishes or for a max amount of time
+            boolean timedOut = !registrationLatch.await(MAX_TIME_TO_WAIT_FOR_REGISTRATION_SECONDS, TimeUnit.SECONDS);
+            if (timedOut)
+            {
+                fail("Timed out waiting for device registration to complete.");
+            }
+
+            ProvisioningDeviceClientRegistrationResult registrationResult = registrationResultReference.get();
+            Exception registrationException = registrationExceptionReference.get();
+
+            if (registrationException != null)
+            {
+                String errorContext = "";
+                errorContext += " Status=" + registrationResult.getStatus();
+                errorContext += " Substatus=" + registrationResult.getSubstatus();
+                if (registrationException instanceof ProvisioningDeviceClientException)
+                {
+                    errorContext += " Error code=" + ((ProvisioningDeviceHubException) registrationException).getErrorCode();
+                }
+
+                fail("Registration finished with exception." + errorContext);
+            }
+
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected status", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), PROVISIONING_DEVICE_STATUS_ASSIGNED, registrationResult.getProvisioningDeviceClientStatus());
+            testInstance.provisionedDeviceId = registrationResult.getDeviceId();
+            testInstance.provisionedIotHubUri = registrationResult.getIothubUri();
+
+            assertEquals(registrationResult.getProvisioningDeviceClientStatus(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
+            assertEquals(registrationResult.getRegistrationId(), testInstance.registrationId);
+            assertNotNull(registrationResult.getCreatedDateTimeUtc());
+            assertNotNull(registrationResult.getLastUpdatesDateTimeUtc());
+            assertNotNull(registrationResult.getLastUpdatesDateTimeUtc());
+            assertNotNull(registrationResult.getSubstatus());
+
+            assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId);
+            assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId.isEmpty());
+            assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected uri", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri);
+            assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected uri", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri.isEmpty());
+
+            assertSame(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected status", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), registrationResult.getProvisioningDeviceClientStatus(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
+            assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected deviceId", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), registrationResult.getDeviceId().isEmpty());
+            assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected uri", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), registrationResult.getIothubUri().isEmpty());
+            assertProvisionedDeviceWorks(registrationResult.getIothubUri(), registrationResult.getDeviceId());
+        }
+        finally
         {
-            if (provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() == ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_ERROR ||
-                    provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() == ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_DISABLED ||
-                    provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus() == ProvisioningDeviceClientStatus.PROVISIONING_DEVICE_STATUS_FAILED)
-            {
-                provisioningStatus.exception.printStackTrace();
-                System.out.println("Registration error, bailing out");
-                throw new ProvisioningDeviceClientException(provisioningStatus.exception);
-            }
-
-            Thread.sleep(1000);
-
-            System.out.println("Waiting for Provisioning Service to register");
-
-            if (System.currentTimeMillis() - startTime > MAX_TIME_TO_WAIT_FOR_REGISTRATION_MILLISECONDS)
-            {
-                fail("Timed out waiting for registration to succeed");
-            }
+            provisioningDeviceClient.close();
         }
-
-        Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected status", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), PROVISIONING_DEVICE_STATUS_ASSIGNED, provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus());
-        testInstance.provisionedDeviceId = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId();
-        testInstance.provisionedIotHubUri = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri();
-
-        assertEquals(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
-        assertEquals(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getRegistrationId(), testInstance.registrationId);
-        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getCreatedDateTimeUtc());
-        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getLastUpdatesDateTimeUtc());
-        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getLastUpdatesDateTimeUtc());
-        assertNotNull(provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getSubstatus());
-
-        assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId);
-        assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected a device id", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId.isEmpty());
-        assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri);
-        assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedIotHubUri.isEmpty());
-    }
-
-    public ProvisioningStatus registerDevice(ProvisioningDeviceClientTransportProtocol protocol, SecurityProvider securityProvider, String globalEndpoint, boolean withRetry, String jsonPayload, String... expectedIotHubsToProvisionTo) throws Exception
-    {
-        ArrayList<String> expectedHubsToProvisionTo = new ArrayList<>(Arrays.asList(expectedIotHubsToProvisionTo));
-        return registerDevice(protocol, securityProvider, globalEndpoint, withRetry, expectedHubsToProvisionTo, jsonPayload);
-    }
-
-    public ProvisioningStatus registerDevice(ProvisioningDeviceClientTransportProtocol protocol, SecurityProvider securityProvider, String globalEndpoint, boolean withRetry, List<String> expectedIotHubsToProvisionTo) throws Exception
-    {
-        return registerDevice(protocol, securityProvider, globalEndpoint, withRetry, expectedIotHubsToProvisionTo, null);
-    }
-
-    public ProvisioningStatus registerDevice(ProvisioningDeviceClientTransportProtocol protocol, SecurityProvider securityProvider, String globalEndpoint, boolean withRetry, List<String> expectedIotHubsToProvisionTo, String jsonPayload) throws Exception
-    {
-        ProvisioningStatus provisioningStatus = null;
-        long startTime = System.currentTimeMillis();
-        long timeoutInMillis = 180*1000; //3 minutes
-        boolean deviceRegisteredSuccessfully = false;
-        do
-        {
-            try
-            {
-                provisioningStatus = new ProvisioningStatus();
-                provisioningStatus.provisioningDeviceClient = ProvisioningDeviceClient.create(globalEndpoint, provisioningServiceIdScope,
-                        protocol,
-                        securityProvider);
-
-                if (jsonPayload == null)
-                {
-                    provisioningStatus.provisioningDeviceClient.registerDevice(new ProvisioningDeviceClientRegistrationCallbackImpl(), provisioningStatus);
-                }
-                else
-                {
-                    AdditionalData additionalData = new AdditionalData();
-                    additionalData.setProvisioningPayload(jsonPayload);
-                    provisioningStatus.provisioningDeviceClient.registerDevice(new ProvisioningDeviceClientRegistrationCallbackImpl(), provisioningStatus, additionalData);
-                }
-                waitForRegistrationCallback(provisioningStatus);
-
-                String deviceId = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getDeviceId();
-                String provisionedHubUri = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getIothubUri();
-
-                assertSame(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected status", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningDeviceClientStatus(), PROVISIONING_DEVICE_STATUS_ASSIGNED);
-                assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected deviceId", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), deviceId.isEmpty());
-                assertFalse(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected uri", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), provisionedHubUri.isEmpty());
-
-                if (jsonPayload != null && !jsonPayload.isEmpty())
-                {
-                    String returnJson = provisioningStatus.provisioningDeviceClientRegistrationInfoClient.getProvisioningPayload();
-                    assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Payload received from service is not the same values. Sent Json: " + jsonPayload + " returned json " + returnJson, getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), returnJson, jsonPayload);
-                }
-                assertProvisionedDeviceWorks(provisionedHubUri, deviceId);
-                deviceRegisteredSuccessfully = true;
-            }
-            catch (Exception | AssertionFailedError e)
-            {
-                if (withRetry)
-                {
-                    if (((System.currentTimeMillis() - startTime) > timeoutInMillis))
-                    {
-                        fail(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Timed out waiting for device to register successfully, last exception: " + Tools.getStackTraceFromThrowable(e), getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId));
-                    }
-
-                    System.out.println("Encountered an exception while registering device, trying again: " + Tools.getStackTraceFromThrowable(e));
-                    Thread.sleep(10*1000);
-                }
-                else
-                {
-                    throw e;
-                }
-            }
-            finally
-            {
-                if (provisioningStatus != null && provisioningStatus.provisioningDeviceClient != null)
-                {
-                    provisioningStatus.provisioningDeviceClient.close();
-                }
-            }
-        }
-        while (withRetry && !deviceRegisteredSuccessfully);
-
-        return provisioningStatus;
     }
 
     private void assertProvisionedDeviceWorks(String iothubUri, String deviceId) throws IOException, IotHubClientException, URISyntaxException
@@ -399,46 +299,9 @@ public class ProvisioningCommon extends IntegrationTest
         deviceClient.close();
     }
 
-    //Parses connection String to retrieve iothub hostname
-    public String getHostName(String connectionString)
-    {
-        String[] tokens = connectionString.split(";");
-        for (String token: tokens)
-        {
-            if (token.contains("HostName"))
-            {
-                String[] hName = token.split("=");
-                return hName[1];
-            }
-        }
-
-        return null;
-    }
-
-    public SecurityProvider getSecurityProviderInstance(EnrollmentType enrollmentType) throws ProvisioningServiceClientException, GeneralSecurityException, IOException, SecurityProviderException, InterruptedException
-    {
-        return getSecurityProviderInstance(enrollmentType, null, null);
-    }
-
-    public SecurityProvider getSecurityProviderInstance(EnrollmentType enrollmentType, AllocationPolicy allocationPolicy, ReprovisionPolicy reprovisionPolicy) throws ProvisioningServiceClientException, GeneralSecurityException, IOException, SecurityProviderException
-    {
-        return getSecurityProviderInstance(enrollmentType, allocationPolicy, reprovisionPolicy, null);
-    }
-
-    public SecurityProvider getSecurityProviderInstance(EnrollmentType enrollmentType, AllocationPolicy allocationPolicy, ReprovisionPolicy reprovisionPolicy, DeviceCapabilities deviceCapabilities) throws ProvisioningServiceClientException, GeneralSecurityException, SecurityProviderException, IOException
+    public SecurityProvider getSecurityProviderInstance(EnrollmentType enrollmentType) throws ProvisioningServiceClientException, GeneralSecurityException, SecurityProviderException, IOException
     {
         SecurityProvider securityProvider = null;
-        TwinCollection tags = new TwinCollection();
-        final String TEST_KEY_TAG = "testTag";
-        final String TEST_VALUE_TAG = "testValue";
-        tags.put(TEST_KEY_TAG, TEST_VALUE_TAG);
-
-        final String TEST_KEY_DP = "testDP";
-        final String TEST_VALUE_DP = "testDPValue";
-        TwinCollection desiredProperties = new TwinCollection();
-        desiredProperties.put(TEST_KEY_DP, TEST_VALUE_DP);
-
-        TwinState twinState = new TwinState(tags, desiredProperties);
 
         if (enrollmentType == EnrollmentType.GROUP)
         {
@@ -455,17 +318,9 @@ public class ProvisioningCommon extends IntegrationTest
                 testInstance.groupId = "java-provisioning-test-group-id-" + testInstance.attestationType.toString().toLowerCase().replace("_", "-") + "-" + UUID.randomUUID().toString();
 
                 testInstance.enrollmentGroup = new EnrollmentGroup(testInstance.groupId, new SymmetricKeyAttestation(null, null));
-                testInstance.enrollmentGroup.setInitialTwin(twinState);
-                testInstance.enrollmentGroup.setAllocationPolicy(allocationPolicy);
-                testInstance.enrollmentGroup.setReprovisionPolicy(reprovisionPolicy);
-                testInstance.enrollmentGroup.setCapabilities(deviceCapabilities);
                 testInstance.enrollmentGroup = testInstance.provisioningServiceClient.createOrUpdateEnrollmentGroup(testInstance.enrollmentGroup);
                 Attestation attestation = testInstance.enrollmentGroup.getAttestation();
                 assertTrue(attestation instanceof SymmetricKeyAttestation);
-
-                assertNotNull(testInstance.enrollmentGroup.getInitialTwin());
-                assertEquals(TEST_VALUE_TAG, testInstance.enrollmentGroup.getInitialTwin().getTags().get(TEST_KEY_TAG));
-                assertEquals(TEST_VALUE_DP, testInstance.enrollmentGroup.getInitialTwin().getDesiredProperties().get(TEST_KEY_DP));
 
                 SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) attestation;
                 byte[] derivedPrimaryKey = SecurityProviderSymmetricKey.ComputeDerivedSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(StandardCharsets.UTF_8), testInstance.registrationId);
@@ -479,83 +334,38 @@ public class ProvisioningCommon extends IntegrationTest
             {
                 securityProvider = new SecurityProviderTPMEmulator(testInstance.registrationId, MAX_TPM_CONNECT_RETRY_ATTEMPTS);
                 Attestation attestation = new TpmAttestation(new String(encodeBase64(((SecurityProviderTpm) securityProvider).getEndorsementKey())));
-                createTestIndividualEnrollment(attestation, allocationPolicy, reprovisionPolicy, twinState, deviceCapabilities);
+                createTestIndividualEnrollment(attestation);
             }
             else if (testInstance.attestationType == AttestationType.X509)
             {
                 X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(testInstance.certificateAlgorithm, testInstance.registrationId);
                 String leafPublicPem = certificateGenerator.getPublicCertificatePEM();
-                String leafPrivateKeyPem = certificateGenerator.getPrivateKeyPEM();
 
                 Collection<X509Certificate> signerCertificates = new LinkedList<>();
                 Attestation attestation = X509Attestation.createFromClientCertificates(leafPublicPem);
-                createTestIndividualEnrollment(attestation, allocationPolicy, reprovisionPolicy, twinState, deviceCapabilities);
+                createTestIndividualEnrollment(attestation);
 
-                X509Certificate leafPublicCert = parsePublicKeyCertificate(leafPublicPem);
-                Key leafPrivateKey = parsePrivateKey(leafPrivateKeyPem);
-
-                securityProvider = new SecurityProviderX509Cert(leafPublicCert, leafPrivateKey, signerCertificates);
+                securityProvider = new SecurityProviderX509Cert(certificateGenerator.getX509Certificate(), certificateGenerator.getPrivateKey(), signerCertificates);
             }
             else if (testInstance.attestationType == AttestationType.SYMMETRIC_KEY)
             {
                 Attestation attestation = new SymmetricKeyAttestation(null, null);
-                createTestIndividualEnrollment(attestation, allocationPolicy, reprovisionPolicy, twinState, deviceCapabilities);
-                assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected symmetric key attestation", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
+                createTestIndividualEnrollment(attestation);
+                assertTrue(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected symmetric key attestation", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getAttestation() instanceof  SymmetricKeyAttestation);
                 SymmetricKeyAttestation symmetricKeyAttestation = (SymmetricKeyAttestation) testInstance.individualEnrollment.getAttestation();
                 securityProvider = new SecurityProviderSymmetricKey(symmetricKeyAttestation.getPrimaryKey().getBytes(StandardCharsets.UTF_8), testInstance.registrationId);
             }
 
-            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected device id assigned", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());
-            assertNotNull(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Expected twin to not be null", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.individualEnrollment.getInitialTwin());
-            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected tags found", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), TEST_VALUE_TAG, testInstance.individualEnrollment.getInitialTwin().getTags().get(TEST_KEY_TAG));
-            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected desired properties", getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), TEST_VALUE_DP, testInstance.individualEnrollment.getInitialTwin().getDesiredProperties().get(TEST_KEY_DP));
+            Assert.assertEquals(CorrelationDetailsLoggingAssert.buildExceptionMessageDpsIndividualOrGroup("Unexpected device id assigned", Tools.getHostName(provisioningServiceConnectionString), testInstance.groupId, testInstance.registrationId), testInstance.provisionedDeviceId, testInstance.individualEnrollment.getDeviceId());
         }
 
         return securityProvider;
     }
 
-    private void createTestIndividualEnrollment(Attestation attestation, AllocationPolicy allocationPolicy, ReprovisionPolicy reprovisionPolicy, TwinState twinState, DeviceCapabilities deviceCapabilities) throws ProvisioningServiceClientException
+    private void createTestIndividualEnrollment(Attestation attestation) throws ProvisioningServiceClientException
     {
         testInstance.individualEnrollment = new IndividualEnrollment(testInstance.registrationId, attestation);
         testInstance.individualEnrollment.setDeviceId(testInstance.provisionedDeviceId);
-        testInstance.individualEnrollment.setCapabilities(deviceCapabilities);
-        testInstance.individualEnrollment.setAllocationPolicy(allocationPolicy);
-        testInstance.individualEnrollment.setReprovisionPolicy(reprovisionPolicy);
-        testInstance.individualEnrollment.setInitialTwin(twinState);
         testInstance.individualEnrollment = testInstance.provisioningServiceClient.createOrUpdateIndividualEnrollment(testInstance.individualEnrollment);
-    }
-
-    private static Key parsePrivateKey(String privateKeyString) throws IOException
-    {
-        Security.addProvider(new BouncyCastleProvider());
-        PEMParser privateKeyParser = new PEMParser(new StringReader(privateKeyString));
-        Object possiblePrivateKey = privateKeyParser.readObject();
-        return getPrivateKey(possiblePrivateKey);
-    }
-
-    private static X509Certificate parsePublicKeyCertificate(String publicKeyCertificateString) throws CertificateException, IOException
-    {
-        Security.addProvider(new BouncyCastleProvider());
-        PemReader publicKeyCertificateReader = new PemReader(new StringReader(publicKeyCertificateString));
-        PemObject possiblePublicKeyCertificate = publicKeyCertificateReader.readPemObject();
-        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-        return (X509Certificate) certFactory.generateCertificate(new ByteArrayInputStream(possiblePublicKeyCertificate.getContent()));
-    }
-
-    private static Key getPrivateKey(Object possiblePrivateKey) throws IOException
-    {
-        if (possiblePrivateKey instanceof PEMKeyPair)
-        {
-            return new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) possiblePrivateKey)
-                .getPrivate();
-        }
-        else if (possiblePrivateKey instanceof PrivateKeyInfo)
-        {
-            return new JcaPEMKeyConverter().getPrivateKey((PrivateKeyInfo) possiblePrivateKey);
-        }
-        else
-        {
-            throw new IOException("Unable to parse private key, type unknown");
-        }
     }
 }


### PR DESCRIPTION
There were a lot of unnecessarily overloaded methods and unused fields that could be removed