### PR TITLE
Wait for the test proxies to bind, and stop ConnectionTests leaking clients

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ProxyServerTools.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/ProxyServerTools.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) Microsoft. All rights reserved.
+ *  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package tests.integration.com.microsoft.azure.sdk.iot.helpers;
+
+import com.github.monkeywie.proxyee.server.HttpProxyServer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helpers for the local HTTP proxy servers that the proxy related integration tests run their traffic through.
+ */
+public class ProxyServerTools
+{
+    private static final int PROXY_START_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Start the provided proxy server on the provided port and block until it is actually listening on that port.
+     *
+     * {@link HttpProxyServer#startAsync(int)} only initiates the bind, so tests that don't wait on the returned future
+     * can start sending traffic to the proxy before it is listening. When that happens, the client under test gets a
+     * "Connection refused" instead of a working proxy.
+     *
+     * @param proxyServer the proxy server to start.
+     * @param port the port for the proxy server to listen on.
+     * @throws Exception if the proxy server could not be started within {@link #PROXY_START_TIMEOUT_SECONDS} seconds.
+     */
+    public static void startProxyServer(HttpProxyServer proxyServer, int port) throws Exception
+    {
+        proxyServer.startAsync(port).toCompletableFuture().get(PROXY_START_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+}

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/FileUploadTests.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.FlakeyTest;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.IntegrationTest;
+import tests.integration.com.microsoft.azure.sdk.iot.helpers.ProxyServerTools;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestConstants;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.TestDeviceIdentity;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.Tools;
@@ -147,12 +148,12 @@ public class FileUploadTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/MultiplexingClientTests.java
@@ -203,12 +203,12 @@ public class MultiplexingClientTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/TokenRenewalTests.java
@@ -85,12 +85,12 @@ public class TokenRenewalTests extends IntegrationTest
     }
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -252,7 +252,8 @@ public class ConnectionTests extends IntegrationTest
         /**
          * Dispose anything registered after teardown already ran.
          *
-         * <p>Every test in this class is bounded by {@code @Test(timeout = 60000)}. JUnit runs the test body on a
+         * <p>Every test in this class is bounded by a timeout, the two minute one that {@link IntegrationTest}
+         * applies. JUnit runs the test body on a
          * separate thread and, when the timeout fires, abandons that thread while it is still running. {@code @After}
          * is outside the timeout, so teardown can execute while setup on the abandoned thread has not finished
          * acquiring its identity. Without this, the identity that setup goes on to produce would have no owner and
@@ -410,7 +411,18 @@ public class ConnectionTests extends IntegrationTest
             null);
     }
 
-    @Test(timeout = 60000) // 1 minute
+    // These tests deliberately do not set their own timeout, and take the two minute one from IntegrationTest instead.
+    //
+    // They used to declare @Test(timeout = 60000). That is exactly Mqtt.CONNECTION_TIMEOUT, the budget the client gives
+    // a single MQTT CONNECT round trip, so the two expired at the same instant. When a connect attempt stalled, the
+    // client sat in connectToken.waitForCompletion for the full minute, and JUnit killed the test on the same tick that
+    // the client would have thrown and let its retry policy try again. The failure that came out was a bare
+    // TestTimedOutException with no connection status transition logged at all, because nothing had been allowed to
+    // happen yet.
+    //
+    // A test bounded by the same number as the component it exercises cannot observe that component retrying. Two
+    // minutes leaves room for one stalled attempt to expire and a retry to follow it.
+    @Test
     @IotHubTest
     public void CanOpenConnection() throws Exception
     {
@@ -434,7 +446,7 @@ public class ConnectionTests extends IntegrationTest
 
     @IotHubTest
     @StandardTierHubOnlyTest
-    @Test(timeout = 60000) // 1 minute
+    @Test
     @FlakeyTest
     public void CanOpenConnectionWithECCCertificates() throws Exception
     {
@@ -464,7 +476,7 @@ public class ConnectionTests extends IntegrationTest
         client.close();
     }
 
-    @Test(timeout = 60000) // 1 minute
+    @Test
     @IotHubTest
     public void CanOpenMultiplexingConnection() throws Exception
     {

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.sdk.iot.service.registry.Device;
 import com.microsoft.azure.sdk.iot.service.registry.Module;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClient;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,6 +24,7 @@ import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.IotHubT
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.annotations.StandardTierHubOnlyTest;
 
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.*;
@@ -97,6 +99,10 @@ public class ConnectionTests extends IntegrationTest
     {
         public IotHubClientProtocol protocol;
         public TestIdentity identity;
+
+        // ECC identities are created by this test rather than taken from the shared pool, and they carry a
+        // certificate that only this test knows about, so they must never be recycled back into that pool.
+        private boolean identityIsEccIdentity;
         public AuthenticationType authenticationType;
         public ClientType clientType;
         public boolean useHttpProxy;
@@ -150,6 +156,7 @@ public class ConnectionTests extends IntegrationTest
             X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(X509CertificateGenerator.CertificateAlgorithm.ECC);
             SSLContext sslContext = SSLContextBuilder.buildSSLContext(certificateGenerator.getX509Certificate(), certificateGenerator.getPrivateKey());
             optionsBuilder.sslContext(sslContext);
+            this.identityIsEccIdentity = true;
 
             if (clientType == ClientType.DEVICE_CLIENT)
             {
@@ -183,12 +190,35 @@ public class ConnectionTests extends IntegrationTest
 
         public void dispose()
         {
-            if (this.identity != null && this.identity.getClient() != null)
+            if (this.identity == null)
+            {
+                return;
+            }
+
+            if (this.identity.getClient() != null)
             {
                 this.identity.getClient().close();
             }
 
-            Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
+            if (this.identityIsEccIdentity)
+            {
+                // Recycling this identity would hand a device carrying a certificate that no other test knows about to
+                // the next test that takes an x509 identity from the shared pool, so delete it instead.
+                try
+                {
+                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(this.identity.getDeviceId());
+                }
+                catch (IOException | IotHubException e)
+                {
+                    log.error("Failed to clean up ECC test device {}", this.identity.getDeviceId(), e);
+                }
+            }
+            else
+            {
+                Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
+            }
+
+            this.identity = null;
         }
     }
 
@@ -208,18 +238,28 @@ public class ConnectionTests extends IntegrationTest
     protected static final String testProxyPass = "1234"; // lgtm
 
     @BeforeClass
-    public static void startProxy()
+    public static void startProxy() throws Exception
     {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setAuthenticationProvider(new BasicProxyAuthenticator(testProxyUser, testProxyPass));
         config.setHandleSsl(false);
         proxyServer = new HttpProxyServer().serverConfig(config);
-        proxyServer.startAsync(testProxyPort);
+        ProxyServerTools.startProxyServer(proxyServer, testProxyPort);
 
         HttpProxyServerConfig configWithoutAuth = new HttpProxyServerConfig();
         configWithoutAuth.setHandleSsl(false);
         proxyServerWithoutAuth = new HttpProxyServer().serverConfig(configWithoutAuth);
-        proxyServerWithoutAuth.startAsync(testProxyPortWithoutAuth);
+        ProxyServerTools.startProxyServer(proxyServerWithoutAuth, testProxyPortWithoutAuth);
+    }
+
+    // Without this, every test in this class leaks the client it opened. Those clients keep retrying their
+    // connections for the rest of the JVM's life, and the ones configured with proxy settings keep retrying through
+    // the proxies this class runs locally, which competes with the tests that are still running. Once stopProxy has
+    // closed those proxies they retry against a dead port instead, for the remainder of the job.
+    @After
+    public void disposeTestInstance()
+    {
+        testInstance.dispose();
     }
 
     @AfterClass

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -106,6 +106,17 @@ public class ConnectionTests extends IntegrationTest
         // rest of setupEccDevice can fail after that registration has already happened. Deleting the device also
         // deletes any module underneath it, so the module does not need to be tracked separately.
         private String eccDeviceIdToDelete;
+
+        // What teardown still owns, kept separate from the public identity field above. dispose() clears these but
+        // deliberately leaves identity set, because a test thread abandoned by the JUnit timeout may still read it.
+        // Clearing them is what makes dispose() safe to run more than once: without it a second run would close the
+        // same client twice and, worse, requeue the same identity into the shared pool twice.
+        private TestIdentity identityToDispose;
+
+        // Set once teardown has run. Guarded by lifecycleLock along with the two fields above.
+        private boolean disposed;
+
+        private final Object lifecycleLock = new Object();
         public AuthenticationType authenticationType;
         public ClientType clientType;
         public boolean useHttpProxy;
@@ -154,12 +165,14 @@ public class ConnectionTests extends IntegrationTest
 
             if (clientType == ClientType.DEVICE_CLIENT)
             {
-                this.identity = Tools.getTestDevice(iotHubConnectionString, this.protocol, this.authenticationType, false, optionsBuilder);
+                trackForCleanup(Tools.getTestDevice(iotHubConnectionString, this.protocol, this.authenticationType, false, optionsBuilder));
             }
             else if (clientType == ClientType.MODULE_CLIENT)
             {
-                this.identity = Tools.getTestModule(iotHubConnectionString, this.protocol, this.authenticationType , false, optionsBuilder);
+                trackForCleanup(Tools.getTestModule(iotHubConnectionString, this.protocol, this.authenticationType , false, optionsBuilder));
             }
+
+            disposeIfTeardownAlreadyRan();
         }
 
         public void setupEccDevice() throws Exception
@@ -177,12 +190,12 @@ public class ConnectionTests extends IntegrationTest
                 eccDevice.setThumbprint(certificateGenerator.getX509Thumbprint(), certificateGenerator.getX509Thumbprint());
 
                 Tools.addDeviceWithRetry(new RegistryClient(iotHubConnectionString), eccDevice);
-                this.eccDeviceIdToDelete = eccDevice.getDeviceId();
+                trackEccDeviceForCleanup(eccDevice.getDeviceId());
 
                 String deviceConnectionString = Tools.getDeviceConnectionString(iotHubConnectionString, eccDevice);
-                this.identity = new TestDeviceIdentity(
+                trackForCleanup(new TestDeviceIdentity(
                     new DeviceClient(deviceConnectionString, testInstance.protocol, optionsBuilder.build()),
-                    eccDevice);
+                    eccDevice));
             }
             else if (clientType == ClientType.MODULE_CLIENT)
             {
@@ -192,26 +205,104 @@ public class ConnectionTests extends IntegrationTest
                 eccModule.setThumbprint(certificateGenerator.getX509Thumbprint(), certificateGenerator.getX509Thumbprint());
 
                 Tools.addDeviceWithRetry(new RegistryClient(iotHubConnectionString), eccDevice);
-                this.eccDeviceIdToDelete = eccDevice.getDeviceId();
+                trackEccDeviceForCleanup(eccDevice.getDeviceId());
 
                 Tools.addModuleWithRetry(new RegistryClient(iotHubConnectionString), eccModule);
 
                 String moduleConnectionString = Tools.getDeviceConnectionString(iotHubConnectionString, eccDevice) + ";ModuleId=" + eccModule.getId();
-                this.identity = new TestModuleIdentity(
+                trackForCleanup(new TestModuleIdentity(
                     new ModuleClient(moduleConnectionString, testInstance.protocol, optionsBuilder.build()),
                     eccDevice,
-                    eccModule);
+                    eccModule));
+            }
+
+            disposeIfTeardownAlreadyRan();
+        }
+
+        /**
+         * Hand an identity to teardown, and publish it for the test body to use.
+         *
+         * @param newIdentity The identity this test just acquired or created
+         */
+        private void trackForCleanup(TestIdentity newIdentity)
+        {
+            // Published for the test body. Never cleared, so a thread the JUnit timeout abandoned can keep reading it.
+            this.identity = newIdentity;
+
+            synchronized (lifecycleLock)
+            {
+                this.identityToDispose = newIdentity;
             }
         }
 
-        public void dispose()
+        /**
+         * Hand a freshly registered ECC device to teardown, so it is removed from the registry even if the rest of
+         * setupEccDevice never completes.
+         *
+         * @param deviceId The device id that was just added to the registry
+         */
+        private void trackEccDeviceForCleanup(String deviceId)
         {
-            if (this.identity != null && this.identity.getClient() != null)
+            synchronized (lifecycleLock)
             {
-                this.identity.getClient().close();
+                this.eccDeviceIdToDelete = deviceId;
+            }
+        }
+
+        /**
+         * Dispose anything registered after teardown already ran.
+         *
+         * <p>Every test in this class is bounded by {@code @Test(timeout = 60000)}. JUnit runs the test body on a
+         * separate thread and, when the timeout fires, abandons that thread while it is still running. {@code @After}
+         * is outside the timeout, so teardown can execute while setup on the abandoned thread has not finished
+         * acquiring its identity. Without this, the identity that setup goes on to produce would have no owner and
+         * would leak, which is precisely the leak this class is trying to stop.</p>
+         *
+         * <p>This does not wait for setup, in either direction. Blocking teardown on a setup that is itself hung -
+         * which is how these tests have actually timed out - would stall the rest of the run.</p>
+         */
+        private void disposeIfTeardownAlreadyRan()
+        {
+            boolean teardownAlreadyRan;
+            synchronized (lifecycleLock)
+            {
+                teardownAlreadyRan = this.disposed;
             }
 
-            if (this.eccDeviceIdToDelete != null)
+            if (teardownAlreadyRan)
+            {
+                dispose();
+            }
+        }
+
+        /**
+         * Close and dispose whatever this instance currently owns.
+         *
+         * <p>Safe to call more than once, and safe to call concurrently with setup: it takes ownership of the tracked
+         * fields and clears them, so a second call finds only what was registered since the first.</p>
+         */
+        public void dispose()
+        {
+            TestIdentity identityToClean;
+            String eccDeviceIdToClean;
+
+            synchronized (lifecycleLock)
+            {
+                this.disposed = true;
+
+                identityToClean = this.identityToDispose;
+                eccDeviceIdToClean = this.eccDeviceIdToDelete;
+
+                this.identityToDispose = null;
+                this.eccDeviceIdToDelete = null;
+            }
+
+            if (identityToClean != null && identityToClean.getClient() != null)
+            {
+                identityToClean.getClient().close();
+            }
+
+            if (eccDeviceIdToClean != null)
             {
                 // Recycling this identity would hand a device carrying a certificate that no other test knows about to
                 // the next test that takes an x509 identity from the shared pool, so delete it instead. This runs even
@@ -219,25 +310,17 @@ public class ConnectionTests extends IntegrationTest
                 // moment it is registered, whether or not the rest of the setup succeeded.
                 try
                 {
-                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(this.eccDeviceIdToDelete);
+                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(eccDeviceIdToClean);
                 }
                 catch (IOException | IotHubException e)
                 {
-                    log.error("Failed to clean up ECC test device {}", this.eccDeviceIdToDelete, e);
+                    log.error("Failed to clean up ECC test device {}", eccDeviceIdToClean, e);
                 }
-
-                this.eccDeviceIdToDelete = null;
             }
-            else if (this.identity != null)
+            else if (identityToClean != null)
             {
-                Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
+                Tools.disposeTestIdentity(identityToClean, iotHubConnectionString);
             }
-
-            // identity is deliberately left set. Every test in this class is bounded by @Test(timeout = 60000), and
-            // JUnit runs that method on a separate thread which it abandons, still running, when the timeout fires.
-            // @After is outside the timeout, so dispose() executes while that abandoned thread is still working its
-            // way through the rest of the test body. Clearing the field here made those threads dereference null.
-            // The other test classes that call dispose() from an @After do not clear it either.
         }
     }
 
@@ -426,10 +509,22 @@ public class ConnectionTests extends IntegrationTest
             multiplexingClient.registerDeviceClients(testClients);
 
             multiplexingClient.open(true);
-            multiplexingClient.close();
         }
         finally
         {
+            // Closing here rather than after open() so that a failed or timed out open still gives the client and the
+            // three device clients registered to it back. Otherwise they keep retrying for the life of the JVM, and
+            // the proxied variants keep retrying through the proxies this class runs locally.
+            try
+            {
+                multiplexingClient.close();
+            }
+            catch (Exception e)
+            {
+                // Swallowed so it cannot mask whatever the test itself threw.
+                log.error("Failed to close the multiplexing client", e);
+            }
+
             Tools.disposeTestIdentities(testIdentities, iotHubConnectionString);
         }
     }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -233,7 +233,11 @@ public class ConnectionTests extends IntegrationTest
                 Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
             }
 
