### PR TITLE
feat(iot-dev): Make SDK thread names configurable

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -11,10 +11,7 @@ import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProvider;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderSymmetricKey;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderTpm;
 import com.microsoft.azure.sdk.iot.provisioning.security.SecurityProviderX509;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.net.ssl.SSLContext;
@@ -85,6 +82,14 @@ public final class ClientConfiguration
     @Getter
     @Setter(AccessLevel.PACKAGE)
     private int sendInterval = DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
+
+    @Getter
+    private String threadNamePostfix = null;
+
+    @Getter
+    private String threadNamePrefix = null;
+
+    private boolean useIdentifiableThreadNames = true;
 
     private IotHubAuthenticationProvider authenticationProvider;
 
@@ -215,6 +220,9 @@ public final class ClientConfiguration
         this.amqpOpenDeviceSessionsTimeout = clientOptions != null && clientOptions.getAmqpDeviceSessionTimeout() != 0 ? clientOptions.getAmqpDeviceSessionTimeout() : DEFAULT_AMQP_OPEN_DEVICE_SESSIONS_TIMEOUT_IN_SECONDS;
         this.proxySettings = clientOptions != null && clientOptions.getProxySettings() != null ? clientOptions.getProxySettings() : null;
         this.sendInterval = clientOptions != null && clientOptions.getSendInterval() != 0 ? clientOptions.getSendInterval() : DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
