### PR TITLE
fix(iot-dev): Add more trace logs to module client createFromEnvironment flow

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
@@ -260,14 +260,14 @@ public class HttpsHsmClient
 
                     byte[] output = outputStream.toByteArray();
                     log.trace("Writing {} bytes to unix domain socket", output.length);
-                    log.trace("{}", new String(output, StandardCharsets.UTF_8));
+                    log.trace("Contents of the request:\r\n{}", new String(output, StandardCharsets.UTF_8));
                     unixDomainSocketChannel.write(output);
                 }
             }
             else
             {
                 log.trace("Writing {} bytes to unix domain socket", requestBytes.length);
-                log.trace("{}", new String(requestBytes, StandardCharsets.UTF_8));
+                log.trace("Contents of the request:\r\n{}", new String(requestBytes, StandardCharsets.UTF_8));
                 unixDomainSocketChannel.write(requestBytes);
             }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
@@ -251,17 +251,23 @@ public class HttpsHsmClient
 
             if (httpsRequest.getBody() != null)
             {
-                //append http request body to the request bytes
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                outputStream.write(requestBytes);
-                outputStream.write(httpsRequest.getBody());
+                // closes the output stream when it exits this block
+                try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                {
+                    //append http request body to the request bytes
+                    outputStream.write(requestBytes);
+                    outputStream.write(httpsRequest.getBody());
 
-                log.trace("Writing {} bytes to unix domain socket", outputStream.size());
-                unixDomainSocketChannel.write(outputStream.toByteArray());
+                    byte[] output = outputStream.toByteArray();
+                    log.trace("Writing {} bytes to unix domain socket", output.length);
+                    log.trace("{}", output);
+                    unixDomainSocketChannel.write(output);
+                }
             }
             else
             {
                 log.trace("Writing {} bytes to unix domain socket", requestBytes.length);
+                log.trace("{}", new String(requestBytes, StandardCharsets.UTF_8));
                 unixDomainSocketChannel.write(requestBytes);
             }
 

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/hsm/HttpsHsmClient.java
@@ -260,7 +260,7 @@ public class HttpsHsmClient
 
                     byte[] output = outputStream.toByteArray();
                     log.trace("Writing {} bytes to unix domain socket", output.length);
-                    log.trace("{}", output);
+                    log.trace("{}", new String(output, StandardCharsets.UTF_8));
                     unixDomainSocketChannel.write(output);
                 }
             }


### PR DESCRIPTION
We didn't have any way to log the contents of the requests sent to the Edgelet over Unix domain socket

Also wrap a closeable stream in a try block so that it closes automatically