### PR TITLE
feat(iot-dev): Allow users to opt-out of treating routine disconnects as errors

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -91,6 +91,8 @@ public final class ClientConfiguration
 
     private boolean useIdentifiableThreadNames = true;
 
+    private boolean logRoutineDisconnectsAsErrors = true;
+
     private IotHubAuthenticationProvider authenticationProvider;
 
     /**
@@ -223,6 +225,7 @@ public final class ClientConfiguration
         this.threadNamePrefix = clientOptions != null ? clientOptions.getThreadNamePrefix() : null;
         this.threadNameSuffix = clientOptions != null ? clientOptions.getThreadNameSuffix() : null;
         this.useIdentifiableThreadNames = clientOptions == null || clientOptions.isUsingIdentifiableThreadNames();
+        this.logRoutineDisconnectsAsErrors = clientOptions == null || clientOptions.isLoggingRoutineDisconnectsAsErrors();
 
         if (proxySettings != null)
         {
@@ -644,6 +647,12 @@ public final class ClientConfiguration
     {
         // Using a manually written method here to override the name that Lombok would have given it
         return this.useIdentifiableThreadNames;
+    }
+
+    public boolean isLoggingRoutineDisconnectsAsErrors()
+    {
+        // Using a manually written method here to override the name that Lombok would have given it
+        return this.logRoutineDisconnectsAsErrors;
     }
 
     /**

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -167,10 +167,23 @@ public final class ClientOptions
     @Builder.Default
     private final boolean useIdentifiableThreadNames = true;
 
+    /**
+     * This option allows for routine disconnect events (such as expired SAS token disconnects
+     * when connecting over MQTT or MQTT_WS) to be logged at debug levels as opposed to error or
+     * warn levels. By default, these routine disconnects are logged at error or warn levels.
+     */
+    @Builder.Default
+    private final boolean logRoutineDisconnectsAsErrors = true;
 
     public boolean isUsingIdentifiableThreadNames()
     {
         // Using a manually written method here to override the name that Lombok would have given it
         return this.useIdentifiableThreadNames;
+    }
+
+    public boolean isLoggingRoutineDisconnectsAsErrors()
+    {
+        // Using a manually written method here to override the name that Lombok would have given it
+        return this.logRoutineDisconnectsAsErrors;
     }
 }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -171,6 +171,12 @@ public final class ClientOptions
      * This option allows for routine disconnect events (such as expired SAS token disconnects
      * when connecting over MQTT or MQTT_WS) to be logged at debug levels as opposed to error or
      * warn levels. By default, these routine disconnects are logged at error or warn levels.
+     *
+     * Note that there is a degree of speculation involved when this client labels a disconnect
+     * as a routine disconnect. Generally, if the client is disconnected when the previous SAS
+     * token was expired, it will assume it was a routine disconnect. However, there may be
+     * legitimate disconnects due to network errors that could be mislabeled and not logged
+     * at a warning or error level if they occur around the time that a routine error is expected.
      */
     @Builder.Default
     private final boolean logRoutineDisconnectsAsErrors = true;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -1644,7 +1644,7 @@ public class IotHubTransport implements IotHubListener
         {
             if (throwable == null)
             {
-                log.debug("Updating transport status to new status {} with reason {}", newConnectionStatus, reason);
+                log.info("Updating transport status to new status {} with reason {}", newConnectionStatus, reason);
             }
             else if (this.getDefaultConfig() != null
                     && !this.getDefaultConfig().isLoggingRoutineDisconnectsAsErrors()
@@ -1655,7 +1655,7 @@ public class IotHubTransport implements IotHubListener
                 // This is a special case where the user has opted out of treating the routine
                 // MQTT/MQTT_WS SAS token disconnects as an error for logging purposes. As such,
                 // log at the debug level instead of warn or error level.
-                log.debug("Updating transport status to new status {} with reason {}", newConnectionStatus, reason);
+                log.info("Updating transport status to new status {} with reason {}", newConnectionStatus, reason);
             }
             else
             {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -327,8 +327,6 @@ public abstract class Mqtt implements MqttCallback
     @Override
     public void connectionLost(Throwable throwable)
     {
-        log.warn("Mqtt connection lost", throwable);
-
         this.disconnect();
 
         if (this.listener != null)
@@ -343,6 +341,10 @@ public abstract class Mqtt implements MqttCallback
             {
                 transportException = new TransportException(throwable);
             }
+
+            // Logging this at a debug level instead of warning or error because the IoThubTransport
+            // level will log it to warning or error if applicable.
+            log.debug("Mqtt connection lost", transportException);
 
             this.listener.onConnectionLost(transportException, this.connectionId);
         }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -329,25 +329,22 @@ public abstract class Mqtt implements MqttCallback
     {
         this.disconnect();
 
-        if (this.listener != null)
+        TransportException transportException;
+        if (throwable instanceof MqttException)
         {
-            TransportException transportException;
-            if (throwable instanceof MqttException)
-            {
-                transportException = PahoExceptionTranslator.convertToMqttException((MqttException) throwable, "Mqtt connection lost");
-                log.trace("Mqtt connection loss interpreted into transport exception", throwable);
-            }
-            else
-            {
-                transportException = new TransportException(throwable);
-            }
-
-            // Logging this at a debug level instead of warning or error because the IoThubTransport
-            // level will log it to warning or error if applicable.
-            log.debug("Mqtt connection lost", transportException);
-
-            this.listener.onConnectionLost(transportException, this.connectionId);
+            transportException = PahoExceptionTranslator.convertToMqttException((MqttException) throwable, "Mqtt connection lost");
+            log.trace("Mqtt connection loss interpreted into transport exception", throwable);
         }
+        else
+        {
+            transportException = new TransportException(throwable);
+        }
+
+        // Logging this at a debug level instead of warning or error because the IoThubTransport
+        // level will log it to warning or error if applicable.
+        log.debug("Mqtt connection lost", transportException);
+
+        this.listener.onConnectionLost(transportException, this.connectionId);
     }
 
     /**


### PR DESCRIPTION
SAS authorized MQTT connections have routine disconnects that some users don't want treated as errors or warnings in logs. This adds a flag they can set in client options to opt out of the current default.

Also defer creating a multiplexing retry policy until a multiplexing client is created to avoid unnecessary logs


Like #1739 but requiring opting in to logging these routine disconnects opt-in