+        this.threadNamePrefix = clientOptions != null ? clientOptions.getThreadNamePrefix() : null;
+        this.threadNamePostfix = clientOptions != null ? clientOptions.getThreadNamePostfix() : null;
+        this.useIdentifiableThreadNames = clientOptions == null || clientOptions.isUsingIdentifiableThreadNames();
 
         if (proxySettings != null)
         {
@@ -630,6 +638,12 @@ public final class ClientConfiguration
         {
             return AuthType.X509_CERTIFICATE;
         }
+    }
+
+    public boolean isUsingIdentifiableThreadNames()
+    {
+        // Using a manually written method here to override the name that Lombok would have given it
+        return this.useIdentifiableThreadNames;
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -84,7 +84,7 @@ public final class ClientConfiguration
     private int sendInterval = DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
 
     @Getter
-    private String threadNamePostfix = null;
+    private String threadNameSuffix = null;
 
     @Getter
     private String threadNamePrefix = null;
@@ -221,7 +221,7 @@ public final class ClientConfiguration
         this.proxySettings = clientOptions != null && clientOptions.getProxySettings() != null ? clientOptions.getProxySettings() : null;
         this.sendInterval = clientOptions != null && clientOptions.getSendInterval() != 0 ? clientOptions.getSendInterval() : DEFAULT_SEND_INTERVAL_IN_MILLISECONDS;
         this.threadNamePrefix = clientOptions != null ? clientOptions.getThreadNamePrefix() : null;
-        this.threadNamePostfix = clientOptions != null ? clientOptions.getThreadNamePostfix() : null;
+        this.threadNameSuffix = clientOptions != null ? clientOptions.getThreadNameSuffix() : null;
         this.useIdentifiableThreadNames = clientOptions == null || clientOptions.isUsingIdentifiableThreadNames();
 
         if (proxySettings != null)

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -147,22 +147,22 @@ public final class ClientOptions
     private final String threadNamePrefix = null;
 
     /**
-     * The postfix that will be applied to the names of all threads created by this client. If
+     * The suffix that will be applied to the names of all threads created by this client. If
      * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
-     * postfix for you.
+     * suffix for you.
      */
     @Getter
     @Builder.Default
-    private final String threadNamePostfix = null;
+    private final String threadNameSuffix = null;
 
     /**
      * If true, all threads created by this client will use names that are unique. This is useful in applications that manage
      * multiple device/module clients and want to be able to correlate logs to a particular client. In addition,
-     * the {@link #threadNamePrefix} and {@link #threadNamePostfix} values will be ignored.
+     * the {@link #threadNamePrefix} and {@link #threadNameSuffix} values will be ignored.
      *
      * If false, all threads created by this client will use simple names that describe the thread's purpose, but are
      * indistinguishable from the same threads created by a different client instance. However, users may still alter
-     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNamePostfix}.
+     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNameSuffix}.
      */
     @Builder.Default
     private final boolean useIdentifiableThreadNames = true;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -136,4 +136,41 @@ public final class ClientOptions
     @Getter
     @Builder.Default
     private final int receiveInterval = RECEIVE_PERIOD_MILLIS;
+
+    /**
+     * The prefix that will be applied to the names of all threads created by this client. If
+     * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
+     * prefix for you.
+     */
+    @Getter
+    @Builder.Default
+    private final String threadNamePrefix = null;
+
+    /**
+     * The postfix that will be applied to the names of all threads created by this client. If
+     * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
+     * postfix for you.
+     */
+    @Getter
+    @Builder.Default
+    private final String threadNamePostfix = null;
+
+    /**
+     * If true, all threads created by this client will use names that are unique. This is useful in applications that manage
+     * multiple device/module clients and want to be able to correlate logs to a particular client. In addition,
+     * the {@link #threadNamePrefix} and {@link #threadNamePostfix} values will be ignored.
+     *
+     * If false, all threads created by this client will use simple names that describe the thread's purpose, but are
+     * indistinguishable from the same threads created by a different client instance. However, users may still alter
+     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNamePostfix}.
+     */
+    @Builder.Default
+    private final boolean useIdentifiableThreadNames = true;
+
+
+    public boolean isUsingIdentifiableThreadNames()
+    {
+        // Using a manually written method here to override the name that Lombok would have given it
+        return this.useIdentifiableThreadNames;
+    }
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -65,9 +65,9 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
-        this.sendTask = new IotHubSendTask(this.transport);
-        this.receiveTask = new IotHubReceiveTask(this.transport);
-        this.reconnectTask = new IotHubReconnectTask(this.transport);
+        this.sendTask = new IotHubSendTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
+        this.receiveTask = new IotHubReceiveTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
+        this.reconnectTask = new IotHubReconnectTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
     }
 
     DeviceIO(
@@ -76,13 +76,16 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         SSLContext sslContext,
         ProxySettings proxySettings,
         int keepAliveInterval,
-        int sendInterval)
+        int sendInterval,
+        boolean useIdentifiableThreadNames,
+        String threadNamePrefix,
+        String threadNamePostfix)
     {
         this.state = IotHubConnectionStatus.DISCONNECTED;
-        this.transport = new IotHubTransport(hostName, protocol, sslContext, proxySettings, this, keepAliveInterval, sendInterval);
-        this.sendTask = new IotHubSendTask(this.transport);
-        this.receiveTask = new IotHubReceiveTask(this.transport);
-        this.reconnectTask = new IotHubReconnectTask(this.transport);
+        this.transport = new IotHubTransport(hostName, protocol, sslContext, proxySettings, this, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
+        this.sendTask = new IotHubSendTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
+        this.receiveTask = new IotHubReceiveTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
+        this.reconnectTask = new IotHubReconnectTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -65,9 +65,9 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
 
         this.state = IotHubConnectionStatus.DISCONNECTED;
 
-        this.sendTask = new IotHubSendTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
-        this.receiveTask = new IotHubReceiveTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
-        this.reconnectTask = new IotHubReconnectTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNamePostfix());
+        this.sendTask = new IotHubSendTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNameSuffix());
+        this.receiveTask = new IotHubReceiveTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNameSuffix());
+        this.reconnectTask = new IotHubReconnectTask(this.transport, config.isUsingIdentifiableThreadNames(), config.getThreadNamePrefix(), config.getThreadNameSuffix());
     }
 
     DeviceIO(
@@ -79,13 +79,13 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         int sendInterval,
         boolean useIdentifiableThreadNames,
         String threadNamePrefix,
-        String threadNamePostfix)
+        String threadNameSuffix)
     {
         this.state = IotHubConnectionStatus.DISCONNECTED;
-        this.transport = new IotHubTransport(hostName, protocol, sslContext, proxySettings, this, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
-        this.sendTask = new IotHubSendTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
-        this.receiveTask = new IotHubReceiveTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
-        this.reconnectTask = new IotHubReconnectTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
+        this.transport = new IotHubTransport(hostName, protocol, sslContext, proxySettings, this, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
+        this.sendTask = new IotHubSendTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
+        this.receiveTask = new IotHubReceiveTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
+        this.reconnectTask = new IotHubReconnectTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -101,6 +101,9 @@ public class MultiplexingClient
         int sendMessagesPerThread = options != null ? options.getMaxMessagesSentPerSendInterval() : DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD;
         int keepAliveInterval = options != null ? options.getKeepAliveInterval() : DEFAULT_KEEP_ALIVE_INTERVAL_IN_SECONDS;
         int sendInterval = (int) (options != null ? options.getSendInterval() : DEFAULT_SEND_INTERVAL_IN_MILLISECONDS);
+        String threadNamePrefix = options != null ? options.getThreadNamePrefix() : null;
+        String threadNamePostfix = options != null ? options.getThreadNamePostfix() : null;
+        boolean useIdentifiableThreadNames = options == null || options.isUsingIdentifiableThreadNames();
 
         if (sendPeriod < 0)
         {
@@ -127,7 +130,7 @@ public class MultiplexingClient
 
         // Optional settings from MultiplexingClientOptions
         SSLContext sslContext = options != null ? options.getSslContext() : null;
-        this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, keepAliveInterval, sendInterval);
+        this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
         this.deviceIO.setMaxNumberOfMessagesSentPerSendThread(sendMessagesPerThread);
         this.deviceIO.setSendPeriodInMilliseconds(sendPeriod);
         this.deviceIO.setReceivePeriodInMilliseconds(receivePeriod);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -102,7 +102,7 @@ public class MultiplexingClient
         int keepAliveInterval = options != null ? options.getKeepAliveInterval() : DEFAULT_KEEP_ALIVE_INTERVAL_IN_SECONDS;
         int sendInterval = (int) (options != null ? options.getSendInterval() : DEFAULT_SEND_INTERVAL_IN_MILLISECONDS);
         String threadNamePrefix = options != null ? options.getThreadNamePrefix() : null;
-        String threadNamePostfix = options != null ? options.getThreadNamePostfix() : null;
+        String threadNameSuffix = options != null ? options.getThreadNameSuffix() : null;
         boolean useIdentifiableThreadNames = options == null || options.isUsingIdentifiableThreadNames();
 
         if (sendPeriod < 0)
@@ -130,7 +130,7 @@ public class MultiplexingClient
 
         // Optional settings from MultiplexingClientOptions
         SSLContext sslContext = options != null ? options.getSslContext() : null;
-        this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNamePostfix);
+        this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
         this.deviceIO.setMaxNumberOfMessagesSentPerSendThread(sendMessagesPerThread);
         this.deviceIO.setSendPeriodInMilliseconds(sendPeriod);
         this.deviceIO.setReceivePeriodInMilliseconds(receivePeriod);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
@@ -78,22 +78,22 @@ public final class MultiplexingClientOptions
     private final String threadNamePrefix = null;
 
     /**
-     * The postfix that will be applied to the names of all threads created by this client. If
+     * The suffix that will be applied to the names of all threads created by this client. If
      * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
-     * postfix for you.
+     * suffix for you.
      */
     @Getter
     @Builder.Default
-    private final String threadNamePostfix = null;
+    private final String threadNameSuffix = null;
 
     /**
      * If true, all threads created by this client will use names that are unique. This is useful in applications that manage
      * multiple device/module clients and want to be able to correlate logs to a particular client. In addition,
-     * the {@link #threadNamePrefix} and {@link #threadNamePostfix} values will be ignored.
+     * the {@link #threadNamePrefix} and {@link #threadNameSuffix} values will be ignored.
      *
      * If false, all threads created by this client will use simple names that describe the thread's purpose, but are
      * indistinguishable from the same threads created by a different client instance. However, users may still alter
-     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNamePostfix}.
+     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNameSuffix}.
      */
     @Builder.Default
     private final boolean useIdentifiableThreadNames = true;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
@@ -67,4 +67,40 @@ public final class MultiplexingClientOptions
     @Getter
     @Builder.Default
     public final int keepAliveInterval = DEFAULT_KEEP_ALIVE_INTERVAL_IN_SECONDS;
+
+    /**
+     * The prefix that will be applied to the names of all threads created by this client. If
+     * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
+     * prefix for you.
+     */
+    @Getter
+    @Builder.Default
+    private final String threadNamePrefix = null;
+
+    /**
+     * The postfix that will be applied to the names of all threads created by this client. If
+     * {@link #useIdentifiableThreadNames} is set to true, then this value is ignored and this client will create the
+     * postfix for you.
+     */
+    @Getter
+    @Builder.Default
+    private final String threadNamePostfix = null;
+
+    /**
+     * If true, all threads created by this client will use names that are unique. This is useful in applications that manage
+     * multiple device/module clients and want to be able to correlate logs to a particular client. In addition,
+     * the {@link #threadNamePrefix} and {@link #threadNamePostfix} values will be ignored.
+     *
+     * If false, all threads created by this client will use simple names that describe the thread's purpose, but are
+     * indistinguishable from the same threads created by a different client instance. However, users may still alter
+     * these thread names by providing values for the {@link #threadNamePrefix} and {@link #threadNamePostfix}.
+     */
+    @Builder.Default
+    private final boolean useIdentifiableThreadNames = true;
+
+    public boolean isUsingIdentifiableThreadNames()
+    {
+        // Using a manually written method here to override the name that Lombok would have given it
+        return this.useIdentifiableThreadNames;
+    }
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -17,6 +17,9 @@ public final class IotHubReceiveTask implements Runnable
 {
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubReceiveTask";
     private final IotHubTransport transport;
+    private final String threadNamePrefix;
+    private final String threadNamePostfix;
+    private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
     // wait until a message has been received in that layer before continuing. This means that if the transport layer
@@ -25,7 +28,7 @@ public final class IotHubReceiveTask implements Runnable
     // layer's responsibility to notify this thread when a message has been received so that this thread can handle it.
     private final Semaphore receiveThreadSemaphore;
 
-    public IotHubReceiveTask(IotHubTransport transport)
+    public IotHubReceiveTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
     {
         if (transport == null)
         {
@@ -34,13 +37,35 @@ public final class IotHubReceiveTask implements Runnable
 
         this.transport = transport;
         this.receiveThreadSemaphore = this.transport.getReceiveThreadSemaphore();
+        this.useIdentifiableThreadNames = useIdentifiableThreadNames;
+        this.threadNamePrefix = threadNamePrefix;
+        this.threadNamePostfix = threadNamePostfix;
     }
 
     public void run()
     {
-        String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
-        String connectionId = transport.getTransportConnectionId();
-        String threadName = deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        String threadName = "";
+        if (this.useIdentifiableThreadNames)
+        {
+            String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
+            String connectionId = transport.getTransportConnectionId();
+            threadName += deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        }
+        else
+        {
+            if (this.threadNamePrefix != null && !this.threadNamePrefix.isEmpty())
+            {
+                threadName += this.threadNamePrefix;
+            }
+
+            threadName += THREAD_NAME;
+
+            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            {
+                threadName += this.threadNamePostfix;
+            }
+        }
+
         Thread.currentThread().setName(threadName);
 
         try

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTask.java
@@ -18,7 +18,7 @@ public final class IotHubReceiveTask implements Runnable
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubReceiveTask";
     private final IotHubTransport transport;
     private final String threadNamePrefix;
-    private final String threadNamePostfix;
+    private final String threadNameSuffix;
     private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
@@ -28,7 +28,7 @@ public final class IotHubReceiveTask implements Runnable
     // layer's responsibility to notify this thread when a message has been received so that this thread can handle it.
     private final Semaphore receiveThreadSemaphore;
 
-    public IotHubReceiveTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
+    public IotHubReceiveTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNameSuffix)
     {
         if (transport == null)
         {
@@ -39,7 +39,7 @@ public final class IotHubReceiveTask implements Runnable
         this.receiveThreadSemaphore = this.transport.getReceiveThreadSemaphore();
         this.useIdentifiableThreadNames = useIdentifiableThreadNames;
         this.threadNamePrefix = threadNamePrefix;
-        this.threadNamePostfix = threadNamePostfix;
+        this.threadNameSuffix = threadNameSuffix;
     }
 
     public void run()
@@ -60,9 +60,9 @@ public final class IotHubReceiveTask implements Runnable
 
             threadName += THREAD_NAME;
 
-            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            if (this.threadNameSuffix != null && !this.threadNameSuffix.isEmpty())
             {
-                threadName += this.threadNamePostfix;
+                threadName += this.threadNameSuffix;
             }
         }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReconnectTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReconnectTask.java
@@ -15,13 +15,16 @@ public final class IotHubReconnectTask implements Runnable
 {
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubReconnectTask";
     private final IotHubTransport transport;
+    private final String threadNamePrefix;
+    private final String threadNamePostfix;
+    private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
     // wait until a disconnection event occurs in that layer before continuing. This means that if the transport layer
     // has no connectivity problems, then this thread will do nothing and cost nothing.
     private final Semaphore reconnectThreadSemaphore;
 
-    public IotHubReconnectTask(IotHubTransport transport)
+    public IotHubReconnectTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
     {
         if (transport == null)
         {
@@ -30,13 +33,35 @@ public final class IotHubReconnectTask implements Runnable
 
         this.transport = transport;
         this.reconnectThreadSemaphore = this.transport.getReconnectThreadSemaphore();
+        this.useIdentifiableThreadNames = useIdentifiableThreadNames;
+        this.threadNamePrefix = threadNamePrefix;
+        this.threadNamePostfix = threadNamePostfix;
     }
 
     public void run()
     {
-        String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
-        String connectionId = transport.getTransportConnectionId();
-        String threadName = deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        String threadName = "";
+        if (this.useIdentifiableThreadNames)
+        {
+            String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
+            String connectionId = transport.getTransportConnectionId();
+            threadName += deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        }
+        else
+        {
+            if (this.threadNamePrefix != null && !this.threadNamePrefix.isEmpty())
+            {
+                threadName += this.threadNamePrefix;
+            }
+
+            threadName += THREAD_NAME;
+
+            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            {
+                threadName += this.threadNamePostfix;
+            }
+        }
+
         Thread.currentThread().setName(threadName);
 
         try

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReconnectTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReconnectTask.java
@@ -16,7 +16,7 @@ public final class IotHubReconnectTask implements Runnable
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubReconnectTask";
     private final IotHubTransport transport;
     private final String threadNamePrefix;
-    private final String threadNamePostfix;
+    private final String threadNameSuffix;
     private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
@@ -24,7 +24,7 @@ public final class IotHubReconnectTask implements Runnable
     // has no connectivity problems, then this thread will do nothing and cost nothing.
     private final Semaphore reconnectThreadSemaphore;
 
-    public IotHubReconnectTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
+    public IotHubReconnectTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNameSuffix)
     {
         if (transport == null)
         {
@@ -35,7 +35,7 @@ public final class IotHubReconnectTask implements Runnable
         this.reconnectThreadSemaphore = this.transport.getReconnectThreadSemaphore();
         this.useIdentifiableThreadNames = useIdentifiableThreadNames;
         this.threadNamePrefix = threadNamePrefix;
-        this.threadNamePostfix = threadNamePostfix;
+        this.threadNameSuffix = threadNameSuffix;
     }
 
     public void run()
@@ -56,9 +56,9 @@ public final class IotHubReconnectTask implements Runnable
 
             threadName += THREAD_NAME;
 
-            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            if (this.threadNameSuffix != null && !this.threadNameSuffix.isEmpty())
             {
-                threadName += this.threadNamePostfix;
+                threadName += this.threadNameSuffix;
             }
         }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -17,7 +17,7 @@ public final class IotHubSendTask implements Runnable
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubSendTask";
     private final IotHubTransport transport;
     private final String threadNamePrefix;
-    private final String threadNamePostfix;
+    private final String threadNameSuffix;
     private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
@@ -28,7 +28,7 @@ public final class IotHubSendTask implements Runnable
     // so that this thread can handle it.
     private final Semaphore sendThreadSemaphore;
 
-    public IotHubSendTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
+    public IotHubSendTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNameSuffix)
     {
         if (transport == null)
         {
@@ -39,7 +39,7 @@ public final class IotHubSendTask implements Runnable
         this.sendThreadSemaphore = this.transport.getSendThreadSemaphore();
         this.useIdentifiableThreadNames = useIdentifiableThreadNames;
         this.threadNamePrefix = threadNamePrefix;
-        this.threadNamePostfix = threadNamePostfix;
+        this.threadNameSuffix = threadNameSuffix;
     }
 
     public void run()
@@ -60,9 +60,9 @@ public final class IotHubSendTask implements Runnable
 
             threadName += THREAD_NAME;
 
-            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            if (this.threadNameSuffix != null && !this.threadNameSuffix.isEmpty())
             {
-                threadName += this.threadNamePostfix;
+                threadName += this.threadNameSuffix;
             }
         }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTask.java
@@ -16,6 +16,9 @@ public final class IotHubSendTask implements Runnable
 {
     private static final String THREAD_NAME = "azure-iot-sdk-IotHubSendTask";
     private final IotHubTransport transport;
+    private final String threadNamePrefix;
+    private final String threadNamePostfix;
+    private final boolean useIdentifiableThreadNames;
 
     // This lock is used to communicate state between this thread and the IoTHubTransport layer. This thread will
     // wait until a message or callback is queued in that layer before continuing. This means that if the transport layer
@@ -25,7 +28,7 @@ public final class IotHubSendTask implements Runnable
     // so that this thread can handle it.
     private final Semaphore sendThreadSemaphore;
 
-    public IotHubSendTask(IotHubTransport transport)
+    public IotHubSendTask(IotHubTransport transport, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
     {
         if (transport == null)
         {
@@ -34,13 +37,35 @@ public final class IotHubSendTask implements Runnable
 
         this.transport = transport;
         this.sendThreadSemaphore = this.transport.getSendThreadSemaphore();
+        this.useIdentifiableThreadNames = useIdentifiableThreadNames;
+        this.threadNamePrefix = threadNamePrefix;
+        this.threadNamePostfix = threadNamePostfix;
     }
 
     public void run()
     {
-        String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
-        String connectionId = transport.getTransportConnectionId();
-        String threadName = deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        String threadName = "";
+        if (this.useIdentifiableThreadNames)
+        {
+            String deviceClientId = this.transport.getDeviceClientUniqueIdentifier();
+            String connectionId = transport.getTransportConnectionId();
+            threadName += deviceClientId + "-" + "Cxn" + connectionId + "-" + THREAD_NAME;
+        }
+        else
+        {
+            if (this.threadNamePrefix != null && !this.threadNamePrefix.isEmpty())
+            {
+                threadName += this.threadNamePrefix;
+            }
+
+            threadName += THREAD_NAME;
+
+            if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+            {
+                threadName += this.threadNamePostfix;
+            }
+        }
+
         Thread.currentThread().setName(threadName);
 
         try

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -113,6 +113,10 @@ public class IotHubTransport implements IotHubListener
     private SSLContext sslContext;
     private final boolean isMultiplexing;
 
+    private final String threadNamePrefix;
+    private final String threadNamePostfix;
+    private final boolean useIdentifiableThreadNames;
+
     // Flag set when close() starts. Acts as a signal to any running reconnection logic to not try again.
     private boolean isClosing;
 
@@ -150,6 +154,9 @@ public class IotHubTransport implements IotHubListener
         this.deviceIOConnectionStatusChangeCallback = deviceIOConnectionStatusChangeCallback;
         this.keepAliveInterval = defaultConfig.getKeepAliveInterval();
         this.sendInterval = defaultConfig.getSendInterval();
+        this.useIdentifiableThreadNames = defaultConfig.isUsingIdentifiableThreadNames();
+        this.threadNamePrefix = defaultConfig.getThreadNamePrefix();
+        this.threadNamePostfix = defaultConfig.getThreadNamePostfix();
     }
 
     public IotHubTransport(
@@ -159,7 +166,10 @@ public class IotHubTransport implements IotHubListener
             ProxySettings proxySettings,
             IotHubConnectionStatusChangeCallback deviceIOConnectionStatusChangeCallback,
             int keepAliveInterval,
-            int sendInterval) throws IllegalArgumentException
+            int sendInterval,
+            boolean useIdentifiableThreadNames,
+            String threadNamePrefix,
+            String threadNamePostfix) throws IllegalArgumentException
     {
         this.protocol = protocol;
         this.hostName = hostName;
@@ -170,6 +180,9 @@ public class IotHubTransport implements IotHubListener
         this.isMultiplexing = true;
         this.keepAliveInterval = keepAliveInterval;
         this.sendInterval = sendInterval;
+        this.useIdentifiableThreadNames = useIdentifiableThreadNames;
+        this.threadNamePrefix = threadNamePrefix;
+        this.threadNamePostfix = threadNamePostfix;
     }
 
     public Semaphore getSendThreadSemaphore()
@@ -1329,7 +1342,10 @@ public class IotHubTransport implements IotHubListener
                                 this.sslContext,
                                 this.proxySettings,
                                 this.keepAliveInterval,
-                                this.sendInterval);
+                                this.sendInterval,
+                                this.useIdentifiableThreadNames,
+                                this.threadNamePrefix,
+                                this.threadNamePostfix);
 
                         for (ClientConfiguration config : this.deviceClientConfigs.values())
                         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -114,7 +114,7 @@ public class IotHubTransport implements IotHubListener
     private final boolean isMultiplexing;
 
     private final String threadNamePrefix;
-    private final String threadNamePostfix;
+    private final String threadNameSuffix;
     private final boolean useIdentifiableThreadNames;
 
     // Flag set when close() starts. Acts as a signal to any running reconnection logic to not try again.
@@ -156,7 +156,7 @@ public class IotHubTransport implements IotHubListener
         this.sendInterval = defaultConfig.getSendInterval();
         this.useIdentifiableThreadNames = defaultConfig.isUsingIdentifiableThreadNames();
         this.threadNamePrefix = defaultConfig.getThreadNamePrefix();
-        this.threadNamePostfix = defaultConfig.getThreadNamePostfix();
+        this.threadNameSuffix = defaultConfig.getThreadNameSuffix();
     }
 
     public IotHubTransport(
@@ -169,7 +169,7 @@ public class IotHubTransport implements IotHubListener
             int sendInterval,
             boolean useIdentifiableThreadNames,
             String threadNamePrefix,
-            String threadNamePostfix) throws IllegalArgumentException
+            String threadNameSuffix) throws IllegalArgumentException
     {
         this.protocol = protocol;
         this.hostName = hostName;
@@ -182,7 +182,7 @@ public class IotHubTransport implements IotHubListener
         this.sendInterval = sendInterval;
         this.useIdentifiableThreadNames = useIdentifiableThreadNames;
         this.threadNamePrefix = threadNamePrefix;
-        this.threadNamePostfix = threadNamePostfix;
+        this.threadNameSuffix = threadNameSuffix;
     }
 
     public Semaphore getSendThreadSemaphore()
@@ -1345,7 +1345,7 @@ public class IotHubTransport implements IotHubListener
                                 this.sendInterval,
                                 this.useIdentifiableThreadNames,
                                 this.threadNamePrefix,
-                                this.threadNamePostfix);
+                                this.threadNameSuffix);
 
                         for (ClientConfiguration config : this.deviceClientConfigs.values())
                         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -110,7 +110,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
     private final Map<IotHubTransportMessage, IotHubMessageResult> queuedAcknowledgements = new ConcurrentHashMap<>();
 
     private final String threadNamePrefix;
-    private final String threadNamePostfix;
+    private final String threadNameSuffix;
     private final boolean useIdentifiableThreadNames;
 
     public AmqpsIotHubConnection(ClientConfiguration config, String transportUniqueIdentifier)
@@ -148,13 +148,13 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         this.sendInterval = clientConfiguration.getSendInterval();
         this.useIdentifiableThreadNames = clientConfiguration.isUsingIdentifiableThreadNames();
         this.threadNamePrefix = clientConfiguration.getThreadNamePrefix();
-        this.threadNamePostfix = clientConfiguration.getThreadNamePostfix();
+        this.threadNameSuffix = clientConfiguration.getThreadNameSuffix();
 
         this.state = IotHubConnectionStatus.DISCONNECTED;
         log.trace("AmqpsIotHubConnection object is created successfully and will use port {}", this.isWebsocketConnection ? WEB_SOCKET_PORT : AMQP_PORT);
     }
 
