### PR TITLE
Add parameter GatewayType to specify E4K

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -86,6 +86,10 @@ public final class ClientConfiguration
     @Setter(AccessLevel.PACKAGE)
     private int sendInterval = DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
 
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private boolean isConnectingToMqttGateway = false;
+
     private IotHubAuthenticationProvider authenticationProvider;
 
     /**
@@ -191,6 +195,13 @@ public final class ClientConfiguration
 
     ClientConfiguration(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, ClientOptions clientOptions)
     {
+        String gatewayHostName = iotHubConnectionString.getGatewayHostName();
+        GatewayType gatewayType = clientOptions.getGatewayType();
+        if (gatewayHostName != null && !gatewayHostName.isEmpty() && gatewayType == GatewayType.E4K)
+        {
+            this.isConnectingToMqttGateway = true;
+        }
+
         this.protocol = protocol;
 
         if (clientOptions != null && clientOptions.getSslContext() != null)
@@ -360,6 +371,14 @@ public final class ClientConfiguration
         // When setting the ClientOptions and a SecurityProvider, the SecurityProvider is responsible for setting the sslContext
         // we do not need to set the context in this constructor.
         this(connectionString, securityProvider, protocol);
+
+        String gatewayHostName = connectionString.getGatewayHostName();
+        GatewayType gatewayType = clientOptions.getGatewayType();
+        if (gatewayHostName != null && !gatewayHostName.isEmpty() && gatewayType == GatewayType.E4K)
+        {
+            this.isConnectingToMqttGateway = true;
+        }
+
         setClientOptionValues(clientOptions);
     }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -667,14 +667,14 @@ public final class ClientConfiguration
         {
             if (gatewayHostName == null || gatewayHostName.isEmpty())
             {
-                throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
+                throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided while connecting to an E4K MQTT broker.");
             }
 
             this.isConnectingToMqttGateway = true;
 
             if (protocol != MQTT && protocol != MQTT_WS)
             {
-                throw new IllegalArgumentException("The transport protocol should be MQTT or MQTT_WS in the E4K mode.");
+                throw new IllegalArgumentException("The transport protocol should be MQTT or MQTT_WS while connecting to an E4K MQTT broker.");
             }
         }
     }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -207,6 +207,11 @@ public final class ClientConfiguration
             {
                 throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
             }
+
+            if (protocol != MQTT && protocol != MQTT_WS)
+            {
+                throw new IllegalArgumentException("The transport protocol should be MQTT or MQTT_WS in the E4K mode.");
+            }
         }
 
         this.protocol = protocol;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -199,14 +199,12 @@ public final class ClientConfiguration
         GatewayType gatewayType = clientOptions.getGatewayType();
         if (gatewayType == GatewayType.E4K)
         {
-            if (gatewayHostName != null && !gatewayHostName.isEmpty())
-            {
-                this.isConnectingToMqttGateway = true;
-            }
-            else
+            if (gatewayHostName == null || gatewayHostName.isEmpty())
             {
                 throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
             }
+
+            this.isConnectingToMqttGateway = true;
 
             if (protocol != MQTT && protocol != MQTT_WS)
             {
@@ -388,13 +386,16 @@ public final class ClientConfiguration
         GatewayType gatewayType = clientOptions.getGatewayType();
         if (gatewayType == GatewayType.E4K)
         {
-            if (gatewayHostName != null && !gatewayHostName.isEmpty())
-            {
-                this.isConnectingToMqttGateway = true;
-            }
-            else
+            if (gatewayHostName == null || gatewayHostName.isEmpty())
             {
                 throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
+            }
+
+            this.isConnectingToMqttGateway = true;
+
+            if (protocol != MQTT && protocol != MQTT_WS)
+            {
+                throw new IllegalArgumentException("The transport protocol should be MQTT or MQTT_WS in the E4K mode.");
             }
         }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -197,9 +197,16 @@ public final class ClientConfiguration
     {
         String gatewayHostName = iotHubConnectionString.getGatewayHostName();
         GatewayType gatewayType = clientOptions.getGatewayType();
-        if (gatewayHostName != null && !gatewayHostName.isEmpty() && gatewayType == GatewayType.E4K)
+        if (gatewayType == GatewayType.E4K)
         {
-            this.isConnectingToMqttGateway = true;
+            if (gatewayHostName != null && !gatewayHostName.isEmpty())
+            {
+                this.isConnectingToMqttGateway = true;
+            }
+            else
+            {
+                throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
+            }
         }
 
         this.protocol = protocol;
@@ -374,9 +381,16 @@ public final class ClientConfiguration
 
         String gatewayHostName = connectionString.getGatewayHostName();
         GatewayType gatewayType = clientOptions.getGatewayType();
-        if (gatewayHostName != null && !gatewayHostName.isEmpty() && gatewayType == GatewayType.E4K)
+        if (gatewayType == GatewayType.E4K)
         {
-            this.isConnectingToMqttGateway = true;
+            if (gatewayHostName != null && !gatewayHostName.isEmpty())
+            {
+                this.isConnectingToMqttGateway = true;
+            }
+            else
+            {
+                throw new IllegalArgumentException("The value of [GatewayHostName] is NOT provided in the E4K mode.");
+            }
         }
 
         setClientOptionValues(clientOptions);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -86,10 +86,6 @@ public final class ClientConfiguration
     @Setter(AccessLevel.PACKAGE)
     private int sendInterval = DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
 
-    @Getter
-    @Setter(AccessLevel.PACKAGE)
-    private boolean isConnectingToMqttGateway = false;
-
     private IotHubAuthenticationProvider authenticationProvider;
 
     /**
@@ -147,12 +143,6 @@ public final class ClientConfiguration
      */
     ClientConfiguration(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol) throws IllegalArgumentException
     {
-        String mqttGatewayHostName = iotHubConnectionString.getMqttGatewayHostName();
-        if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            this.isConnectingToMqttGateway = true;
-        }
-
         this.protocol = protocol;
         configSasAuth(iotHubConnectionString);
     }
@@ -164,7 +154,6 @@ public final class ClientConfiguration
         this.authenticationProvider = new IotHubSasTokenSoftwareAuthenticationProvider(
                 iotHubConnectionString.getHostName(),
                 iotHubConnectionString.getGatewayHostName(),
-                iotHubConnectionString.getMqttGatewayHostName(),
                 iotHubConnectionString.getDeviceId(),
                 iotHubConnectionString.getModuleId(),
                 iotHubConnectionString.getSharedAccessKey(),
@@ -178,12 +167,6 @@ public final class ClientConfiguration
         if (!(authenticationProvider instanceof IotHubSasTokenAuthenticationProvider))
         {
             throw new UnsupportedOperationException("This constructor only support sas token authentication currently");
-        }
-
-        String mqttGatewayHostName = authenticationProvider.getMqttGatewayHostname();
-        if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            this.isConnectingToMqttGateway = true;
         }
 
         this.protocol = protocol;
@@ -208,12 +191,6 @@ public final class ClientConfiguration
 
     ClientConfiguration(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, ClientOptions clientOptions)
     {
-        String mqttGatewayHostName = iotHubConnectionString.getMqttGatewayHostName();
-        if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            this.isConnectingToMqttGateway = true;
-        }
-
         this.protocol = protocol;
 
         if (clientOptions != null && clientOptions.getSslContext() != null)
@@ -287,12 +264,6 @@ public final class ClientConfiguration
 
     ClientConfiguration(IotHubConnectionString iotHubConnectionString, IotHubClientProtocol protocol, SSLContext sslContext)
     {
-        String mqttGatewayHostName = iotHubConnectionString.getMqttGatewayHostName();
-        if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            this.isConnectingToMqttGateway = true;
-        }
-
         this.protocol = protocol;
         configSsl(iotHubConnectionString, sslContext);
     }
@@ -305,7 +276,6 @@ public final class ClientConfiguration
             this.authenticationProvider = new IotHubX509SoftwareAuthenticationProvider(
                     iotHubConnectionString.getHostName(),
                     iotHubConnectionString.getGatewayHostName(),
-                    iotHubConnectionString.getMqttGatewayHostName(),
                     iotHubConnectionString.getDeviceId(),
                     iotHubConnectionString.getModuleId(),
                     sslContext);
