### PR TITLE
Disable file upload tests while test infrastructure is replaced

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -225,6 +226,7 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Ignore("Current test infrastructure doesn't support file upload to a storage account")
     public void getAndCompleteSasUriWithUpload() throws URISyntaxException, IOException, InterruptedException, IotHubException, GeneralSecurityException, StorageException, TimeoutException, IotHubClientException
     {
         // Android has some compatibility issues with the azure storage SDK
@@ -258,8 +260,8 @@ public class FileUploadTests extends IntegrationTest
         tearDownDeviceClient(deviceClient);
     }
 
-    @FlakeyTest
     @Test (timeout = MAX_MILLISECS_TIMEOUT_KILL_TEST)
+    @Ignore("Current test infrastructure doesn't support file upload to a storage account")
     public void getAndCompleteSasUriWithMultipleUploads() throws URISyntaxException, IOException, InterruptedException, IotHubException, GeneralSecurityException, StorageException, TimeoutException, IotHubClientException
     {
         // Android has some compatibility issues with the azure storage SDK

--- a/iot-e2e-tests/device-deletion-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceDeletionSample.java
+++ b/iot-e2e-tests/device-deletion-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/DeviceDeletionSample.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.sdk.iot.service.twin.TwinClient;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -194,7 +195,7 @@ public class DeviceDeletionSample
 
         String sasTokenString = new IotHubServiceSasToken(iotHubConnectionString).toString();
 
-        HttpRequest request = new HttpRequest(url, HttpMethod.POST, body.toJson().getBytes(), sasTokenString);
+        HttpRequest request = new HttpRequest(url, HttpMethod.POST, body.toJson().getBytes(StandardCharsets.UTF_8), sasTokenString);
         request.setHeaderField("Accept", "application/json");
         request.setHeaderField("Content-Type", "application/json");
         request.setHeaderField("charset", "utf-8");

--- a/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
+++ b/vsts/windowsLinuxAndAndroidBuildMatrixConfig.yaml
@@ -119,7 +119,7 @@ jobs:
     timeoutInMinutes: 180
     pool:
       # If this is changed, don't forget to update supported_platforms.md in the root directory. That document outlines what OS we test on and should stay up to date.
-      vmImage: 'ubuntu-22.04'
+      name: 'sdk-net--ubuntu-20'
     displayName: Linux
     strategy:
       maxParallel: $[variables.maxParallel]


### PR DESCRIPTION
Also make linux jobs run on 1ES hosted agent so that they can access the ACR container the TPM simulator image