-    public AmqpsIotHubConnection(String hostName, String transportUniqueIdentifier, boolean isWebsocketConnection, SSLContext sslContext, ProxySettings proxySettings, int keepAliveInterval, int sendInterval, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
+    public AmqpsIotHubConnection(String hostName, String transportUniqueIdentifier, boolean isWebsocketConnection, SSLContext sslContext, ProxySettings proxySettings, int keepAliveInterval, int sendInterval, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNameSuffix)
     {
         // This allows us to create thread safe sets despite there being no such type default in Java 7 or 8
         this.clientConfigurations = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -182,7 +182,7 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         this.sendInterval = sendInterval;
         this.useIdentifiableThreadNames = useIdentifiableThreadNames;
         this.threadNamePrefix = threadNamePrefix;
-        this.threadNamePostfix = threadNamePostfix;
+        this.threadNameSuffix = threadNameSuffix;
     }
 
     public void registerMultiplexedDevice(ClientConfiguration config)
@@ -1277,9 +1277,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
                 threadName += ReactorRunner.THREAD_NAME;
 
-                if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+                if (this.threadNameSuffix != null && !this.threadNameSuffix.isEmpty())
                 {
-                    threadName += this.threadNamePostfix;
+                    threadName += this.threadNameSuffix;
                 }
             }
         }
