### PR TITLE
fix(iot-dev): fix bug where client options was overridden

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -13,7 +13,7 @@ import static com.microsoft.azure.sdk.iot.device.ClientConfiguration.DEFAULT_KEE
 /**
  * Options that allow configuration of the device client instance during initialization.
  */
-@Builder
+@Builder(toBuilder = true)
 public final class ClientOptions
 {
     private static final int DEFAULT_HTTPS_CONNECT_TIMEOUT_MILLISECONDS = 0;

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -227,23 +227,7 @@ public class ModuleClient extends InternalClient
             if (clientOptions != null && clientOptions.getSslContext() == null)
             {
                 // Clone the existing client options, but with the new SSLContext
-                clientOptions = ClientOptions.builder()
-                        .sasTokenExpiryTime(clientOptions.getSasTokenExpiryTime())
-                        .logRoutineDisconnectsAsErrors(clientOptions.isLoggingRoutineDisconnectsAsErrors())
-                        .receiveInterval(clientOptions.getReceiveInterval())
-                        .amqpAuthenticationSessionTimeout(clientOptions.getAmqpAuthenticationSessionTimeout())
-                        .amqpDeviceSessionTimeout(clientOptions.getAmqpDeviceSessionTimeout())
-                        .httpsConnectTimeout(clientOptions.getHttpsConnectTimeout())
-                        .httpsReadTimeout(clientOptions.getHttpsReadTimeout())
-                        .modelId(clientOptions.getModelId())
-                        .proxySettings(clientOptions.getProxySettings())
-                        .keepAliveInterval(clientOptions.getKeepAliveInterval())
-                        .threadNamePrefix(clientOptions.getThreadNamePrefix())
-                        .threadNameSuffix(clientOptions.getThreadNameSuffix())
-                        .useIdentifiableThreadNames(clientOptions.isUsingIdentifiableThreadNames())
-                        .sendInterval(clientOptions.getSendInterval())
-                        .messagesSentPerSendInterval(clientOptions.getMessagesSentPerSendInterval())
-                        .sslContext(sslContext)
+                clientOptions = clientOptions.toBuilder().sslContext(sslContext)
                         .build();
             }
             else if (clientOptions == null)

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ModuleClient.java
@@ -224,9 +224,31 @@ public class ModuleClient extends InternalClient
                 sslContext = new IotHubSSLContext().getSSLContext();
             }
 
-            if (clientOptions == null || clientOptions.getSslContext() == null)
+            if (clientOptions != null && clientOptions.getSslContext() == null)
             {
-                // only override the SSLContext if the user didn't set it
+                // Clone the existing client options, but with the new SSLContext
+                clientOptions = ClientOptions.builder()
+                        .sasTokenExpiryTime(clientOptions.getSasTokenExpiryTime())
+                        .logRoutineDisconnectsAsErrors(clientOptions.isLoggingRoutineDisconnectsAsErrors())
+                        .receiveInterval(clientOptions.getReceiveInterval())
+                        .amqpAuthenticationSessionTimeout(clientOptions.getAmqpAuthenticationSessionTimeout())
+                        .amqpDeviceSessionTimeout(clientOptions.getAmqpDeviceSessionTimeout())
+                        .httpsConnectTimeout(clientOptions.getHttpsConnectTimeout())
+                        .httpsReadTimeout(clientOptions.getHttpsReadTimeout())
+                        .modelId(clientOptions.getModelId())
+                        .proxySettings(clientOptions.getProxySettings())
+                        .keepAliveInterval(clientOptions.getKeepAliveInterval())
+                        .threadNamePrefix(clientOptions.getThreadNamePrefix())
+                        .threadNameSuffix(clientOptions.getThreadNameSuffix())
+                        .useIdentifiableThreadNames(clientOptions.isUsingIdentifiableThreadNames())
+                        .sendInterval(clientOptions.getSendInterval())
+                        .messagesSentPerSendInterval(clientOptions.getMessagesSentPerSendInterval())
+                        .sslContext(sslContext)
+                        .build();
+            }
+            else if (clientOptions == null)
+            {
+                // only override the client options completely if the user didn't provide any
                 clientOptions = ClientOptions.builder().sslContext(sslContext).build();
             }
             else


### PR DESCRIPTION
If a user provides a client options instance, but without an SSLContext, we should still keep all the settings they provided while adding the SSLContext generated by the SDK