### PR TITLE
fix(iot-dev): fix bug where client opening with retry isn't cancelled by close

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -206,6 +206,10 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
      */
     void close()
     {
+        // Notify the transport layer that the user wants to close the connection. This
+        // will end any "open with retry" operations. Once any running open calls have ended,
+        // the state lock will be released and this close operation can proceed
+        this.transport.setClosing(true);
         synchronized (this.stateLock)
         {
             if (state == IotHubConnectionStatus.DISCONNECTED)


### PR DESCRIPTION
If a client is struggling to open the connection (no network scenarios, for example), then users should be able to close the client without waiting for the retry to expire on the "open with retry" operation

#1759