@@ -1298,9 +1298,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
                 threadName += ReactorRunner.THREAD_NAME;
 
-                if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+                if (this.threadNameSuffix != null && !this.threadNameSuffix.isEmpty())
                 {
-                    threadName += this.threadNamePostfix;
+                    threadName += this.threadNameSuffix;
                 }
             }
         }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -109,6 +109,10 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
     private final Map<IotHubTransportMessage, IotHubMessageResult> queuedAcknowledgements = new ConcurrentHashMap<>();
 
+    private final String threadNamePrefix;
+    private final String threadNamePostfix;
+    private final boolean useIdentifiableThreadNames;
+
     public AmqpsIotHubConnection(ClientConfiguration config, String transportUniqueIdentifier)
     {
         // This allows us to create thread safe sets despite there being no such type default in Java 7 or 8
@@ -142,12 +146,15 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         this.keepAliveInterval = config.getKeepAliveInterval();
         this.sendInterval = clientConfiguration.getSendInterval();
+        this.useIdentifiableThreadNames = clientConfiguration.isUsingIdentifiableThreadNames();
+        this.threadNamePrefix = clientConfiguration.getThreadNamePrefix();
+        this.threadNamePostfix = clientConfiguration.getThreadNamePostfix();
 
         this.state = IotHubConnectionStatus.DISCONNECTED;
         log.trace("AmqpsIotHubConnection object is created successfully and will use port {}", this.isWebsocketConnection ? WEB_SOCKET_PORT : AMQP_PORT);
     }
 