@@ -317,7 +287,6 @@ public final class ClientConfiguration
             this.authenticationProvider = new IotHubSasTokenSoftwareAuthenticationProvider(
                     iotHubConnectionString.getHostName(),
                     iotHubConnectionString.getGatewayHostName(),
-                    iotHubConnectionString.getMqttGatewayHostName(),
                     iotHubConnectionString.getDeviceId(),
                     iotHubConnectionString.getModuleId(),
                     iotHubConnectionString.getSharedAccessKey(),
@@ -338,12 +307,6 @@ public final class ClientConfiguration
     {
         commonConstructorSetup(connectionString);
 
-        String mqttGatewayHostName = connectionString.getMqttGatewayHostName();
-        if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            this.isConnectingToMqttGateway = true;
-        }
-
         this.protocol = protocol;
 
         if (securityProvider == null)
@@ -356,7 +319,6 @@ public final class ClientConfiguration
             this.authenticationProvider = new IotHubSasTokenHardwareAuthenticationProvider(
                     connectionString.getHostName(),
                     connectionString.getGatewayHostName(),
-                    connectionString.getMqttGatewayHostName(),
                     connectionString.getDeviceId(),
                     connectionString.getModuleId(),
                     securityProvider);
@@ -366,7 +328,6 @@ public final class ClientConfiguration
             this.authenticationProvider = new IotHubSasTokenSoftwareAuthenticationProvider(
                     connectionString.getHostName(),
                     connectionString.getGatewayHostName(),
-                    connectionString.getMqttGatewayHostName(),
                     connectionString.getDeviceId(),
                     connectionString.getModuleId(),
                     new String(((SecurityProviderSymmetricKey) securityProvider).getSymmetricKey(), StandardCharsets.UTF_8),
@@ -377,7 +338,6 @@ public final class ClientConfiguration
             this.authenticationProvider = new IotHubX509HardwareAuthenticationProvider(
                     connectionString.getHostName(),
                     connectionString.getGatewayHostName(),
-                    connectionString.getMqttGatewayHostName(),
                     connectionString.getDeviceId(),
                     connectionString.getModuleId(),
                     securityProvider);
@@ -508,15 +468,6 @@ public final class ClientConfiguration
     public String getGatewayHostname() 
     {
         return this.authenticationProvider.getGatewayHostname();
-    }
-
-    /**
-     * Getter for MqttGatewayHostName.
-     * @return the value of MqttGatewayHostName
-     */
-    public String getMqttGatewayHostName()
-    {
-        return this.authenticationProvider.getMqttGatewayHostname();
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -138,10 +138,10 @@ public final class ClientOptions
     private final int receiveInterval = RECEIVE_PERIOD_MILLIS;
 
     /**
-     * This option specifies the type of gateway to which the device/module client is connecting while
-     * specifying the property of GatewayHostName. By default, the value is EDGE.
+     * This option specifies the type of gateway to which the device/module client is connecting. By default,
+     * the value is None.
      */
     @Getter
     @Builder.Default
-    private final GatewayType gatewayType = GatewayType.EDGE;
+    private final GatewayType gatewayType = GatewayType.None;
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -136,4 +136,12 @@ public final class ClientOptions
     @Getter
     @Builder.Default
     private final int receiveInterval = RECEIVE_PERIOD_MILLIS;
+
+    /**
+     * This option specifies the type of gateway to which the device/module client is connecting while
+     * specifying the property of GatewayHostName. By default, the value is EDGE.
+     */
+    @Getter
+    @Builder.Default
+    private final GatewayType gatewayType = GatewayType.EDGE;
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -138,10 +138,10 @@ public final class ClientOptions
     private final int receiveInterval = RECEIVE_PERIOD_MILLIS;
 
     /**
-     * This option specifies the type of gateway to which the device/module client is connecting. By default,
-     * the value is None.
+     * This option specifies the type of gateway to which the device/module client is connecting. The default value is Edge.
+     * This option will be ignored if its value is set to Edge but no GatewayHostname is provided.
      */
     @Getter
     @Builder.Default
-    private final GatewayType gatewayType = GatewayType.None;
+    private final GatewayType gatewayType = GatewayType.EDGE;
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
@@ -9,12 +9,12 @@ package com.microsoft.azure.sdk.iot.device;
 public enum GatewayType
 {
     /**
-     * The device/module client is connecting to an Edge hub in the default mode.
+     * The device/module client is connecting to Edgehub.
      */
     EDGE,
 
     /**
-     * The device/module client is connecting to an Edge hub in the E4K mode.
+     * The device/module client is connecting to an E4K MQTT broker.
      */
     E4K
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
@@ -9,11 +9,6 @@ package com.microsoft.azure.sdk.iot.device;
 public enum GatewayType
 {
     /**
-     * The device/module client is connecting to an IoT hub. This is the default value.
-     */
-    None,
-
-    /**
      * The device/module client is connecting to an Edge hub in the default mode.
      */
     EDGE,

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.sdk.iot.device;
+
+/**
+ * The type of gateway to which the device/module client is connecting while specifying the property of GatewayHostName.
+ */
+public enum GatewayType
+{
+    EDGE, E4K
+}

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/GatewayType.java
@@ -8,5 +8,18 @@ package com.microsoft.azure.sdk.iot.device;
  */
 public enum GatewayType
 {
-    EDGE, E4K
+    /**
+     * The device/module client is connecting to an IoT hub. This is the default value.
+     */
+    None,
+
+    /**
+     * The device/module client is connecting to an Edge hub in the default mode.
+     */
+    EDGE,
+
+    /**
+     * The device/module client is connecting to an Edge hub in the E4K mode.
+     */
+    E4K
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
@@ -20,29 +20,17 @@ public class IotHubConnectionString
 {
     /** The hostName attribute name in a connection string. */
     private static final String HOSTNAME_ATTRIBUTE = "HostName=";
-
     /** The device ID attribute name in a connection string. */
     private static final String DEVICE_ID_ATTRIBUTE = "DeviceId=";
-
     /** The shared access key attribute name in a connection string. */
     private static final String SHARED_ACCESS_KEY_ATTRIBUTE = "SharedAccessKey=";
-
     /** The shared access signature attribute name in a connection string. */
     private static final String SHARED_ACCESS_TOKEN_ATTRIBUTE = "SharedAccessSignature=";
 
-    /** The module ID attribute name in a connection string. */
     private static final String MODULE_ID_ATTRIBUTE = "ModuleId=";
 
-    /**
-     * IP address or internet name of the host machine working as a device or protocol gateway.
-     * Used when communicating with Azure Edge devices.
-     * */
     private static final String GATEWAY_HOST_NAME_ATTRIBUTE = "GatewayHostName=";
 
-    /** Used for E4K. */
-    private static final String MQTT_GATEWAY_HOST_NAME_ATTRIBUTE = "MqttGatewayHostName=";
-
-    /** Specify when using X.509 certificate to authenticate */
     private static final String X509_ENABLED_ATTRIBUTE = "x509=true";
 
     /**
@@ -59,7 +47,6 @@ public class IotHubConnectionString
     private String moduleId;
     private final boolean isUsingX509;
     private String gatewayHostName;
-    private String mqttGatewayHostName;
 
     /**
      * CONSTRUCTOR.
@@ -116,16 +103,6 @@ public class IotHubConnectionString
             {
                 this.gatewayHostName = attr.substring(GATEWAY_HOST_NAME_ATTRIBUTE.length());
             }
-            else if (attr.toLowerCase().startsWith(MQTT_GATEWAY_HOST_NAME_ATTRIBUTE.toLowerCase()))
-            {
-                this.mqttGatewayHostName = attr.substring(MQTT_GATEWAY_HOST_NAME_ATTRIBUTE.length());
-            }
-        }
-
-        if (gatewayHostName != null && !gatewayHostName.isEmpty()
-                && mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-        {
-            throw new IllegalArgumentException("[GatewayHostName] and [MqttGatewayHostName] should NOT be specified at the same time.");
         }
 
         this.isUsingX509 = connectionString.contains(X509_ENABLED_ATTRIBUTE);
@@ -173,6 +150,7 @@ public class IotHubConnectionString
         this.sharedAccessToken = sharedAccessToken;
 
         this.gatewayHostName = gatewayHostName;
+
         if (this.gatewayHostName != null && !this.gatewayHostName.isEmpty())
         {
             this.hostName = gatewayHostName;
@@ -192,8 +170,6 @@ public class IotHubConnectionString
     {
         return this.gatewayHostName;
     }
-
-    public String getMqttGatewayHostName() { return this.mqttGatewayHostName; }
 
     /**
      * Getter for the hubName.

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionString.java
@@ -20,17 +20,26 @@ public class IotHubConnectionString
 {
     /** The hostName attribute name in a connection string. */
     private static final String HOSTNAME_ATTRIBUTE = "HostName=";
+
     /** The device ID attribute name in a connection string. */
     private static final String DEVICE_ID_ATTRIBUTE = "DeviceId=";
+
     /** The shared access key attribute name in a connection string. */
     private static final String SHARED_ACCESS_KEY_ATTRIBUTE = "SharedAccessKey=";
+
     /** The shared access signature attribute name in a connection string. */
     private static final String SHARED_ACCESS_TOKEN_ATTRIBUTE = "SharedAccessSignature=";
 
+    /** The module ID attribute name in a connection string. */
     private static final String MODULE_ID_ATTRIBUTE = "ModuleId=";
 
+    /**
+     * IP address or internet name of the host machine working as a device or protocol gateway.
+     * Used when communicating with Azure Edge devices.
+     * */
     private static final String GATEWAY_HOST_NAME_ATTRIBUTE = "GatewayHostName=";
 
+    /** Specify when using X.509 certificate to authenticate */
     private static final String X509_ENABLED_ATTRIBUTE = "x509=true";
 
     /**
@@ -150,7 +159,6 @@ public class IotHubConnectionString
         this.sharedAccessToken = sharedAccessToken;
 
         this.gatewayHostName = gatewayHostName;
-
         if (this.gatewayHostName != null && !this.gatewayHostName.isEmpty())
         {
             this.hostName = gatewayHostName;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -47,7 +47,6 @@ public class ModuleClient extends InternalClient
     private static final String IotEdgedUriVariableName = "IOTEDGE_WORKLOADURI";
     private static final String IotHubHostnameVariableName = "IOTEDGE_IOTHUBHOSTNAME";
     private static final String GatewayHostnameVariableName = "IOTEDGE_GATEWAYHOSTNAME";
-    private static final String MqttGatewayHostnameVariableName = "IOTEDGE_MQTTGATEWAYHOSTNAME";
     private static final String DeviceIdVariableName = "IOTEDGE_DEVICEID";
     private static final String ModuleIdVariableName = "IOTEDGE_MODULEID";
     private static final String ModuleGenerationIdVariableName = "IOTEDGE_MODULEGENERATIONID";
@@ -66,7 +65,7 @@ public class ModuleClient extends InternalClient
      *                         or
      *
      *                         HostName=xxxx;DeviceId=xxxx;SharedAccessKey=
-     *                         xxxx;moduleId=xxxx;GatewayHostName=xxxx
+     *                         xxxx;moduleId=xxxx;HostNameGateway=xxxx
      * @param protocol The protocol to use when communicating with the module
      * @throws UnsupportedOperationException if using any protocol besides MQTT, if the connection string is missing
      * the "moduleId" field, or if the connection string uses x509
@@ -246,7 +245,6 @@ public class ModuleClient extends InternalClient
             String hostname = envVariables.get(IotHubHostnameVariableName);
             String authScheme = envVariables.get(AuthSchemeVariableName);
             String gatewayHostname = envVariables.get(GatewayHostnameVariableName);
-            String mqttGatewayHostname = envVariables.get(MqttGatewayHostnameVariableName);
             String generationId = envVariables.get(ModuleGenerationIdVariableName);
 
             if (edgedUri == null)
@@ -297,8 +295,7 @@ public class ModuleClient extends InternalClient
             try
             {
                 SSLContext sslContext;
-                if ((gatewayHostname != null && !gatewayHostname.isEmpty())
-                    || (mqttGatewayHostname != null && !mqttGatewayHostname.isEmpty()))
+                if (gatewayHostname != null && !gatewayHostname.isEmpty())
                 {
                     TrustBundleProvider trustBundleProvider = new HttpsHsmTrustBundleProvider();
                     String trustCertificates = trustBundleProvider.getTrustBundleCerts(edgedUri, DEFAULT_API_VERSION, unixDomainSocketChannel);
@@ -317,7 +314,6 @@ public class ModuleClient extends InternalClient
                             moduleId,
                             hostname,
                             gatewayHostname,
-                            mqttGatewayHostname,
                             generationId,
                             DEFAULT_SAS_TOKEN_TIME_TO_LIVE_SECONDS,
                             DEFAULT_SAS_TOKEN_BUFFER_PERCENTAGE,

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -65,7 +65,7 @@ public class ModuleClient extends InternalClient
      *                         or
      *
      *                         HostName=xxxx;DeviceId=xxxx;SharedAccessKey=
-     *                         xxxx;moduleId=xxxx;HostNameGateway=xxxx
+     *                         xxxx;moduleId=xxxx;GatewayHostName=xxxx
      * @param protocol The protocol to use when communicating with the module
      * @throws UnsupportedOperationException if using any protocol besides MQTT, if the connection string is missing
      * the "moduleId" field, or if the connection string uses x509
@@ -88,7 +88,7 @@ public class ModuleClient extends InternalClient
      *                         or
      *
      *                         HostName=xxxx;DeviceId=xxxx;SharedAccessKey=
-     *                         xxxx;moduleId=xxxx;HostNameGateway=xxxx
+     *                         xxxx;moduleId=xxxx;GatewayHostName=xxxx
      * @param protocol The protocol to use when communicating with the module
      * @param clientOptions The options that allow configuration of the module client instance during initialization
      * @throws UnsupportedOperationException if using any protocol besides MQTT, if the connection string is missing

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProvider.java
@@ -16,31 +16,23 @@ public abstract class IotHubAuthenticationProvider
 {
     protected String hostname;
     protected final String gatewayHostname;
-    protected final String mqttGatewayHostname;
     protected String deviceId;
     protected final String moduleId;
 
     IotHubSSLContext iotHubSSLContext;
 
-    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId)
+    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
     {
-        this(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, null);
+        this(hostname, gatewayHostname, deviceId, moduleId, null);
     }
 
-    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+    public IotHubAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
     {
         Objects.requireNonNull(hostname);
         Objects.requireNonNull(deviceId);
 
-        if (gatewayHostname != null && !gatewayHostname.isEmpty()
-            && mqttGatewayHostname != null && !mqttGatewayHostname.isEmpty())
-        {
-            throw new IllegalArgumentException("[GatewayHostname] and [MqttGatewayHostname] should NOT be specified at the same time.");
-        }
-
         this.hostname = hostname;
         this.gatewayHostname = gatewayHostname;
-        this.mqttGatewayHostname = mqttGatewayHostname;
         this.deviceId = deviceId;
         this.moduleId = moduleId;
 
@@ -75,15 +67,6 @@ public abstract class IotHubAuthenticationProvider
     public String getGatewayHostname()
     {
         return this.gatewayHostname;
-    }
-
-    /**
-     * Get the mqttGatewayHostname
-     * @return the saved mqttGatewayHostname
-     */
-    public String getMqttGatewayHostname()
-    {
-        return mqttGatewayHostname;
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProvider.java
@@ -36,19 +36,19 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
     public abstract boolean canRefreshToken();
     public abstract char[] getSasToken() throws IOException, TransportException;
 
-    public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId)
+    public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+        super(hostname, gatewayHostname, deviceId, moduleId);
     }
 
-    IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+    IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, sslContext);
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
     }
 
-    public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, long tokenValidSecs, int timeBufferPercentage)
+    public IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, long tokenValidSecs, int timeBufferPercentage)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+        super(hostname, gatewayHostname, deviceId, moduleId);
 
         //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_015: [This function shall save the provided tokenValidSecs as the number of seconds that created sas tokens are valid for.]
         //Codes_SRS_IOTHUBSASTOKENAUTHENTICATION_34_016: [If the provided tokenValidSecs is less than 1, this function shall throw an IllegalArgumentException.]
@@ -64,9 +64,9 @@ public abstract class IotHubSasTokenAuthenticationProvider extends IotHubAuthent
         this.timeBufferPercentage = timeBufferPercentage;
     }
 
-    IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, long tokenValidSecs, int timeBufferPercentage, SSLContext sslContext)
+    IotHubSasTokenAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, long tokenValidSecs, int timeBufferPercentage, SSLContext sslContext)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, sslContext);
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
 
         this.setTokenValidSecs(tokenValidSecs);
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProvider.java
@@ -28,15 +28,14 @@ public class IotHubSasTokenHardwareAuthenticationProvider extends IotHubSasToken
      *
      * @param hostname The host name of the hub to authenticate against
      * @param gatewayHostname The gateway hostname to use, or null if connecting to an IotHub
