### PR TITLE
fix(iot-dev): avoid MQTT cast during reconnect

### DIFF
--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransport.java
@@ -236,11 +236,14 @@ public class IotHubTransport implements IotHubListener
             return true;
         }
 
-        for (MultiplexedDeviceState multiplexedDeviceState : this.multiplexedDeviceConnectionStates.values())
+        if (this.isMultiplexing)
         {
-            if (multiplexedDeviceState.getConnectionStatus() == IotHubConnectionStatus.DISCONNECTED_RETRYING)
+            for (MultiplexedDeviceState multiplexedDeviceState : this.multiplexedDeviceConnectionStates.values())
             {
-                return true;
+                if (multiplexedDeviceState.getConnectionStatus() == IotHubConnectionStatus.DISCONNECTED_RETRYING)
+                {
+                    return true;
+                }
             }
         }
 

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/IotHubTransportTest.java
@@ -118,6 +118,50 @@ public class IotHubTransportTest
         IotHubTransport transport = new IotHubTransport(null, mockedIotHubConnectionStatusChangeCallback, false);
     }
 
+    @Test
+    public void needsReconnectIgnoresDeviceSessionStateWhenNotMultiplexing()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                mockedConfig.getDeviceId();
+                result = "someDeviceId";
+            }
+        };
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, false);
+        Map<String, MultiplexedDeviceState> deviceConnectionStates = Deencapsulation.getField(transport, "multiplexedDeviceConnectionStates");
+        deviceConnectionStates.values().iterator().next().setConnectionStatus(DISCONNECTED_RETRYING);
+
+        //act
+        boolean needsReconnect = transport.needsReconnect();
+
+        //assert
+        assertFalse(needsReconnect);
+    }
+
+    @Test
+    public void needsReconnectChecksDeviceSessionStateWhenMultiplexing()
+    {
+        //arrange
+        new Expectations()
+        {
+            {
+                mockedConfig.getDeviceId();
+                result = "someDeviceId";
+            }
+        };
+        IotHubTransport transport = new IotHubTransport(mockedConfig, mockedIotHubConnectionStatusChangeCallback, true);
+        Map<String, MultiplexedDeviceState> deviceConnectionStates = Deencapsulation.getField(transport, "multiplexedDeviceConnectionStates");
+        deviceConnectionStates.values().iterator().next().setConnectionStatus(DISCONNECTED_RETRYING);
+
+        //act
+        boolean needsReconnect = transport.needsReconnect();
+
+        //assert
+        assertTrue(needsReconnect);
+    }
+
     //Tests_SRS_IOTHUBTRANSPORT_34_004: [This function shall retrieve a packet from the inProgressPackets queue with the message id from the provided message if there is one.]
     //Tests_SRS_IOTHUBTRANSPORT_34_006: [If there was a packet in the inProgressPackets queue tied to the provided message, and the provided throwable is a TransportException, this function shall call "handleMessageException" with the provided packet and transport exception.]
     @Test


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Java SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 

# Reference/Link to the issue solved with this PR (if any)

Fixes #1853

# Description of the problem

Non-multiplexed clients maintain a device connection state entry for status tracking. The reconnect logic checked this state regardless of whether the transport was multiplexing.

During a close/reconnect race, an MQTT client's transport-level status could be `DISCONNECTED` while its device state remained `DISCONNECTED_RETRYING`. This caused the reconnect flow to treat the MQTT connection as a multiplexed AMQP connection and cast `MqttIotHubConnection` to `AmqpsIotHubConnection`, resulting in a `ClassCastException`.

# Description of the solution

Updated `IotHubTransport.needsReconnect()` so that device-session reconnect states are checked only when the transport is multiplexing. Transport-level reconnection behavior remains unchanged for non-multiplexed clients, while AMQP multiplexing continues to reconnect individual device sessions as before.

Added regression tests verifying that:

- Non-multiplexed transports ignore device-session reconnect state.
- Multiplexed transports continue to honor device-session reconnect state.

Targeted test results:

```]
Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```