-    public AmqpsIotHubConnection(String hostName, String transportUniqueIdentifier, boolean isWebsocketConnection, SSLContext sslContext, ProxySettings proxySettings, int keepAliveInterval, int sendInterval)
+    public AmqpsIotHubConnection(String hostName, String transportUniqueIdentifier, boolean isWebsocketConnection, SSLContext sslContext, ProxySettings proxySettings, int keepAliveInterval, int sendInterval, boolean useIdentifiableThreadNames, String threadNamePrefix, String threadNamePostfix)
     {
         // This allows us to create thread safe sets despite there being no such type default in Java 7 or 8
         this.clientConfigurations = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -173,6 +180,9 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
 
         this.keepAliveInterval = keepAliveInterval;
         this.sendInterval = sendInterval;
+        this.useIdentifiableThreadNames = useIdentifiableThreadNames;
+        this.threadNamePrefix = threadNamePrefix;
+        this.threadNamePostfix = threadNamePostfix;
     }
 
     public void registerMultiplexedDevice(ClientConfiguration config)
@@ -1249,14 +1259,57 @@ public final class AmqpsIotHubConnection extends BaseHandler implements IotHubTr
         String runnerUniqueIdentifier = this.isMultiplexing
                 ? "Multiplexed-" + this.transportUniqueIdentifier
                 : this.clientConfiguration.getDeviceClientUniqueIdentifier();
