### PR TITLE
Fix android emulator testing

### DIFF
--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -24,7 +24,7 @@ nohup $ANDROID_HOME/emulator/emulator -avd $avdName -gpu auto -no-snapshot > /de
 
 echo ''
 echo 'Waiting for emulator to boot up...'
-nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
+nohup $ANDROID_HOME/emulator/emulator -avd $avdName -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
     $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
     $ANDROID_HOME/platform-tools/adb devices echo "Emulator started"
 

--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 echo 'Listing available android sdks for installation'
-$ANDROID_HOME/tools/bin/sdkmanager --list | grep system-images
+$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list | grep system-images
 
 emulatorImage='system-images;android-28;google_apis;x86_64'
 avdName='Pixel_9.0'
 
 echo ''
 echo "Installing emulator image ${emulatorImage}"
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install $emulatorImage
+echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install $emulatorImage
 
 echo ''
 echo "Creating android emulator with name ${avdName}"
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n $avdName -k $emulatorImage --force
+echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n $avdName -k $emulatorImage --force
 
 echo ''
 echo 'Listing active android emulators'

--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -24,9 +24,9 @@ nohup $ANDROID_HOME/emulator/emulator -avd $avdName -gpu auto -no-snapshot > /de
 
 echo ''
 echo 'Waiting for emulator to boot up...'
-$ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
-echo ''
-echo "Emulator started"
+nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
+    $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
+    $ANDROID_HOME/platform-tools/adb devices echo "Emulator started"
 
 $ANDROID_HOME/platform-tools/adb devices
 

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -413,14 +413,6 @@ jobs:
         env:
           TEST_GROUP_ID: $(ANDROID_TEST_GROUP_ID)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish Test Results'
-        inputs:
-          testResultsFiles: '**/outputs/androidTest-results/**/TEST*.xml'
-          failTaskOnFailedTests: true
-          testRunTitle: 'Test results'
-        condition: succeededOrFailed()
-
       - task : ComponentGovernanceComponentDetection@0
         displayName : Component Governance Detection
         inputs :

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -413,6 +413,14 @@ jobs:
         env:
           TEST_GROUP_ID: $(ANDROID_TEST_GROUP_ID)
 
+      - task: PublishTestResults@2
+        displayName: 'Publish Test Results'
+        inputs:
+          testResultsFiles: '**/outputs/androidTest-results/**/TEST*.xml'
+          failTaskOnFailedTests: true
+          testRunTitle: 'Test results'
+        condition: succeededOrFailed()
+
       - task : ComponentGovernanceComponentDetection@0
         displayName : Component Governance Detection
         inputs :


### PR DESCRIPTION
The old code frequently timed out waiting for the android emulator to start, but this new code makes it much more consistently successful at starting up the emulator