-     * @param mqttGatewayHostname The mqttGatewayHostname to use in E4K context, or null if connecting to an IotHub
      * @param deviceId The unique id of the device to authenticate
      * @param moduleId the module id. May be null if not using a module
      * @param securityProvider the security provider to use for authentication
      * @throws IOException if the provided securityProvider throws while retrieving a sas token or ssl context instance
      */
-    public IotHubSasTokenHardwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SecurityProvider securityProvider) throws IOException
+    public IotHubSasTokenHardwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SecurityProvider securityProvider) throws IOException
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+        super(hostname, gatewayHostname, deviceId, moduleId);
 
         try
         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenProvidedAuthenticationProvider.java
@@ -21,7 +21,7 @@ public class IotHubSasTokenProvidedAuthenticationProvider extends IotHubSasToken
     private char[] lastSasToken;
 
     public IotHubSasTokenProvidedAuthenticationProvider(String hostName, String deviceId, String moduleId, SasTokenProvider sasTokenProvider, SSLContext sslContext) {
-        super(hostName, null, null, deviceId, moduleId, sslContext);
+        super(hostName, null, deviceId, moduleId, sslContext);
 
         if (sasTokenProvider == null)
         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareAuthenticationProvider.java
@@ -16,7 +16,6 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      *
      * @param hostname the IotHub host name
      * @param gatewayHostname The gateway hostname to use, or null if connecting to an IotHub
-     * @param mqttGatewayHostname The mqttGatewayHostname to use in E4K context, or null if connecting to an IotHub
      * @param deviceId the IotHub device id
      * @param moduleId the module id. May be null if not using a module
      * @param deviceKey the device key for the device. Must be null if the provided sharedAccessToken is not
@@ -24,9 +23,9 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      * @param tokenValidSecs the number of seconds that the token will be valid for
      * @param timeBufferPercentage the percent of the sas token's life that will be exhausted before renewal is attempted
      */
-    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken, int tokenValidSecs, int timeBufferPercentage)
+    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken, int tokenValidSecs, int timeBufferPercentage)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, tokenValidSecs, timeBufferPercentage);
+        super(hostname, gatewayHostname, deviceId, moduleId, tokenValidSecs, timeBufferPercentage);
         this.deviceKey = deviceKey;
         this.sasToken = new IotHubSasToken(hostname, deviceId, deviceKey, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
     }
@@ -35,15 +34,14 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      * Constructor that takes a connection string containing a sas token or a device key and uses the default token valid seconds and timeBufferPercentage
      * @param hostname the IotHub host name
      * @param gatewayHostname The gateway hostname to use, or null if connecting to an IotHub
-     * @param mqttGatewayHostname The mqttGatewayHostname to use in E4K context, or null if connecting to an IotHub
      * @param deviceId the IotHub device id
      * @param moduleId the module id. May be null if not using a module
      * @param deviceKey the device key for the device. Must be null if the provided sharedAccessToken is not
      * @param sharedAccessToken the sas token string for accessing the device. Must be null if the provided deviceKey is not.
      */
-    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken)
+    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+        super(hostname, gatewayHostname, deviceId, moduleId);
         this.deviceKey = deviceKey;
         this.sasToken = new IotHubSasToken(hostname, deviceId, deviceKey, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
     }
@@ -52,16 +50,15 @@ public class IotHubSasTokenSoftwareAuthenticationProvider extends IotHubSasToken
      * Constructor that takes a connection string containing a sas token or a device key and uses the default token valid seconds and timeBufferPercentage
      * @param hostname the IotHub host name
      * @param gatewayHostname The gateway hostname to use, or null if connecting to an IotHub
-     * @param mqttGatewayHostname The mqttGatewayHostname to use in E4K context, or null if connecting to an IotHub
      * @param deviceId the IotHub device id
      * @param moduleId the module id. May be null if not using a module
      * @param deviceKey the device key for the device. Must be null if the provided sharedAccessToken is not
      * @param sharedAccessToken the sas token string for accessing the device. Must be null if the provided deviceKey is not.
      * @param sslContext the sslContext to use for SSL negotiation
      */
-    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken, SSLContext sslContext)
+    public IotHubSasTokenSoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, String deviceKey, String sharedAccessToken, SSLContext sslContext)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, sslContext);
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
         this.deviceKey = deviceKey;
         this.sasToken = new IotHubSasToken(hostname, deviceId, deviceKey, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
     }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProvider.java
@@ -24,16 +24,15 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * Constructor for IotHubSasTokenWithRefreshAuthenticationProvider
      * @param hostname the hostname
      * @param gatewayHostName the gateway hostname
-     * @param mqttGatewayHostname the mqttGatewayHostname
      * @param deviceId the device id
      * @param moduleId the module id
      * @param sharedAccessToken the shared access token
      * @param suggestedTimeToLiveSeconds the time to live for generated tokens
      * @param timeBufferPercentage the percent of a sas token's life to live before renewing
      */
-    protected IotHubSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String mqttGatewayHostname, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)
+    protected IotHubSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)
     {
-        super(hostname, gatewayHostName, mqttGatewayHostname, deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage);
+        super(hostname, gatewayHostName, deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage);
         this.sasToken = new IotHubSasToken(hostname, deviceId, null, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
     }
 
@@ -41,7 +40,6 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * Constructor for IotHubSasTokenWithRefreshAuthenticationProvider
      * @param hostname the hostname
      * @param gatewayHostName the gateway hostname
-     * @param mqttGatewayHostname the mqttGatewayHostname
      * @param deviceId the device id
      * @param moduleId the module id
      * @param sharedAccessToken the shared access token
@@ -49,9 +47,9 @@ public abstract class IotHubSasTokenWithRefreshAuthenticationProvider extends Io
      * @param timeBufferPercentage the percent of a sas token's life to live before renewing
      * @param sslContext the SSLContext the connection will use
      */
-    protected IotHubSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String mqttGatewayHostname, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage, SSLContext sslContext)
+    protected IotHubSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage, SSLContext sslContext)
     {
-        super(hostname, gatewayHostName, mqttGatewayHostname, deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage, sslContext);
+        super(hostname, gatewayHostName, deviceId, moduleId, suggestedTimeToLiveSeconds, timeBufferPercentage, sslContext);
         this.sasToken = new IotHubSasToken(hostname, deviceId, null, sharedAccessToken, moduleId, getExpiryTimeInSeconds());
     }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509HardwareAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509HardwareAuthenticationProvider.java
@@ -16,9 +16,9 @@ public class IotHubX509HardwareAuthenticationProvider extends IotHubAuthenticati
 {
     private final SecurityProviderX509 securityProviderX509;
 
-    public IotHubX509HardwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SecurityProvider securityProvider)
+    public IotHubX509HardwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SecurityProvider securityProvider)
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+        super(hostname, gatewayHostname, deviceId, moduleId);
 
         if (!(securityProvider instanceof SecurityProviderX509))
         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509SoftwareAuthenticationProvider.java
@@ -9,8 +9,8 @@ import javax.net.ssl.SSLContext;
 
 public class IotHubX509SoftwareAuthenticationProvider extends IotHubAuthenticationProvider
 {
-    public IotHubX509SoftwareAuthenticationProvider(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SSLContext sslContext) throws IllegalArgumentException
+    public IotHubX509SoftwareAuthenticationProvider(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext) throws IllegalArgumentException
     {
-        super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, sslContext);
+        super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
     }
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProvider.java
@@ -27,9 +27,8 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
      * @param signatureProvider the signature provider to be used when generating sas tokens
      * @param deviceId the id of the device the module belongs to
      * @param moduleId the id of the module to be authenticated for
-     * @param hostname the hostname of the iothub to be authenticated for. May be null if either gatewayHostname or mqttGatewayHostname is not
-     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if either hostname or mqttGatewayHostname is not
-     * @param mqttGatewayHostname the mqttGatewayHostname of the edge hub to be authenticated for. May be null if either hostname or gatewayHostname is not
+     * @param hostname the hostname of the iothub to be authenticated for. May be null if gatewayHostname is not
+     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if hostname is not
      * @param generationId the generation id
      * @param suggestedTimeToLiveSeconds the time for the generated sas tokens to live for
      * @param timeBufferPercentage the percent of the life a sas token will live before attempting to be renewed. (100 means don't renew until end of life)
@@ -43,7 +42,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         String moduleId,
         String hostname,
         String gatewayHostname,
-        String mqttGatewayHostname,
         String generationId,
         int suggestedTimeToLiveSeconds,
         int timeBufferPercentage) throws IOException, TransportException