-
         String reactorRunnerPrefix = this.hostName + "-" + runnerUniqueIdentifier + "-" + "Cnx" + this.connectionId;
+
+        String threadName = "";
+        if (this.isMultiplexing)
+        {
+            if (this.useIdentifiableThreadNames)
+            {
+                threadName += reactorRunnerPrefix + "-" + ReactorRunner.THREAD_NAME + "-ConnectionOwner";
+            }
+            else
+            {
+                if (this.threadNamePrefix != null && !this.threadNamePrefix.isEmpty())
+                {
+                    threadName += this.threadNamePrefix;
+                }
+
+                threadName += ReactorRunner.THREAD_NAME;
+
+                if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+                {
+                    threadName += this.threadNamePostfix;
+                }
+            }
+        }
+        else
+        {
+            if (this.useIdentifiableThreadNames)
+            {
+                threadName += reactorRunnerPrefix + "-" + ReactorRunner.THREAD_NAME + "-ConnectionOwner";
+            }
+            else
+            {
+                if (this.threadNamePrefix != null && !this.threadNamePrefix.isEmpty())
+                {
+                    threadName += this.threadNamePrefix;
+                }
+
+                threadName += ReactorRunner.THREAD_NAME;
+
+                if (this.threadNamePostfix != null && !this.threadNamePostfix.isEmpty())
+                {
+                    threadName += this.threadNamePostfix;
+                }
+            }
+        }
+
         ReactorRunner reactorRunner = new ReactorRunner(
             this.reactor,
             this.listener,
             this.connectionId,
-            reactorRunnerPrefix,
-            "ConnectionOwner",
+            threadName,
             this);
 
         executorService.submit(reactorRunner);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/ReactorRunner.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/ReactorRunner.java
