### PR TITLE
Bound e2e test parallelism, set the MQTT connect timeout explicitly, and improve failure diagnostics

### DIFF
--- a/iot-e2e-tests/common/pom.xml
+++ b/iot-e2e-tests/common/pom.xml
@@ -200,8 +200,23 @@
                     <skipTests>${shouldSkipTests}</skipTests> <!--This property is created at build time by the build-helper-maven-plugin, so it will appear as a compilation issue even though it will build just fine.-->
                     <parallel>both</parallel>
 
-                    <!--Maven will spawn up as many threads as it wants/can while running tests in parallel-->
-                    <useUnlimitedThreads>true</useUnlimitedThreads>
+                    <!--
+                    These tests run in a single JVM, and several of them stand up an embedded proxy server inside that
+                    same JVM: ConnectionTests on 8899 and 9000, TokenRenewalTests on 8898, FileUploadTests on 8897 and
+                    MultiplexingClientTests on 8849. Those proxies need to be scheduled promptly to forward traffic.
+
+                    With useUnlimitedThreads there was no cap on how many tests ran at once, so a burst of test threads
+                    could starve those proxies of CPU on a two core hosted agent. The connection would be established
+                    and then nothing would flow, which is why only the proxied variants of these tests ever failed,
+                    across three different test classes and both HTTPS and MQTT_WS.
+
+                    6 is chosen to sit above the concurrency the suite actually achieves, so throughput is not
+                    constrained. Measured on build 162050, the whole run is 49 CPU-minutes finishing in 12.8 minutes of
+                    wall clock, which is an average of 3.8 tests at a time. The wall clock is floored by
+                    tokenRenewalWorks, which takes 12.8 minutes on its own because it deliberately waits out a sas
+                    token expiry, so anything from 4 upwards leaves the total run time unchanged.
+                    -->
+                    <threadCount>6</threadCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/BasicTierHubOnlyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/BasicTierHubOnlyTestRule.java
@@ -30,7 +30,7 @@ public class BasicTierHubOnlyTestRule implements TestRule
             BasicTierHubOnlyTest classAnnotation = description.getTestClass().getAnnotation(BasicTierHubOnlyTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", IntegrationTest.isBasicTierHub);
+                Assume.assumeTrue("Test is ignored because it is annotated @BasicTierHubOnlyTest and the hub under test is not a basic tier hub", IntegrationTest.isBasicTierHub);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ContinuousIntegrationTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/ContinuousIntegrationTestRule.java
@@ -30,7 +30,7 @@ public class ContinuousIntegrationTestRule implements TestRule
             ContinuousIntegrationTest classAnnotation = description.getTestClass().getAnnotation(ContinuousIntegrationTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", !IntegrationTest.isPullRequest);
+                Assume.assumeTrue("Test is ignored because it is annotated @ContinuousIntegrationTest and this is a pull request build", !IntegrationTest.isPullRequest);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DeviceProvisioningServiceTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DeviceProvisioningServiceTestRule.java
@@ -30,7 +30,7 @@ public class DeviceProvisioningServiceTestRule implements TestRule
             DeviceProvisioningServiceTest classAnnotation = description.getTestClass().getAnnotation(DeviceProvisioningServiceTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", IntegrationTest.runProvisioningTests);
+                Assume.assumeTrue("Test is ignored because it is a provisioning test and the RUN_PROVISIONING_TESTS environment variable is set to false", IntegrationTest.runProvisioningTests);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
@@ -31,7 +31,7 @@ public class DigitalTwinTestRule implements TestRule {
             DigitalTwinTest methodAnnotation = description.getAnnotation(DigitalTwinTest.class);
             DigitalTwinTest classAnnotation = description.getTestClass().getAnnotation(DigitalTwinTest.class);
             if (methodAnnotation != null || classAnnotation != null) {
-                Assume.assumeTrue("Test is ignored because it is a digital twin test and the RUN_DIGITAL_TWIN_TESTS environment variable is set to false", IntegrationTest.runDigitalTwinTests);
+                Assume.assumeTrue("Test is ignored because it is a digital twin test and the RUN_DIGITAL_TESTS environment variable is set to false", IntegrationTest.runDigitalTwinTests);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/DigitalTwinTestRule.java
@@ -31,7 +31,7 @@ public class DigitalTwinTestRule implements TestRule {
             DigitalTwinTest methodAnnotation = description.getAnnotation(DigitalTwinTest.class);
             DigitalTwinTest classAnnotation = description.getTestClass().getAnnotation(DigitalTwinTest.class);
             if (methodAnnotation != null || classAnnotation != null) {
-                Assume.assumeTrue("Test is ignored", IntegrationTest.runDigitalTwinTests);
+                Assume.assumeTrue("Test is ignored because it is a digital twin test and the RUN_DIGITAL_TWIN_TESTS environment variable is set to false", IntegrationTest.runDigitalTwinTests);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/FlakeyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/FlakeyTestRule.java
@@ -30,7 +30,7 @@ public class FlakeyTestRule implements TestRule
             FlakeyTest classAnnotation = description.getTestClass().getAnnotation(FlakeyTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", !IntegrationTest.isPullRequest);
+                Assume.assumeTrue("Test is ignored because it is annotated @FlakeyTest and this is a pull request build", !IntegrationTest.isPullRequest);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/IotHubTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/IotHubTestRule.java
@@ -30,7 +30,7 @@ public class IotHubTestRule implements TestRule
             IotHubTest classAnnotation = description.getTestClass().getAnnotation(IotHubTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", IntegrationTest.runIotHubTests);
+                Assume.assumeTrue("Test is ignored because it is an IoT hub test and the RUN_IOTHUB_TESTS environment variable is set to false", IntegrationTest.runIotHubTests);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/StandardTierHubOnlyTestRule.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/rules/StandardTierHubOnlyTestRule.java
@@ -30,7 +30,7 @@ public class StandardTierHubOnlyTestRule implements TestRule
             StandardTierHubOnlyTest classAnnotation = description.getTestClass().getAnnotation(StandardTierHubOnlyTest.class);
             if (annotation != null || classAnnotation != null)
             {
-                Assume.assumeTrue("Test is ignored", !IntegrationTest.isBasicTierHub);
+                Assume.assumeTrue("Test is ignored because it is annotated @StandardTierHubOnlyTest and the hub under test is a basic tier hub", !IntegrationTest.isBasicTierHub);
             }
 
             base.evaluate();

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -236,11 +236,44 @@ public class ConnectionTests extends IntegrationTest
         }
     }
 
+    /**
+     * Log every connection status change for a client so that a test which times out while opening leaves behind
+     * something explaining why.
+     *
+     * <p>These tests open with retry, and the default retry policy retries an unlimited number of times, so a
+     * connection that never succeeds is never abandoned by the client. That means the client never throws, and the
+     * only thing that ends the test is the JUnit timeout, which reports nothing beyond the line it was stuck on. The
+     * status callback is the one place the underlying reason is visible, so it gets written to the log as it
+     * arrives.</p>
+     *
+     * @param client The client to report status changes for
+     */
+    private static void logConnectionStatusChanges(InternalClient client)
+    {
+        client.setConnectionStatusChangeCallback(
+            (context) ->
+            {
+                Throwable cause = context.getCause();
+                log.info("Connection status changed from {} to {} because of {}{}",
+                    context.getPreviousStatus(),
+                    context.getNewStatus(),
+                    context.getNewStatusReason(),
+                    cause == null ? "" : ", cause: " + cause);
+
+                if (cause != null)
+                {
+                    log.info("Connection status change cause", cause);
+                }
+            },
+            null);
+    }
+
     @Test(timeout = 60000) // 1 minute
     @IotHubTest
     public void CanOpenConnection() throws Exception
     {
         testInstance.setup();
+        logConnectionStatusChanges(testInstance.identity.getClient());
         testInstance.identity.getClient().open(true);
 
         // deviceClient.open() is a no-op on HTTP, so a message needs to be sent to actually test opening the connection
@@ -270,6 +303,7 @@ public class ConnectionTests extends IntegrationTest
 
         testInstance.setupEccDevice();
 
+        logConnectionStatusChanges(testInstance.identity.getClient());
         testInstance.identity.getClient().open(true);
 
         // deviceClient.open() is a no-op on HTTP, so a message needs to be sent to actually test opening the connection

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/Mqtt.java
@@ -24,7 +24,10 @@ import java.util.Queue;
 @Slf4j
 public abstract class Mqtt implements MqttCallback
 {
-    private static final int CONNECTION_TIMEOUT = 60 * 1000;
+    // How long to wait for the service to acknowledge a CONNECT packet. This covers the whole round trip, so it has to
+    // leave room for the TCP connect, the TLS handshake and the CONNACK. Paho is given a shorter budget for the
+    // connect itself, see MqttIotHubConnection.TCP_CONNECTION_TIMEOUT_SECONDS.
+    static final int CONNECTION_TIMEOUT = 60 * 1000;
     private static final int DISCONNECTION_TIMEOUT = 60 * 1000;
 
     //mqtt connection options

--- a/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
+++ b/iothub/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnection.java
@@ -47,6 +47,17 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
     private static final int MQTT_VERSION = MQTT_VERSION_3_1_1;
     private static final boolean SET_CLEAN_SESSION = false;
 
+    // How long Paho is allowed to spend establishing the connection, which is mainly the TCP connect and the TLS
+    // handshake. This is deliberately shorter than Mqtt.CONNECTION_TIMEOUT, which bounds the whole CONNECT round trip
+    // including the CONNACK. Keeping it shorter means a connection that cannot be established at all fails with the
+    // specific reason Paho reports, rather than with the generic "Timed out waiting for a response from the server"
+    // that the outer wait produces once its own budget runs out.
+    //
+    // This is set explicitly because Paho otherwise applies its own default. That default happens to be the same value
+    // today, but relying on it means the effective timeout is chosen by the library rather than by us, and it would
+    // change silently underneath us if Paho ever changed it.
+    private static final int TCP_CONNECTION_TIMEOUT_SECONDS = (Mqtt.CONNECTION_TIMEOUT / 2) / 1000;
+
     private static final String MODEL_ID = "model-id";
 
     private String connectionId;
@@ -181,6 +192,7 @@ public class MqttIotHubConnection implements IotHubTransportConnection, MqttMess
 
         MqttConnectOptions connectOptions = new MqttConnectOptions();
         connectOptions.setKeepAliveInterval(config.getKeepAliveInterval());
+        connectOptions.setConnectionTimeout(TCP_CONNECTION_TIMEOUT_SECONDS);
         connectOptions.setCleanSession(SET_CLEAN_SESSION);
         connectOptions.setMqttVersion(MQTT_VERSION);
         connectOptions.setUserName(iotHubUserName);

--- a/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
+++ b/iothub/device/iot-device-client/src/test/java/com/microsoft/azure/sdk/iot/device/transport/mqtt/MqttIotHubConnectionTest.java
@@ -121,6 +121,32 @@ public class MqttIotHubConnectionTest
         assertEquals(expectedClientConfig, actualClientConfig);
     }
 
+    // The connect timeout has to be set explicitly rather than left to whatever default Paho happens to ship, and it
+    // has to stay below the timeout that Mqtt applies to the whole CONNECT round trip. If Paho were allowed as much
+    // time as the outer wait, a connection that cannot be established at all would surface as the outer wait expiring,
+    // which reports only "Timed out waiting for a response from the server" and says nothing about what went wrong.
+    @Test
+    public void constructorSetsConnectTimeoutShorterThanTheOverallConnectTimeout() throws TransportException
+    {
+        baseExpectations();
+
+        final int expectedTimeoutSeconds = (Mqtt.CONNECTION_TIMEOUT / 2) / 1000;
+
+        new MqttIotHubConnection(mockConfig);
+
+        new Verifications()
+        {
+            {
+                mockedConnectOptions.setConnectionTimeout(expectedTimeoutSeconds);
+                times = 1;
+            }
+        };
+
+        assertTrue(
+            "The timeout given to Paho must be shorter than the timeout applied to the whole CONNECT round trip",
+            expectedTimeoutSeconds * 1000 < Mqtt.CONNECTION_TIMEOUT);
+    }
+
     // Tests_SRS_MQTTIOTHUBCONNECTION_15_003: [The constructor shall throw a new IllegalArgumentException
     // if any of the parameters of the configuration is null or empty.]
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Addresses four items on ADO [39339528](https://dev.azure.com/msazure/One/_workitems/edit/39339528). All four are about a failure arriving with nothing that explains it, or a failure that is nobody's fault but the harness's.

## 1. Bound the e2e test parallelism so the embedded proxies are not starved

**This is the one that should fix the long-running red on `main`.**

The e2e tests run in a single JVM with `parallel=both` and `useUnlimitedThreads`, so there was no cap on how many ran at once. Several of them stand up an embedded `proxyee` server *inside that same JVM* — `ConnectionTests` on 8899/9000, `TokenRenewalTests` on 8898, `FileUploadTests` on 8897, `MultiplexingClientTests` on 8849. Those proxies must be scheduled promptly to forward traffic, and a burst of test threads starves them of CPU on a two core hosted agent.

That explains the failure signature that has been on `main` for months. **Only the proxied variants ever fail**, and they fail by connecting and then having nothing flow — not by failing to connect. It is not specific to one protocol or one class:

| Test | Class |
| --- | --- |
| `CanOpenConnection[MQTT_WS_SAS_DEVICE_CLIENT_true_true]` | ConnectionTests |
| `CanOpenConnection[MQTT_WS_SAS_DEVICE_CLIENT_true_false]` | ConnectionTests |
| `getAndCompleteSasUriWithoutUpload[HTTPS_SAS_true]` | FileUploadTests |
| `getSasUriWithoutUploadConnectionToggle[HTTPS_SAS_true]` | FileUploadTests |
| `tokenRenewalWorks` | TokenRenewalTests |

Three classes, three separate proxies, both HTTPS and MQTT_WS — and in every case the **non-proxied variant of the same test passes in the same run**. A non-proxied client talks straight to Azure and needs no local CPU to make progress, which is why it is unaffected.

### This is expected to cost nothing in run time

I measured rather than guessed. On build 162050 (a successful run):

| | |
| --- | --- |
| Total CPU across all tests | 49.1 min |
| Actual wall clock | **12.8 min** |
| Average concurrency achieved | **3.8x** |
| `tokenRenewalWorks` alone | **12.8 min** |

`useUnlimitedThreads` was not buying throughput — the suite only ever reached 3.8x. And the wall clock is *floored* by `tokenRenewalWorks`, which takes 12.8 minutes on its own because it deliberately waits out a SAS token expiry.

Predicted wall = `max(longest test, totalCPU / threadCount)`:

| threadCount | predicted | change |
| --- | --- | --- |
| 2 | 24.6 min | +92% |
| 3 | 16.4 min | +28% |
| **4** | **12.8 min** | none |
| **6** (chosen) | **12.8 min** | none |
| 8 | 12.8 min | none |

49 CPU-minutes over 6 threads is 8.2 minutes, comfortably inside the 12.8 minute floor, leaving ~4.6 minutes of scheduling slack. 6 was chosen to sit above the 3.8x average rather than right on it.

This does not make a slow agent fast. It stops an unbounded burst of test threads from starving a server the same JVM depends on.

## 2. The MQTT connect timeout was whatever Paho happened to default to

`MqttIotHubConnection` built its `MqttConnectOptions` without ever calling `setConnectionTimeout`, so the value was chosen by the library rather than by us, and would change silently underneath us if Paho changed it.

It also needs to stay *below* the 60s that `Mqtt.connect` waits for the CONNECT to be acknowledged. If Paho were given as much time as the outer wait, a connection that cannot be established would surface as the outer wait expiring, reporting only `Timed out waiting for a response from the server` — exactly the unhelpful message the recent `tokenRenewalWorks` failures came back with.

It is now derived from `Mqtt.CONNECTION_TIMEOUT` so the two cannot drift. The value works out to 30s, which is what Paho was already applying, so **behaviour is unchanged today**.

`constructorSetsConnectTimeoutShorterThanTheOverallConnectTimeout` verifies the call and asserts the relationship holds. Deleting the `setConnectionTimeout` line fails it with `MissingInvocation`.

## 3. `CanOpenConnection` timing out with no diagnostics

The work item originally described this as a race between the SDK's 60s timeout and the test's `@Test(timeout = 60000)`, fixable by changing one of the numbers. **That was my own diagnosis and it was wrong.**

These tests call `open(true)`, and the default retry policy is `ExponentialBackoffWithJitter` with `retryCount = Integer.MAX_VALUE`. A connection that never succeeds is never abandoned, so the client never throws. Nothing ends the test but the JUnit timeout, and no timeout value changes that — raising it would only make it take longer to say:

```
org.junit.runners.model.TestTimedOutException: test timed out after 60000 milliseconds
    at ...ConnectionTests.CanOpenConnection(ConnectionTests.java:244)
```

The reason is only visible through the connection status change callback, so the two tests that open a client now register one and log every transition with reason and cause.

## 4. Skipped tests all said the same thing

Seven rules decide whether an integration test runs, and every one skipped with `"Test is ignored"`, so a skipped test told you nothing about which rule fired or why. Each now names the annotation or environment variable responsible, following what `ErrInjTestRule` already did.

I deliberately did **not** enable `@FlakeyTest` tests in PR builds. Turning known-flaky tests back on would make PR builds less reliable, which is the opposite of the point. Only four tests are affected, and they still run in non-PR builds.

## Verification

- `iot-device-client` unit tests: **959 + 1 new = 0 failures** on JDK 8.
- New unit test **passed in CI** on the previous push, and fails with `MissingInvocation` when the fix is removed.
- `CanOpenConnection` passed **28/28 variants on every JDK** in CI on the previous push, confirming the status-callback change is sound.
- `mvn -pl iot-e2e-tests/common -am test-compile` on JDK 8: BUILD SUCCESS; POM parses with `parallel=both`, `threadCount=6`, `useUnlimitedThreads` removed.

Note on the earlier red run: the three failures on the previous push were a Maven Central TLS failure (Windows), emulator DNS failure (Android), and `tokenRenewalWorks` — i.e. two infra flakes and the very issue item 1 above addresses.
