### PR TITLE
Fixing issue: Version 2.x of iot-device-client, requires version of reported properties to be sent, while 1.x not require that #1776

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessage.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessage.java
@@ -25,7 +25,7 @@ public class IotHubTransportMessage extends Message
     private String uriPath;
 
     private String methodName;
-    private int version;
+    private Integer version;
     private String requestId;
     private String status;
     private DeviceOperations operationType;
@@ -46,7 +46,7 @@ public class IotHubTransportMessage extends Message
         super(data);
         super.setMessageType(messageType);
         this.methodName = null;
-        this.version = 0;
+        this.version = null;
         this.requestId = null;
         this.status = null;
         this.operationType = DeviceOperations.DEVICE_OPERATION_UNKNOWN;
@@ -61,7 +61,7 @@ public class IotHubTransportMessage extends Message
         super(body);
         super.setMessageType(MessageType.UNKNOWN);
         this.methodName = null;
-        this.version = 0;
+        this.version = null;
         this.requestId = null;
         this.status = null;
         this.operationType = DeviceOperations.DEVICE_OPERATION_UNKNOWN;
@@ -104,7 +104,7 @@ public class IotHubTransportMessage extends Message
      * Setter for the message version
      * @param version The String containing the version.
      */
-    public void setVersion(int version)
+    public void setVersion(Integer version)
     {
         this.version = version;
     }
@@ -113,7 +113,7 @@ public class IotHubTransportMessage extends Message
      * Getter for the message version
      * @return the String containing the version.
      */
-    public int getVersion()
+    public Integer getVersion()
     {
         return this.version;
     }

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwin.java
@@ -122,10 +122,12 @@ class MqttTwin extends Mqtt
                     throw new IllegalArgumentException("Request Id is Mandatory");
                 }
 
-                int version = message.getVersion();
-                topic.append(AND);
-                topic.append(VERSION);
-                topic.append(version);
+                Integer version = message.getVersion();
+                if (version != null) {
+                    topic.append(AND);
+                    topic.append(VERSION);
+                    topic.append(version);
+                }
                 break;
             }
             case DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_REQUEST:

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/ReportedPropertiesUpdateResponse.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/twin/ReportedPropertiesUpdateResponse.java
@@ -15,5 +15,5 @@ public class ReportedPropertiesUpdateResponse
      * does not apply this reported properties update immediately.
      */
     @Getter
-    private final int version;
+    private final Integer version;
 }

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessageTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportMessageTest.java
@@ -62,7 +62,7 @@ public class IotHubTransportMessageTest
 
         // assert
         assertEquals(messageType, iotHubTransportMessage.getMessageType());
-        assertEquals(0, iotHubTransportMessage.getVersion());
+        assertNull(iotHubTransportMessage.getVersion());
         assertNull(iotHubTransportMessage.getRequestId());
         assertNull(iotHubTransportMessage.getStatus());
         assertEquals(DEVICE_OPERATION_UNKNOWN, iotHubTransportMessage.getDeviceOperationType());
@@ -89,7 +89,7 @@ public class IotHubTransportMessageTest
     public void setVersionSetsTheVersion()
     {
         // arrange
-        int version = 1234;
+        Integer version = 1234;
         byte[] data = new byte[1];
         MessageType messageType = MessageType.DEVICE_TWIN;
         IotHubTransportMessage iotHubTransportMessage = new IotHubTransportMessage(data, messageType);

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttTwinTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.*;
 public class MqttTwinTest
 {
     final String resTopic = "$iothub/twin/res/#";
-    final int mockVersion = 5;
+    final Integer mockVersion = 5;
     final String mockReqId = String.valueOf(100);
 
     @Mocked
@@ -210,6 +210,44 @@ public class MqttTwinTest
                 result = mockReqId;
                 mockMessage.getVersion();
                 result = mockVersion;
+            }
+        };
+
+        //act
+        testTwin.send(mockMessage);
+
+        //assert
+        new Verifications()
+        {
+            {
+                mockMessage.getBytes();
+                times = 1;
+                Deencapsulation.invoke(mockMqtt, "publish", expectedTopic, mockMessage);
+                times = 1;
+            }
+        };
+    }
+    @Test
+    public void sendPublishesMessageForUpdateReportedPropertiesOnCorrectTopicWithoutVersion(@Mocked final Mqtt mockMqtt, @Mocked final IotHubTransportMessage mockMessage) throws TransportException
+    {
+        //arrange
+        final byte[] actualPayload = {0x61, 0x62, 0x63};
+        final String expectedTopic = "$iothub/twin/PATCH/properties/reported/?$rid="+ mockReqId;
+        MqttTwin testTwin = new MqttTwin("", mockedConnectOptions, new HashMap<>(), new ConcurrentLinkedQueue<>());
+        testTwin.start();
+        new NonStrictExpectations()
+        {
+            {
+                mockMessage.getBytes();
+                result = actualPayload;
+                mockMessage.getMessageType();
+                result = MessageType.DEVICE_TWIN;
+                mockMessage.getDeviceOperationType();
+                result = DEVICE_OPERATION_TWIN_UPDATE_REPORTED_PROPERTIES_REQUEST;
+                mockMessage.getRequestId();
+                result = mockReqId;
+                mockMessage.getVersion();
+                result = null;
             }
         };
 
@@ -462,7 +500,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_GET_RESPONSE);
             assertEquals(receivedMessage.getRequestId(), mockReqId);
             assertEquals("200", receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
         }
     }
     @Test