@@ -56,7 +54,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         IotHubSasToken sasToken = createNewSasToken(
             hostname,
             gatewayHostname,
-            mqttGatewayHostname,
             deviceId,
             moduleId,
             generationId,
@@ -66,7 +63,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         return new IotHubSasTokenHsmAuthenticationProvider(
             hostname,
             gatewayHostname,
-            mqttGatewayHostname,
             deviceId,
             moduleId,
             generationId,
@@ -81,9 +77,8 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
      * @param signatureProvider the signature provider to be used when generating sas tokens
      * @param deviceId the id of the device the module belongs to
      * @param moduleId the id of the module to be authenticated for
-     * @param hostname the hostname of the iothub to be authenticated for. May be null if either gatewayHostname or mqttGatewayHostname is not
-     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if either hostname or mqttGatewayHostname is not
-     * @param mqttGatewayHostname the mqttGatewayHostname of the edge hub to be authenticated for. May be null if either hostname or gatewayHostname is not
+     * @param hostname the hostname of the iothub to be authenticated for. May be null if gatewayHostname is not
+     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if hostname is not
      * @param generationId the generation id
      * @param suggestedTimeToLiveSeconds the time for the generated sas tokens to live for
      * @param timeBufferPercentage the percent of the life a sas token will live before attempting to be renewed. (100 means don't renew until end of life)
@@ -98,7 +93,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         String moduleId,
         String hostname,
         String gatewayHostname,
-        String mqttGatewayHostname,
         String generationId,
         int suggestedTimeToLiveSeconds,
         int timeBufferPercentage,
@@ -113,7 +107,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
             createNewSasToken(
                 hostname,
                 gatewayHostname,
-                mqttGatewayHostname,
                 deviceId,
                 moduleId,
                 generationId,
@@ -123,7 +116,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         return new IotHubSasTokenHsmAuthenticationProvider(
             hostname,
             gatewayHostname,
-            mqttGatewayHostname,
             deviceId,
             moduleId,
             generationId,
@@ -144,7 +136,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         this.sasToken = createNewSasToken(
             this.hostname,
             this.gatewayHostname,
-            this.mqttGatewayHostname,
             this.deviceId,
             this.moduleId,
             this.generationId,
@@ -164,7 +155,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
     private static IotHubSasToken createNewSasToken(
         String hostname,
         String gatewayHostName,
-        String mqttGatewayHostName,
         String deviceId,
         String moduleId,
         String generationId,
@@ -179,23 +169,7 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
             String data = audience + "\n" + expiresOn;
             String signature = signatureProvider.sign(moduleId, data, generationId);
 
-            if (gatewayHostName != null && !gatewayHostName.isEmpty()
-                    && mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-            {
-                throw new IllegalArgumentException("[GatewayHostName] and [MqttGatewayHostName] should NOT be specified at the same time.");
-            }
-
-            String host = hostname;
-
-            if (gatewayHostName != null && !gatewayHostName.isEmpty())
-            {
-                host = gatewayHostName;
-            }
-            else if (mqttGatewayHostName != null && !mqttGatewayHostName.isEmpty())
-            {
-                host = mqttGatewayHostName;
-            }
-
+            String host = gatewayHostName != null && !gatewayHostName.isEmpty() ? gatewayHostName : hostname;
             String sharedAccessToken = IotHubSasToken.buildSharedAccessToken(audience, signature, expiresOn);
 
             return new IotHubSasToken(host, deviceId, null, sharedAccessToken, moduleId, expiresOn);
@@ -209,7 +183,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
     private IotHubSasTokenHsmAuthenticationProvider(
         String hostname,
         String gatewayHostName,
-        String mqttGatewayHostname,
         String deviceId,
         String moduleId,
         String generationId,
@@ -218,7 +191,7 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         int suggestedTimeToLiveSeconds,
         int timeBufferPercentage)
     {
-        super(hostname, gatewayHostName, mqttGatewayHostname, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage);
+        super(hostname, gatewayHostName, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage);
         this.signatureProvider = signatureProvider;
         this.generationId = generationId;
     }
@@ -226,7 +199,6 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
     private IotHubSasTokenHsmAuthenticationProvider(
         String hostname,
         String gatewayHostName,
-        String mqttGatewayHostname,
         String deviceId,
         String moduleId,
         String generationId,
@@ -236,7 +208,7 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
         int timeBufferPercentage,
         SSLContext sslContext)
     {
-        super(hostname, gatewayHostName, mqttGatewayHostname, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage, sslContext);
+        super(hostname, gatewayHostName, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage, sslContext);
         this.signatureProvider = signatureProvider;
         this.generationId = generationId;
     }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProvider.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProvider.java
@@ -27,8 +27,8 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
      * @param signatureProvider the signature provider to be used when generating sas tokens
      * @param deviceId the id of the device the module belongs to
      * @param moduleId the id of the module to be authenticated for
-     * @param hostname the hostname of the iothub to be authenticated for. May be null if gatewayHostname is not
-     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if hostname is not
+     * @param hostname the hostname of the iothub to be authenticated for.
+     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null
      * @param generationId the generation id
      * @param suggestedTimeToLiveSeconds the time for the generated sas tokens to live for
      * @param timeBufferPercentage the percent of the life a sas token will live before attempting to be renewed. (100 means don't renew until end of life)
@@ -77,8 +77,8 @@ public class IotHubSasTokenHsmAuthenticationProvider extends IotHubSasTokenWithR
      * @param signatureProvider the signature provider to be used when generating sas tokens
      * @param deviceId the id of the device the module belongs to
      * @param moduleId the id of the module to be authenticated for
-     * @param hostname the hostname of the iothub to be authenticated for. May be null if gatewayHostname is not
-     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null if hostname is not
+     * @param hostname the hostname of the iothub to be authenticated for.
+     * @param gatewayHostname the gatewayHostname of the edge hub to be authenticated for. May be null
      * @param generationId the generation id
      * @param suggestedTimeToLiveSeconds the time for the generated sas tokens to live for
      * @param timeBufferPercentage the percent of the life a sas token will live before attempting to be renewed. (100 means don't renew until end of life)

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -1242,6 +1242,7 @@ public class ClientConfigurationTest
 
         //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
+        // [protocol] would be E4K-unsupported protocols including HTTPS, AMQP, AMQP_WS.
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, protocol, options);
     }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -1225,6 +1225,7 @@ public class ClientConfigurationTest
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
 
         //assert
+        assertEquals(GatewayType.EDGE, options.getGatewayType());
         assertEquals(false, config.isConnectingToMqttGateway());
     }
 

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -1114,4 +1114,80 @@ public class ClientConfigurationTest
         //assert
         assertEquals(mockedProxySettings, actualProxySettings);
     }
+
+    @Test
+    public void ConstructorWithValidGatewayHostNameAndE4KGatewayType()
+    {
+        //arrange - act
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = "testGatewayHostName";
+            }
+        };
+
+        ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+
+        //assert
+        assertEquals(true, config.isConnectingToMqttGateway());
+    }
+
+    @Test
+    public void ConstructorWithNullGatewayHostNameAndE4KGatewayType()
+    {
+        //arrange - act
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = null;
+            }
+        };
+
+        ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+
+        //assert
+        assertEquals(false, config.isConnectingToMqttGateway());
+    }
+
+    @Test
+    public void ConstructorWithValidGatewayHostNameAndEdgeGatewayType()
+    {
+        //arrange - act
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = "testGatewayHostName";
+            }
+        };
+
+        ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.EDGE).build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+
+        //assert
+        assertEquals(false, config.isConnectingToMqttGateway());
+    }
+
+    @Test
+    public void ConstructorWithNullGatewayHostNameAndEdgeGatewayType()
+    {
+        //arrange - act
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = null;
+            }
+        };
+
+        ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.EDGE).build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+
+        //assert
+        assertEquals(false, config.isConnectingToMqttGateway());
+    }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -146,7 +146,7 @@ public class ClientConfigurationTest
         new NonStrictExpectations()
         {
             {
-                new IotHubSasTokenSoftwareAuthenticationProvider(anyString, anyString, anyString, anyString, anyString, anyString, anyString);
+                new IotHubSasTokenSoftwareAuthenticationProvider(anyString, anyString, anyString, anyString, anyString, anyString);
                 result = mockSasTokenSoftwareAuthentication;
 
                 mockSasTokenSoftwareAuthentication.getDeviceId();
@@ -638,7 +638,6 @@ public class ClientConfigurationTest
     {
         final String hostname = "hostname";
         final String gatewayhostname = "gatewayhostname";
-        final String mqttGatewayHostname = "mqttGatewayHostname";
         final String deviceId = "deviceId";
         final String moduleId = "moduleId";
         new Expectations()
@@ -653,16 +652,13 @@ public class ClientConfigurationTest
                 mockIotHubConnectionString.getGatewayHostName();
                 result = gatewayhostname;
 
-                mockIotHubConnectionString.getMqttGatewayHostName();
-                result = mqttGatewayHostname;
-
                 mockIotHubConnectionString.getDeviceId();
                 result = deviceId;
 
                 mockIotHubConnectionString.getModuleId();
                 result = moduleId;
 
-                new IotHubX509SoftwareAuthenticationProvider(hostname, gatewayhostname, mqttGatewayHostname, deviceId, moduleId, mockSSLContext);
+                new IotHubX509SoftwareAuthenticationProvider(hostname, gatewayhostname, deviceId, moduleId, mockSSLContext);
             }
         };
 
@@ -674,7 +670,6 @@ public class ClientConfigurationTest
     {
         final String hostname = "hostname";
         final String gatewayhostname = "gatewayhostname";
-        final String mqttGatewayHostname = "mqttgatewayhostname";
         final String deviceId = "deviceId";
         final String moduleId = "moduleId";
         final String sharedAccessKey = "sharedAccessKey";
@@ -691,9 +686,6 @@ public class ClientConfigurationTest
                 mockIotHubConnectionString.getGatewayHostName();
                 result = gatewayhostname;
 
-                mockIotHubConnectionString.getMqttGatewayHostName();
-                result = mqttGatewayHostname;
-
                 mockIotHubConnectionString.getDeviceId();
                 result = deviceId;
 
@@ -706,7 +698,7 @@ public class ClientConfigurationTest
                 mockIotHubConnectionString.getSharedAccessToken();
                 result = sharedAccessToken;
 
-                new IotHubSasTokenSoftwareAuthenticationProvider(hostname, gatewayhostname, mqttGatewayHostname, deviceId, moduleId, sharedAccessKey, sharedAccessToken, mockSSLContext);
+                new IotHubSasTokenSoftwareAuthenticationProvider(hostname, gatewayhostname, deviceId, moduleId, sharedAccessKey, sharedAccessToken, mockSSLContext);
             }
         };
 
@@ -794,9 +786,6 @@ public class ClientConfigurationTest
                 mockIotHubConnectionString.getGatewayHostName();
                 result = "gatewayHostname";
 
-                mockIotHubConnectionString.getMqttGatewayHostName();
-                result = "mqttGatewayHostname";
-
                 mockIotHubConnectionString.getDeviceId();
                 result = "deviceId";
 
@@ -812,7 +801,7 @@ public class ClientConfigurationTest
         new Verifications()
         {
             {
-                new IotHubX509HardwareAuthenticationProvider("hostname", "gatewayHostname", "mqttGatewayHostname", "deviceId", "moduleId", mockSecurityProviderX509);
+                new IotHubX509HardwareAuthenticationProvider("hostname", "gatewayHostname", "deviceId", "moduleId", mockSecurityProviderX509);
                 times = 1;
             }
         };
@@ -844,7 +833,7 @@ public class ClientConfigurationTest
         new Verifications()
         {
             {
-                new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, null, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+                new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
                 times = 1;
             }
         };
