### PR TITLE
Bump versions for 4/21/2026 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.5.0</iot-device-client-version>
+        <iot-device-client-version>2.5.1</iot-device-client-version>
         <iot-service-client-version>2.1.6</iot-service-client-version>  <!--e2e tests only-->
         <provisioning-device-client-version>2.1.3</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.3</provisioning-service-client-version>


### PR DESCRIPTION
## Java IotHub Device Client (com.microsoft.azure.sdk.iot:iot-device-client:2.5.1)
 - Configure AMQP layer to send server name indication (#1779)
   - This configuration is required for connecting with TLS 1.3 to the upcoming IoT hub hostnames

https://central.sonatype.com/artifact/com.microsoft.azure.sdk.iot/iot-device-client/2.5.1
