### PR TITLE
feat(iot-dev): Add configurable message expiration check job

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientConfiguration.java
@@ -48,6 +48,8 @@ public final class ClientConfiguration
 
     private static final long MAX_SAS_TOKEN_EXPIRY_TIME_SECONDS = 10 * 365 * 24 * 60 * 60; //10 years
 
+    private static final long DEFAULT_MESSAGE_EXPIRATION_CHECK_PERIOD = 10000;
+
     private boolean useWebsocket;
 
     @Getter
@@ -90,6 +92,9 @@ public final class ClientConfiguration
 
     @Getter
     private String threadNamePrefix = null;
+
+    @Getter
+    private long messageExpiredCheckPeriod;
 
     private boolean useIdentifiableThreadNames = true;
 
@@ -229,6 +234,7 @@ public final class ClientConfiguration
         this.threadNameSuffix = clientOptions != null ? clientOptions.getThreadNameSuffix() : null;
         this.useIdentifiableThreadNames = clientOptions == null || clientOptions.isUsingIdentifiableThreadNames();
         this.logRoutineDisconnectsAsErrors = clientOptions == null || clientOptions.isLoggingRoutineDisconnectsAsErrors();
+        this.messageExpiredCheckPeriod = clientOptions != null ? clientOptions.getMessageExpirationCheckPeriod() : DEFAULT_MESSAGE_EXPIRATION_CHECK_PERIOD;
 
         if (proxySettings != null)
         {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/ClientOptions.java
@@ -181,6 +181,28 @@ public final class ClientOptions
     @Builder.Default
     private final boolean logRoutineDisconnectsAsErrors = true;
 
+    /**
+     * The period (in milliseconds) for how often the client will check queued and in-flight messages for expiry.
+     *
+     * Higher values mean that messages will be checked for expiry less often but this client will use less CPU. Higher
+     * values also mean that messages may not execute their callback with MESSAGE_EXPIRED close to the expected
+     * expiry time.
+     *
+     * Lower values mean that messages will be checked for expiry more often but this client will use more CPU. Lower
+     * values also mean that messages will execute their callback with MESSAGE_EXPIRED closer to the expected
+     * expiry time.
+     *
+     * By default, this value is 10 seconds.
+     *
+     * If set to 0, message expiry will never be checked.
+     *
+     * If this client will be used in a multiplexed connection, this value is ignored in favor of the same setting in
+     * {@link MultiplexingClientOptions}.
+     */
+    @Getter
+    @Builder.Default
+    private final long messageExpirationCheckPeriod = 10000;
+
     public boolean isUsingIdentifiableThreadNames()
     {
         // Using a manually written method here to override the name that Lombok would have given it

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/DeviceIO.java
@@ -79,10 +79,23 @@ final class DeviceIO implements IotHubConnectionStatusChangeCallback
         int sendInterval,
         boolean useIdentifiableThreadNames,
         String threadNamePrefix,
-        String threadNameSuffix)
+        String threadNameSuffix,
+        long messageExpirationCheckPeriod)
     {
         this.state = IotHubConnectionStatus.DISCONNECTED;
-        this.transport = new IotHubTransport(hostName, protocol, sslContext, proxySettings, this, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
+        this.transport = new IotHubTransport(
+            hostName,
+            protocol,
+            sslContext,
+            proxySettings,
+            this,
+            keepAliveInterval,
+            sendInterval,
+            useIdentifiableThreadNames,
+            threadNamePrefix,
+            threadNameSuffix,
+            messageExpirationCheckPeriod);
+
         this.sendTask = new IotHubSendTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
         this.receiveTask = new IotHubReceiveTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
         this.reconnectTask = new IotHubReconnectTask(this.transport, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClient.java
@@ -34,6 +34,7 @@ public class MultiplexingClient
     static final int DEFAULT_MAX_MESSAGES_TO_SEND_PER_THREAD = 10;
     private static final long DEFAULT_REGISTRATION_TIMEOUT_MILLISECONDS = 60 * 1000; // 1 minute
     private static final long DEFAULT_UNREGISTRATION_TIMEOUT_MILLISECONDS = 60 * 1000; // 1 minute
+    private static final long DEFAULT_MESSAGE_EXPIRATION_CHECK_PERIOD = 10000;
 
     // keys are deviceIds. Helps to optimize look ups later on which device Ids are already registered.
     private final Map<String, DeviceClient> multiplexedDeviceClients;
@@ -104,6 +105,7 @@ public class MultiplexingClient
         String threadNamePrefix = options != null ? options.getThreadNamePrefix() : null;
         String threadNameSuffix = options != null ? options.getThreadNameSuffix() : null;
         boolean useIdentifiableThreadNames = options == null || options.isUsingIdentifiableThreadNames();
+        long messageExpiredCheckPeriod = options != null ? options.getMessageExpirationCheckPeriod() : DEFAULT_MESSAGE_EXPIRATION_CHECK_PERIOD;
 
         if (sendPeriod < 0)
         {
@@ -130,7 +132,18 @@ public class MultiplexingClient
 
         // Optional settings from MultiplexingClientOptions
         SSLContext sslContext = options != null ? options.getSslContext() : null;
-        this.deviceIO = new DeviceIO(hostName, protocol, sslContext, proxySettings, keepAliveInterval, sendInterval, useIdentifiableThreadNames, threadNamePrefix, threadNameSuffix);
+        this.deviceIO = new DeviceIO(
+            hostName,
+            protocol,
+            sslContext,
+            proxySettings,
+            keepAliveInterval,
+            sendInterval,
+            useIdentifiableThreadNames,
+            threadNamePrefix,
+            threadNameSuffix,
+            messageExpiredCheckPeriod);
+
         this.deviceIO.setMaxNumberOfMessagesSentPerSendThread(sendMessagesPerThread);
         this.deviceIO.setSendPeriodInMilliseconds(sendPeriod);
         this.deviceIO.setReceivePeriodInMilliseconds(receivePeriod);

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/MultiplexingClientOptions.java
@@ -98,6 +98,25 @@ public final class MultiplexingClientOptions
     @Builder.Default
     private final boolean useIdentifiableThreadNames = true;
 
+    /**
+     * The period (in milliseconds) for how often the client will check queued and in-flight messages for expiry.
+     *
+     * Higher values mean that messages will be checked for expiry less often but this client will use less CPU. Higher
+     * values also mean that messages may not execute their callback with MESSAGE_EXPIRED close to the expected
+     * expiry time.
+     *
+     * Lower values mean that messages will be checked for expiry more often but this client will use more CPU. Lower
+     * values also mean that messages will execute their callback with MESSAGE_EXPIRED closer to the expected
+     * expiry time.
+     *
+     * By default, this value is 10 seconds.
+     *
+     * If set to 0, message expiry will never be checked.
+     */
+    @Getter
+    @Builder.Default
+    private final long messageExpirationCheckPeriod = 10000;
+
     public boolean isUsingIdentifiableThreadNames()
     {
         // Using a manually written method here to override the name that Lombok would have given it


### PR DESCRIPTION
Previously, the client would only check for expired messages each time it tried to send a message. Now it will check for expired messages even if the client is idle.