@@ -875,7 +864,7 @@ public class ClientConfigurationTest
         new Verifications()
         {
             {
-                new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, null, null, expectedDeviceId, expectedModuleId, new String(mockSecurityProviderSymKey.getSymmetricKey(), StandardCharsets.UTF_8), null);
+                new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, null, expectedDeviceId, expectedModuleId, new String(mockSecurityProviderSymKey.getSymmetricKey(), StandardCharsets.UTF_8), null);
                 times = 1;
             }
         };

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -14,13 +14,16 @@ import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderX509;
 import com.microsoft.azure.sdk.iot.provisioning.security.exceptions.SecurityProviderException;
 import mockit.*;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import java.util.*;
 
+import static com.microsoft.azure.sdk.iot.device.IotHubClientProtocol.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
@@ -30,6 +33,7 @@ import static org.junit.Assert.*;
  * Lines: 91%
  * (Untested lines and method are the unused default constructor)
  */
+@RunWith(Parameterized.class)
 public class ClientConfigurationTest
 {
     @Mocked
@@ -68,6 +72,18 @@ public class ClientConfigurationTest
     private static final String expectedDeviceId = "deviceId";
     private static final String expectedModuleId = "moduleId";
     private static final String expectedHostname = "hostname";
+
+    @Parameterized.Parameter()
+    public IotHubClientProtocol protocol;
+
+    @Parameterized.Parameters(name = "{index}: ClientConfigurationTest: protocol={0}")
+    public static Collection<Object[]> data() {
+        return (List) new ArrayList(Arrays.asList(new Object[][]{
+                {HTTPS},
+                {AMQPS},
+                {AMQPS_WS},
+        }));
+    }
 
     // Tests_SRS_DEVICECLIENTCONFIG_11_002: [The function shall return the IoT Hub hostname given in the constructor.]
     @Test
@@ -1129,7 +1145,7 @@ public class ClientConfigurationTest
 
         //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
-        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, MQTT, options);
 
         //assert
         assertEquals(true, config.isConnectingToMqttGateway());
@@ -1210,5 +1226,22 @@ public class ClientConfigurationTest
 
         //assert
         assertEquals(false, config.isConnectingToMqttGateway());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ConstructorWithValidGatewayHostNameAndE4KGatewayTypeAndUnsupportedProtocol()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = "testGatewayHostName";
+            }
+        };
+
+        //act
+        ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, protocol, options);
     }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -1118,7 +1118,7 @@ public class ClientConfigurationTest
     @Test
     public void ConstructorWithValidGatewayHostNameAndE4KGatewayType()
     {
-        //arrange - act
+        //arrange
         new Expectations()
         {
             {
@@ -1127,6 +1127,7 @@ public class ClientConfigurationTest
             }
         };
 
+        //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
 
@@ -1134,10 +1135,10 @@ public class ClientConfigurationTest
         assertEquals(true, config.isConnectingToMqttGateway());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void ConstructorWithNullGatewayHostNameAndE4KGatewayType()
     {
-        //arrange - act
+        //arrange
         new Expectations()
         {
             {
@@ -1146,17 +1147,15 @@ public class ClientConfigurationTest
             }
         };
 
+        //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.E4K).build();
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
-
-        //assert
-        assertEquals(false, config.isConnectingToMqttGateway());
     }
 
     @Test
     public void ConstructorWithValidGatewayHostNameAndEdgeGatewayType()
     {
-        //arrange - act
+        //arrange
         new Expectations()
         {
             {
@@ -1165,6 +1164,7 @@ public class ClientConfigurationTest
             }
         };
 
+        //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.EDGE).build();
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
 
@@ -1175,7 +1175,7 @@ public class ClientConfigurationTest
     @Test
     public void ConstructorWithNullGatewayHostNameAndEdgeGatewayType()
     {
-        //arrange - act
+        //arrange
         new Expectations()
         {
             {
@@ -1184,6 +1184,7 @@ public class ClientConfigurationTest
             }
         };
 
+        //act
         ClientOptions options = ClientOptions.builder().gatewayType(GatewayType.EDGE).build();
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
 
@@ -1194,7 +1195,7 @@ public class ClientConfigurationTest
     @Test
     public void ConstructorWithValidGatewayHostNameAndDefaultGatewayType()
     {
-        //arrange - act
+        //arrange
         new Expectations()
         {
             {
@@ -1203,6 +1204,7 @@ public class ClientConfigurationTest
             }
         };
 
+        //act
         ClientOptions options = ClientOptions.builder().build();
         ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
 

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ClientConfigurationTest.java
@@ -1190,4 +1190,23 @@ public class ClientConfigurationTest
         //assert
         assertEquals(false, config.isConnectingToMqttGateway());
     }
+
+    @Test
+    public void ConstructorWithValidGatewayHostNameAndDefaultGatewayType()
+    {
+        //arrange - act
+        new Expectations()
+        {
+            {
+                mockIotHubConnectionString.getGatewayHostName();
+                result = "testGatewayHostName";
+            }
+        };
+
+        ClientOptions options = ClientOptions.builder().build();
+        ClientConfiguration config = new ClientConfiguration(mockIotHubConnectionString, IotHubClientProtocol.MQTT, options);
+
+        //assert
+        assertEquals(false, config.isConnectingToMqttGateway());
+    }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
  * Methods: 100%
  * Lines: 97%
  */
-public class IotHubConnectionStringTest 
+public class IotHubConnectionStringTest
 {
     private static final String VALID_HUBNAME = "iothub";
     private static final String VALID_HOSTNAME = VALID_HUBNAME + ".device.com";

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/IotHubConnectionStringTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
  * Methods: 100%
  * Lines: 97%
  */
-public class IotHubConnectionStringTest
+public class IotHubConnectionStringTest 
 {
     private static final String VALID_HUBNAME = "iothub";
     private static final String VALID_HOSTNAME = VALID_HUBNAME + ".device.com";
@@ -26,8 +26,6 @@ public class IotHubConnectionStringTest
     private static final String IOTHUB_CONNECTION_STRING_CLASS = "com.microsoft.azure.sdk.iot.device.IotHubConnectionString";
     private static final String VALID_MODULEID = "moduleId";
     private static final String VALID_GATEWAYHOSTNAME = "edgeHubHostName";
-
-    private static final String VALID_MQTTGATEWAYHOSTNAME = "mqttGatewayHostName";
 
     @SuppressWarnings("SameParameterValue") // Since this is a helper method, the expected assertion param can be passed any value.
     private void assertConnectionString(Object iotHubConnectionString, String expectedHostName,
@@ -76,11 +74,11 @@ public class IotHubConnectionStringTest
     // Tests_SRS_IOTHUB_CONNECTIONSTRING_34_041: [The constructor shall save the gateway host name as the value of 'GatewayHostName' in the connection string.]
     // Tests_SRS_IOTHUB_CONNECTIONSTRING_34_043: [The getGatewayHostName shall return the stored gateway host name.]
     @Test
-    public void ConstructorSavesModuleIdAndGatewayHostName() throws URISyntaxException
+    public void ConstructorSavesModuleIdAndGatewayHostname() throws URISyntaxException
     {
         //arrange
-        final String connString = "HostName=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey" +
-                ";DeviceId=" + VALID_DEVICEID + ";SharedAccessKey=" + VALID_SHARED_ACCESS_KEY + ";ModuleId=" +
+        final String connString = "HostName=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey;" +
+                "DeviceId=" + VALID_DEVICEID + ";SharedAccessKey=" + VALID_SHARED_ACCESS_KEY + ";ModuleId=" +
                 VALID_MODULEID +";GatewayHostName=" + VALID_GATEWAYHOSTNAME + ";";
 
         //act
@@ -92,26 +90,10 @@ public class IotHubConnectionStringTest
         assertEquals(VALID_GATEWAYHOSTNAME, connectionString.getGatewayHostName());
     }
 
-    @Test
-    public void ConstructorSavesMqttGatewayHostName() throws URISyntaxException
-    {
-        //arrange
-        final String connString = "HostName=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey" +
-                ";DeviceId=" + VALID_DEVICEID + ";SharedAccessKey=" + VALID_SHARED_ACCESS_KEY +
-                ";MqttGatewayHostName=" + VALID_MQTTGATEWAYHOSTNAME + ";";
-
-        //act
-        IotHubConnectionString connectionString = new IotHubConnectionString(connString);
-
-        //assert
-        assertEquals(VALID_HOSTNAME, connectionString.getHostName());
-        assertEquals(VALID_MQTTGATEWAYHOSTNAME, connectionString.getMqttGatewayHostName());
-    }
-
     // Tests_SRS_IOTHUB_CONNECTIONSTRING_34_041: [The constructor shall save the gateway host name as the value of 'GatewayHostName' in the connection string.]
     // Tests_SRS_IOTHUB_CONNECTIONSTRING_34_043: [The getGatewayHostName shall return the stored gateway host name.]
     @Test
-    public void ConstructorSavesGatewayHostNameCaseInsensitively() throws URISyntaxException
+    public void ConstructorSavesAttributesCaseInsensitively() throws URISyntaxException
     {
         //arrange
         final String connString = "HOSTNAME=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey;" +
@@ -125,23 +107,6 @@ public class IotHubConnectionStringTest
         assertEquals(VALID_MODULEID, connectionString.getModuleId());
         assertEquals(VALID_HOSTNAME, connectionString.getHostName());
         assertEquals(VALID_GATEWAYHOSTNAME, connectionString.getGatewayHostName());
-    }
-
-    @Test
-    public void ConstructorSavesMqttGatewayHostNameCaseInsensitively() throws URISyntaxException
-    {
-        //arrange
-        final String connString = "HOSTNAME=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey" +
-                ";DeVicEid=" + VALID_DEVICEID + ";SharedACCESSKey=" + VALID_SHARED_ACCESS_KEY + ";MoDuLeId=" +
-                VALID_MODULEID +";mQttGATeWayHOstnaMe=" + VALID_MQTTGATEWAYHOSTNAME + ";";
-
-        //act
-        IotHubConnectionString connectionString = new IotHubConnectionString(connString);
-
-        //assert
-        assertEquals(VALID_MODULEID, connectionString.getModuleId());
-        assertEquals(VALID_HOSTNAME, connectionString.getHostName());
-        assertEquals(VALID_MQTTGATEWAYHOSTNAME, connectionString.getMqttGatewayHostName());
     }
 
     /* Tests_SRS_IOTHUB_CONNECTIONSTRING_21_020: [The constructor shall save the IoT Hub hostname as the value of `hostName` in the connection string.] */
@@ -694,18 +659,5 @@ public class IotHubConnectionStringTest
 
         //assert
         assertFalse(isUsingX509);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void IotHubConnectionStringWithGatewayHostNameAndMqttGatewayHostNameThrows()
-    {
-        // arrange
-        final String connString ="HostName=" + VALID_HOSTNAME + ";CredentialType=SharedAccessKey" +
-                ";DeviceId=" + VALID_DEVICEID + ";SharedAccessKey=" + VALID_SHARED_ACCESS_KEY + ";ModuleId=" +
-                VALID_MODULEID +";GatewayHostName=" + VALID_GATEWAYHOSTNAME + ";MqttGatewayHostName=" +
-                VALID_MQTTGATEWAYHOSTNAME + ";";
-
-        // act
-        new IotHubConnectionString(connString);
     }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/ModuleClientTest.java
@@ -383,7 +383,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = null;
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = "5678";
         String expectedGenerationId = "gen1";
@@ -398,7 +397,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -423,7 +421,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = null;
         String expectedModuleId = "5678";
         String expectedGenerationId = "gen1";
@@ -438,7 +435,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -463,7 +459,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = null;
         String expectedGenerationId = "gen1";
@@ -478,7 +473,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -503,7 +497,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = "5678";
         String expectedGenerationId = "gen1";
@@ -518,7 +511,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -541,7 +533,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = "5678";
         String expectedAuthScheme = "not sas token auth";
@@ -554,7 +545,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "AuthSchemeVariableName").toString(), expectedAuthScheme);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -582,7 +572,6 @@ public class ModuleClientTest
         final String expectedGenerationId = "gen1";
         final String expectedHostname = "someHostname";
         final String expectedGatewayHostname = "someGatewayHostname";
-        final String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         final String expectedDeviceId = "1234";
         final String expectedModuleId = "5678";
         String expectedAuthScheme = Deencapsulation.getField(ModuleClient.class, "SasTokenAuthScheme");
@@ -597,7 +586,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
 
         new Expectations()
         {
@@ -608,7 +596,7 @@ public class ModuleClientTest
                 new HttpHsmSignatureProvider(expectedIotEdgedUri, expectedApiVersion, mockedUnixDomainSocketChannel);
                 result = mockedHttpHsmSignatureProvider;
 
-                IotHubSasTokenHsmAuthenticationProvider.create(mockedHttpHsmSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, expectedGenerationId, anyInt, anyInt, (SSLContext) any);
+                IotHubSasTokenHsmAuthenticationProvider.create(mockedHttpHsmSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, expectedGenerationId, anyInt, anyInt, (SSLContext) any);
                 result = mockedModuleAuthenticationWithHsm;
 
                 new HttpsHsmTrustBundleProvider();
@@ -639,7 +627,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = "5678";
         String expectedGenerationId = "gen1";
@@ -654,7 +641,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), expectedGenerationId);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         new NonStrictExpectations()
         {
             {
@@ -679,7 +665,6 @@ public class ModuleClientTest
         String expectedApiVersion = "1.1.1";
         String expectedHostname = "someHostname";
         String expectedGatewayHostname = "someGatewayHostname";
-        String expectedMqttGatewayHostname = "someMqttGatewayHostname";
         String expectedDeviceId = "1234";
         String expectedModuleId = "5678";
         String expectedAuthScheme = Deencapsulation.getField(ModuleClient.class, "SasTokenAuthScheme");
@@ -692,7 +677,6 @@ public class ModuleClientTest
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "AuthSchemeVariableName").toString(), expectedAuthScheme);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "IotEdgedUriVariableName").toString(), expectedIotEdgedUri);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "GatewayHostnameVariableName").toString(), expectedGatewayHostname);
-        mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "MqttGatewayHostnameVariableName").toString(), expectedMqttGatewayHostname);
         mockedSystemVariables.put(Deencapsulation.getField(ModuleClient.class, "ModuleGenerationIdVariableName").toString(), null);
         new NonStrictExpectations()
         {

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubAuthenticationProviderTest.java
@@ -26,58 +26,36 @@ public class IotHubAuthenticationProviderTest
     
     private static final String expectedHostname = "hostname";
     private static final String expectedGatewayHostname = "gatewayhostname";
-    private static final String expectedMqttGatewayHostname = "mqttGatewayHostname";
     private static final String expectedDeviceId = "deviceId";
     private static final String expectedModuleId = "moduleId";
     
     private static class IotHubAuthenticationProviderMock extends IotHubAuthenticationProvider
     {
-        public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId)
+        public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String deviceId, String moduleId)
         {
-            super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId);
+            super(hostname, gatewayHostname, deviceId, moduleId);
         }
 
