### PR TITLE
Honor the connect timeout when connecting through an HTTP proxy

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ProxyServerTools.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ProxyServerTools.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package tests.integration.com.microsoft.azure.sdk.iot.helpers;
+
+import com.github.monkeywie.proxyee.server.HttpProxyServer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helpers for the local HTTP proxy servers that the proxy related integration tests run their traffic through.
+ */
+public class ProxyServerTools
+{
+    private static final int PROXY_START_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Start the provided proxy server on the provided port and block until it is actually listening on that port.
+     *
+     * {@link HttpProxyServer#startAsync(int)} only initiates the bind, so tests that don't wait on the returned future
+     * can start sending traffic to the proxy before it is listening. When that happens, the client under test gets a
+     * "Connection refused" instead of a working proxy.
+     *
+     * @param proxyServer the proxy server to start.
+     * @param port the port for the proxy server to listen on.
+     * @throws Exception if the proxy server could not be started within {@link #PROXY_START_TIMEOUT_SECONDS} seconds.
+     */
+    public static void startProxyServer(HttpProxyServer proxyServer, int port) throws Exception
+    {
+        proxyServer.startAsync(port).toCompletableFuture().get(PROXY_START_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+}

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.FlakeyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.ProxyServerTools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestDeviceIdentity;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
@@ -147,12 +148,15 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+
+        // startAsync() only starts the bind, so the returned future must be waited on. Otherwise the tests in this
+        // class can start connecting before the proxy is listening, and they fail with "Connection refused".
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -203,12 +203,15 @@ public class MultiplexingClientTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+
+        // startAsync() only starts the bind, so the returned future must be waited on. Otherwise the tests in this
+        // class can start connecting before the proxy is listening, and they fail with "Connection refused".
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
@@ -85,12 +85,15 @@ public class TokenRenewalTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+
+        // startAsync() only starts the bind, so the returned future must be waited on. Otherwise the tests in this
+        // class can start connecting before the proxy is listening, and they fail with "Connection refused".
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.service.registry.Device;
 import com.microsoft.azure.sdk.iot.service.registry.Module;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClient;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,6 +24,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.*;
@@ -102,6 +104,10 @@ public class ConnectionTests extends IntegrationTest
         public boolean useHttpProxy;
         public boolean useHttpProxyAuth;
 
+        // ECC identities are created by this test rather than taken from the shared pool of test identities, and they
+        // carry a certificate that only this test knows about, so they must never be recycled back into that pool.
+        private boolean identityIsEccIdentity;
+
         public ConnectionTestInstance(IotHubClientProtocol protocol, AuthenticationType authenticationType, ClientType clientType, boolean useHttpProxy, boolean useHttpProxyAuth)
         {
             this.protocol = protocol;
@@ -150,6 +156,7 @@ public class ConnectionTests extends IntegrationTest
             X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(X509CertificateGenerator.CertificateAlgorithm.ECC);
             SSLContext sslContext = SSLContextBuilder.buildSSLContext(certificateGenerator.getX509Certificate(), certificateGenerator.getPrivateKey());
             optionsBuilder.sslContext(sslContext);
+            this.identityIsEccIdentity = true;
 
             if (clientType == ClientType.DEVICE_CLIENT)
             {
@@ -183,12 +190,35 @@ public class ConnectionTests extends IntegrationTest
 
         public void dispose()
         {
-            if (this.identity != null && this.identity.getClient() != null)
+            if (this.identity == null)
+            {
+                return;
+            }
+
+            if (this.identity.getClient() != null)
             {
                 this.identity.getClient().close();
             }
 
-            Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
+            if (this.identityIsEccIdentity)
+            {
+                // Recycling this identity would hand a device with a certificate that no other test knows about to
+                // the next test that takes an x509 identity from the shared pool, so delete it instead.
+                try
+                {
+                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(this.identity.getDeviceId());
+                }
+                catch (IOException | IotHubException e)
+                {
+                    log.error("Failed to clean up ECC test device {}", this.identity.getDeviceId(), e);
+                }
+            }
+            else
+            {
+                Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
+            }
+
+            this.identity = null;
         }
     }
 
@@ -208,18 +238,21 @@ public class ConnectionTests extends IntegrationTest
     protected static final String testProxyPass = "1234"; // lgtm
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setAuthenticationProvider(new BasicProxyAuthenticator(testProxyUser, testProxyPass));
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
 
         HttpProxyServerConfig configWithoutAuth = new HttpProxyServerConfig();
         configWithoutAuth.setHandleSsl(false);
         proxyServerWithoutAuth = new HttpProxyServer().serverConfig(configWithoutAuth);
-        proxyServerWithoutAuth.startAsync(testProxyPortWithoutAuth);
+
+        // startAsync() only starts the bind, so the returned future must be waited on. Otherwise the tests in this
+        // class can start connecting before the proxy is listening, and they fail with "Connection refused".
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
+        ProxyServerTools.startProxyServer(proxyServerWithoutAuth, testProxyPortWithoutAuth);
     }
 
     @AfterClass
@@ -236,7 +269,16 @@ public class ConnectionTests extends IntegrationTest
         }
     }
 
-    @Test(timeout = 60000) // 1 minute
+    // Without this, every test in this class leaks its client. Those leaked clients keep reconnecting in the
+    // background for the rest of the test run, and once this class' proxy servers are closed they endlessly retry
+    // against a dead proxy, which destabilizes every test that runs afterwards.
+    @After
+    public void tearDown()
+    {
+        testInstance.dispose();
+    }
+
+    @Test
     @IotHubTest
     public void CanOpenConnection() throws Exception
     {
@@ -254,7 +296,7 @@ public class ConnectionTests extends IntegrationTest
 
     @IotHubTest
     @StandardTierHubOnlyTest
-    @Test(timeout = 60000) // 1 minute
+    @Test
     @FlakeyTest
     public void CanOpenConnectionWithECCCertificates() throws Exception
     {
@@ -281,7 +323,7 @@ public class ConnectionTests extends IntegrationTest
         testInstance.identity.getClient().close();
     }
 
-    @Test(timeout = 60000) // 1 minute
+    @Test
     @IotHubTest
     public void CanOpenMultiplexingConnection() throws Exception
     {

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/HttpProxySocketFactory.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/HttpProxySocketFactory.java
@@ -24,8 +24,11 @@ public class HttpProxySocketFactory extends SSLSocketFactory
     @Override
     public Socket createSocket() throws IOException
     {
-        Socket proxySocket = new Socket(proxySettings.getHostname(), proxySettings.getPort());
-        return new ProxiedSSLSocket(delegate, proxySocket, proxySettings.getUsername(), proxySettings.getPassword());
+        // The socket is deliberately left unconnected here. Connecting to the proxy is done in
+        // ProxiedSSLSocket.connect(SocketAddress, int) so that the connect timeout that the caller supplies is
+        // applied to the connection to the proxy as well. Connecting here would ignore that timeout and could
+        // block the calling thread indefinitely.
+        return new ProxiedSSLSocket(delegate, new Socket(), proxySettings);
     }
 
     @SuppressWarnings("unused") // Seems as if it's used in the Lombok delegate

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/ProxiedSSLSocket.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.sdk.iot.device.transport;
 
+import com.microsoft.azure.sdk.iot.device.ProxySettings;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
@@ -40,20 +41,21 @@ class ProxiedSSLSocket extends SSLSocket
     @Delegate(excludes = ProxiedSSLSocketNonDelegatedFunctions.class)
     private SSLSocket sslSocket;
 
-    private final String proxyUsername;
-    private final char[] proxyPassword;
+    private final ProxySettings proxySettings;
 
     private static final String HTTP = "HTTP/";
     private static final String HTTP_VERSION_1_1 = HTTP + "1.1";
 
+    // Callers may ask to connect without a timeout (a timeout of 0 means "block forever" for a plain socket).
+    // Blocking forever while connecting to a proxy, or while waiting for the proxy to answer the CONNECT request,
+    // would hang the calling thread with no way to recover, so this timeout is used instead in that case.
+    private static final int DEFAULT_PROXY_CONNECT_TIMEOUT_MILLISECONDS = 60 * 1000;
 
-    ProxiedSSLSocket(SSLSocketFactory socketFactory, Socket proxySocket, String proxyUsername, char[] proxyPassword)
+    ProxiedSSLSocket(SSLSocketFactory socketFactory, Socket proxySocket, ProxySettings proxySettings)
     {
         this.socketFactory = socketFactory;
         this.proxySocket = proxySocket;
-
-        this.proxyUsername = proxyUsername;
-        this.proxyPassword = proxyPassword;
+        this.proxySettings = proxySettings;
     }
 
     @Override
@@ -65,18 +67,61 @@ class ProxiedSSLSocket extends SSLSocket
     @Override
     public void connect(SocketAddress socketAddress, int timeout) throws IOException
     {
+        int effectiveTimeout = timeout > 0 ? timeout : DEFAULT_PROXY_CONNECT_TIMEOUT_MILLISECONDS;
+        long deadline = System.currentTimeMillis() + effectiveTimeout;
+
+        InetSocketAddress destination = (InetSocketAddress) socketAddress;
+        String destinationHost = destination.getHostName();
+        int destinationPort = destination.getPort();
+
+        log.debug("Connecting to HTTP proxy");
+        this.proxySocket.connect(new InetSocketAddress(proxySettings.getHostname(), proxySettings.getPort()), effectiveTimeout);
+
         log.debug("Sending tunnel handshake to HTTP proxy");
-        doTunnelHandshake(proxySocket, ((InetSocketAddress) socketAddress).getHostName(), ((InetSocketAddress) socketAddress).getPort());
+        int previousSoTimeout = this.proxySocket.getSoTimeout();
+
+        // Without a read timeout, a proxy that accepts the TCP connection but never answers the CONNECT request
+        // would block this thread forever.
+        this.proxySocket.setSoTimeout(getRemainingTimeout(deadline));
+
+        try
+        {
+            doTunnelHandshake(this.proxySocket, destinationHost, destinationPort);
+        }
+        finally
+        {
+            // doTunnelHandshake() closes the socket when the proxy rejects the tunnel, and setting a timeout on a
+            // closed socket would throw an exception that masks the actual failure.
+            if (!this.proxySocket.isClosed())
+            {
+                this.proxySocket.setSoTimeout(previousSoTimeout);
+            }
+        }
+
         log.debug("Handshake to HTTP proxy succeeded");
 
         //Wrap the proxy socket into the new SSLSocket so all further communication gets forwarded through the proxy
-        this.sslSocket = (SSLSocket) socketFactory.createSocket(proxySocket, ((InetSocketAddress) socketAddress).getHostName(), ((InetSocketAddress) socketAddress).getPort(), true);
+        this.sslSocket = (SSLSocket) socketFactory.createSocket(proxySocket, destinationHost, destinationPort, true);
     }
 
     @Override
     public void close() throws IOException {
         this.proxySocket.close();
-        this.sslSocket.close();
+
+        // The ssl socket is only created once the tunnel to the proxy has been established, so it may be null if this
+        // socket is closed after a failed connect attempt.
+        if (this.sslSocket != null)
+        {
+            this.sslSocket.close();
+        }
+    }
+
+    private static int getRemainingTimeout(long deadline)
+    {
+        long remainingMilliseconds = deadline - System.currentTimeMillis();
+
+        // A SO_TIMEOUT of 0 means "block forever", so the remaining time must never be allowed to reach 0.
+        return remainingMilliseconds < 1 ? 1 : (int) Math.min(remainingMilliseconds, Integer.MAX_VALUE);
     }
 
     /**
@@ -91,11 +136,13 @@ class ProxiedSSLSocket extends SSLSocket
         Charset byteEncoding = StandardCharsets.UTF_8;
         OutputStream out = tunnel.getOutputStream();
         String hostWithPort = host + ":" + port;
+        String proxyUsername = this.proxySettings.getUsername();
+        char[] proxyPassword = this.proxySettings.getPassword();
 
         String proxyConnectMessage = String.format("CONNECT %s %s\r\nHost: %s\r\nUser-Agent: %s\r\n", hostWithPort, HTTP_VERSION_1_1, hostWithPort, TransportUtils.USER_AGENT_STRING);
-        if (this.proxyUsername != null && this.proxyPassword != null)
+        if (proxyUsername != null && proxyPassword != null)
         {
-            String base64EncodedCredentials = new String(Base64.encodeBase64(String.format("%s:%s", this.proxyUsername, new String(this.proxyPassword)).getBytes(byteEncoding)), byteEncoding);
+            String base64EncodedCredentials = new String(Base64.encodeBase64(String.format("%s:%s", proxyUsername, new String(proxyPassword)).getBytes(byteEncoding)), byteEncoding);
             proxyConnectMessage += String.format("Proxy-Authorization: Basic %s\r\nUser-Agent: %s\r\n", base64EncodedCredentials, TransportUtils.USER_AGENT_STRING);
         }
 

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/HttpProxySocketFactoryTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/HttpProxySocketFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.sdk.iot.device.transport;
+
+import com.microsoft.azure.sdk.iot.device.ProxySettings;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for HttpProxySocketFactory and the ProxiedSSLSocket that it creates.
+ */
+public class HttpProxySocketFactoryTest
+{
+    private static final int CONNECT_TIMEOUT_MILLISECONDS = 2 * 1000;
+
+    /**
+     * A proxy that accepts the TCP connection but never answers the HTTP CONNECT request used to block the calling
+     * thread forever because no timeout was applied while waiting for that answer.
+     */
+    @Test
+    public void connectTimesOutWhenProxyNeverAnswersConnectRequest() throws Exception
+    {
+        // The TCP connection is completed by the OS and left in this server socket's backlog since accept() is never
+        // called, so the proxy never answers the CONNECT request that the socket under test sends it.
+        try (ServerSocket unresponsiveProxy = new ServerSocket(0, 1, InetAddress.getLoopbackAddress()))
+        {
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getLoopbackAddress(), unresponsiveProxy.getLocalPort()));
+            ProxySettings proxySettings = new ProxySettings(proxy);
+
+            SSLSocketFactory sslSocketFactory = SSLContext.getDefault().getSocketFactory();
+            HttpProxySocketFactory httpProxySocketFactory = new HttpProxySocketFactory(sslSocketFactory, proxySettings);
+
+            long startTime = System.currentTimeMillis();
+
+            try (Socket socket = httpProxySocketFactory.createSocket())
+            {
+                socket.connect(new InetSocketAddress("some-host.example.com", 443), CONNECT_TIMEOUT_MILLISECONDS);
+                fail("Expected the connect to time out since the proxy never answered the CONNECT request");
+            }
+            catch (SocketTimeoutException expected)
+            {
+                long elapsedTime = System.currentTimeMillis() - startTime;
+                assertTrue(
+                    "Expected the connect to give up at around the supplied timeout, but it took " + elapsedTime + " milliseconds",
+                    elapsedTime < 4 * CONNECT_TIMEOUT_MILLISECONDS);
+            }
+        }
+    }
+}

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
@@ -68,9 +68,6 @@ public class ContractAPIAmqpTest
     Map<String, Object> mockedHashMap;
 
     @Mocked
-    Object mockSendLock;
-
-    @Mocked
     ProvisioningDeviceClientConfig mockedProvisioningDeviceClientConfig;
 
     @Mocked

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqttTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqttTest.java
@@ -74,16 +74,10 @@ public class ContractAPIMqttTest
     MqttMessage mockedMqttMessage;
 
     @Mocked
-    Object mockSendLock;
-
-    @Mocked
     ProvisioningDeviceClientConfig mockedProvisioningDeviceClientConfig;
 
     @Mocked
     DeviceRegistrationParser mockedDeviceRegistrationParser;
-
-    @Mocked
-    Integer mockedInteger;
 
     @Mocked
     byte[] mockedByteArray = new byte[10];


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-java/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch:
  - [x] This pull-request is submitted against the `main` branch.

# Reference/Link to the issue solved with this PR (if any)

Nightly `Java Linux` (pipeline definition 533) failures, e.g. builds [161572](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161572&view=results) and [161517](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161517&view=results).

# Description of the problem

## 1. The device client can block forever when connecting through an HTTP proxy

`ProxiedSSLSocket.connect(SocketAddress, int timeout)` **discarded the `timeout` argument**, and ran the HTTP `CONNECT` tunnel handshake against the proxy socket with `SO_TIMEOUT` left at `0`. A proxy that accepts the TCP connection but stalls before answering `CONNECT` therefore blocks the calling thread indefinitely, with no way for the caller to recover.

Both callers do supply a timeout today, and both were being ignored:

* MQTT/MQTT_WS &mdash; `MqttConnectOptions.getConnectionTimeout()` (default 30s) reaches the socket via `WebSocketSecureNetworkModuleFactory` &rarr; `SSLNetworkModule.setSSLhandshakeTimeout` &rarr; `TCPNetworkModule.setConnectTimeout` &rarr; `socket.connect(addr, conTimeout * 1000)`.
* HTTPS &mdash; `ClientOptions.httpsConnectTimeout` reaches the socket via `HttpsURLConnection.setConnectTimeout` &rarr; `sun.net.NetworkClient.doConnect` &rarr; `socket.connect(addr, connectTimeout)`.

`HttpProxySocketFactory.createSocket()` also connected to the proxy eagerly using the blocking `new Socket(host, port)` constructor, which has no connect timeout either. And `ProxiedSSLSocket.close()` threw a `NullPointerException` when it ran after a failed connect attempt (`sslSocket` is still `null` at that point), which hid the original failure.

This is what breaks the nightly runs. `ConnectionTests.CanOpenConnection[MQTT_WS_SAS_DEVICE_CLIENT_true_*]` fails with

```
org.junit.runners.model.TestTimedOutException: test timed out after 60000 milliseconds
    at ...ConnectionTests.CanOpenConnection(ConnectionTests.java:244)
```

where line 244 is `open(true)` and the blocked frame is `Object.wait` (Paho's connect token). Instead of failing fast and letting `IotHubTransport`'s retry policy recover, the client sat in the unbounded read until the test's own timeout fired.

Looking at the last 12 failed nightly runs, **8 of them fail on this same proxy path**: `CanOpenConnection[MQTT_WS_SAS_DEVICE_CLIENT_true_false]` / `[..._true_true]` (6 runs), `getAndCompleteSasUriWithoutUpload[HTTPS_SAS_true]` + `getSasUriWithoutUploadConnectionToggle[HTTPS_SAS_true]`, and `tokenRenewalWorks` (which creates proxied HTTPS/MQTT_WS/AMQPS_WS clients).

## 2. E2E test harness issues that make the above much worse

* `HttpProxyServer.startAsync(port)` returns a `CompletionStage` that completes when the bind completes, and all four test classes that start a local proxy ignored it. With `<parallel>both</parallel>` + `useUnlimitedThreads`, all ~29 parameterized `ConnectionTests` fire within ~150ms of `@BeforeClass`, so tests can try to connect before the port is listening.
* `ConnectionTests.ConnectionTestInstance.dispose()` was dead code &mdash; nothing ever called it. Every test in the class leaked its `DeviceClient` (and its identity). Those leaked clients keep reconnecting in the background, and once `@AfterClass` closes the proxies they retry forever against a dead proxy. A single failing run's log contains **117** stacks of:

```
Caused by: java.net.ConnectException: Connection refused
    at java.base/java.net.Socket.<init>(Socket.java:287)
    at ...HttpProxySocketFactory.createSocket(HttpProxySocketFactory.java:27)
    at org.eclipse.paho.client.mqttv3.internal.TCPNetworkModule.start(TCPNetworkModule.java:73)
```

  all after `stopProxy()` ran, burning threads and CPU for the remaining ~15 minutes of the job.
* `@Test(timeout = 60000)` on the `ConnectionTests` methods is **exactly equal** to `Mqtt.CONNECTION_TIMEOUT` (60s), so a single slow connect attempt guarantees the test times out before the SDK's own retry can even start.

## 3. `ContractAPIMqttTest` corrupts the JVM on JDK 8

Visible in build 161517 (JDK 8 is the only job that runs unit tests), masked by `rerunFailingTestsCount`:

```
Exception in thread "Reference Handler" java.lang.UnsatisfiedLinkError: java.lang.Object.wait(J)V
...
java.lang.IllegalStateException: Not in the recording phase
    at ...ContractAPIMqttTest.createContractClass(ContractAPIMqttTest.java:93)
```

`ContractAPIMqttTest` declares `@Mocked Object mockSendLock` and `@Mocked Integer mockedInteger`, and `ContractAPIAmqpTest` declares `@Mocked Object mockSendLock`. **None of the three are used anywhere.** Mocking `java.lang.Object` makes JMockit retransform it, which unbinds `Object.wait(J)V` and kills the Reference Handler thread, after which JMockit's phase tracking is inconsistent and unrelated tests in the class fail.

# Description of the solution

## `iot-device-client`

* `ProxiedSSLSocket` now connects to the proxy inside `connect(SocketAddress, int)` using the supplied timeout, and applies the remaining part of that same budget as `SO_TIMEOUT` while waiting for the `CONNECT` response (restoring the previous value afterwards, unless the handshake already closed the socket). When the caller supplies no timeout at all, a 60s default is used rather than blocking forever.
* `HttpProxySocketFactory.createSocket()` returns an unconnected socket so the connect can be deferred to where the timeout is known.
* `ProxiedSSLSocket.close()` is null-safe.

The resulting `SocketTimeoutException` / `ConnectException` are already classified as retryable by `PahoExceptionTranslator`, so `IotHubTransport.open(withRetry = true)` retries instead of hanging.

New unit test `HttpProxySocketFactoryTest.connectTimesOutWhenProxyNeverAnswersConnectRequest` covers this against a `ServerSocket` that accepts but never replies. It fails (hangs) without the fix.

## `iot-e2e-tests`

* New `ProxyServerTools.startProxyServer(server, port)` waits on the future returned by `startAsync`; used by `ConnectionTests`, `FileUploadTests`, `MultiplexingClientTests` and `TokenRenewalTests`.
* `ConnectionTests` disposes its test instance in an `@After`. The one-off ECC identities it creates itself are deleted from the registry rather than recycled, so a device carrying a certificate no other test knows about can never be handed to a later x509 test from the shared pool.
* Removed the per-method `@Test(timeout = 60000)` in `ConnectionTests`; the shared 2 minute `IntegrationTest` timeout rule still bounds these tests.

## `provisioning-device-client`

* Removed the unused `@Mocked Object` / `@Mocked Integer` fields from `ContractAPIMqttTest` and `ContractAPIAmqpTest`.

# Validation

Run locally (JDK 8 for unit tests, matching `vsts/build_repo.ps1`, since JMockit 1.24 cannot run on newer JDKs):

* `mvn install -DskipTests` &mdash; `BUILD SUCCESS` for the whole repo, including `iot-e2e-common` test compilation.
* `mvn test` for `iot-device-client` and `provisioning-device-client` on JDK 8 &mdash; `BUILD SUCCESS`.
  * `HttpProxySocketFactoryTest` passes in 2.168s against its 2s budget (unbounded block before the fix).
  * `ContractAPIMqttTest` 34/34 and `ContractAPIAmqpTest` 31/31, with no `Reference Handler` `UnsatisfiedLinkError` and no `Not in the recording phase`. The "36 tests" reported by CI was 34 real tests plus 2 surefire reruns.

The e2e changes need a gated run against real resources to confirm.
