### PR TITLE
fix(prov-dev): Fix small logic error around multiple open calls in MQTT layer

### DIFF
--- a/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
+++ b/provisioning/provisioning-device-client/src/main/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqtt.java
@@ -158,7 +158,7 @@ public class ContractAPIMqtt extends ProvisioningDeviceClientContract implements
     @Override
     public synchronized void open(RequestData requestData) throws ProvisioningDeviceConnectionException
     {
-        if (this.mqttConnection != null && !this.mqttConnection.isMqttConnected())
+        if (this.mqttConnection != null && this.mqttConnection.isMqttConnected())
         {
             throw new ProvisioningDeviceConnectionException("Open called on an already open connection");
         }
@@ -203,7 +203,7 @@ public class ContractAPIMqtt extends ProvisioningDeviceClientContract implements
     {
         try
         {
-            if (this.mqttConnection != null && this.mqttConnection.isMqttConnected() )
+            if (this.mqttConnection != null && this.mqttConnection.isMqttConnected())
             {
                 this.mqttConnection.disconnect();
             }


### PR DESCRIPTION
The exception message suggests that we are checking if the client is already open, not if it is already closed.

#1772 