@@ -12,28 +12,25 @@ import java.util.concurrent.Callable;
 
 public class ReactorRunner implements Callable<Object>
 {
-    private static final String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
+    static final String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
     private final Reactor reactor;
     private final IotHubListener listener;
     private final String connectionId;
+    private final String threadName;
     private final ReactorRunnerStateCallback reactorRunnerStateCallback;
-    private final String threadPostfix;
-    private final String threadPrefix;
 
     ReactorRunner(
             Reactor reactor,
             IotHubListener listener,
             String connectionId,
-            String threadPrefix,
-            String threadPostfix,
+            String threadName,
             ReactorRunnerStateCallback reactorRunnerStateCallback)
     {
         this.listener = listener;
         this.reactor = reactor;
         this.connectionId = connectionId;
+        this.threadName = threadName;
         this.reactorRunnerStateCallback = reactorRunnerStateCallback;
-        this.threadPrefix = threadPrefix;
-        this.threadPostfix = threadPostfix;
     }
 
     @Override
@@ -41,8 +38,7 @@ public class ReactorRunner implements Callable<Object>
     {
         try
         {
-            String threadName = this.threadPrefix + "-" + THREAD_NAME + "-" + this.threadPostfix;
-            Thread.currentThread().setName(threadName);
+            Thread.currentThread().setName(this.threadName);
             this.reactor.setTimeout(10);
             this.reactor.start();
 

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTaskTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubReceiveTaskTest.java
@@ -40,7 +40,7 @@ public class IotHubReceiveTaskTest
                 result = IotHubClientProtocol.AMQPS;
             }
         };
-        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
+        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport, true, null, null);
 
         // act
         receiveTask.run();