-        public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String mqttGatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
+        public IotHubAuthenticationProviderMock(String hostname, String gatewayHostname, String deviceId, String moduleId, SSLContext sslContext)
         {
-            super(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, sslContext);
+            super(hostname, gatewayHostname, deviceId, moduleId, sslContext);
         }
     }
 
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_001: [The constructor shall save the provided hostname, gatewayhostname, deviceid and moduleid.]
     @Test
-    public void constructorSavesArgumentsWithGatewayHostname()
+    public void constructorSavesArguments()
     {
         //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId);
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
         
         //assert
         assertEquals(expectedHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "hostname"));
         assertEquals(expectedGatewayHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "gatewayHostname"));
-        assertEquals(null, Deencapsulation.getField(iotHubAuthenticationProvider, "mqttGatewayHostname"));
         assertEquals(expectedDeviceId, Deencapsulation.getField(iotHubAuthenticationProvider, "deviceId"));
         assertEquals(expectedModuleId, Deencapsulation.getField(iotHubAuthenticationProvider, "moduleId"));
     }
 
-    @Test
-    public void constructorSavesArgumentsWithMqttGatewayHostname()
-    {
-        //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, null, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId);
-
-        //assert
-        assertEquals(expectedHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "hostname"));
-        assertEquals(null, Deencapsulation.getField(iotHubAuthenticationProvider, "gatewayHostname"));
-        assertEquals(expectedMqttGatewayHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "mqttGatewayHostname"));
-        assertEquals(expectedDeviceId, Deencapsulation.getField(iotHubAuthenticationProvider, "deviceId"));
-        assertEquals(expectedModuleId, Deencapsulation.getField(iotHubAuthenticationProvider, "moduleId"));
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorWithGatewayHostnameAndMqttGatewayHostnameThrows()
-    {
-        //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId);
-    }
 
     @Test
     public void constructorSuccessWithSSLContext()
@@ -92,7 +70,7 @@ public class IotHubAuthenticationProviderTest
         };
 
         //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockedSSLContext);
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockedSSLContext);
 
         //assert
         assertEquals(expectedHostname, Deencapsulation.getField(iotHubAuthenticationProvider, "hostname"));
@@ -108,10 +86,10 @@ public class IotHubAuthenticationProviderTest
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_008: [This function shall return the saved iotHubTrustedCert.]
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_009: [This function shall return the saved pathToIotHubTrustedCert.]
     @Test
-    public void gettersWorkWithGatewayHostname()
+    public void gettersWork()
     {
         //arrange
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId);
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
 
         //act
         String actualHostName = iotHubAuthenticationProvider.getHostname();
@@ -126,31 +104,12 @@ public class IotHubAuthenticationProviderTest
         assertEquals(expectedModuleId, actualModuleId);
     }
 
-    @Test
-    public void gettersWorkWithMqttGatewayHostname()
-    {
-        //arrange
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, null, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId);
-
-        //act
-        String actualHostName = iotHubAuthenticationProvider.getHostname();
-        String actualMqttGatewayHostname = iotHubAuthenticationProvider.getMqttGatewayHostname();
-        String actualDeviceId = iotHubAuthenticationProvider.getDeviceId();
-        String actualModuleId = iotHubAuthenticationProvider.getModuleId();
-
-        //assert
-        assertEquals(expectedHostname, actualHostName);
-        assertEquals(expectedMqttGatewayHostname, actualMqttGatewayHostname);
-        assertEquals(expectedDeviceId, actualDeviceId);
-        assertEquals(expectedModuleId, actualModuleId);
-    }
-
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_006: [If the provided hostname is null, this function shall throw an IllegalArgumentException.]
     @Test (expected = NullPointerException.class)
     public void constructorThrowsForNullHostname()
     {
         //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(null, expectedGatewayHostname, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId);
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(null, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
     }
 
     // Tests_SRS_AUTHENTICATIONPROVIDER_34_007: [If the provided device id is null, this function shall throw an IllegalArgumentException.]
@@ -158,7 +117,7 @@ public class IotHubAuthenticationProviderTest
     public void constructorThrowsForNullDeviceId()
     {
         //act
-        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, null, expectedModuleId);
+        IotHubAuthenticationProvider iotHubAuthenticationProvider = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedModuleId);
     }
 
     //Codes_SRS_AUTHENTICATIONPROVIDER_34_012: [If a CertificateException, NoSuchAlgorithmException, KeyManagementException, or KeyStoreException is thrown during this function, this function shall throw an IOException.]
@@ -175,7 +134,7 @@ public class IotHubAuthenticationProviderTest
             }
         };
 
-        IotHubAuthenticationProvider sasAuth = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId);
+        IotHubAuthenticationProvider sasAuth = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
 
         //act
         sasAuth.getSSLContext();
@@ -197,7 +156,7 @@ public class IotHubAuthenticationProviderTest
             }
         };
 
