### PR TITLE
Fixing issue: QOS not set for incoming messages from $iothub/twin/PAT…

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
@@ -342,7 +342,7 @@ class MqttTwin extends Mqtt
                                 {
                                     message = new IotHubTransportMessage(data, MessageType.DEVICE_TWIN);
                                     message.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
-                                    message.setQualityOfService(messagePair.getValue().getQos());
+                                    message.setQualityOfService(mqttMessage.getQos());
                                 }
 
                                 // Case for $iothub/twin/PATCH/properties/desired/?$version={new version}

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
@@ -342,6 +342,7 @@ class MqttTwin extends Mqtt
                                 {
                                     message = new IotHubTransportMessage(data, MessageType.DEVICE_TWIN);
                                     message.setDeviceOperationType(DeviceOperations.DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
+                                    message.setQualityOfService(messagePair.getValue().getQos());
                                 }
 
                                 // Case for $iothub/twin/PATCH/properties/desired/?$version={new version}

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
@@ -904,6 +904,33 @@ public class MqttTwinTest
         }
     }
 
+    @Test
+    public void receiveSetQosForDesiredProp() throws TransportException
+    {
+        final byte[] actualPayload = "NotificationResponseDataContainingDesiredPropertiesDocument".getBytes(StandardCharsets.UTF_8);
+        final String expectedTopic = "$iothub/twin/PATCH/properties/desired/";
+        IotHubTransportMessage receivedMessage = null;
+        int expectedQualityOfService = 2;
+        try
+        {
+            //arrange
+            Queue<Pair<String, MqttMessage>> testreceivedMessages = new ConcurrentLinkedQueue<>();
+            MqttMessage mqttMessage = new MqttMessage(actualPayload);
+            mqttMessage.setQos(expectedQualityOfService);
+            testreceivedMessages.add(new MutablePair<>(expectedTopic, mqttMessage));
+            MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), testreceivedMessages);
+
+            //act
+            receivedMessage = testTwin.receive();
+        }
+        finally
+        {
+            //assert
+            assertNotNull(receivedMessage);
+            assertEquals(expectedQualityOfService, receivedMessage.getQualityOfService());
+        }
+    }
+
     /*
     **Tests_SRS_MQTTDEVICETWIN_25_042: [If the topic is of type patch for desired properties then this method shall parse further to look for version which if found is set by calling setVersion]
      */


### PR DESCRIPTION
…CH/properties/desired/ topic #1746

<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
- [x] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-java/issues/1746

# Description of the problem
Problem is described in the issue.

# Description of the solution
Added code to copy QOS from original message.