### PR TITLE
Bump versions for 7/25/2023 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 
         <iot-device-client-version>2.2.0</iot-device-client-version>
         <iot-service-client-version>2.1.6</iot-service-client-version>  <!--e2e tests only-->
-        <provisioning-device-client-version>2.1.0</provisioning-device-client-version>
+        <provisioning-device-client-version>2.1.1</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.2</provisioning-service-client-version>
         <security-provider-version>2.0.1</security-provider-version>
         <tpm-provider-emulator-version>2.0.1</tpm-provider-emulator-version>


### PR DESCRIPTION
## Java Provisioning Device Client (com.microsoft.azure.sdk.iot.provisioning:provisioning-device-client:2.1.1)

### Bug fixes
 - Fix bug where sync overload of register ignores additional data (#1732)

https://search.maven.org/artifact/com.microsoft.azure.sdk.iot.provisioning/provisioning-device-client/2.1.1/jar