-        IotHubAuthenticationProvider sasAuth = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId);
+        IotHubAuthenticationProvider sasAuth = new IotHubAuthenticationProviderMock(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId);
 
         //act
         SSLContext actualSSLContext = sasAuth.getSSLContext();

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenAuthenticationProviderTest.java
@@ -43,7 +43,7 @@ public class IotHubSasTokenAuthenticationProviderTest
     {
         public mockIotHubSasTokenAuthenticationImplementation()
         {
-            super(expectedHostname, null, null, expectedDeviceId, null);
+            super(expectedHostname, null, expectedDeviceId, null);
             this.sasToken = mockSasToken;
             this.deviceId = expectedDeviceId;
             this.hostname = expectedHostname;
@@ -51,7 +51,7 @@ public class IotHubSasTokenAuthenticationProviderTest
 
         public mockIotHubSasTokenAuthenticationImplementation(long expectedTimeToLive, int expectedBufferPercentage)
         {
-            super(expectedHostname, null, null, expectedDeviceId, null, expectedTimeToLive, expectedBufferPercentage);
+            super(expectedHostname, null, expectedDeviceId, null, expectedTimeToLive, expectedBufferPercentage);
             this.sasToken = mockSasToken;
             this.deviceId = expectedDeviceId;
             this.hostname = expectedHostname;

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenHardwareAuthenticationProviderTest.java
@@ -45,14 +45,13 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     private static final String expectedDeviceId = "deviceId";
     private static final String expectedModuleId = "moduleId";
     private static final String expectedHostname = "hostname";
-    private static final String expectedGatewayHostname = "gatewayHostname";
-    private static final String expectedMqttGatewayHostname = "mqttGatewayHostname";
+    private static final String expectedGatewayHostname = "gateway";
     private static final String expectedSasToken = "sasToken";
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_033: [This constructor shall generate and save a sas token from the security provider with the default time to live.]
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_034: [This constructor shall retrieve and save the ssl context from the security provider.]
     @Test
-    public void securityProviderConstructorSavesNeededInfoWithGatewayHostname() throws IOException, InvalidKeyException, SecurityProviderException
+    public void securityProviderConstructorSavesNeededInfo() throws IOException, InvalidKeyException, SecurityProviderException
     {
         //arrange
         final String someToken = "someToken";
@@ -78,68 +77,17 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //assert
         String actualHostname = sasTokenAuthentication.getHostname();
         String actualDeviceId = sasTokenAuthentication.getDeviceId();
         String actualModuleId = sasTokenAuthentication.getModuleId();
-        String actualGatewayHostname = sasTokenAuthentication.getGatewayHostname();
         SecurityProviderTpm actualSecurityProvider = Deencapsulation.getField(sasTokenAuthentication, "securityProvider");
         assertEquals(expectedHostname, actualHostname);
         assertEquals(expectedDeviceId, actualDeviceId);
         assertEquals(expectedModuleId, actualModuleId);
-        assertEquals(expectedGatewayHostname, actualGatewayHostname);
         assertEquals(mockSecurityProviderTpm, actualSecurityProvider);
-    }
-
-    @Test
-    public void securityProviderConstructorSavesNeededInfoWithMqttGatewayHostname() throws IOException, InvalidKeyException, SecurityProviderException
-    {
-        //arrange
-        final String someToken = "someToken";
-        final byte[] tokenBytes = someToken.getBytes(StandardCharsets.UTF_8);
-        new Expectations()
-        {
-            {
-                URLEncoder.encode(anyString, encodingName);
-                result = someToken;
-
-                mockSecurityProviderTpm.signWithIdentity((byte[]) any);
-                result = tokenBytes;
-
-                URLEncoder.encode(anyString, encodingName);
-                result = someToken;
-
-                mockSecurityProviderTpm.getSSLContext();
-                result = mockSSLContext;
-
-                Deencapsulation.newInstance(IotHubSSLContext.class, new Class[] {SSLContext.class}, mockSSLContext);
-                result = mockIotHubSSLContext;
-            }
-        };
-
-        //act
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, null, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
-
-        //assert
-        String actualHostname = sasTokenAuthentication.getHostname();
-        String actualDeviceId = sasTokenAuthentication.getDeviceId();
-        String actualModuleId = sasTokenAuthentication.getModuleId();
-        String actualMqttGatewayHostname = sasTokenAuthentication.getMqttGatewayHostname();
-        SecurityProviderTpm actualSecurityProvider = Deencapsulation.getField(sasTokenAuthentication, "securityProvider");
-        assertEquals(expectedHostname, actualHostname);
-        assertEquals(expectedDeviceId, actualDeviceId);
-        assertEquals(expectedModuleId, actualModuleId);
-        assertEquals(expectedMqttGatewayHostname, actualMqttGatewayHostname);
-        assertEquals(mockSecurityProviderTpm, actualSecurityProvider);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void securityProviderConstructorWithGatewayHostnameAndMqttGatewayHostnameThrows() throws IOException
-    {
-        //act
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_003: [If the provided security provider is not an instance of SecurityProviderTpm, this function shall throw an IllegalArgumentException.]
@@ -147,7 +95,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
     public void securityProviderConstructorThrowsForInvalidSecurityProviderInstance() throws IOException, InvalidKeyException, SecurityProviderException
     {
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProvider);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProvider);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_023: [If the security provider throws an exception while retrieving a sas token or ssl context from it, this function shall throw an IOException.]
@@ -178,7 +126,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_035: [If the saved sas token has expired and there is a security provider, the saved sas token shall be refreshed with a new token from the security provider.]
@@ -208,7 +156,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         sasAuth.getSasToken();
@@ -241,7 +189,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         sasAuth.getSasToken();
@@ -277,7 +225,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         sasAuth.getSasToken();
@@ -308,7 +256,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         char[] actualSasToken = sasAuth.getSasToken();
@@ -379,7 +327,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         SSLContext actualSSLContext = sasTokenAuthentication.getSSLContext();
@@ -402,7 +350,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_010: [If the call for the saved security provider to sign with identity returns null or empty bytes, this function shall throw an IOException.]
@@ -422,7 +370,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_010: [If the call for the saved security provider to sign with identity returns null or empty bytes, this function shall throw an IOException.]
@@ -442,7 +390,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_011: [When generating the sas token signature from the security provider, if an UnsupportedEncodingException or SecurityProviderException is thrown, this function shall throw an IOException.]
@@ -459,7 +407,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_011: [When generating the sas token signature from the security provider, if an UnsupportedEncodingException or SecurityProviderException is thrown, this function shall throw an IOException.]
@@ -479,7 +427,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
         };
 
         //act
-        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
     }
 
     //Tests_SRS_IOTHUBSASTOKENHARDWAREAUTHENTICATION_34_012: [This function shall return false.]
@@ -512,7 +460,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         boolean result = sasTokenAuthentication.isAuthenticationProviderRenewalNecessary();
@@ -551,7 +499,7 @@ public class IotHubSasTokenHardwareAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
+        IotHubSasTokenAuthenticationProvider sasTokenAuthentication = new IotHubSasTokenHardwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, mockSecurityProviderTpm);
 
         //act
         boolean result = sasTokenAuthentication.canRefreshToken();

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenSoftwareIotHubAuthenticationProviderTest.java
@@ -29,8 +29,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
 {
     private static final String expectedDeviceId = "deviceId";
     private static final String expectedHostname = "hostname";
-    private static final String expectedGatewayHostname = "gatewayHostname";
-    private static final String expectedMqttGatewayHostname = "mqttGatewayHostname";
+    private static final String expectedGatewayHostname = "gateway";
     private static final String expectedModuleId = "moduleId";
     private static final String expectedDeviceKey = "deviceKey";
     private static final String expectedSasToken = "sasToken";
@@ -43,7 +42,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
 
     //Tests_SRS_IOTHUBSASTOKENSOFTWAREAUTHENTICATION_34_002: [This constructor shall save the provided hostname, device id, module id, deviceKey, and sharedAccessToken.]
     @Test
-    public void constructorSavesArgumentsWithGatewayHostname()
+    public void constructorSavesArguments()
     {
         //arrange
         new NonStrictExpectations()
@@ -58,54 +57,18 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //assert
         String actualDeviceId = sasAuth.getDeviceId();
         String actualModuleId = sasAuth.getModuleId();
         String actualHostName = sasAuth.getHostname();
-        String actualGatewayHostname = sasAuth.getGatewayHostname();
         String actualDeviceKey = Deencapsulation.getField(sasAuth, "deviceKey");
         IotHubSasToken actualSasToken = Deencapsulation.getField(sasAuth, "sasToken");
 
         assertEquals(expectedDeviceId, actualDeviceId);
         assertEquals(expectedModuleId, actualModuleId);
         assertEquals(expectedHostname, actualHostName);
-        assertEquals(expectedGatewayHostname, actualGatewayHostname);
-        assertEquals(expectedDeviceKey, actualDeviceKey);
-        assertEquals(expectedSasToken, actualSasToken.toString());
-    }
-
-    @Test
-    public void constructorSavesArgumentsWithMqttGatewayHostname()
-    {
-        //arrange
-        new NonStrictExpectations()
-        {
-            {
-                Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, anyString, anyString, anyString, anyString, anyString, anyLong);
-                result = mockSasToken;
-
-                mockSasToken.toString();
-                result = expectedSasToken;
-            }
-        };
-
-        //act
-        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, null, expectedMqttGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
-
-        //assert
-        String actualDeviceId = sasAuth.getDeviceId();
-        String actualModuleId = sasAuth.getModuleId();
-        String actualHostName = sasAuth.getHostname();
-        String actualMqttGatewayHostname = sasAuth.getMqttGatewayHostname();
-        String actualDeviceKey = Deencapsulation.getField(sasAuth, "deviceKey");
-        IotHubSasToken actualSasToken = Deencapsulation.getField(sasAuth, "sasToken");
-
-        assertEquals(expectedDeviceId, actualDeviceId);
-        assertEquals(expectedModuleId, actualModuleId);
-        assertEquals(expectedHostname, actualHostName);
-        assertEquals(expectedMqttGatewayHostname, actualMqttGatewayHostname);
         assertEquals(expectedDeviceKey, actualDeviceKey);
         assertEquals(expectedSasToken, actualSasToken.toString());
     }
@@ -129,20 +92,18 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken, mockSSLContext);
+        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken, mockSSLContext);
 
         //assert
         String actualDeviceId = sasAuth.getDeviceId();
         String actualModuleId = sasAuth.getModuleId();
         String actualHostName = sasAuth.getHostname();
-        String actualGatewayHostname = sasAuth.getGatewayHostname();
         String actualDeviceKey = Deencapsulation.getField(sasAuth, "deviceKey");
         IotHubSasToken actualSasToken = Deencapsulation.getField(sasAuth, "sasToken");
 
         assertEquals(expectedDeviceId, actualDeviceId);
         assertEquals(expectedModuleId, actualModuleId);
         assertEquals(expectedHostname, actualHostName);
-        assertEquals(expectedGatewayHostname, actualGatewayHostname);
         assertEquals(expectedDeviceKey, actualDeviceKey);
         assertEquals(expectedSasToken, actualSasToken.toString());
     }
@@ -164,20 +125,18 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken, 10, 10);
+        IotHubSasTokenSoftwareAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken, 10, 10);
 
         //assert
         String actualDeviceId = sasAuth.getDeviceId();
         String actualModuleId = sasAuth.getModuleId();
         String actualHostName = sasAuth.getHostname();
-        String actualGatewayHostname = sasAuth.getGatewayHostname();
         String actualDeviceKey = Deencapsulation.getField(sasAuth, "deviceKey");
         IotHubSasToken actualSasToken = Deencapsulation.getField(sasAuth, "sasToken");
 
         assertEquals(expectedDeviceId, actualDeviceId);
         assertEquals(expectedModuleId, actualModuleId);
         assertEquals(expectedHostname, actualHostName);
-        assertEquals(expectedGatewayHostname, actualGatewayHostname);
         assertEquals(expectedDeviceKey, actualDeviceKey);
         assertEquals(expectedSasToken, actualSasToken.toString());
     }
@@ -200,7 +159,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         sasAuth.getSasToken();
@@ -233,7 +192,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         sasAuth.getSasToken();
@@ -264,7 +223,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         sasAuth.getSasToken();
@@ -294,7 +253,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         };
 
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         sasAuth.getSasToken();
@@ -314,7 +273,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         char[] actualSasToken = sasAuth.getSasToken();
@@ -336,7 +295,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, null, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, null, expectedSasToken);
 
         //act
         boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
@@ -360,7 +319,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
@@ -382,7 +341,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         boolean needsToRenew = Deencapsulation.invoke(sasAuth, "isAuthenticationProviderRenewalNecessary");
@@ -396,7 +355,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
     public void isRenewalNecessaryReturnsTrueIfDeviceKeyPresent()
     {
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         boolean result = sasAuth.isAuthenticationProviderRenewalNecessary();
@@ -410,7 +369,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
     public void canRefreshTokenReturnsTrueIfDeviceKeyPresent()
     {
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedDeviceKey, expectedSasToken);
 
         //act
         boolean result = sasAuth.canRefreshToken();
@@ -424,7 +383,7 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
     public void canRefreshTokenReturnsFalseIfDeviceKeyAbsent()
     {
         //arrange
-        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, null, expectedSasToken);
+        IotHubSasTokenAuthenticationProvider sasAuth = new IotHubSasTokenSoftwareAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, null, expectedSasToken);
 
         //act
         boolean result = sasAuth.canRefreshToken();
@@ -432,4 +391,5 @@ public class IotHubSasTokenSoftwareIotHubAuthenticationProviderTest
         //assert
         assertFalse(result);
     }
+
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubSasTokenWithRefreshAuthenticationProviderTest.java
@@ -20,9 +20,9 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
     private static class IotHubImplSasTokenWithRefreshAuthenticationProvider extends IotHubSasTokenWithRefreshAuthenticationProvider
     {
         @SuppressWarnings("SameParameterValue") // Since this is a constructor, the constructor params can be passed any value.
-        protected IotHubImplSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String mqttGatewayHostname, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)
+        protected IotHubImplSasTokenWithRefreshAuthenticationProvider(String hostname, String gatewayHostName, String deviceId, String moduleId, String sharedAccessToken, int suggestedTimeToLiveSeconds, int timeBufferPercentage)
         {
-            super(hostname, gatewayHostName, mqttGatewayHostname, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage);
+            super(hostname, gatewayHostName, deviceId, moduleId, sharedAccessToken, suggestedTimeToLiveSeconds, timeBufferPercentage);
         }
 
         public void refreshSasToken() throws IOException, TransportException
