### PR TITLE
fix(iot-dev): Fix bug where link detach events were ignored

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsReceiverLinkHandler.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsReceiverLinkHandler.java
@@ -159,6 +159,21 @@ abstract class AmqpsReceiverLinkHandler extends BaseHandler
         }
     }
 
+    @Override
+    public void onLinkLocalDetach(Event e)
+    {
+        // Link detach vs link close is functionally the same for our purposes.
+        // In both cases, the higher layers need to be notified that the link
+        // is no longer active so that retry can begin.
+        this.onLinkLocalClose(e);
+    }
+
+    @Override
+    public void onLinkRemoteDetach(Event e)
+    {
+        this.onLinkRemoteClose(e);
+    }
+
     public boolean acknowledgeReceivedMessage(IotHubTransportMessage message, DeliveryState ackType)
     {
         if (this.receivedMessagesMap.containsKey(message))

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsSenderLinkHandler.java
@@ -154,6 +154,21 @@ abstract class AmqpsSenderLinkHandler extends BaseHandler
     }
 
     @Override
+    public void onLinkLocalDetach(Event e)
+    {
+        // Link detach vs link close is functionally the same for our purposes.
+        // In both cases, the higher layers need to be notified that the link
+        // is no longer active so that retry can begin.
+        this.onLinkLocalClose(e);
+    }
+
+    @Override
+    public void onLinkRemoteDetach(Event e)
+    {
+        this.onLinkRemoteClose(e);
+    }
+
+    @Override
     public void onLinkFlow(Event event)
     {
         log.trace("Link flow received on {} sender link with address {} and link correlation id {}. Current link credit is now {}.", getLinkInstanceType(), this.senderLinkAddress, this.linkCorrelationId, event.getSender().getCredit());


### PR DESCRIPTION
gwv2 hubs send a "link detach" event when a device is disabled, so we need to respond to this event by notifying higher layers that the link was lost.

For reference, gwv1 hubs send a "link close" event which we already handle