### PR TITLE
fix(prov-dev): Fix bug where closing provisioning device client didn't cleanup all threads

### DIFF
--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/task/ProvisioningTask.java
@@ -343,7 +343,7 @@ public class ProvisioningTask implements Callable<Object>
             this.executeStateMachineForStatus(registrationOperationStatusParser);
             this.close();
         }
-        catch (ExecutionException | TimeoutException | ProvisioningDeviceClientException | SecurityProviderException e)
+        catch (ExecutionException | TimeoutException | ProvisioningDeviceClientException | SecurityProviderException | InterruptedException e)
         {
             //SRS_ProvisioningTask_25_006: [ This method shall invoke the status callback, if any of the task fail or throw any exception. ]
             this.dpsStatus = PROVISIONING_DEVICE_STATUS_ERROR;


### PR DESCRIPTION
If the provisioning task was interrupted by the user closing the client, it needs to shutdown its executor service that runs the RegisterTask

This fix addresses #1736