@@ -51,7 +51,6 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
     private final String expectedDeviceId = "somedeviceid";
     private final String expectedModuleId = "somemoduleid";
     private final String expectedGatewayHostname = "somegatewayhostname";
-    private final String expectedMqttGatewayHostname = "somemqttgatewayhostname";
     private final String expectedSharedAccessToken = "1234";
     private final int expectedTimeToLive = 10;
     private final int expectedTimeBufferPercentage = 10;
@@ -106,7 +105,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
     public void isRenewalNecessaryReturnsFalse()
     {
         //arrange
-        IotHubSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
+        IotHubSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
 
         //act, assert
         assertFalse(moduleAuthenticationWithTokenRefresh.isAuthenticationProviderRenewalNecessary());
@@ -120,7 +119,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         //arrange
         final IotHubSasToken oldSasToken = Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, "", "", "", "", "", 1);
         final IotHubSasToken newSasToken = mockedIotHubSasToken;
-        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
+        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
         Deencapsulation.setField(moduleAuthenticationWithTokenRefresh, "sasToken", oldSasToken);
         moduleAuthenticationWithTokenRefresh.shouldRefresh = true;
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;
@@ -138,7 +137,7 @@ public class IotHubSasTokenWithRefreshAuthenticationProviderTest
         //arrange
         final IotHubSasToken oldSasToken = Deencapsulation.newInstance(IotHubSasToken.class, new Class[] {String.class, String.class, String.class, String.class, String.class, long.class}, "", "", "", "", "", 1);
         final IotHubSasToken newSasToken = mockedIotHubSasToken;
-        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, null, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
+        IotHubImplSasTokenWithRefreshAuthenticationProvider moduleAuthenticationWithTokenRefresh = new IotHubImplSasTokenWithRefreshAuthenticationProvider(expectedHostname, expectedGatewayHostname, expectedDeviceId, expectedModuleId, expectedSharedAccessToken, expectedTimeToLive, expectedTimeBufferPercentage);
         Deencapsulation.setField(moduleAuthenticationWithTokenRefresh, "sasToken", oldSasToken);
         moduleAuthenticationWithTokenRefresh.shouldRefresh = false;
         moduleAuthenticationWithTokenRefresh.nextToken = newSasToken;

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509HardwareIotHubAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/auth/IotHubX509HardwareIotHubAuthenticationProviderTest.java
@@ -32,28 +32,16 @@ public class IotHubX509HardwareIotHubAuthenticationProviderTest
     @Mocked SSLContext mockSSLContext;
 
     private static final String hostname = "hostname";
-    private static final String gatewayHostname = "gatewayHostname";
-    private static final String mqttGatewayHostname = "mqttGatewayHostname";
+    private static final String gatewayHostname = "gateway";
     private static final String deviceId = "deviceId";
     private static final String moduleId = "moduleId";
 
     //Tests_SRS_IOTHUBX509HARDWAREAUTHENTICATION_34_001: [This function shall save the provided security provider.]
     @Test
-    public void constructorWithGatewayHostnameSuccess()
+    public void constructorSuccess()
     {
         //act
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, null, deviceId, moduleId, mockSecurityProviderX509);
-
-        //assert
-        SecurityProvider actualSecurityProvider = Deencapsulation.getField(authentication, "securityProviderX509");
-        assertEquals(mockSecurityProviderX509, actualSecurityProvider);
-    }
-
-    @Test
-    public void constructorWithMqttGatewayHostnameSuccess()
-    {
-        //act
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, null, mqttGatewayHostname, deviceId, moduleId, mockSecurityProviderX509);
+        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, deviceId, moduleId, mockSecurityProviderX509);
 
         //assert
         SecurityProvider actualSecurityProvider = Deencapsulation.getField(authentication, "securityProviderX509");
@@ -65,14 +53,7 @@ public class IotHubX509HardwareIotHubAuthenticationProviderTest
     public void constructorThrowsForInvalidSecurityProviderInstance()
     {
         //act
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, null, deviceId, moduleId, mockSecurityProvider);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void constructorWithGatewayHostnameAndMqttGatewayHostnameThrows()
-    {
-        //act
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, mqttGatewayHostname, deviceId, moduleId, mockSecurityProvider);
+        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, deviceId, moduleId, mockSecurityProvider);
     }
 
     //Tests_SRS_IOTHUBX509HARDWAREAUTHENTICATION_34_004: [If the security provider throws a SecurityProviderException while generating an SSLContext, this function shall throw an IOException.]
@@ -80,7 +61,7 @@ public class IotHubX509HardwareIotHubAuthenticationProviderTest
     public void getSSLContextThrowsIOExceptionIfExceptionEncountered() throws SecurityProviderException, IOException, TransportException
     {
         //arrange
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, null, deviceId, moduleId, mockSecurityProviderX509);
+        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, deviceId, moduleId, mockSecurityProviderX509);
 
         new NonStrictExpectations()
         {
@@ -100,7 +81,7 @@ public class IotHubX509HardwareIotHubAuthenticationProviderTest
     public void getSSLContextSuccess() throws SecurityProviderException, IOException, TransportException
     {
         //arrange
-        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, null, deviceId, moduleId, mockSecurityProviderX509);
+        IotHubAuthenticationProvider authentication = new IotHubX509HardwareAuthenticationProvider(hostname, gatewayHostname, deviceId, moduleId, mockSecurityProviderX509);
 
         new NonStrictExpectations()
         {

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProviderTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/hsm/IotHubSasTokenHsmAuthenticationProviderTest.java
@@ -28,7 +28,6 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
 
     private static final String expectedHostname = "hostname";
     private static final String expectedGatewayHostname = "gatewayHostname";
-    private static final String expectedMqttGatewayHostname = "mqttGatewayHostname";
     private static final String expectedDeviceId = "device";
     private static final String expectedModuleId = "module";
     private static final int expectedTimeToLive = 56;
@@ -40,7 +39,7 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
     // Tests_SRS_MODULEAUTHENTICATIONWITHHSM_34_001: [This function shall construct a sas token from the provided arguments and then return a IotHubSasTokenHsmAuthenticationProvider instance that uses that sas token.]
     // Tests_SRS_MODULEAUTHENTICATIONWITHHSM_34_003: [If the gatewayHostname is not null or empty, this function shall construct the sas token using the gateway hostname instead of the hostname.]
     @Test
-    public void staticConstructorWithGatewayHostnameSuccess() throws IOException, TransportException, URISyntaxException
+    public void staticConstructorSuccess() throws IOException, TransportException, URISyntaxException
     {
         //arrange
         new MockUp<System>()
@@ -67,38 +66,7 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, null, "gen1", expectedTimeToLive, expectedBufferPercent);
-    }
-
-    @Test
-    public void staticConstructorWithMqttGatewayHostnameSuccess() throws IOException, TransportException, URISyntaxException
-    {
-        //arrange
-        new MockUp<System>()
-        {
-            @Mock long currentTimeMillis()
-            {
-                return 0;
-            }
-        };
-        new Expectations()
-        {
-            {
-                mockedSignatureProvider.sign("module", anyString, anyString);
-                result = expectedSignature;
-
-                IotHubSasToken.buildSharedAccessToken(anyString, expectedSignature, anyLong);
-                result = expectedSharedAccessToken;
-
-                Deencapsulation.newInstance(IotHubSasToken.class,
-                        new Class[] {String.class, String.class, String.class, String.class, String.class, long.class},
-                        expectedMqttGatewayHostname, expectedDeviceId, null, expectedSharedAccessToken, expectedModuleId, expectedTimeToLive);
-                result = mockedIotHubSasToken;
-            }
-        };
-
-        //act
-        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, null, expectedMqttGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
+        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
     }
 
     // Codes_SRS_MODULEAUTHENTICATIONWITHHSM_34_006: [If the gatewayHostname is present, this function shall construct the sas token using the gateway hostname instead of the hostname.]
@@ -130,38 +98,7 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, null, "gen1", expectedTimeToLive, expectedBufferPercent);
-    }
-
-    @Test
-    public void staticConstructorSuccessWithMqttGatewayHostname() throws IOException, TransportException, URISyntaxException
-    {
-        //arrange
-        new MockUp<System>()
-        {
-            @Mock long currentTimeMillis()
-            {
-                return 0;
-            }
-        };
-        new Expectations()
-        {
-            {
-                mockedSignatureProvider.sign("module", anyString, anyString);
-                result = expectedSignature;
-
-                IotHubSasToken.buildSharedAccessToken(anyString, expectedSignature, anyLong);
-                result = expectedSharedAccessToken;
-
-                Deencapsulation.newInstance(IotHubSasToken.class,
-                        new Class[] {String.class, String.class, String.class, String.class, String.class, long.class},
-                        expectedMqttGatewayHostname, expectedDeviceId, null, expectedSharedAccessToken, expectedModuleId, expectedTimeToLive);
-                result = mockedIotHubSasToken;
-            }
-        };
-
-        //act
-        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, null, expectedMqttGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
+        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
     }
 
     // Tests_SRS_MODULEAUTHENTICATIONWITHHSM_34_004: [If the gatewayHostname is null or empty, this function shall construct the sas token using the hostname instead of the gateway hostname.]
@@ -194,7 +131,7 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
         };
 
         //act
-        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, null, null, "gen1", expectedTimeToLive, expectedBufferPercent);
+        IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, null, "gen1", expectedTimeToLive, expectedBufferPercent);
     }
 
     // Tests_SRS_MODULEAUTHENTICATIONWITHHSM_34_005: [This function shall create a new sas token and save it locally.]
@@ -226,10 +163,9 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
             }
         };
 
-        IotHubSasTokenHsmAuthenticationProvider auth = IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, "", "", "gen1", expectedTimeToLive, expectedBufferPercent);
+        IotHubSasTokenHsmAuthenticationProvider auth = IotHubSasTokenHsmAuthenticationProvider.create(mockedSignatureProvider, expectedDeviceId, expectedModuleId, expectedHostname, "", "gen1", expectedTimeToLive, expectedBufferPercent);
         Deencapsulation.setField(auth, "hostname", expectedHostname);
         Deencapsulation.setField(auth, "gatewayHostname", "");
-        Deencapsulation.setField(auth, "mqttGatewayHostname", "");
         Deencapsulation.setField(auth, "deviceId", expectedDeviceId);
         Deencapsulation.setField(auth, "moduleId", expectedModuleId);
         Deencapsulation.setField(auth, "signatureProvider", mockedSignatureProvider);
@@ -244,6 +180,6 @@ public class IotHubSasTokenHsmAuthenticationProviderTest
     public void staticConstructorThrowsForNullSignatureProvider() throws IOException, TransportException
     {
         //act
-        IotHubSasTokenHsmAuthenticationProvider.create(null, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, expectedMqttGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
+        IotHubSasTokenHsmAuthenticationProvider.create(null, expectedDeviceId, expectedModuleId, expectedHostname, expectedGatewayHostname, "gen1", expectedTimeToLive, expectedBufferPercent);
     }
 }


### PR DESCRIPTION
Per new discussion we have, to specify E4K, more of us prefer to the option of adding a new property `GatewayType` (which can be one of two enum values "Edge" and "E4K") so that it can work with the existing property `GatewayHostName` which already supported for Edge. 

Also reverting the changes of adding `MqttGatewayHostName` committed [before](https://github.com/Azure/azure-iot-sdk-java/commit/8d152f70fe2816af5cd881bae5dc0753e334e6ed) in this PR. 