### PR TITLE
Tag the gate resource group with CreatedOn when it is created

### DIFF
--- a/vsts/E2ETestsSetup/e2eTestsSetup.ps1
+++ b/vsts/E2ETestsSetup/e2eTestsSetup.ps1
@@ -62,10 +62,11 @@ if ($rgExists -eq "False")
     # Tagged as part of the creation itself, not afterwards: the scheduled cleanup in
     # Azure/azure-iot-sdk-csharp vsts/resource-group-cleanup.yaml (which deletes leftover
     # 'javasdkgate*' groups as well as 'dotnetsdkgate*' ones) uses 'CreatedOn' to tell a leftover
-    # group from one whose gate run is still in flight. A group created in one step and tagged in
-    # a second can be left untagged forever if the run dies in between. A single tag is passed
-    # here on purpose -- under the AzureCLI@2 task, '--tags' with several key=value arguments
-    # collapses them into one tag value.
+    # group from one whose gate run is still in flight. Tagging in a second, separate call would
+    # leave a window where a run that dies in between produces an untagged group. That cleanup
+    # still reclaims such a group, but only via the slower 24-hour first-observed fallback rather
+    # than the 3-hour path. A single tag is passed here on purpose -- under the AzureCLI@2 task,
+    # '--tags' with several key=value arguments collapses them into one tag value.
     az group create --name $ResourceGroup --location $Region --tags "CreatedOn=$([datetime]::UtcNow.ToString('o'))" --output none
 }
 

--- a/vsts/E2ETestsSetup/e2eTestsSetup.ps1
+++ b/vsts/E2ETestsSetup/e2eTestsSetup.ps1
@@ -58,7 +58,15 @@ $rgExists = az group exists --name $ResourceGroup
 if ($rgExists -eq "False")
 {
     Write-Host "`nCreating resource group $ResourceGroup in $Region"
-    az group create --name $ResourceGroup --location $Region --output none
+
+    # Tagged as part of the creation itself, not afterwards: the scheduled cleanup in
+    # Azure/azure-iot-sdk-csharp vsts/resource-group-cleanup.yaml (which deletes leftover
+    # 'javasdkgate*' groups as well as 'dotnetsdkgate*' ones) uses 'CreatedOn' to tell a leftover
+    # group from one whose gate run is still in flight. A group created in one step and tagged in
+    # a second can be left untagged forever if the run dies in between. A single tag is passed
+    # here on purpose -- under the AzureCLI@2 task, '--tags' with several key=value arguments
+    # collapses them into one tag value.
+    az group create --name $ResourceGroup --location $Region --tags "CreatedOn=$([datetime]::UtcNow.ToString('o'))" --output none
 }
 
 $resourceGroupId = az group show -n $ResourceGroup --query id --out tsv


### PR DESCRIPTION
## What

One line: tag the gate resource group with `CreatedOn` **as part of** `az group create`.

```diff
-    az group create --name $ResourceGroup --location $Region --output none
+    az group create --name $ResourceGroup --location $Region --tags "CreatedOn=$([datetime]::UtcNow.ToString('o'))" --output none
```

## Why

The scheduled cleanup that deletes leftover `javasdkgate*` groups lives in the **C# repo** (`Azure/azure-iot-sdk-csharp`, `vsts/resource-group-cleanup.yaml`) — it handles `javasdkgate*` and `dotnetsdkgate*` together. Today it deletes every matching group **unconditionally, with no age check**, including groups belonging to a Java gate run that is still executing. When it fires mid-run it removes that run's IoT hub, DPS instance and storage account, and the run fails on unrelated errors.

Azure/azure-iot-sdk-csharp#3538 fixes that by only deleting a group once it is at least 3 h old, judged by a `CreatedOn` tag.

Groups created here carry **no tags at all**, so without this change every Java gate group lands on the slower fallback path that PR keeps for untagged groups (stamp on first sight, delete after 24 h). They would still be cleaned up and still be safe from mid-run deletion — just reclaimed roughly a day later than necessary. This restores the fast 3 h path.

## Two details

- **Tagged during creation, not after.** A separate follow-up call would leave a window where a run that dies mid-setup leaves an untagged group behind — the same class of bug being fixed elsewhere in this family.
- **A single tag, on purpose.** Under the `AzureCLI@2` task, `--tags` with several `key=value` arguments collapses them into one tag value. `Azure/iot-sdks-e2e-fx` already hit this (d87ebbb). One pair has nothing to collapse.

## Ordering

Independent of Azure/azure-iot-sdk-csharp#3538 and safe to merge in either order. Before it, this tag is simply unused; after it, it moves Java groups onto the fast path.

## Testing

I have no ARM credential in this environment, so this is **not** verified against live Azure — please confirm on a gate run.

Verified locally with PowerShell 7.4.6: the script parses clean, the tag reaches `az` as a **single** argument token (`CreatedOn=2026-08-24T20:17:00.0327400Z`, confirmed by argument-count check, so the collapsing bug cannot apply), and the value round-trips through the exact `[datetimeoffset]::Parse(..., AssumeUniversal)` call the cleanup uses to judge age.

The existing behaviour is otherwise untouched: the group is still only created when `az group exists` reports `False`, so a pre-existing group is not retagged.
