### PR TITLE
refactor(prov-dev): Add SDK-side check for "/" and "\" characters in registrationId

### DIFF
--- a/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKey.java
+++ b/provisioning/security/security-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKey.java
@@ -41,6 +41,18 @@ public class SecurityProviderSymmetricKey extends SecurityProvider
             throw new IllegalArgumentException("Registration ID cannot be null");
         }
 
+        // There are other invalid characters, but these characters affect the request path when registering
+        // and are difficult to notice without this catch
+        if (registrationId.contains("/"))
+        {
+            throw new IllegalArgumentException("Registration ID cannot contain \"/\" character");
+        }
+
+        if (registrationId.contains("\\"))
+        {
+            throw new IllegalArgumentException("Registration ID cannot contain \"\\\" character");
+        }
+
         this.primaryKey = symmetricKey;
         this.registrationId = registrationId;
     }
@@ -61,6 +73,18 @@ public class SecurityProviderSymmetricKey extends SecurityProvider
         if (registrationId == null || registrationId.isEmpty())
         {
             throw new IllegalArgumentException("Registration ID cannot be null");
+        }
+
+        // There are other invalid characters, but these characters affect the request path when registering
+        // and are difficult to notice without this catch
+        if (registrationId.contains("/"))
+        {
+            throw new IllegalArgumentException("Registration ID cannot contain \"/\" character");
+        }
+
+        if (registrationId.contains("\\"))
+        {
+            throw new IllegalArgumentException("Registration ID cannot contain \"\\\" character");
         }
 
         this.primaryKey = primaryKey.getBytes(StandardCharsets.UTF_8);

--- a/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKeyTest.java
+++ b/provisioning/security/security-provider/src/test/java/com/microsoft/azure/sdk/iot/provisioning/security/SecurityProviderSymmetricKeyTest.java
@@ -300,4 +300,28 @@ public class SecurityProviderSymmetricKeyTest
         //act
         securityProviderSymmetricKey.getSSLContext();
     }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testConstructorThrowsForInvalidChar() throws SecurityProviderException
+    {
+        SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, "some/invalidRegistrationId");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testConstructorThrowsForInvalidChar2() throws SecurityProviderException
+    {
+        SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(testSymKey, "some\\invalidRegistrationId");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testConstructorThrowsForInvalidChar3() throws SecurityProviderException
+    {
+        SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(new byte[10], "some/invalidRegistrationId");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testConstructorThrowsForInvalidChar4() throws SecurityProviderException
+    {
+        SecurityProviderSymmetricKey securityProviderSymmetricKey = new SecurityProviderSymmetricKey(new byte[10], "some\\invalidRegistrationId");
+    }
 }

--- a/provisioning/security/x509-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderX509Cert.java
+++ b/provisioning/security/x509-provider/src/main/java/com/microsoft/azure/sdk/iot/provisioning/security/hsm/SecurityProviderX509Cert.java
@@ -43,6 +43,23 @@ public class SecurityProviderX509Cert extends SecurityProviderX509
         this.leafPrivateKey = leafPrivateKey;
         this.signerCertificates = signerCertificates;
         this.commonNameLeaf = this.getCommonName(this.leafCertificatePublic);
+
+        if (this.commonNameLeaf == null || this.commonNameLeaf.isEmpty())
+        {
+            throw new IllegalArgumentException("Common name cannot be null or empty");
+        }
+
+        // There are other invalid characters, but these characters affect the request path when registering
+        // and are difficult to notice without this catch
+        if (this.commonNameLeaf.contains("/"))
+        {
+            throw new IllegalArgumentException("Common name cannot contain \"/\" character");
+        }
+
+        if (this.commonNameLeaf.contains("\\"))
+        {
+            throw new IllegalArgumentException("Common name cannot contain \"\\\" character");
+        }
     }
 
     private String getCommonName(X509Certificate certificate)


### PR DESCRIPTION
Normally we don't do this kind of validation on the SDK side since the service is the source of truth on what characters are allowed, but these particular characters break the service's request path logic so they are don't log like normal requests.

TPM security providers already do more extensive validation of the registration id, so this commit only adds it for x509 and symmetric key cases