-            this.identity = null;
+            // identity is deliberately left set. Every test in this class is bounded by @Test(timeout = 60000), and
+            // JUnit runs that method on a separate thread which it abandons, still running, when the timeout fires.
+            // @After is outside the timeout, so dispose() executes while that abandoned thread is still working its
+            // way through the rest of the test body. Clearing the field here made those threads dereference null.
+            // The other test classes that call dispose() from an @After do not clear it either.
         }
     }
 
@@ -328,16 +332,21 @@ public class ConnectionTests extends IntegrationTest
     public void CanOpenConnection() throws Exception
     {
         testInstance.setup();
-        logConnectionStatusChanges(testInstance.identity.getClient());
-        testInstance.identity.getClient().open(true);
+
+        // Held locally rather than read back off testInstance for each call. The @After that disposes this instance
+        // runs outside this method's timeout, so it can execute while this thread is still here after a timeout.
+        InternalClient client = testInstance.identity.getClient();
+
+        logConnectionStatusChanges(client);
+        client.open(true);
 
         // deviceClient.open() is a no-op on HTTP, so a message needs to be sent to actually test opening the connection
         if (testInstance.protocol == HTTPS)
         {
-            testInstance.identity.getClient().sendEvent(new Message("some message"));
+            client.sendEvent(new Message("some message"));
         }
 
-        testInstance.identity.getClient().close();
+        client.close();
     }
 
     @IotHubTest
