### PR TITLE
fix(iot-dev): Preserve response callback context

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -322,6 +322,16 @@ public class IotHubTransport implements IotHubListener
     @Override
     public void onMessageReceived(IotHubTransportMessage message, TransportException e)
     {
+        CorrelationCallbackContext callbackContext = null;
+        if (message != null)
+        {
+            String correlationId = message.getCorrelationId();
+            if (!correlationId.isEmpty())
+            {
+                callbackContext = correlationCallbacks.get(correlationId);
+            }
+        }
+
         if (message != null && e != null)
         {
             log.error("Exception encountered while receiving a message from service {}", message, e);
@@ -338,36 +348,28 @@ public class IotHubTransport implements IotHubListener
 
         try
         {
-            if (message != null)
+            if (callbackContext != null && callbackContext.getCallback() != null)
             {
-                String correlationId = message.getCorrelationId();
-                if (!correlationId.isEmpty())
+                IotHubClientException clientException = null;
+                if (e != null)
                 {
-                    CorrelationCallbackContext callbackContext = correlationCallbacks.get(correlationId);
-                    if (callbackContext != null && callbackContext.getCallback() != null)
+                    // This case indicates that the transport layer failed to construct a valid message out of
+                    // a message delivered by the service
+                    clientException = e.toIotHubClientException();
+                }
+                else
+                {
+                    // This case indicates that the transport layer constructed a valid message out of a message
+                    // delivered by the service, but that message may contain an unsuccessful status code in cases
+                    // such as if an operation was rejected because it was badly formatted.
+                    IotHubStatusCode statusCode = IotHubStatusCode.getIotHubStatusCode(Integer.parseInt(message.getStatus()));
+                    if (!IotHubStatusCode.isSuccessful(statusCode))
                     {
-                        IotHubClientException clientException = null;
-                        if (e != null)
-                        {
-                            // This case indicates that the transport layer failed to construct a valid message out of
-                            // a message delivered by the service
-                            clientException = e.toIotHubClientException();
-                        }
-                        else
-                        {
-                            // This case indicates that the transport layer constructed a valid message out of a message
-                            // delivered by the service, but that message may contain an unsuccessful status code in cases
-                            // such as if an operation was rejected because it was badly formatted.
-                            IotHubStatusCode statusCode = IotHubStatusCode.getIotHubStatusCode(Integer.parseInt(message.getStatus()));
-                            if (!IotHubStatusCode.isSuccessful(statusCode))
-                            {
-                                clientException = new IotHubClientException(statusCode, "Received an unsuccessful operation error code from the service: " + statusCode);
-                            }
-                        }
-
-                        callbackContext.getCallback().onResponseReceived(message, callbackContext.getUserContext(), clientException);
+                        clientException = new IotHubClientException(statusCode, "Received an unsuccessful operation error code from the service: " + statusCode);
                     }
                 }
+
+                callbackContext.getCallback().onResponseReceived(message, callbackContext.getUserContext(), clientException);
             }
         }
         catch (Exception ex)

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -225,6 +225,54 @@ public class IotHubTransportTest
         assertEquals(mockedTransportMessage, receivedMessagesQueue.poll());
     }
 
+    //Tests_SRS_IOTHUBTRANSPORT_34_010: [If a correlation callback exists for a received message, this function shall call onResponseReceived even if the saved correlation callback is removed while queueing the received message.]
+    @Test
+    public void onMessageReceivedCallsResponseCallbackEvenIfCallbackIsRemovedWhileAddingMessageToQueue(@Mocked final CorrelatingMessageCallback mockedCorrelationCallback)
+    {
+        //arrange
+        final String correlationId = "1234";
+        final Object callbackContext = new Object();
+        final Map<String, CorrelationCallbackContext> correlationCallbacks = new ConcurrentHashMap<>();
+        correlationCallbacks.put(correlationId, new CorrelationCallbackContext(mockedCorrelationCallback, callbackContext, System.currentTimeMillis()));
+
+        new Expectations()
+        {
+            {
+                mockedConfig.getDeviceId();
+                result = "someDeviceId";
+
+                mockedTransportMessage.getCorrelationId();
+                result = correlationId;
+
+                mockedTransportMessage.getStatus();
+                result = "200";
+            }
+        };
+
+        new MockUp<IotHubTransport>()
+        {
+            @Mock void addToReceivedMessagesQueue(IotHubTransportMessage message)
+            {
+                correlationCallbacks.remove(correlationId);
+            }
+        };
+
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
+        Deencapsulation.setField(transport, "correlationCallbacks", correlationCallbacks);
+
+        //act
+        transport.onMessageReceived(mockedTransportMessage, null);
+
+        //assert
+        new Verifications()
+        {
+            {
+                mockedCorrelationCallback.onResponseReceived(mockedTransportMessage, callbackContext, null);
+                times = 1;
+            }
+        };
+    }
+
     //Tests_SRS_IOTHUBTRANSPORT_34_014: [If the provided connectionId is associated with the current connection, This function shall invoke updateStatus with status CONNECTED, change reason CONNECTION_OK and a null throwable.]
     @Test
     public void onConnectionEstablishedCallsUpdateStatus()


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch:
  - [x] This pull-request is submitted against the `main` branch.

# Reference/Link to the issue solved with this PR (if any)

Fixes #1803

# Description of the problem

For correlated device client operations such as `getTwinAsync` and `updateReportedPropertiesAsync`, `onResponseReceived` could be skipped in a race condition.

In `IotHubTransport.onMessageReceived`, the received message was added to the receive queue before the matching `CorrelationCallbackContext` was read from `correlationCallbacks`. Adding the message to the queue wakes the receive task, which may acknowledge the message and remove the correlation callback before `onMessageReceived` looks it up. When that happens, the response callback is never invoked.

# Description of the solution

Capture the `CorrelationCallbackContext` before adding the received message to the receive queue. `onResponseReceived` now uses that saved context, so it still fires even if the receive task acknowledges the message and removes the callback entry immediately afterward.

Added a regression unit test that simulates the correlation callback being removed while the received message is queued, and verifies that `onResponseReceived` is still called.