### PR TITLE
Run JDK versions in parallel for PR, serial for CI

### DIFF
--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -4,10 +4,7 @@ trigger:
   batch: true
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-  ${{ if eq(parameters.os, 'win') }}:
     maxParallel: 2
-  ${{ else }}:
-    maxParallel: 1
   branches:
     include:
       - main

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -4,7 +4,7 @@ trigger:
   batch: true
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  ${{ if eq(parameters.os, 'win') }}:
     maxParallel: 2
   ${{ else }}:
     maxParallel: 1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -24,7 +24,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: [variables.maxParallel]
+      maxParallel: $[variables.maxParallel]
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
@@ -125,7 +125,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     displayName: Linux
     strategy:
-      maxParallel: [variables.maxParallel]
+      maxParallel: $[variables.maxParallel]
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -4,7 +4,11 @@ trigger:
   batch: true
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-    maxParallel: 2
+${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  maxParallel: 2
+${{ else }}:
+  maxParallel: 1
+
   branches:
     include:
       - main

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -3,9 +3,9 @@ name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Re
 trigger:
   batch: true
 variables:
-  ${{ if eq(parameters.os, 'win') }}:
+  ${{ if eq('win', 'win') }}:
     testsFolder: windows
-  ${{ elseif eq(parameters.os, 'linux' }}:
+  ${{ elseif eq('win', 'linux' }}:
     testsFolder: linux
   ${{ else }}:
     testsFolder: mac

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -2,6 +2,12 @@ name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Re
 
 trigger:
   batch: true
+variables:
+  # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
+  ${{ if eq(build.reason, 'PullRequest') }}:
+    maxParallel: 2
+  ${{ else }}:
+    maxParallel: 1
   branches:
     include:
       - main
@@ -17,7 +23,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: 2
+      maxParallel: $(maxParallel)
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
@@ -118,7 +124,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     displayName: Linux
     strategy:
-      maxParallel: 2
+      maxParallel: $(maxParallel)
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -14,11 +14,11 @@ trigger:
 
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-  ${{ if eq(build.reason, 'PullRequest') }}:
+  ${{ if eq($('Build.Reason'), 'PullRequest') }}:
     maxParallel: 2
   ${{ else }}:
     maxParallel: 1
-    
+
 jobs:
   ### Windows ###
   - job: Windows

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -14,7 +14,7 @@ trigger:
 
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-  ${{ if eq($('Build.Reason'), 'PullRequest') }}:
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     maxParallel: 2
   ${{ else }}:
     maxParallel: 1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -4,7 +4,7 @@ trigger:
   batch: true
 variables:
   # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-  ${{ if eq(build.reason, 'PullRequest') }}:
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     maxParallel: 2
   ${{ else }}:
     maxParallel: 1

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -3,11 +3,12 @@ name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Re
 trigger:
   batch: true
 variables:
-  # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
-${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-  maxParallel: 2
-${{ else }}:
-  maxParallel: 1
+  ${{ if eq(parameters.os, 'win') }}:
+    testsFolder: windows
+  ${{ elseif eq(parameters.os, 'linux' }}:
+    testsFolder: linux
+  ${{ else }}:
+    testsFolder: mac
 
   branches:
     include:

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -2,14 +2,6 @@ name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Re
 
 trigger:
   batch: true
-variables:
-  ${{ if eq('win', 'win') }}:
-    testsFolder: windows
-  ${{ elseif eq('win', 'linux' }}:
-    testsFolder: linux
-  ${{ else }}:
-    testsFolder: mac
-
   branches:
     include:
       - main
@@ -20,6 +12,13 @@ variables:
       - service/iot-service-samples/*
       - provisioning/provisioning-samples/*
 
+variables:
+  # Run JDK 8 + 11 in parallel if it is a pull request, but in serial otherwise
+  ${{ if eq(build.reason, 'PullRequest') }}:
+    maxParallel: 2
+  ${{ else }}:
+    maxParallel: 1
+    
 jobs:
   ### Windows ###
   - job: Windows

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -24,7 +24,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: $(maxParallel)
+      maxParallel: variables['maxParallel']
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
@@ -125,7 +125,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     displayName: Linux
     strategy:
-      maxParallel: $(maxParallel)
+      maxParallel: variables['maxParallel']
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -24,7 +24,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 180
     strategy:
-      maxParallel: variables['maxParallel']
+      maxParallel: [variables.maxParallel]
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11
@@ -125,7 +125,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     displayName: Linux
     strategy:
-      maxParallel: variables['maxParallel']
+      maxParallel: [variables.maxParallel]
       matrix:
         JDK 11: # always run Java 11
           JAVA_VERSION: 11


### PR DESCRIPTION
CI builds are running into throttling from the service when running both windows/linux jdk 8/11 e2e tests all at once.