@@ -358,16 +367,18 @@ public class ConnectionTests extends IntegrationTest
 
         testInstance.setupEccDevice();
 
-        logConnectionStatusChanges(testInstance.identity.getClient());
-        testInstance.identity.getClient().open(true);
+        InternalClient client = testInstance.identity.getClient();
+
+        logConnectionStatusChanges(client);
+        client.open(true);
 
         // deviceClient.open() is a no-op on HTTP, so a message needs to be sent to actually test opening the connection
         if (testInstance.protocol == HTTPS)
         {
-            testInstance.identity.getClient().sendEvent(new Message("some message"));
+            client.sendEvent(new Message("some message"));
         }
 
-        testInstance.identity.getClient().close();
+        client.close();
     }
 
     @Test(timeout = 60000) // 1 minute

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -117,22 +117,37 @@ public class ConnectionTests extends IntegrationTest
             this.useHttpProxyAuth = useHttpProxyAuth;
         }
 
+        /**
+         * Configure this test's proxy settings on the given builder, if this variant uses a proxy at all.
+         *
+         * <p>Both setup paths go through here so that they cannot drift apart. They previously had separate copies of
+         * this logic, and the copy in setupEccDevice was missing the unauthenticated branch entirely.</p>
+         *
+         * @param optionsBuilder The builder to apply the proxy settings to
+         */
+        private void applyProxySettings(ClientOptions.ClientOptionsBuilder optionsBuilder)
+        {
+            if (!this.useHttpProxy)
+            {
+                return;
+            }
+
+            if (this.useHttpProxyAuth)
+            {
+                Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
+                optionsBuilder.proxySettings(new ProxySettings(testProxy, testProxyUser, testProxyPass.toCharArray()));
+            }
+            else
+            {
+                Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostnameWithoutAuth, testProxyPortWithoutAuth));
+                optionsBuilder.proxySettings(new ProxySettings(testProxy));
+            }
+        }
+
         public void setup() throws Exception
         {
             ClientOptions.ClientOptionsBuilder optionsBuilder = ClientOptions.builder();
-            if (this.useHttpProxy)
-            {
-                if (this.useHttpProxyAuth)
-                {
-                    Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-                    optionsBuilder.proxySettings(new ProxySettings(testProxy, testProxyUser, testProxyPass.toCharArray()));
-                }
-                else
-                {
-                    Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostnameWithoutAuth, testProxyPortWithoutAuth));
-                    optionsBuilder.proxySettings(new ProxySettings(testProxy));
-                }
-            }
+            applyProxySettings(optionsBuilder);
 
             if (clientType == ClientType.DEVICE_CLIENT)
             {
@@ -147,11 +162,7 @@ public class ConnectionTests extends IntegrationTest
         public void setupEccDevice() throws Exception
         {
             ClientOptions.ClientOptionsBuilder optionsBuilder = ClientOptions.builder();
-            if (this.useHttpProxy)
-            {
-                Proxy testProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(testProxyHostname, testProxyPort));
-                optionsBuilder.proxySettings(new ProxySettings(testProxy, testProxyUser, testProxyPass.toCharArray()));
-            }
+            applyProxySettings(optionsBuilder);
 
             X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(X509CertificateGenerator.CertificateAlgorithm.ECC);
             SSLContext sslContext = SSLContextBuilder.buildSSLContext(certificateGenerator.getX509Certificate(), certificateGenerator.getPrivateKey());

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -113,6 +113,12 @@ public class ConnectionTests extends IntegrationTest
         // same client twice and, worse, requeue the same identity into the shared pool twice.
         private TestIdentity identityToDispose;
 
+        // Set once setupEccDevice starts creating an identity, and never cleared. Identity classification has to
+        // outlive eccDeviceIdToDelete: teardown claims and clears that id, so if teardown runs between the device
+        // being registered and the identity being published, the late disposeIfTeardownAlreadyRan would see an
+        // identity with no ecc id and hand a self signed identity to the shared x509 pool.
+        private volatile boolean identityIsEcc;
+
         // Set once teardown has run. Guarded by lifecycleLock along with the two fields above.
         private boolean disposed;
 
@@ -177,6 +183,10 @@ public class ConnectionTests extends IntegrationTest
 
         public void setupEccDevice() throws Exception
         {
+            // Marked before anything is created, so that every identity this method goes on to publish is classified
+            // as ECC even if teardown runs partway through.
+            this.identityIsEcc = true;
+
             ClientOptions.ClientOptionsBuilder optionsBuilder = ClientOptions.builder();
             applyProxySettings(optionsBuilder);
 
@@ -317,6 +327,13 @@ public class ConnectionTests extends IntegrationTest
                 {
                     log.error("Failed to clean up ECC test device {}", eccDeviceIdToClean, e);
                 }
+            }
+            else if (identityToClean != null && this.identityIsEcc)
+            {
+                // An earlier dispose already claimed and deleted the device id, and this identity was published after
+                // that. The device is gone from the registry, so there is nothing left to delete, but it must still
+                // not be recycled: it is self signed with a certificate no other test knows about.
+                log.debug("Discarding late ECC identity {} rather than recycling it", identityToClean.getDeviceId());
             }
             else if (identityToClean != null)
             {
@@ -509,15 +526,19 @@ public class ConnectionTests extends IntegrationTest
         int multiplexCount = 3;
         List<TestIdentity> testIdentities = new ArrayList<>(multiplexCount);
         List<DeviceClient> testClients = new ArrayList<>(multiplexCount);
-        for (int i = 0; i < multiplexCount; i++)
-        {
-            TestIdentity testIdentity = Tools.getTestDevice(iotHubConnectionString, testInstance.protocol, testInstance.authenticationType, false);
-            testIdentities.add(testIdentity);
-            testClients.add((DeviceClient) testIdentity.getClient());
-        }
 
+        // The acquisition loop is inside the protected scope because it can throw partway through. Acquiring the
+        // second or third identity can fail after the first is already in the list, and this method never assigns
+        // testInstance.identity, so the @After cannot reclaim them. Everything acquired so far is disposed instead.
         try
         {
+            for (int i = 0; i < multiplexCount; i++)
+            {
+                TestIdentity testIdentity = Tools.getTestDevice(iotHubConnectionString, testInstance.protocol, testInstance.authenticationType, false);
+                testIdentities.add(testIdentity);
+                testClients.add((DeviceClient) testIdentity.getClient());
+            }
+
             multiplexingClient.registerDeviceClients(testClients);
 
             multiplexingClient.open(true);

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/iothub/connection/ConnectionTests.java
@@ -101,8 +101,11 @@ public class ConnectionTests extends IntegrationTest
         public TestIdentity identity;
 
         // ECC identities are created by this test rather than taken from the shared pool, and they carry a
-        // certificate that only this test knows about, so they must never be recycled back into that pool.
-        private boolean identityIsEccIdentity;
+        // certificate that only this test knows about, so they must never be recycled back into that pool. This is
+        // recorded as soon as the device is registered, rather than being derived from the identity, because the
+        // rest of setupEccDevice can fail after that registration has already happened. Deleting the device also
+        // deletes any module underneath it, so the module does not need to be tracked separately.
+        private String eccDeviceIdToDelete;
         public AuthenticationType authenticationType;
         public ClientType clientType;
         public boolean useHttpProxy;
@@ -167,7 +170,6 @@ public class ConnectionTests extends IntegrationTest
             X509CertificateGenerator certificateGenerator = new X509CertificateGenerator(X509CertificateGenerator.CertificateAlgorithm.ECC);
             SSLContext sslContext = SSLContextBuilder.buildSSLContext(certificateGenerator.getX509Certificate(), certificateGenerator.getPrivateKey());
             optionsBuilder.sslContext(sslContext);
-            this.identityIsEccIdentity = true;
 
             if (clientType == ClientType.DEVICE_CLIENT)
             {
@@ -175,6 +177,7 @@ public class ConnectionTests extends IntegrationTest
                 eccDevice.setThumbprint(certificateGenerator.getX509Thumbprint(), certificateGenerator.getX509Thumbprint());
 
                 Tools.addDeviceWithRetry(new RegistryClient(iotHubConnectionString), eccDevice);
+                this.eccDeviceIdToDelete = eccDevice.getDeviceId();
 
                 String deviceConnectionString = Tools.getDeviceConnectionString(iotHubConnectionString, eccDevice);
                 this.identity = new TestDeviceIdentity(
@@ -189,6 +192,8 @@ public class ConnectionTests extends IntegrationTest
                 eccModule.setThumbprint(certificateGenerator.getX509Thumbprint(), certificateGenerator.getX509Thumbprint());
 
                 Tools.addDeviceWithRetry(new RegistryClient(iotHubConnectionString), eccDevice);
+                this.eccDeviceIdToDelete = eccDevice.getDeviceId();
+
                 Tools.addModuleWithRetry(new RegistryClient(iotHubConnectionString), eccModule);
 
                 String moduleConnectionString = Tools.getDeviceConnectionString(iotHubConnectionString, eccDevice) + ";ModuleId=" + eccModule.getId();
@@ -201,30 +206,29 @@ public class ConnectionTests extends IntegrationTest
 
         public void dispose()
         {
-            if (this.identity == null)
-            {
-                return;
-            }
-
-            if (this.identity.getClient() != null)
+            if (this.identity != null && this.identity.getClient() != null)
             {
                 this.identity.getClient().close();
             }
 
-            if (this.identityIsEccIdentity)
+            if (this.eccDeviceIdToDelete != null)
             {
                 // Recycling this identity would hand a device carrying a certificate that no other test knows about to
-                // the next test that takes an x509 identity from the shared pool, so delete it instead.
+                // the next test that takes an x509 identity from the shared pool, so delete it instead. This runs even
+                // when the identity was never finished being built, because the device is in the registry from the
+                // moment it is registered, whether or not the rest of the setup succeeded.
                 try
                 {
-                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(this.identity.getDeviceId());
+                    Tools.getRegistyManager(iotHubConnectionString).removeDevice(this.eccDeviceIdToDelete);
                 }
                 catch (IOException | IotHubException e)
                 {
-                    log.error("Failed to clean up ECC test device {}", this.identity.getDeviceId(), e);
+                    log.error("Failed to clean up ECC test device {}", this.eccDeviceIdToDelete, e);
                 }
+
+                this.eccDeviceIdToDelete = null;
             }
-            else
+            else if (this.identity != null)
             {
                 Tools.disposeTestIdentity(this.identity, iotHubConnectionString);
             }

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/amqp/ContractAPIAmqpTest.java
@@ -68,9 +68,6 @@ public class ContractAPIAmqpTest
     Map<String, Object> mockedHashMap;
 
     @Mocked
-    Object mockSendLock;
-
-    @Mocked
     ProvisioningDeviceClientConfig mockedProvisioningDeviceClientConfig;
 
     @Mocked

--- a/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqttTest.java
+++ b/provisioning/provisioning-device-client/src/test/java/com/microsoft/azure/sdk/iot/provisioning/device/internal/contract/mqtt/ContractAPIMqttTest.java
@@ -74,16 +74,10 @@ public class ContractAPIMqttTest
     MqttMessage mockedMqttMessage;
 
     @Mocked
-    Object mockSendLock;
-
-    @Mocked
     ProvisioningDeviceClientConfig mockedProvisioningDeviceClientConfig;
 
     @Mocked
     DeviceRegistrationParser mockedDeviceRegistrationParser;
-
-    @Mocked
-    Integer mockedInteger;
 
     @Mocked
     byte[] mockedByteArray = new byte[10];


### PR DESCRIPTION
Salvages the three test-harness fixes from #1856 that are still relevant. That PR is now `CONFLICTING` and most of it has been overtaken — this carries forward only the parts that were never picked up, rebased onto current `main`.

## Relationship to #1856

| #1856 proposed | Status |
| --- | --- |
| `ProxiedSSLSocket` honors the connect timeout | already fixed independently in #1859 |
| `HttpProxySocketFactory` returns an unconnected socket | already fixed in #1859 |
| `ProxiedSSLSocket.close()` null-safety | already on `main` |
| Remove `@Test(timeout = 60000)` | **carried forward here**, see below |
| **Wait for the proxies to bind** | **carried forward here** |
| **`ConnectionTests` client leak** | **carried forward here** |
| **Unused `@Mocked Object`** | **carried forward here** |

On the timeout: #1856 was right and my original reasoning here was wrong. I argued that because the retry policy is `ExponentialBackoffWithJitter` with `retryCount = Integer.MAX_VALUE` the client never gives up and never throws, so no timeout value could matter. That conflates the overall policy with a single attempt. `Mqtt.connect` bounds one CONNECT round trip with `connectToken.waitForCompletion(Mqtt.CONNECTION_TIMEOUT)`, and `CONNECTION_TIMEOUT` is 60000 - exactly the `@Test(timeout = 60000)` these tests declared. A stalled attempt and the test therefore expired on the same tick, so JUnit killed the thread precisely when the client would have thrown and let the retry run. Linux build 163287 shows the consequence: 60 seconds with not one connection status transition logged, because nothing was ever allowed to happen. The three overrides are removed here so `IntegrationTest`s two minute rule applies, which leaves room for one stalled attempt to expire and a retry to follow. This does not stop the stalls, it stops a single stall being fatal.

## 1. Wait for the test proxies to bind

`HttpProxyServer.startAsync(int)` returns `CompletionStage<Void>` that completes once the port is listening. All four classes that stand up a local proxy discarded it. Because the e2e tests run in parallel, a test can start sending traffic before the proxy is accepting and get a connection refused from a proxy that is about to be perfectly healthy.

`ProxyServerTools.startProxyServer` waits on that future, capped at 30s so a proxy that never binds fails the run with a clear error instead of hanging.

Applied to all five call sites across `ConnectionTests`, `FileUploadTests`, `MultiplexingClientTests` and `TokenRenewalTests`.

## 2. `ConnectionTests` was leaking every client it opened

`ConnectionTestInstance.dispose()` was **dead code** — defined, never called. Four other test classes call `testInstance.dispose()`; this one didn't. So every `CanOpenConnection` variant leaked its client and its identity.

Those clients keep retrying for the life of the JVM, and the proxied ones keep retrying *through the proxies this class runs locally*, competing with tests that are still running. Once `stopProxy()` closes them they retry against a dead port for the rest of the job.

This is the same leak #1861 fixed in `TokenRenewalTests`, and it works directly against the parallelism cap added in #1862 — the entire point of that cap was to stop these proxies being starved. Now called from an `@After`.

### ECC identities have to be deleted, not recycled

Worth calling out, because it is a trap. Unlike every other identity here, the ECC ones are created by the test rather than drawn from the shared pool, and carry a self-signed cert only this test knows about. `disposeTestIdentity` **recycles** rather than deletes when `RECYCLE_TEST_IDENTITIES` is set, and these are `SELF_SIGNED` — so recycling one would drop a device with an unknown thumbprint into the x509 pool for a later test to fail on. They are removed from the registry instead.

## 3. Unused `@Mocked Object` in the provisioning tests

`ContractAPIMqttTest` declared `@Mocked Object mockSendLock` and `@Mocked Integer mockedInteger`; `ContractAPIAmqpTest` declared `@Mocked Object mockSendLock`. **None of the three is referenced anywhere.** Mocking `java.lang.Object` makes JMockit retransform it, which is a hazard to the whole JVM rather than to one test.

Being straight about the evidence: **this is not currently failing.** #1856 cited build 161517, but I could not reproduce it — the full provisioning suite passes on JDK 8 with reruns disabled, and no `ContractAPI*` failure appears in the last seven CI builds. These are removed because they are unused and risky, not because they are breaking something today. If you would rather not touch them, that commit can be dropped without affecting the other two fixes.

## Verification

On JDK 8:
- `mvn -pl iot-e2e-tests/common -am test-compile` — BUILD SUCCESS
- `mvn -pl provisioning/provisioning-device-client test -Dsurefire.rerunFailingTestsCount=0` — **544 tests, 0 failures**, the same count as before the removal

The proxy bind wait and the client leak fix only show their effect in a live gated run, so those are exercised by the gate rather than locally.

Closes #1856.

