### PR TITLE
Fix some threading issues with correlation callback maps

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/CorrelationCallbackContext.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/CorrelationCallbackContext.java
@@ -1,0 +1,19 @@
+package com.microsoft.azure.sdk.iot.device.transport;
+
+import com.microsoft.azure.sdk.iot.device.CorrelatingMessageCallback;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+class CorrelationCallbackContext
+{
+    @Getter
+    private final CorrelatingMessageCallback callback;
+
+    @Getter
+    private final Object userContext;
+
+    // Used to store the number of milliseconds since epoch that this packet was created for a correlationId
+    @Getter
+    private final Long startTimeMillis;
+}

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1212,7 +1212,7 @@ public class IotHubTransport implements IotHubListener
 
                         // We need to remove the CorrelatingMessageCallback with the current correlation ID from the map after the received C2D
                         // message has been acknowledged. Otherwise, the size of map will grow endlessly which results in OutOfMemory eventually.
-                        correlationCallbacks.remove(correlationId);
+                        new Thread(() -> correlationCallbacks.remove(correlationId)).start();
                     }
                 }
                 catch (Exception ex)

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -8,7 +8,8 @@
 package com.microsoft.azure.sdk.iot.device.transport;
 
 import com.microsoft.azure.sdk.iot.device.*;
-import com.microsoft.azure.sdk.iot.device.exceptions.*;
+import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
+import com.microsoft.azure.sdk.iot.device.exceptions.MultiplexingClientRegistrationException;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.AmqpsIotHubConnection;
 import com.microsoft.azure.sdk.iot.device.transport.amqps.exceptions.AmqpUnauthorizedAccessException;
 import com.microsoft.azure.sdk.iot.device.transport.https.HttpsIotHubConnection;
@@ -1699,7 +1700,14 @@ public class IotHubTransport implements IotHubListener
 
             if (newConnectionStatus == IotHubConnectionStatus.CONNECTED)
             {
-                correlationCallbackCleanupThread.start();
+                try
+                {
+                    correlationCallbackCleanupThread.start();
+                }
+                catch (IllegalThreadStateException e)
+                {
+                    // Thread has already started. No need to report this exception
+                }
             }
             else if (newConnectionStatus == IotHubConnectionStatus.DISCONNECTED)
             {
@@ -1751,7 +1759,14 @@ public class IotHubTransport implements IotHubListener
 
         if (newConnectionStatus == IotHubConnectionStatus.CONNECTED)
         {
-            correlationCallbackCleanupThread.start();
+            try
+            {
+                correlationCallbackCleanupThread.start();
+            }
+            catch (IllegalThreadStateException e)
+            {
+                // Thread has already started. No need to report this exception
+            }
         }
         else if (newConnectionStatus == IotHubConnectionStatus.DISCONNECTED)
         {


### PR DESCRIPTION
- Make correlation callback cleanup job run less frequently
  - Previously ran several times per second. Now runs once per hour
- Make correlation callback operation blocks atomic
  - We don't want cases where one thread is calling callbacks.get("some id") while another just removed that entry.

#1718 