### PR TITLE
Replace the failing Semmle task with a CodeQL 3000 job

### DIFF
--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # produces incidental databases that displace the one from the 'SDL' pipeline
+  # (vsts/sdl.yaml), because S360 records arg_max(SnapshotDate) per
+  # (repo, language). See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 resources:
   repositories:

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -30,16 +30,17 @@ jobs:
       
   - task: CodeQL3000Init@0
     displayName: 'Initialize CodeQL'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
   - powershell: ./vsts/package_repo_for_sdl.ps1
     displayName: 'Build packages to scan'
 
   # Must follow the maven build above: CodeQL builds the java database from the
   # traced compilation. always() so a build failure still surfaces the CodeQL
-  # status instead of silently skipping the upload.
+  # status instead of silently skipping the upload, but still only on main.
   - task: CodeQL3000Finalize@0
     displayName: 'Finalize CodeQL'
-    condition: always()
+    condition: and(always(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/vsts/sdl.yaml
+++ b/vsts/sdl.yaml
@@ -8,6 +8,15 @@ jobs:
 - job: SDL
   displayName: SDL Tasks
 
+  variables:
+    # Owns the 'java' CodeQL snapshot for this repo (Microsoft.Security.CodeQL.10000).
+    # CodeQL traces the maven build below, so this job -- not an incidentally
+    # instrumented e2e or provisioning job -- is what S360 records.
+    # Only on main: this pipeline also runs on PRs, which do not need a snapshot.
+    # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+    Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+    Codeql.Language: java
+
   condition: succeeded()
   pool:
     vmImage: windows-latest
@@ -19,8 +28,18 @@ jobs:
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
       
+  - task: CodeQL3000Init@0
+    displayName: 'Initialize CodeQL'
+
   - powershell: ./vsts/package_repo_for_sdl.ps1
     displayName: 'Build packages to scan'
+
+  # Must follow the maven build above: CodeQL builds the java database from the
+  # traced compilation. always() so a build failure still surfaces the CodeQL
+  # status instead of silently skipping the upload.
+  - task: CodeQL3000Finalize@0
+    displayName: 'Finalize CodeQL'
+    condition: always()
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
@@ -61,24 +80,6 @@ jobs:
   - powershell: ./vsts/spotbugs.ps1
     displayName: 'Run Spotbugs'
 
-    ## Semmle doesn't have a false positive list, but instead recommends marking the lines of code in question
-    ## with "// lgtm"
-    ## https://help.semmle.com/lgtm-enterprise/user/help/alert-suppression.html#suppresswarnings-annotation
-  - task: Semmle@1
-    #Only run this step if it isn't a pull request. Semmle only needs to run nightly
-    condition: ne(variables['Build.Reason'], 'PullRequest')
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    inputs:
-      toolVersion: 'Latest'
-      sourceCodeDirectory: '$(Build.SourcesDirectory)'
-      language: 'java'
-      buildCommandsString: 'mvn clean install -DskipTests -T 2C --batch-mode -q'
-      querySuite: 'Recommended'
-      timeout: '1800'
-      ram: '16384'
-      addProjectDirToScanningExclusionList: true
-
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
     displayName: PoliCheck
     inputs:
@@ -100,7 +101,6 @@ jobs:
     displayName: 'Post Analysis'
     inputs:
       CredScan: true
-      Semmle: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: 'TSA upload'


### PR DESCRIPTION
Replace the failing Semmle task with a CodeQL 3000 job

The SDL pipeline's Semmle@1 task has been failing (build 161544: CodeQL CLI
2.8.4 exits with code 32), and because it is not marked continueOnError it takes
the whole SDL job down with it -- PoliCheck, AntiMalware, Publish Security
Analysis Logs, Post Analysis and TSA upload were all skipped. That is also what
S360 reports against this repo for Microsoft.Security.CodeQL.10000:
"Pipeline build job failed or was canceled."

Semmle is the deprecated predecessor of CodeQL and pins its own ancient CLI.
Replace it with the current CodeQL 3000 tasks, wrapped around the maven build
that package_repo_for_sdl.ps1 already performs, so the java database is built
from a real traced compilation. PostAnalysis no longer asks for Semmle results.

CodeQL is enabled only on main. This pipeline also runs on PRs and CI, which do
not need to produce a snapshot.

Also disable the auto-injected CodeQL in the horton e2e gate. S360 records
arg_max(SnapshotDate) per (repo, language), so a database produced incidentally
by a job that does not build the product silently replaces the intended one.

The auto-injection in the Java Linux / Java Windows / Java Android pipelines is
deliberately left alone for now, as a safety net until the SDL job is confirmed
to be uploading a java snapshot; it should be turned off in a follow-up.
