### PR TITLE
Give the Android emulator fixed DNS servers

### DIFF
--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -22,8 +22,20 @@ echo "List AVDs:"
 $EMU -list-avds
 
 # Start emulator in background and with no UI (-no-window), as we're only running database tests.
-nohup $EMU -avd ${NAME_EMU} -no-window -no-snapshot -no-audio -no-boot-anim > /dev/null 2>&1 &
+#
+# -dns-server is set explicitly because the emulator otherwise resolves through its own DNS proxy, which forwards to
+# whatever resolvers the host agent happens to have. On the hosted agents that has proven unreliable: lookups of the
+# test hub and provisioning service hostnames intermittently come back as
+#   java.net.UnknownHostException: Unable to resolve host "...": No address associated with hostname
+# for some tests while other tests in the same run resolve the same hostname successfully. Pointing the guest at fixed
+# public resolvers takes the host's resolver configuration out of the picture.
+nohup $EMU -avd ${NAME_EMU} -no-window -no-snapshot -no-audio -no-boot-anim -dns-server 8.8.8.8,8.8.4.4 > /dev/null 2>&1 &
 
 $ADB wait-for-device
 $ADB shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
 $ADB devices
+
+# Logged so that a DNS failure later in the run can be told apart from an emulator that never had working name
+# resolution to begin with. Does not fail the task; the tests report their own failures.
+echo "Checking name resolution from inside the emulator:"
+$ADB shell ping -c 1 -W 5 azure-devices-provisioning.net || echo "WARNING: emulator could not resolve azure-devices-provisioning.net"

--- a/vsts/StartEmulator.sh
+++ b/vsts/StartEmulator.sh
@@ -37,5 +37,19 @@ $ADB devices
 
 # Logged so that a DNS failure later in the run can be told apart from an emulator that never had working name
 # resolution to begin with. Does not fail the task; the tests report their own failures.
+#
+# ping's exit status is not used to judge DNS, because it also fails when ICMP is simply not allowed out, which is
+# common and harmless here. Only the resolution step is inspected: ping prints the resolved address when the lookup
+# succeeded, and reports an unknown host or bad address when it did not.
 echo "Checking name resolution from inside the emulator:"
-$ADB shell ping -c 1 -W 5 azure-devices-provisioning.net || echo "WARNING: emulator could not resolve azure-devices-provisioning.net"
+resolutionOutput=$($ADB shell ping -c 1 -W 5 azure-devices-provisioning.net 2>&1)
+echo "${resolutionOutput}"
+
+case "${resolutionOutput}" in
+    *"unknown host"*|*"bad address"*|*"Name or service not known"*|*"Temporary failure in name resolution"*)
+        echo "WARNING: emulator could not resolve azure-devices-provisioning.net. Name resolution is broken in the guest."
+        ;;
+    *)
+        echo "Name resolution succeeded. Any ping failure above is ICMP reachability, not DNS."
+        ;;
+esac


### PR DESCRIPTION
Android test jobs intermittently fail with:

```
java.net.UnknownHostException: Unable to resolve host
"javasdkgate<random>-dps.azure-devices-provisioning.net":
No address associated with hostname
    at ContractApiHttp.request(ContractApiHttp.java:157)
```

thrown from the first HTTPS call, before any SDK logic runs.

## Why it is the emulator's DNS

`StartEmulator.sh` started the emulator without `-dns-server`, so the guest resolves through the emulator's DNS proxy, which forwards to whatever resolvers the host agent has.

It is not deterministic. In build 162434, 5 of 17 tests in `TestGroup1` failed on that hostname while the other 12 — which reach the same host through `ProvisioningCommon` — passed in the same emulator process. A missing or misdeployed resource would fail all 17.

Recent `Android Test TestGroup1` failures, all the same exception:

| Build | Branch | Failures / 17 |
| --- | --- | --- |
| 161767 | `main` | 6 |
| 162061 | PR #1862 | 11 |
| 162434 | PR #1863 | 5 |
| 162511 | PR #1863 | 6 |

4 of the last 39 Android builds (~10%), across `main` and unrelated PRs. `DeployCloudTestResources` succeeded in every one.

## Change

- `-dns-server 8.8.8.8,8.8.4.4` on emulator start, so the guest does not depend on the host agent's resolver configuration.
- One name resolution check logged after boot, so a later DNS failure can be told apart from an emulator that never had working resolution. It only logs and cannot fail the task.

## Verification

- `bash -n`: clean.
- ShellCheck 0.10.0: same 3 pre-existing informational findings as the unmodified file, none new.
- Not run end to end: that needs a macOS agent with the Android emulator, which I do not have. The gate on this PR exercises it.

Given the ~10% base rate, one green run will not prove this fixed. Several consecutive green Android runs would.