@@ -624,7 +662,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_GET_RESPONSE);
             assertEquals(receivedMessage.getRequestId(), mockReqId);
             assertEquals("200", receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
         }
     }
 
@@ -658,7 +696,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_UNKNOWN);
             assertNull(receivedMessage.getRequestId());
             assertEquals("200", receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
         }
     }
 
@@ -731,7 +769,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_GET_RESPONSE);
             assertEquals(receivedMessage.getRequestId(), mockReqId);
             assertEquals("201", receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
         }
     }
 
@@ -768,7 +806,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_GET_RESPONSE);
             assertEquals(receivedMessage.getRequestId(), mockReqId);
             assertEquals("200", receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
 
             byte[] receivedMessageBytes = receivedMessage.getBytes();
             assertEquals(receivedMessageBytes.length, actualPayload.length);
@@ -854,7 +892,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
             assertNull(receivedMessage.getRequestId());
             assertNull(receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
 
             byte[] receivedMessageBytes = receivedMessage.getBytes();
             assertEquals(receivedMessageBytes.length, actualPayload.length);
@@ -893,7 +931,7 @@ public class MqttTwinTest
             assertSame(receivedMessage.getDeviceOperationType(), DEVICE_OPERATION_TWIN_SUBSCRIBE_DESIRED_PROPERTIES_RESPONSE);
             assertNull(receivedMessage.getRequestId());
             assertNull(receivedMessage.getStatus());
-            assertEquals(0, receivedMessage.getVersion());
+            assertNull(receivedMessage.getVersion());
 
             byte[] receivedMessageBytes = receivedMessage.getBytes();
             assertEquals(receivedMessageBytes.length, actualPayload.length);

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/twin/DeviceTwinMessageTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/twin/DeviceTwinMessageTest.java
@@ -32,11 +32,12 @@ public class DeviceTwinMessageTest
         IotHubTransportMessage msg = new IotHubTransportMessage(actualData, MessageType.DEVICE_TWIN);
 
         //assert
-        int actualVersion = Deencapsulation.getField(msg, "version");
+        Integer actualVersion = Deencapsulation.getField(msg, "version");
         String actualRequestId = Deencapsulation.getField(msg, "requestId");
         String actualStatus = Deencapsulation.getField(msg, "status");
         DeviceOperations operationType = Deencapsulation.getField(msg, "operationType");
 
+        assertNull(actualVersion);
         assertNull(actualRequestId);
         assertNull(actualStatus);
         assertEquals(operationType, DeviceOperations.DEVICE_OPERATION_UNKNOWN);
@@ -60,20 +61,21 @@ public class DeviceTwinMessageTest
         IotHubTransportMessage msg = new IotHubTransportMessage(actualData, MessageType.DEVICE_TWIN);
 
         //act
-        int testVersion = msg.getVersion();
+        Integer testVersion = msg.getVersion();
         String testRequestId = msg.getRequestId();
         String testStatus = msg.getStatus();
         DeviceOperations testOpType = msg.getDeviceOperationType();
 
         //assert
-        int actualVersion = Deencapsulation.getField(msg, "version");
+        Integer actualVersion = Deencapsulation.getField(msg, "version");
         String actualRequestId = Deencapsulation.getField(msg, "requestId");
         String actualStatus = Deencapsulation.getField(msg, "status");
-        DeviceOperations operationType = Deencapsulation.getField(msg, "operationType");
+        DeviceOperations actualOperationType = Deencapsulation.getField(msg, "operationType");
 
-        assertEquals(actualRequestId, testRequestId);
-        assertEquals(actualStatus, testStatus);
-        assertEquals(actualVersion, testVersion);
+        assertEquals(testRequestId, actualRequestId);
+        assertEquals(testStatus, actualStatus);
+        assertEquals(testVersion, actualVersion);
+        assertEquals(testOpType, actualOperationType);
     }
 
     /*
@@ -87,10 +89,10 @@ public class DeviceTwinMessageTest
         IotHubTransportMessage msg = new IotHubTransportMessage(actualData, MessageType.DEVICE_TWIN);
 
         //act
-       msg.setVersion(12);
+        msg.setVersion(12);
 
         //assert
-        assertEquals(msg.getVersion(), 12);
+        assertEquals(12, msg.getVersion().intValue());
     }
 
     /*
@@ -108,7 +110,7 @@ public class DeviceTwinMessageTest
         int version = msg.getVersion();
 
         //assert
-        assertEquals(version, 12);
+        assertEquals(12, version);
 
     }
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 