@@ -64,7 +64,7 @@ public class IotHubReceiveTaskTest
             }
         };
 
-        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
+        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport, true, null, null);
 
         // act
         receiveTask.run();
@@ -90,7 +90,7 @@ public class IotHubReceiveTaskTest
             }
         };
 
-        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
+        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport, true, null, null);
         receiveTask.run();
     }
 
@@ -106,7 +106,7 @@ public class IotHubReceiveTaskTest
             }
         };
 
-        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport);
+        IotHubReceiveTask receiveTask = new IotHubReceiveTask(mockTransport, true, null, null);
         receiveTask.run();
     }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTaskTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubSendTaskTest.java
@@ -35,7 +35,7 @@ public class IotHubSendTaskTest
             }
         };
 
-        IotHubSendTask sendTask = new IotHubSendTask(mockTransport);
+        IotHubSendTask sendTask = new IotHubSendTask(mockTransport, true, null, null);
         sendTask.run();
 
         new Verifications()
@@ -64,7 +64,7 @@ public class IotHubSendTaskTest
             }
         };
 
-        IotHubSendTask sendTask = new IotHubSendTask(mockTransport);
+        IotHubSendTask sendTask = new IotHubSendTask(mockTransport, true, null, null);
         sendTask.run();
 
         new Verifications()
@@ -87,7 +87,7 @@ public class IotHubSendTaskTest
             }
         };
 
-        IotHubSendTask sendTask = new IotHubSendTask(mockTransport);
+        IotHubSendTask sendTask = new IotHubSendTask(mockTransport, true, null, null);
         sendTask.run();
     }
 
@@ -103,7 +103,7 @@ public class IotHubSendTaskTest
             }
         };
 
-        IotHubSendTask sendTask = new IotHubSendTask(mockTransport);
+        IotHubSendTask sendTask = new IotHubSendTask(mockTransport, true, null, null);
         sendTask.run();
     }
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -526,7 +526,7 @@ public class AmqpsIotHubConnectionTest {
         new NonStrictExpectations()
         {
             {
-                new ReactorRunner((Reactor) any, (IotHubListener) any, anyString, anyString, anyString, (ReactorRunnerStateCallback) any);
+                new ReactorRunner((Reactor) any, (IotHubListener) any, anyString, anyString, (ReactorRunnerStateCallback) any);
                 result = new IOException();
             }
         };
@@ -572,7 +572,7 @@ public class AmqpsIotHubConnectionTest {
         new Verifications()
         {
             {
-                new ReactorRunner((Reactor) any, (IotHubListener) any, anyString, anyString, anyString, (ReactorRunnerStateCallback) any);
+                new ReactorRunner((Reactor) any, (IotHubListener) any, anyString, anyString, (ReactorRunnerStateCallback) any);
                 times = 1;
             }
         };

--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/transport/amqp/AmqpsConnection.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/transport/amqp/AmqpsConnection.java
@@ -541,20 +541,20 @@ public class AmqpsConnection extends ErrorLoggingBaseHandlerWithCleanup
     {
         private final static String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
         private final AmqpReactor amqpReactor;
-        private final String threadPostFix;
+        private final String threadSuffix;
         private final String threadPreFix;
 
-        ReactorRunner(AmqpReactor reactor, String threadPrefix, String threadPostFix)
+        ReactorRunner(AmqpReactor reactor, String threadPrefix, String threadSuffix)
         {
             this.amqpReactor = reactor;
-            this.threadPostFix = threadPostFix;
+            this.threadSuffix = threadSuffix;
             this.threadPreFix = threadPrefix;
         }
 
         @Override
         public Object call()
         {
-            String threadName = threadPreFix + "-" + THREAD_NAME + "-" + this.threadPostFix;
+            String threadName = threadPreFix + "-" + THREAD_NAME + "-" + this.threadSuffix;
             Thread.currentThread().setName(threadName);
             log.trace("Amqp reactor thread {} has started", threadName);
 


### PR DESCRIPTION
- By default, don't change the existing behavior where threads are given unique prefix/postfix so users can correlate threads to clients
- Allow users to opt out of these unique thread names
- Allow users to provide custom prefix and postfix to thread names

#1715 