### PR TITLE
Bump versions for 6/6/2023 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,9 +189,9 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.1.5</iot-device-client-version>
+        <iot-device-client-version>2.2.0</iot-device-client-version>
         <iot-service-client-version>2.1.6</iot-service-client-version>  <!--e2e tests only-->
-        <provisioning-device-client-version>2.0.3</provisioning-device-client-version>
+        <provisioning-device-client-version>2.1.0</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.2</provisioning-service-client-version>
         <security-provider-version>2.0.1</security-provider-version>
         <tpm-provider-emulator-version>2.0.1</tpm-provider-emulator-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.2.0)
 - Make SDK thread names configurable (#1720)

### Bug fixes
 - Fix some threading issues around correlation callback map states (#1719)

## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:2.1.0)
 - Add synchronous overloads for registerDevice (#1700)